### PR TITLE
Add unbiased LD estimators via multinomial projection

### DIFF
--- a/docs/source/missing_data.rst
+++ b/docs/source/missing_data.rst
@@ -9,7 +9,7 @@ Missing Data Modes
 ------------------
 
 Every function that operates on genetic data accepts a ``missing_data``
-parameter with three options:
+parameter with three options (plus a fourth for LD statistics):
 
 **include** (default)
    Skip missing entries per site, computing statistics from observed
@@ -29,6 +29,20 @@ parameter with three options:
    observed data contribute proportionally more weight. Invariant sites
    can be included in the denominator when ``n_total_sites`` is set on
    the matrix (see :ref:`invariant-sites`).
+
+**project** (LD statistics only)
+   Unbiased multinomial projection estimators following Ragsdale & Gravel
+   (2019). For each pair of sites, counts the four haplotype
+   configurations among individuals observed at both sites, then applies
+   falling-factorial corrections to obtain unbiased estimates of D² and
+   pi2. The per-pair statistic is sigma_d^2 = D² / pi2, which avoids
+   the upward bias of naive r² that worsens with small or variable
+   sample sizes. Currently supported by ``zns()`` and ``omega()``.
+   Requires a ``HaplotypeMatrix`` as input (not a pre-computed r² array).
+
+   Reference: Ragsdale AP, Gravel S (2019) "Unbiased estimation of
+   linkage disequilibrium from unphased data." *Mol Biol Evol*
+   37(3):923-932.
 
 The old ``'ignore'`` mode (which treated missing as reference allele)
 has been removed because it silently biases allele frequencies.
@@ -115,48 +129,58 @@ Every public function accepts the ``missing_data`` parameter:
 
 .. list-table::
    :header-rows: 1
-   :widths: 30 15 15 15
+   :widths: 25 13 13 13 13
 
    * - Function
      - include
      - exclude
      - pairwise
+     - project
    * - Diversity (pi, theta_w, theta_h, theta_l)
      - per-site n
      - filter sites
      - sum/sum
+     - \-
    * - Neutrality tests (tajimas_d, fay_wus_h, H*, E, DH)
      - per-site n
      - filter sites
      - harmonic mean n
+     - \-
    * - Divergence (dxy, fst, da)
      - per-site n
      - filter sites
      - sum/sum
+     - \-
    * - SFS (sfs, joint_sfs, folded variants)
      - per-site n
      - filter sites
      - maps to include
+     - \-
    * - Admixture (patterson_d, f2, f3)
      - per-site n
      - NaN at missing
      - maps to include
+     - \-
    * - Selection scans (ihs, nsl, xpehh)
      - wildcard in SSL
      - filter sites
      - maps to include
+     - \-
    * - Haplotype stats (garud_h, haplotype_diversity)
      - wildcard match
      - filter sites
      - maps to include
+     - \-
    * - Distance (pairwise_diffs, pca)
      - per-pair norm
      - filter sites
      - maps to include
-   * - LD (zns, omega, mu_ld)
+     - \-
+   * - LD (zns, omega)
      - per-site n
      - filter sites
      - maps to include
+     - unbiased sigma_d^2
 
 Haplotype Identity and Missing Data
 ------------------------------------
@@ -228,7 +252,26 @@ Best Practices
 3. **Use exclude mode** when you need all samples to be comparable
    at exactly the same sites (e.g., for certain LD analyses).
 
-4. **Check missingness patterns** before analysis with
+4. **Use project mode** for LD statistics (ZnS, Omega) when sample
+   sizes are small or variable across sites. The unbiased estimators
+   correct the upward bias inherent in naive r², which can be
+   substantial when n < 50. This mode computes sigma_d^2 = D^2/pi2
+   using falling-factorial estimators (Ragsdale & Gravel 2019).
+
+   .. code-block:: python
+
+      from pg_gpu import ld_statistics
+
+      # Unbiased ZnS and Omega
+      zns = ld_statistics.zns(h, missing_data='project')
+      omega = ld_statistics.omega(h, missing_data='project')
+
+      # Also works in windowed analysis
+      from pg_gpu.windowed_analysis import windowed_analysis
+      results = windowed_analysis(h, statistics=['zns', 'omega'],
+                                  missing_data='project')
+
+5. **Check missingness patterns** before analysis with
    ``summarize_missing_data()`` and consider filtering sites with
    very high missing rates.
 

--- a/pg_gpu/ld_statistics.py
+++ b/pg_gpu/ld_statistics.py
@@ -205,25 +205,20 @@ def r_squared(counts: cp.ndarray,
     return r(counts, n_valid) ** 2
 
 
-def _zns_tiled(mat, missing_data='include', tile_size=512):
-    """Compute ZnS without materializing the full r² matrix.
+def _prepare_segregating(mat, missing_data='include'):
+    """Filter to segregating sites and return cleaned arrays.
 
-    Uses tile-based accumulation: computes D and r² for B×B blocks and
-    sums r² per tile, keeping memory at O(B²) instead of O(m²).
+    Returns (hap_clean, valid_mask, m) or (None, None, 0) if < 2 sites.
     """
-    from .haplotype_matrix import HaplotypeMatrix
-
     if hasattr(mat, 'device') and mat.device == 'CPU':
         mat.transfer_to_gpu()
 
-    # Filter missing data sites
     if missing_data == 'exclude':
         hap = mat.haplotypes
         missing_per_var = cp.sum(hap < 0, axis=0)
         valid = cp.where(missing_per_var == 0)[0]
         mat = mat.get_subset(valid)
 
-    # Filter monomorphic sites
     hap = mat.haplotypes
     dac = cp.sum(cp.maximum(hap, 0).astype(cp.int32), axis=0)
     n_valid_per_site = cp.sum((hap >= 0).astype(cp.int32), axis=0)
@@ -235,55 +230,139 @@ def _zns_tiled(mat, missing_data='include', tile_size=512):
     hap = mat.haplotypes
     m = hap.shape[1]
     if m < 2:
-        return 0.0
+        return None, None, 0
 
-    # Precompute shared arrays
     valid_mask = (hap >= 0).astype(cp.float64)
     hap_clean = cp.where(hap >= 0, hap, 0).astype(cp.float64)
-    n_valid = cp.sum(valid_mask, axis=0).astype(cp.float64)
-    p = cp.where(n_valid > 0, cp.sum(hap_clean, axis=0) / n_valid, 0.0)
-    pq = p * (1 - p)
+    return hap_clean, valid_mask, m
+
+
+def _tile_counts(hi, vi, hj, vj):
+    """Compute 4-way haplotype counts for all pairs in a tile.
+
+    Returns c1, c2, c3, c4 as (B_i, B_j) matrices where:
+        c1 = n_AB (derived at both)
+        c2 = n_Ab (derived at i, ancestral at j)
+        c3 = n_aB (ancestral at i, derived at j)
+        c4 = n_ab (ancestral at both)
+        n  = c1+c2+c3+c4 (valid at both sites)
+    """
+    c1 = hi.T @ hj           # derived at both
+    s12 = hi.T @ vj           # derived at i, valid at j  (= c1 + c2)
+    s13 = vi.T @ hj           # valid at i, derived at j  (= c1 + c3)
+    n = vi.T @ vj             # valid at both
+    c2 = s12 - c1
+    c3 = s13 - c1
+    c4 = n - c1 - c2 - c3
+    return c1, c2, c3, c4, n
+
+
+def _tile_r2_naive(hi, vi, hj, vj, pi, pqi, pj, pqj):
+    """Compute naive r² for a tile (frequency-based, biased)."""
+    joint_n = vi.T @ vj
+    joint_11 = hi.T @ hj
+    p_AB = cp.where(joint_n > 0, joint_11 / joint_n, 0.0)
+    D = p_AB - cp.outer(pi, pj)
+    denom = cp.outer(pqi, pqj)
+    return cp.where(denom > 0, (D ** 2) / denom, 0.0)
+
+
+def _tile_sigma_d2(hi, vi, hj, vj):
+    """Compute unbiased D²/π² (sigma_d^2) for a tile.
+
+    Uses multinomial projection estimators (Ragsdale & Gravel 2019):
+      D² = [c1(c1-1)c4(c4-1) + c2(c2-1)c3(c3-1) - 2*c1*c2*c3*c4]
+           / [n(n-1)(n-2)(n-3)]
+      π² = [(c1+c2)(c1+c3)(c2+c4)(c3+c4) - c1*c4*(-1+c1+3c2+3c3+c4)
+            - c2*c3*(-1+3c1+c2+c3+3c4)] / [n(n-1)(n-2)(n-3)]
+
+    Returns sigma_d2 tile and valid mask (n >= 4).
+    """
+    c1, c2, c3, c4, n = _tile_counts(hi, vi, hj, vj)
+
+    # Unbiased D² numerator
+    dd_num = (c1 * (c1 - 1) * c4 * (c4 - 1)
+              + c2 * (c2 - 1) * c3 * (c3 - 1)
+              - 2 * c1 * c2 * c3 * c4)
+
+    # Unbiased π² numerator
+    s12 = c1 + c2
+    s13 = c1 + c3
+    s24 = c2 + c4
+    s34 = c3 + c4
+    pi2_num = (s12 * s13 * s24 * s34
+               - c1 * c4 * (-1 + c1 + 3 * c2 + 3 * c3 + c4)
+               - c2 * c3 * (-1 + 3 * c1 + c2 + c3 + 3 * c4))
+
+    valid = n >= 4
+    sigma_d2 = cp.where(valid & (pi2_num != 0),
+                        dd_num / pi2_num, 0.0)
+    return sigma_d2, valid
+
+
+def _zns_tiled(mat, missing_data='include', tile_size=512):
+    """Compute ZnS without materializing the full r² matrix.
+
+    Uses tile-based accumulation: computes r² for B×B blocks and
+    sums per tile, keeping memory at O(B²) instead of O(m²).
+
+    When missing_data='project', uses unbiased multinomial projection
+    estimators (Ragsdale & Gravel 2019) computing σ_D² = D²/π²
+    per pair instead of naive r².
+    """
+    hap_clean, valid_mask, m = _prepare_segregating(mat, missing_data)
+    if m < 2:
+        return 0.0
+
+    use_projection = (missing_data == 'project')
 
     B = tile_size
     total = 0.0
+    n_pairs = 0
+
+    if not use_projection:
+        n_valid = cp.sum(valid_mask, axis=0).astype(cp.float64)
+        p = cp.where(n_valid > 0,
+                     cp.sum(hap_clean, axis=0) / n_valid, 0.0)
+        pq = p * (1 - p)
 
     for i0 in range(0, m, B):
         i1 = min(i0 + B, m)
         hi = hap_clean[:, i0:i1]
         vi = valid_mask[:, i0:i1]
-        pi = p[i0:i1]
-        pqi = pq[i0:i1]
 
         for j0 in range(i0, m, B):
             j1 = min(j0 + B, m)
             hj = hap_clean[:, j0:j1]
             vj = valid_mask[:, j0:j1]
-            pj = p[j0:j1]
-            pqj = pq[j0:j1]
 
-            # D for this tile
-            joint_n = vi.T @ vj
-            joint_11 = hi.T @ hj
-            p_AB = cp.where(joint_n > 0, joint_11 / joint_n, 0.0)
-            D = p_AB - cp.outer(pi, pj)
-
-            # r² for this tile
-            denom = cp.outer(pqi, pqj)
-            r2_tile = cp.where(denom > 0, (D ** 2) / denom, 0.0)
-
-            if i0 == j0:
-                # Diagonal block: zero the diagonal, count once
-                cp.fill_diagonal(r2_tile, 0.0)
-                total += float(cp.sum(r2_tile).get())
+            if use_projection:
+                tile, valid = _tile_sigma_d2(hi, vi, hj, vj)
+                if i0 == j0:
+                    cp.fill_diagonal(tile, 0.0)
+                    cp.fill_diagonal(valid, False)
+                    total += float(cp.sum(tile).get())
+                    n_pairs += int(cp.sum(valid).get())
+                else:
+                    total += 2.0 * float(cp.sum(tile).get())
+                    n_pairs += 2 * int(cp.sum(valid).get())
             else:
-                # Off-diagonal block: count twice (upper + lower triangle)
-                total += 2.0 * float(cp.sum(r2_tile).get())
+                r2_tile = _tile_r2_naive(
+                    hi, vi, hj, vj,
+                    p[i0:i1], pq[i0:i1], p[j0:j1], pq[j0:j1])
+                if i0 == j0:
+                    cp.fill_diagonal(r2_tile, 0.0)
+                    total += float(cp.sum(r2_tile).get())
+                else:
+                    total += 2.0 * float(cp.sum(r2_tile).get())
 
+    if use_projection:
+        return total / n_pairs if n_pairs > 0 else 0.0
     return total / (m * (m - 1))
 
 
 def _zns_from_precomputed(hap_clean, valid_mask, col_start, col_end,
-                          tile_size=512):
+                          tile_size=512, use_projection=False):
     """Compute ZnS for a column range using precomputed arrays.
 
     This avoids creating a HaplotypeMatrix and recomputing valid_mask/hap_clean
@@ -299,6 +378,8 @@ def _zns_from_precomputed(hap_clean, valid_mask, col_start, col_end,
         Column range [col_start, col_end) to compute ZnS over.
     tile_size : int
         Tile size for accumulation.
+    use_projection : bool
+        If True, use unbiased multinomial projection estimators.
 
     Returns
     -------
@@ -319,40 +400,48 @@ def _zns_from_precomputed(hap_clean, valid_mask, col_start, col_end,
 
     hc = hc[:, seg_idx]
     vm = vm[:, seg_idx]
-    n_valid = n_valid[seg_idx]
-    p = cp.where(n_valid > 0, cp.sum(hc, axis=0) / n_valid, 0.0)
-    pq = p * (1 - p)
+
+    if not use_projection:
+        n_valid = n_valid[seg_idx]
+        p = cp.where(n_valid > 0, cp.sum(hc, axis=0) / n_valid, 0.0)
+        pq = p * (1 - p)
 
     B = tile_size
     total = 0.0
+    n_pairs = 0
 
     for i0 in range(0, m, B):
         i1 = min(i0 + B, m)
         hi = hc[:, i0:i1]
         vi = vm[:, i0:i1]
-        pi = p[i0:i1]
-        pqi = pq[i0:i1]
 
         for j0 in range(i0, m, B):
             j1 = min(j0 + B, m)
             hj = hc[:, j0:j1]
             vj = vm[:, j0:j1]
-            pj = p[j0:j1]
-            pqj = pq[j0:j1]
 
-            joint_n = vi.T @ vj
-            joint_11 = hi.T @ hj
-            p_AB = cp.where(joint_n > 0, joint_11 / joint_n, 0.0)
-            D = p_AB - cp.outer(pi, pj)
-            denom = cp.outer(pqi, pqj)
-            r2_tile = cp.where(denom > 0, (D ** 2) / denom, 0.0)
-
-            if i0 == j0:
-                cp.fill_diagonal(r2_tile, 0.0)
-                total += float(cp.sum(r2_tile).get())
+            if use_projection:
+                tile, valid = _tile_sigma_d2(hi, vi, hj, vj)
+                if i0 == j0:
+                    cp.fill_diagonal(tile, 0.0)
+                    cp.fill_diagonal(valid, False)
+                    total += float(cp.sum(tile).get())
+                    n_pairs += int(cp.sum(valid).get())
+                else:
+                    total += 2.0 * float(cp.sum(tile).get())
+                    n_pairs += 2 * int(cp.sum(valid).get())
             else:
-                total += 2.0 * float(cp.sum(r2_tile).get())
+                r2_tile = _tile_r2_naive(
+                    hi, vi, hj, vj,
+                    p[i0:i1], pq[i0:i1], p[j0:j1], pq[j0:j1])
+                if i0 == j0:
+                    cp.fill_diagonal(r2_tile, 0.0)
+                    total += float(cp.sum(r2_tile).get())
+                else:
+                    total += 2.0 * float(cp.sum(r2_tile).get())
 
+    if use_projection:
+        return total / n_pairs if n_pairs > 0 else 0.0
     return total / (m * (m - 1))
 
 
@@ -369,17 +458,25 @@ def zns(r2_matrix_or_matrix, missing_data='include'):
     missing_data : str
         'include' - per-site valid data for frequency computation
         'exclude' - filter to sites with no missing data
+        'project' - unbiased multinomial projection (Ragsdale & Gravel 2019);
+          computes mean σ_D² = D²/π² per pair using falling-factorial
+          estimators. Requires HaplotypeMatrix input.
 
     Returns
     -------
     float
-        Mean r-squared (excluding diagonal).
+        Mean r-squared (or mean σ_D² for 'project' mode).
     """
     from .haplotype_matrix import HaplotypeMatrix
 
     # Streaming path for HaplotypeMatrix: O(B²) memory instead of O(m²)
     if isinstance(r2_matrix_or_matrix, HaplotypeMatrix):
         return _zns_tiled(r2_matrix_or_matrix, missing_data)
+
+    if missing_data == 'project':
+        raise ValueError(
+            "missing_data='project' requires a HaplotypeMatrix, "
+            "not a pre-computed r² array")
 
     r2_matrix = _resolve_r2_matrix(r2_matrix_or_matrix, missing_data)
 
@@ -388,6 +485,33 @@ def zns(r2_matrix_or_matrix, missing_data='include'):
         return 0.0
     total = cp.sum(r2_matrix) - cp.trace(r2_matrix)
     return float((total / (m * (m - 1))).get())
+
+
+def _build_sigma_d2_matrix(mat, missing_data='include'):
+    """Build full m×m σ_D² matrix using unbiased estimators.
+
+    Used by omega() when missing_data='project'.
+    """
+    hap_clean, valid_mask, m = _prepare_segregating(mat, missing_data)
+    if m < 2:
+        return cp.zeros((0, 0), dtype=cp.float64)
+
+    c1, c2, c3, c4, n = _tile_counts(hap_clean, valid_mask,
+                                       hap_clean, valid_mask)
+
+    dd_num = (c1 * (c1 - 1) * c4 * (c4 - 1)
+              + c2 * (c2 - 1) * c3 * (c3 - 1)
+              - 2 * c1 * c2 * c3 * c4)
+
+    s12, s13, s24, s34 = c1 + c2, c1 + c3, c2 + c4, c3 + c4
+    pi2_num = (s12 * s13 * s24 * s34
+               - c1 * c4 * (-1 + c1 + 3 * c2 + 3 * c3 + c4)
+               - c2 * c3 * (-1 + 3 * c1 + c2 + c3 + 3 * c4))
+
+    valid = (n >= 4) & (pi2_num != 0)
+    result = cp.where(valid, dd_num / pi2_num, 0.0)
+    cp.fill_diagonal(result, 0.0)
+    return result
 
 
 def omega(r2_matrix_or_matrix, missing_data='include'):
@@ -410,13 +534,22 @@ def omega(r2_matrix_or_matrix, missing_data='include'):
     missing_data : str
         'include' - per-site valid data for frequency computation
         'exclude' - filter to sites with no missing data
+        'project' - unbiased multinomial projection (Ragsdale & Gravel 2019)
 
     Returns
     -------
     float
         Maximum omega value. Returns 0 if fewer than 5 SNPs.
     """
-    r2_matrix = _resolve_r2_matrix(r2_matrix_or_matrix, missing_data)
+    from .haplotype_matrix import HaplotypeMatrix
+
+    if missing_data == 'project':
+        if not isinstance(r2_matrix_or_matrix, HaplotypeMatrix):
+            raise ValueError(
+                "missing_data='project' requires a HaplotypeMatrix")
+        r2_matrix = _build_sigma_d2_matrix(r2_matrix_or_matrix)
+    else:
+        r2_matrix = _resolve_r2_matrix(r2_matrix_or_matrix, missing_data)
 
     m = r2_matrix.shape[0]
     if m < 5:

--- a/pg_gpu/ld_statistics.py
+++ b/pg_gpu/ld_statistics.py
@@ -458,9 +458,11 @@ def zns(r2_matrix_or_matrix, missing_data='include'):
     missing_data : str
         'include' - per-site valid data for frequency computation
         'exclude' - filter to sites with no missing data
-        'project' - unbiased multinomial projection (Ragsdale & Gravel 2019);
-          computes mean σ_D² = D²/π² per pair using falling-factorial
-          estimators. Requires HaplotypeMatrix input.
+        'project' - unbiased multinomial projection estimators, computing
+          mean σ_D² = D²/π² per pair using falling-factorial corrections
+          for finite sample size. Requires HaplotypeMatrix input.
+          See: Ragsdale & Gravel (2019) "Unbiased estimation of linkage
+          disequilibrium from unphased data", MBE 37(3):923-932.
 
     Returns
     -------
@@ -534,7 +536,10 @@ def omega(r2_matrix_or_matrix, missing_data='include'):
     missing_data : str
         'include' - per-site valid data for frequency computation
         'exclude' - filter to sites with no missing data
-        'project' - unbiased multinomial projection (Ragsdale & Gravel 2019)
+        'project' - unbiased multinomial projection estimators, using
+          σ_D² = D²/π² instead of naive r². Requires HaplotypeMatrix input.
+          See: Ragsdale & Gravel (2019) "Unbiased estimation of linkage
+          disequilibrium from unphased data", MBE 37(3):923-932.
 
     Returns
     -------

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -666,7 +666,8 @@ def windowed_analysis(haplotype_matrix: HaplotypeMatrix,
                  | fused_diploshic)
     requested = set(statistics)
 
-    can_fuse = (missing_data == 'include' and requested <= fused_all)
+    can_fuse = (missing_data in ('include', 'project')
+                and requested <= fused_all)
 
     if can_fuse:
         if haplotype_matrix.device == 'CPU':
@@ -704,6 +705,7 @@ def windowed_analysis(haplotype_matrix: HaplotypeMatrix,
             per_base=(span_denominator == 'total'),
             _win_starts=win_starts,
             _win_stops=win_stops,
+            missing_data=missing_data,
         )
         return pd.DataFrame(result_dict)
 
@@ -1104,7 +1106,8 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
                               per_base: bool = True,
                               is_accessible=None,
                               _win_starts=None,
-                              _win_stops=None):
+                              _win_stops=None,
+                              missing_data='include'):
     """GPU-native windowed statistics using fused CUDA kernels.
 
     One kernel launch processes ALL windows in parallel. Each thread block
@@ -1443,6 +1446,7 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
                        or need_dist)
 
         # Precompute for fused ZnS path
+        use_proj = (missing_data == 'project')
         if 'zns' in stat_arrays:
             hap = matrix.haplotypes
             hap_clean = cp.where(hap >= 0, hap, 0).astype(cp.float64)
@@ -1455,13 +1459,15 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
 
             if 'zns' in stat_arrays:
                 stat_arrays['zns'][wi] = ld_statistics._zns_from_precomputed(
-                    hap_clean, valid_mask, s, e)
+                    hap_clean, valid_mask, s, e,
+                    use_projection=use_proj)
 
             if need_winmat:
                 win_mat = HaplotypeMatrix(matrix.haplotypes[:, s:e],
                                            matrix.positions[s:e])
                 if 'omega' in stat_arrays:
-                    stat_arrays['omega'][wi] = ld_statistics.omega(win_mat)
+                    stat_arrays['omega'][wi] = ld_statistics.omega(
+                        win_mat, missing_data=missing_data)
                 if 'mu_ld' in stat_arrays:
                     stat_arrays['mu_ld'][wi] = ld_statistics.mu_ld(win_mat)
                 if need_dist:


### PR DESCRIPTION
## Summary
- Add `missing_data='project'` mode to `zns()` and `omega()` using unbiased multinomial projection estimators from Ragsdale & Gravel (2019, MBE 37:923-932)
- Per-pair sigma_d^2 = D^2/pi2 computed via falling-factorial corrections on 4-way haplotype counts, correcting the upward bias of naive r^2 that worsens with small/variable sample sizes
- Streaming tiled implementation preserves O(B^2) memory for ZnS
- Threaded through windowed_analysis for windowed ZnS/Omega
- Documented in missing_data.rst with usage examples

## Test plan
- [x] All 417 tests pass
- [x] Lint clean
- [x] Projection ZnS converges to naive r^2 for large samples, diverges (corrects bias) for small samples
- [x] Omega projection produces valid results for adequate sample sizes