### PR TITLE
Deduplicate pairwise LD, streaming ZnS, fused window stats

### DIFF
--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -749,67 +749,64 @@ class HaplotypeMatrix:
         return diversity.tajimas_d(self)
 
 
-    def pairwise_LD_v(self) -> cp.ndarray:
-        """
-        Optimized pairwise linkage disequilibrium (D statistic) computation
-        using matrix multiplication for CuPy acceleration.
-        """
-        # Ensure data is on GPU
-        if self.device == 'CPU':
-            self.transfer_to_gpu()
+    def _pairwise_ld_core(self, hap_clean=None, valid_mask=None):
+        """Shared computation for pairwise LD methods.
 
-        hap = self.haplotypes
-        valid_mask = (hap >= 0).astype(cp.float64)
-        hap_clean = cp.where(hap >= 0, hap, 0).astype(cp.float64)
-        n_valid = cp.sum(valid_mask, axis=0).astype(cp.float64)  # per-site
+        Computes allele frequencies, joint frequencies, and D matrix from
+        haplotype data, handling missing values.
 
-        # Allele frequencies from valid data only
-        p = cp.where(n_valid > 0, cp.sum(hap_clean, axis=0) / n_valid, 0.0)
-
-        # p_AB: joint frequency of derived at both sites
-        # Only count haplotypes valid at both sites
-        joint_n = valid_mask.T @ valid_mask  # (n_var, n_var)
-        joint_11 = hap_clean.T @ hap_clean
-        p_AB = cp.where(joint_n > 0, joint_11 / joint_n, 0.0)
-
-        p_Ap_B = cp.outer(p, p)
-        D = p_AB - p_Ap_B
-        cp.fill_diagonal(D, 0)
-
-        return D
-
-    def pairwise_r2(self) -> np.ndarray:
-        """
-        Calculate the pairwise r2 (correlation coefficient) for all pairs of variants
-        in the haplotype matrix.
+        Parameters
+        ----------
+        hap_clean : cupy.ndarray, optional
+            Pre-cleaned haplotype submatrix (missing set to 0). If None,
+            uses self.haplotypes.
+        valid_mask : cupy.ndarray, optional
+            Validity mask (1 where not missing). Must be provided iff
+            hap_clean is provided.
 
         Returns
         -------
-        ndarray, float64, shape (n_variants, n_variants)
+        D : cupy.ndarray, shape (m, m)
+            Pairwise D = p_AB - p_A*p_B.
+        p : cupy.ndarray, shape (m,)
+            Per-site allele frequencies.
         """
         if self.device == 'CPU':
             self.transfer_to_gpu()
 
-        hap = self.haplotypes
-        valid_mask = (hap >= 0).astype(cp.float64)
-        hap_clean = cp.where(hap >= 0, hap, 0).astype(cp.float64)
-        n_valid = cp.sum(valid_mask, axis=0).astype(cp.float64)
+        if hap_clean is None:
+            hap = self.haplotypes
+            valid_mask = (hap >= 0).astype(cp.float64)
+            hap_clean = cp.where(hap >= 0, hap, 0).astype(cp.float64)
 
+        n_valid = cp.sum(valid_mask, axis=0).astype(cp.float64)
         p = cp.where(n_valid > 0, cp.sum(hap_clean, axis=0) / n_valid, 0.0)
 
         joint_n = valid_mask.T @ valid_mask
         joint_11 = hap_clean.T @ hap_clean
         p_AB = cp.where(joint_n > 0, joint_11 / joint_n, 0.0)
 
-        p_Ap_B = cp.outer(p, p)
-        D = p_AB - p_Ap_B
+        D = p_AB - cp.outer(p, p)
+        return D, p
 
+    def pairwise_LD_v(self) -> cp.ndarray:
+        """Pairwise linkage disequilibrium (D statistic) via matrix multiply."""
+        D, _ = self._pairwise_ld_core()
+        cp.fill_diagonal(D, 0)
+        return D
+
+    def pairwise_r2(self) -> cp.ndarray:
+        """Pairwise r-squared for all variant pairs.
+
+        Returns
+        -------
+        cupy.ndarray, float64, shape (n_variants, n_variants)
+        """
+        D, p = self._pairwise_ld_core()
         denom_squared = cp.outer(p * (1 - p), p * (1 - p))
         r2 = cp.where(denom_squared > 0, (D ** 2) / denom_squared, 0)
-
         cp.fill_diagonal(r2, 0)
-
-        return r2.get()
+        return r2
 
     def locate_unlinked(self, size=100, step=20, threshold=0.1):
         """Locate variants in approximate linkage equilibrium.
@@ -835,14 +832,9 @@ class HaplotypeMatrix:
             self.transfer_to_gpu()
 
         m = self.num_variants
-        n_hap = self.num_haplotypes
-
-        # allele frequencies from valid data
         hap = self.haplotypes
         valid_mask = (hap >= 0).astype(cp.float64)
         hap_clean = cp.where(hap >= 0, hap, 0).astype(cp.float64)
-        n_valid = cp.sum(valid_mask, axis=0).astype(cp.float64)
-        p = cp.where(n_valid > 0, cp.sum(hap_clean, axis=0) / n_valid, 0.0)
 
         # pruning state kept on CPU to avoid per-scalar GPU transfers
         loc = np.ones(m, dtype=bool)
@@ -856,18 +848,12 @@ class HaplotypeMatrix:
 
             active_idx = np.where(active)[0] + w_start
             active_idx_gpu = cp.asarray(active_idx)
-            hw = hap_clean[:, active_idx_gpu]
-            vm = valid_mask[:, active_idx_gpu]
-            p_window = p[active_idx_gpu]
 
-            # pairwise r² within window via matrix multiply
-            joint_n = vm.T @ vm
-            joint_11 = hw.T @ hw
-            p_AB = cp.where(joint_n > 0, joint_11 / joint_n, 0.0)
-            p_Ap_B = cp.outer(p_window, p_window)
-            D = p_AB - p_Ap_B
-            denom = cp.outer(p_window * (1 - p_window),
-                             p_window * (1 - p_window))
+            D, p_w = self._pairwise_ld_core(
+                hap_clean[:, active_idx_gpu],
+                valid_mask[:, active_idx_gpu],
+            )
+            denom = cp.outer(p_w * (1 - p_w), p_w * (1 - p_w))
             r2_mat = cp.where(denom > 0, (D ** 2) / denom, 0.0)
             cp.fill_diagonal(r2_mat, 0.0)
 

--- a/pg_gpu/ld_statistics.py
+++ b/pg_gpu/ld_statistics.py
@@ -282,6 +282,80 @@ def _zns_tiled(mat, missing_data='include', tile_size=512):
     return total / (m * (m - 1))
 
 
+def _zns_from_precomputed(hap_clean, valid_mask, col_start, col_end,
+                          tile_size=512):
+    """Compute ZnS for a column range using precomputed arrays.
+
+    This avoids creating a HaplotypeMatrix and recomputing valid_mask/hap_clean
+    for each window in the windowed_analysis loop.
+
+    Parameters
+    ----------
+    hap_clean : cupy.ndarray, shape (n_hap, n_variants)
+        Haplotype data with missing values set to 0.
+    valid_mask : cupy.ndarray, shape (n_hap, n_variants)
+        1 where data is valid, 0 where missing.
+    col_start, col_end : int
+        Column range [col_start, col_end) to compute ZnS over.
+    tile_size : int
+        Tile size for accumulation.
+
+    Returns
+    -------
+    float
+        ZnS value, or 0.0 if fewer than 2 segregating sites.
+    """
+    hc = hap_clean[:, col_start:col_end]
+    vm = valid_mask[:, col_start:col_end]
+
+    # Filter to segregating sites
+    n_valid = cp.sum(vm, axis=0).astype(cp.float64)
+    dac = cp.sum(hc, axis=0)
+    seg = (dac > 0) & (dac < n_valid)
+    seg_idx = cp.where(seg)[0]
+    m = len(seg_idx)
+    if m < 2:
+        return 0.0
+
+    hc = hc[:, seg_idx]
+    vm = vm[:, seg_idx]
+    n_valid = n_valid[seg_idx]
+    p = cp.where(n_valid > 0, cp.sum(hc, axis=0) / n_valid, 0.0)
+    pq = p * (1 - p)
+
+    B = tile_size
+    total = 0.0
+
+    for i0 in range(0, m, B):
+        i1 = min(i0 + B, m)
+        hi = hc[:, i0:i1]
+        vi = vm[:, i0:i1]
+        pi = p[i0:i1]
+        pqi = pq[i0:i1]
+
+        for j0 in range(i0, m, B):
+            j1 = min(j0 + B, m)
+            hj = hc[:, j0:j1]
+            vj = vm[:, j0:j1]
+            pj = p[j0:j1]
+            pqj = pq[j0:j1]
+
+            joint_n = vi.T @ vj
+            joint_11 = hi.T @ hj
+            p_AB = cp.where(joint_n > 0, joint_11 / joint_n, 0.0)
+            D = p_AB - cp.outer(pi, pj)
+            denom = cp.outer(pqi, pqj)
+            r2_tile = cp.where(denom > 0, (D ** 2) / denom, 0.0)
+
+            if i0 == j0:
+                cp.fill_diagonal(r2_tile, 0.0)
+                total += float(cp.sum(r2_tile).get())
+            else:
+                total += 2.0 * float(cp.sum(r2_tile).get())
+
+    return total / (m * (m - 1))
+
+
 def zns(r2_matrix_or_matrix, missing_data='include'):
     """Kelly's ZnS: mean pairwise r-squared across all SNP pairs.
 

--- a/pg_gpu/ld_statistics.py
+++ b/pg_gpu/ld_statistics.py
@@ -413,8 +413,7 @@ def _resolve_r2_matrix(r2_matrix_or_matrix, missing_data='include'):
             seg_idx = cp.where(seg)[0]
             if len(seg_idx) < mat.num_variants:
                 mat = mat.get_subset(seg_idx)
-            # pairwise_r2 returns numpy; convert back for internal GPU ops
-            return cp.asarray(mat.pairwise_r2(), dtype=cp.float64)
+            return mat.pairwise_r2().astype(cp.float64)
         else:
             return _r2_matrix_diploid(mat)
     else:

--- a/pg_gpu/ld_statistics.py
+++ b/pg_gpu/ld_statistics.py
@@ -205,6 +205,83 @@ def r_squared(counts: cp.ndarray,
     return r(counts, n_valid) ** 2
 
 
+def _zns_tiled(mat, missing_data='include', tile_size=512):
+    """Compute ZnS without materializing the full r² matrix.
+
+    Uses tile-based accumulation: computes D and r² for B×B blocks and
+    sums r² per tile, keeping memory at O(B²) instead of O(m²).
+    """
+    from .haplotype_matrix import HaplotypeMatrix
+
+    if hasattr(mat, 'device') and mat.device == 'CPU':
+        mat.transfer_to_gpu()
+
+    # Filter missing data sites
+    if missing_data == 'exclude':
+        hap = mat.haplotypes
+        missing_per_var = cp.sum(hap < 0, axis=0)
+        valid = cp.where(missing_per_var == 0)[0]
+        mat = mat.get_subset(valid)
+
+    # Filter monomorphic sites
+    hap = mat.haplotypes
+    dac = cp.sum(cp.maximum(hap, 0).astype(cp.int32), axis=0)
+    n_valid_per_site = cp.sum((hap >= 0).astype(cp.int32), axis=0)
+    seg = (dac > 0) & (dac < n_valid_per_site)
+    seg_idx = cp.where(seg)[0]
+    if len(seg_idx) < mat.num_variants:
+        mat = mat.get_subset(seg_idx)
+
+    hap = mat.haplotypes
+    m = hap.shape[1]
+    if m < 2:
+        return 0.0
+
+    # Precompute shared arrays
+    valid_mask = (hap >= 0).astype(cp.float64)
+    hap_clean = cp.where(hap >= 0, hap, 0).astype(cp.float64)
+    n_valid = cp.sum(valid_mask, axis=0).astype(cp.float64)
+    p = cp.where(n_valid > 0, cp.sum(hap_clean, axis=0) / n_valid, 0.0)
+    pq = p * (1 - p)
+
+    B = tile_size
+    total = 0.0
+
+    for i0 in range(0, m, B):
+        i1 = min(i0 + B, m)
+        hi = hap_clean[:, i0:i1]
+        vi = valid_mask[:, i0:i1]
+        pi = p[i0:i1]
+        pqi = pq[i0:i1]
+
+        for j0 in range(i0, m, B):
+            j1 = min(j0 + B, m)
+            hj = hap_clean[:, j0:j1]
+            vj = valid_mask[:, j0:j1]
+            pj = p[j0:j1]
+            pqj = pq[j0:j1]
+
+            # D for this tile
+            joint_n = vi.T @ vj
+            joint_11 = hi.T @ hj
+            p_AB = cp.where(joint_n > 0, joint_11 / joint_n, 0.0)
+            D = p_AB - cp.outer(pi, pj)
+
+            # r² for this tile
+            denom = cp.outer(pqi, pqj)
+            r2_tile = cp.where(denom > 0, (D ** 2) / denom, 0.0)
+
+            if i0 == j0:
+                # Diagonal block: zero the diagonal, count once
+                cp.fill_diagonal(r2_tile, 0.0)
+                total += float(cp.sum(r2_tile).get())
+            else:
+                # Off-diagonal block: count twice (upper + lower triangle)
+                total += 2.0 * float(cp.sum(r2_tile).get())
+
+    return total / (m * (m - 1))
+
+
 def zns(r2_matrix_or_matrix, missing_data='include'):
     """Kelly's ZnS: mean pairwise r-squared across all SNP pairs.
 
@@ -213,6 +290,8 @@ def zns(r2_matrix_or_matrix, missing_data='include'):
     r2_matrix_or_matrix : ndarray, HaplotypeMatrix, or GenotypeMatrix
         Square r-squared matrix, or a matrix object (dispatches to
         haploid or diploid r-squared computation automatically).
+        When a HaplotypeMatrix is passed, uses tiled computation to
+        avoid materializing the full m×m r² matrix.
     missing_data : str
         'include' - per-site valid data for frequency computation
         'exclude' - filter to sites with no missing data
@@ -222,6 +301,12 @@ def zns(r2_matrix_or_matrix, missing_data='include'):
     float
         Mean r-squared (excluding diagonal).
     """
+    from .haplotype_matrix import HaplotypeMatrix
+
+    # Streaming path for HaplotypeMatrix: O(B²) memory instead of O(m²)
+    if isinstance(r2_matrix_or_matrix, HaplotypeMatrix):
+        return _zns_tiled(r2_matrix_or_matrix, missing_data)
+
     r2_matrix = _resolve_r2_matrix(r2_matrix_or_matrix, missing_data)
 
     m = r2_matrix.shape[0]

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -1439,27 +1439,39 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
 
         stat_arrays = {s: np.full(n_windows, np.nan) for s in perwin_stats}
         need_dist = bool(perwin_stats & dist_pairwise)
+        need_winmat = ('omega' in stat_arrays or 'mu_ld' in stat_arrays
+                       or need_dist)
+
+        # Precompute for fused ZnS path
+        if 'zns' in stat_arrays:
+            hap = matrix.haplotypes
+            hap_clean = cp.where(hap >= 0, hap, 0).astype(cp.float64)
+            valid_mask = (hap >= 0).astype(cp.float64)
 
         for wi in range(n_windows):
             s, e = int(ws_np[wi]), int(we_np[wi])
             if e - s < 4:
                 continue
-            win_mat = HaplotypeMatrix(matrix.haplotypes[:, s:e],
-                                       matrix.positions[s:e])
+
             if 'zns' in stat_arrays:
-                stat_arrays['zns'][wi] = ld_statistics.zns(win_mat)
-            if 'omega' in stat_arrays:
-                stat_arrays['omega'][wi] = ld_statistics.omega(win_mat)
-            if 'mu_ld' in stat_arrays:
-                stat_arrays['mu_ld'][wi] = ld_statistics.mu_ld(win_mat)
-            if need_dist:
-                v, sk, ku = distance_stats.dist_moments(win_mat)
-                if 'dist_var' in stat_arrays:
-                    stat_arrays['dist_var'][wi] = v
-                if 'dist_skew' in stat_arrays:
-                    stat_arrays['dist_skew'][wi] = sk
-                if 'dist_kurt' in stat_arrays:
-                    stat_arrays['dist_kurt'][wi] = ku
+                stat_arrays['zns'][wi] = ld_statistics._zns_from_precomputed(
+                    hap_clean, valid_mask, s, e)
+
+            if need_winmat:
+                win_mat = HaplotypeMatrix(matrix.haplotypes[:, s:e],
+                                           matrix.positions[s:e])
+                if 'omega' in stat_arrays:
+                    stat_arrays['omega'][wi] = ld_statistics.omega(win_mat)
+                if 'mu_ld' in stat_arrays:
+                    stat_arrays['mu_ld'][wi] = ld_statistics.mu_ld(win_mat)
+                if need_dist:
+                    v, sk, ku = distance_stats.dist_moments(win_mat)
+                    if 'dist_var' in stat_arrays:
+                        stat_arrays['dist_var'][wi] = v
+                    if 'dist_skew' in stat_arrays:
+                        stat_arrays['dist_skew'][wi] = sk
+                    if 'dist_kurt' in stat_arrays:
+                        stat_arrays['dist_kurt'][wi] = ku
 
         results.update(stat_arrays)
 

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -116,7 +116,7 @@ class StatisticsComputer:
 
     # LD-based statistics
     LD_STATS = {
-        'ld_decay': lambda w, **kwargs: _compute_ld_decay(w.matrix, **kwargs),
+        'ld_decay': lambda w, **kwargs: _compute_mean_r2(w.matrix, **kwargs),
         'mean_r2': lambda w, max_dist: _compute_mean_r2(w.matrix, max_dist),
     }
 
@@ -725,54 +725,18 @@ def windowed_analysis(haplotype_matrix: HaplotypeMatrix,
 
 
 
-def _compute_ld_decay(matrix: HaplotypeMatrix, bins: List[int],
-                     max_distance: int = 50000) -> float:
-    """Compute mean LD decay (mean r² across all distance bins)."""
-    # Simplified implementation - returns single summary value
-    # In practice, might want to return the full decay curve
+def _compute_mean_r2(matrix: HaplotypeMatrix, max_distance: int,
+                     **kwargs) -> float:
+    """Compute mean r² for variant pairs within a genomic distance."""
     r2_matrix = matrix.pairwise_r2()
     positions = matrix.positions
 
-    # Calculate pairwise distances
-    if matrix.device == 'GPU':
-        pos_i, pos_j = cp.meshgrid(positions, positions, indexing='ij')
-        distances = cp.abs(pos_j - pos_i)
-
-        # Get mean r² within max distance
-        mask = (distances > 0) & (distances <= max_distance)
-        if cp.any(mask):
-            mean_r2 = float(cp.mean(r2_matrix[mask]).get())
-        else:
-            mean_r2 = np.nan
-    else:
-        # CPU version
-        pos_i, pos_j = np.meshgrid(positions, positions, indexing='ij')
-        distances = np.abs(pos_j - pos_i)
-
-        mask = (distances > 0) & (distances <= max_distance)
-        if np.any(mask):
-            mean_r2 = float(np.mean(r2_matrix[mask]))
-        else:
-            mean_r2 = np.nan
-
-    return mean_r2
-
-
-def _compute_mean_r2(matrix: HaplotypeMatrix, max_distance: int) -> float:
-    """Compute mean r² within a distance."""
-    r2_matrix = matrix.pairwise_r2()
-    positions = matrix.positions
-
-    if matrix.device == 'GPU':
-        pos_i, pos_j = cp.meshgrid(positions, positions, indexing='ij')
-        distances = cp.abs(pos_j - pos_i)
-        mask = (distances > 0) & (distances <= max_distance)
-        return float(cp.mean(r2_matrix[mask]).get()) if cp.any(mask) else np.nan
-    else:
-        pos_i, pos_j = np.meshgrid(positions, positions, indexing='ij')
-        distances = np.abs(pos_j - pos_i)
-        mask = (distances > 0) & (distances <= max_distance)
-        return float(np.mean(r2_matrix[mask])) if np.any(mask) else np.nan
+    pos_i, pos_j = cp.meshgrid(positions, positions, indexing='ij')
+    distances = cp.abs(pos_j - pos_i)
+    mask = (distances > 0) & (distances <= max_distance)
+    if cp.any(mask):
+        return float(cp.mean(r2_matrix[mask]).get())
+    return np.nan
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ld_r_squared.py
+++ b/tests/test_ld_r_squared.py
@@ -70,7 +70,7 @@ class TestRSquaredVsAllel:
         matrix = HaplotypeMatrix(hap, pos, 0, n_var * 1000)
 
         # method 1: pairwise_r2 matrix (uses freq-based formula)
-        r2_mat = matrix.pairwise_r2()
+        r2_mat = matrix.pairwise_r2().get()
         idx_i, idx_j = np.triu_indices(n_var, k=1)
         r2_from_mat = r2_mat[idx_i, idx_j]
 
@@ -93,7 +93,7 @@ class TestPairwiseR2:
         hap = np.random.randint(0, 2, (10, 20), dtype=np.int8)
         pos = np.arange(20) * 1000
         matrix = HaplotypeMatrix(hap, pos, 0, 20000)
-        r2 = matrix.pairwise_r2()
+        r2 = matrix.pairwise_r2().get()
         assert r2.shape == (20, 20)
         # diagonal should be 0
         np.testing.assert_array_almost_equal(np.diag(r2), 0.0)
@@ -105,7 +105,7 @@ class TestPairwiseR2:
         pos = np.arange(10) * 1000
         matrix = HaplotypeMatrix(hap, pos, 0, 10000)
 
-        r2_mat = matrix.pairwise_r2()
+        r2_mat = matrix.pairwise_r2().get()
         counts, n_valid = matrix.tally_gpu_haplotypes()
         r2_flat = ld_statistics.r_squared(counts, n_valid=n_valid).get()
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -59,7 +59,7 @@ class TestLDPlots:
         matrix, _, pos = sim_data
         r2 = matrix.pairwise_r2()
         if hasattr(r2, 'get'):
-            r2 = np.asarray(r2)
+            r2 = r2.get()
         ax = plotting.plot_pairwise_ld(r2, positions=pos)
         assert ax is not None
 


### PR DESCRIPTION
## Summary
- Extract `_pairwise_ld_core()` shared helper, eliminating code triplicated across `pairwise_r2`, `pairwise_LD_v`, and `locate_unlinked`
- `pairwise_r2()` now returns CuPy, removing the GPU->CPU->GPU roundtrip in `_resolve_r2_matrix()`
- Merge duplicate `_compute_ld_decay` / `_compute_mean_r2` in windowed_analysis
- Add tiled ZnS computation: O(B^2) memory instead of O(m^2)
- Fuse per-window ZnS in windowed_analysis loop via precomputed arrays

## Test plan
- [x] All 417 tests pass (`pixi run pytest tests/ -v`)
- [x] Lint clean (`pixi run -e lint ruff check pg_gpu/ tests/`)
- [x] Tiled ZnS produces exact match with full-matrix path across multiple window sizes
- [x] Fused windowed ZnS matches per-window HaplotypeMatrix path at machine precision