### PR TITLE
Achaz (2009) generalized theta estimation framework

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,8 +77,10 @@ pixi run python examples/performance_comparison.py
    - `pg_gpu/relatedness.py`: GRM, IBS
    - `pg_gpu/windowed_analysis.py`: Fused CUDA kernels for windowed statistics
    - `pg_gpu/moments_ld.py`: Drop-in replacement for moments.LD.Parsing (requires moments env)
-3. **Accessible Site Masks** (`pg_gpu/accessible.py`): BED file parsing and `AccessibleMask` class for genome accessibility. Dense boolean arrays with lazy prefix-sum for O(1) windowed range queries. Integrated into HaplotypeMatrix, GenotypeMatrix, and windowed analysis.
-4. **Memory Management** (`pg_gpu/_memutil.py`): Adaptive chunked GPU processing. All modules use `chunked_dac_and_n` for memory-safe allele counting. Large operations auto-detect available GPU memory and chunk accordingly.
+   - `pg_gpu/achaz.py`: Achaz (2009) generalized theta estimation framework
+3. **Achaz Framework** (`pg_gpu/achaz.py`): All frequency-spectrum-based theta estimators are linear combinations of the SFS. The `FrequencySpectrum` class computes the SFS once on GPU and derives all estimators as dot products. Includes weight vectors for 8 standard estimators, Fu (1995) covariance structure for neutrality test variance, SFS projection via hypergeometric sampling (Gutenkunst et al. 2009), and custom weight vector support. Use `diversity.diversity_stats_fast()` for batch computation or `FrequencySpectrum` directly for custom estimators.
+4. **Accessible Site Masks** (`pg_gpu/accessible.py`): BED file parsing and `AccessibleMask` class for genome accessibility. Dense boolean arrays with lazy prefix-sum for O(1) windowed range queries. Integrated into HaplotypeMatrix, GenotypeMatrix, and windowed analysis.
+5. **Memory Management** (`pg_gpu/_memutil.py`): Adaptive chunked GPU processing. All modules use `chunked_dac_and_n` for memory-safe allele counting. Large operations auto-detect available GPU memory and chunk accordingly.
 
 ### Key Design Patterns
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,42 @@ results = windowed_analysis(hm, statistics=["pi", "theta_w", "tajimas_d"],
                             window_size=50000, step_size=10000)
 ```
 
+## Achaz Framework
+
+Compute all theta estimators and neutrality tests from a single SFS pass using the
+[Achaz (2009)](https://doi.org/10.1534/genetics.109.104042) generalized framework:
+
+```python
+from pg_gpu import FrequencySpectrum
+
+# Build SFS (one GPU pass)
+fs = FrequencySpectrum(hm, population="pop1")
+
+# All standard estimators as weight vector dot products
+fs.theta("pi")          # nucleotide diversity
+fs.theta("watterson")   # Watterson's theta
+fs.theta("theta_h")     # Fay & Wu's theta_H
+fs.theta("theta_l")     # Zeng's theta_L
+fs.theta("eta1")        # singleton-based theta (Fu & Li)
+
+# Neutrality tests
+fs.tajimas_d()          # Tajima's D
+fs.fay_wu_h()           # Fay & Wu's H
+
+# All at once (8 thetas + 4 tests)
+fs.all_thetas()
+fs.all_tests()
+
+# SFS projection for missing data handling
+fs_projected = fs.project(target_n=50)
+
+# Custom weight vector
+fs.theta(lambda n: my_weights(n))
+
+# Batch computation (uses Achaz internally)
+diversity.diversity_stats_fast(hm, population="pop1")
+```
+
 ## Loading Data
 
 ```python

--- a/debug/verify_missing_data_projection.py
+++ b/debug/verify_missing_data_projection.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+"""
+Verify theta estimation under missing data with and without SFS projection.
+
+Simulates under a standard neutral model with known theta = 4*N*mu*L,
+injects missing data at varying rates, and compares:
+  1. FrequencySpectrum with missing_data='include' (group-by-n approach)
+  2. FrequencySpectrum with .project(target_n) (hypergeometric projection)
+  3. FrequencySpectrum with missing_data='exclude' (drop incomplete sites)
+
+For each approach we examine bias (E[theta_hat] vs true theta) and
+variance across replicates.
+
+Usage:
+    pixi run python debug/verify_missing_data_projection.py
+"""
+
+import numpy as np
+import msprime
+from pg_gpu import HaplotypeMatrix
+from pg_gpu.achaz import FrequencySpectrum
+
+
+# ── Simulation parameters ───────────────────────────────────────────────
+N = 10_000           # diploid effective population size
+MU = 1e-8            # per-site per-generation mutation rate
+L = 200_000          # sequence length
+N_HAP = 100          # number of haploid chromosomes (50 diploids)
+N_REPS = 200         # replicates per missing rate
+MISSING_RATES = [0.0, 0.01, 0.05, 0.10, 0.20, 0.40]
+ESTIMATORS = ['pi', 'watterson', 'theta_h', 'theta_l']
+
+THETA_TRUE = 4 * N * MU * L  # expected total theta (unnormalized)
+
+
+def simulate_haplotypes(seed):
+    """Simulate haplotypes under standard neutral model."""
+    ts = msprime.sim_ancestry(
+        samples=N_HAP // 2,
+        sequence_length=L,
+        recombination_rate=1e-8,
+        population_size=N,
+        random_seed=seed,
+        ploidy=2,
+    )
+    ts = msprime.sim_mutations(ts, rate=MU, random_seed=seed)
+    return ts.genotype_matrix().T, ts.tables.sites.position
+
+
+def inject_missing(haplotypes, rate, rng):
+    """Randomly set entries to -1 (missing) at the given rate."""
+    if rate == 0:
+        return haplotypes.copy()
+    hap = haplotypes.copy()
+    mask = rng.random(hap.shape) < rate
+    hap[mask] = -1
+    return hap
+
+
+def estimate_thetas(hm, method, projection_n=None):
+    """Compute theta estimates using the specified method."""
+    if method == 'include':
+        fs = FrequencySpectrum(hm, missing_data='include')
+    elif method == 'exclude':
+        fs = FrequencySpectrum(hm, missing_data='exclude')
+    elif method == 'project':
+        fs = FrequencySpectrum(hm, missing_data='include')
+        if projection_n is not None and fs.n_max >= projection_n:
+            fs = fs.project(projection_n)
+        else:
+            return {name: np.nan for name in ESTIMATORS}
+    else:
+        raise ValueError(f"Unknown method: {method}")
+
+    return {name: fs.theta(name) for name in ESTIMATORS}
+
+
+def main():
+    print(f"Simulation: N={N}, mu={MU}, L={L:,}, n={N_HAP} haplotypes")
+    print(f"True theta = 4*N*mu*L = {THETA_TRUE:.2f}")
+    print(f"Replicates: {N_REPS}")
+    print()
+
+    # Determine projection target: use the minimum n that all sites
+    # will have even at the highest missing rate.
+    # At 40% missing, expected n_valid per site ~ 0.6 * 100 = 60.
+    # Use a conservative target: 50
+    projection_n = 50
+
+    print(f"{'Missing':>8s} {'Method':<10s}", end="")
+    for est in ESTIMATORS:
+        print(f" {'E['+est+']':>14s} {'bias%':>7s} {'SD':>10s}", end="")
+    print()
+    print("-" * (20 + len(ESTIMATORS) * 32))
+
+    for miss_rate in MISSING_RATES:
+        results = {
+            'include': {e: [] for e in ESTIMATORS},
+            'exclude': {e: [] for e in ESTIMATORS},
+            'project': {e: [] for e in ESTIMATORS},
+        }
+
+        rng = np.random.default_rng(42)
+
+        for rep in range(N_REPS):
+            seed = rep + 1
+            hap_clean, positions = simulate_haplotypes(seed)
+
+            if hap_clean.shape[1] < 2:
+                continue
+
+            hap_missing = inject_missing(hap_clean, miss_rate, rng)
+            positions_np = np.array(positions, dtype=np.float64)
+            hm = HaplotypeMatrix(hap_missing, positions_np)
+
+            for method in ['include', 'exclude', 'project']:
+                proj_n = projection_n if method == 'project' else None
+                try:
+                    thetas = estimate_thetas(hm, method, projection_n=proj_n)
+                    for est in ESTIMATORS:
+                        v = thetas[est]
+                        if np.isfinite(v):
+                            results[method][est].append(v)
+                except Exception:
+                    pass
+
+        # Print results for this missing rate
+        for method in ['include', 'exclude', 'project']:
+            label = f"{miss_rate:.0%}" if method == 'include' else ""
+            print(f"{label:>8s} {method:<10s}", end="")
+            for est in ESTIMATORS:
+                vals = results[method][est]
+                if len(vals) > 5:
+                    mean = np.mean(vals)
+                    sd = np.std(vals)
+                    bias_pct = 100 * (mean - THETA_TRUE) / THETA_TRUE
+                    print(f" {mean:>14.2f} {bias_pct:>+6.1f}% {sd:>10.2f}", end="")
+                else:
+                    print(f" {'---':>14s} {'---':>7s} {'---':>10s}", end="")
+            print()
+        print()
+
+    print(f"\nNotes:")
+    print(f"  - True theta = {THETA_TRUE:.2f}")
+    print(f"  - 'include': groups variants by per-site sample size, applies n-specific weights")
+    print(f"  - 'exclude': drops sites with any missing data, uses fixed n={N_HAP}")
+    print(f"  - 'project': projects all sites to n={projection_n} via hypergeometric sampling")
+    print(f"  - bias% = (E[theta_hat] - theta_true) / theta_true * 100")
+
+
+if __name__ == "__main__":
+    main()

--- a/debug/verify_missing_data_projection.py
+++ b/debug/verify_missing_data_projection.py
@@ -148,5 +148,203 @@ def main():
     print(f"  - bias% = (E[theta_hat] - theta_true) / theta_true * 100")
 
 
+def make_figure():
+    """Generate publication-quality figure showing bias and variance
+    of theta estimators under missing data."""
+    import matplotlib
+    matplotlib.use('Agg')
+    import matplotlib.pyplot as plt
+    import matplotlib.gridspec as gridspec
+
+    print("Running simulations for figure...", flush=True)
+
+    N = 10_000
+    mu = 1e-8
+    L = 200_000
+    n_hap = 100
+    n_reps = 200
+    missing_rates = [0.0, 0.01, 0.02, 0.05, 0.10, 0.20, 0.30, 0.40]
+    theta_true = 4 * N * mu * L
+    projection_n = 50
+    estimators = ['pi', 'watterson', 'theta_h', 'theta_l']
+    methods = ['include', 'project', 'exclude']
+    method_labels = {
+        'include': 'Group by $n_i$ (default)',
+        'project': f'Project to $n={projection_n}$',
+        'exclude': 'Exclude incomplete sites',
+    }
+    method_colors = {
+        'include': '#2ecc71',
+        'project': '#3498db',
+        'exclude': '#e74c3c',
+    }
+    est_labels = {
+        'pi': r'$\hat{\theta}_\pi$',
+        'watterson': r'$\hat{\theta}_W$',
+        'theta_h': r'$\hat{\theta}_H$',
+        'theta_l': r'$\hat{\theta}_L$',
+    }
+
+    # Collect results: {method: {estimator: {rate: [values]}}}
+    all_results = {m: {e: {r: [] for r in missing_rates}
+                       for e in estimators} for m in methods}
+
+    rng = np.random.default_rng(42)
+
+    for rep in range(n_reps):
+        if (rep + 1) % 50 == 0:
+            print(f"  rep {rep + 1}/{n_reps}", flush=True)
+        seed = rep + 1
+        hap_clean, positions = simulate_haplotypes(seed)
+        if hap_clean.shape[1] < 2:
+            continue
+        positions_np = np.array(positions, dtype=np.float64)
+
+        for rate in missing_rates:
+            hap_miss = inject_missing(hap_clean, rate, rng)
+            hm = HaplotypeMatrix(hap_miss, positions_np)
+
+            for method in methods:
+                proj_n = projection_n if method == 'project' else None
+                try:
+                    thetas = estimate_thetas(hm, method, projection_n=proj_n)
+                    for est in estimators:
+                        v = thetas[est]
+                        if np.isfinite(v):
+                            all_results[method][est][rate].append(v)
+                except Exception:
+                    pass
+
+    # ── Figure ───────────────────────────────────────────────────────────
+    fig = plt.figure(figsize=(14, 10))
+    gs = gridspec.GridSpec(2, 2, hspace=0.35, wspace=0.3)
+
+    rates_pct = [r * 100 for r in missing_rates]
+
+    for idx, est in enumerate(estimators):
+        ax = fig.add_subplot(gs[idx])
+
+        for method in methods:
+            means = []
+            ci_lo = []
+            ci_hi = []
+            for rate in missing_rates:
+                vals = all_results[method][est][rate]
+                if len(vals) > 5:
+                    m = np.mean(vals)
+                    se = np.std(vals) / np.sqrt(len(vals))
+                    means.append(m)
+                    ci_lo.append(m - 1.96 * se)
+                    ci_hi.append(m + 1.96 * se)
+                else:
+                    means.append(np.nan)
+                    ci_lo.append(np.nan)
+                    ci_hi.append(np.nan)
+
+            means = np.array(means)
+            ci_lo = np.array(ci_lo)
+            ci_hi = np.array(ci_hi)
+            valid = np.isfinite(means)
+
+            ax.plot(np.array(rates_pct)[valid], means[valid],
+                    'o-', color=method_colors[method],
+                    label=method_labels[method], markersize=5, linewidth=1.5)
+            ax.fill_between(np.array(rates_pct)[valid],
+                            ci_lo[valid], ci_hi[valid],
+                            alpha=0.15, color=method_colors[method])
+
+        ax.axhline(theta_true, color='black', linestyle='--',
+                    linewidth=1, alpha=0.7, label=r'True $\theta$')
+        ax.set_xlabel('Missing data rate (%)')
+        ax.set_ylabel(r'$E[\hat{\theta}]$')
+        ax.set_title(est_labels[est], fontsize=14)
+        ax.set_ylim(0, theta_true * 1.5)
+
+        if idx == 0:
+            ax.legend(fontsize=8, loc='lower left')
+
+    fig.suptitle(
+        r'Theta estimation under missing data ($\theta_{true}$ = '
+        f'{theta_true:.0f}, n = {n_hap}, '
+        f'{n_reps} replicates)\n'
+        'Shaded regions: 95% CI of the mean',
+        fontsize=13, y=1.01)
+
+    outpath = 'debug/verify_missing_data_projection.png'
+    fig.savefig(outpath, dpi=150, bbox_inches='tight')
+    print(f"\nFigure saved to {outpath}")
+
+    # ── Also make a bias + variance panel ────────────────────────────────
+    fig2, axes2 = plt.subplots(1, 2, figsize=(14, 5))
+
+    # Panel A: Relative bias
+    ax = axes2[0]
+    for method in methods:
+        biases = []
+        for rate in missing_rates:
+            # Average bias across all four estimators
+            bias_per_est = []
+            for est in estimators:
+                vals = all_results[method][est][rate]
+                if len(vals) > 5:
+                    bias_per_est.append(
+                        (np.mean(vals) - theta_true) / theta_true * 100)
+            if bias_per_est:
+                biases.append(np.mean(bias_per_est))
+            else:
+                biases.append(np.nan)
+
+        biases = np.array(biases)
+        valid = np.isfinite(biases)
+        ax.plot(np.array(rates_pct)[valid], biases[valid],
+                'o-', color=method_colors[method],
+                label=method_labels[method], markersize=6, linewidth=2)
+
+    ax.axhline(0, color='black', linestyle='--', linewidth=1, alpha=0.5)
+    ax.set_xlabel('Missing data rate (%)', fontsize=12)
+    ax.set_ylabel('Mean relative bias (%)', fontsize=12)
+    ax.set_title('Bias (averaged across 4 estimators)', fontsize=13)
+    ax.legend(fontsize=10)
+    ax.set_ylim(-110, 20)
+
+    # Panel B: Coefficient of variation
+    ax = axes2[1]
+    for method in methods:
+        cvs = []
+        for rate in missing_rates:
+            cv_per_est = []
+            for est in estimators:
+                vals = all_results[method][est][rate]
+                if len(vals) > 5:
+                    cv_per_est.append(np.std(vals) / np.mean(vals) * 100)
+            if cv_per_est:
+                cvs.append(np.mean(cv_per_est))
+            else:
+                cvs.append(np.nan)
+
+        cvs = np.array(cvs)
+        valid = np.isfinite(cvs)
+        ax.plot(np.array(rates_pct)[valid], cvs[valid],
+                's-', color=method_colors[method],
+                label=method_labels[method], markersize=6, linewidth=2)
+
+    ax.set_xlabel('Missing data rate (%)', fontsize=12)
+    ax.set_ylabel('Coefficient of variation (%)', fontsize=12)
+    ax.set_title('Precision (averaged across 4 estimators)', fontsize=13)
+    ax.legend(fontsize=10)
+
+    fig2.suptitle(
+        r'Missing data handling strategies for $\theta$ estimation'
+        f'\n(Standard neutral model, $\\theta$ = {theta_true:.0f}, '
+        f'n = {n_hap}, {n_reps} replicates)',
+        fontsize=13, y=1.03)
+
+    outpath2 = 'debug/verify_missing_data_bias_variance.png'
+    fig2.savefig(outpath2, dpi=150, bbox_inches='tight')
+    print(f"Figure saved to {outpath2}")
+
+
 if __name__ == "__main__":
     main()
+    print()
+    make_figure()

--- a/docs/source/achaz_framework.rst
+++ b/docs/source/achaz_framework.rst
@@ -1,0 +1,148 @@
+Achaz Framework
+===============
+
+pg_gpu implements the generalized theta estimation framework from
+`Achaz (2009) <https://doi.org/10.1534/genetics.109.104042>`_. This
+framework unifies all frequency-spectrum-based theta estimators and
+neutrality tests as linear combinations of the site frequency spectrum
+(SFS).
+
+Background
+----------
+
+Every standard theta estimator can be written as a weighted sum of the SFS:
+
+.. math::
+
+   \hat{\theta}_\omega = \frac{1}{\sum_i \omega_i} \sum_{i=1}^{n-1} \omega_i \cdot i \cdot \xi_i
+
+where :math:`\xi_i` is the number of variants with derived allele count
+:math:`i` in a sample of :math:`n` haplotypes, and :math:`\omega_i` is a
+weight vector specific to each estimator.
+
+Different weight vectors recover different estimators:
+
+==================== ========================== ====================
+Estimator            Weight :math:`\omega_i`    Reference
+==================== ========================== ====================
+Watterson's theta    :math:`1`                  Watterson 1975
+Pi (nuc. diversity)  :math:`i(n-i)/\binom{n}{2}` Tajima 1983
+Theta H              :math:`i^2/\binom{n}{2}`   Fay & Wu 2000
+Theta L              :math:`i`                  Zeng et al. 2006
+Eta1 (singletons)    :math:`\delta_{i,1}`       Fu & Li 1993
+==================== ========================== ====================
+
+Neutrality tests are contrasts between two estimators:
+
+- **Tajima's D** = pi - theta_W (normalized)
+- **Fay & Wu's H** = pi - theta_H
+- **Zeng's E** = theta_L - theta_W (normalized)
+
+The framework computes the SFS once on GPU, then derives all estimators
+as trivial dot products. This is faster than calling individual functions
+when computing multiple statistics.
+
+Usage
+-----
+
+Basic usage:
+
+.. code-block:: python
+
+   from pg_gpu import HaplotypeMatrix, FrequencySpectrum
+
+   h = HaplotypeMatrix.from_vcf("data.vcf.gz")
+   h.sample_sets = {"pop1": [0, 1, 2, 3], "pop2": [4, 5, 6, 7]}
+
+   # Build the SFS (one GPU pass)
+   fs = FrequencySpectrum(h, population="pop1")
+
+   # Compute any theta estimator by name
+   pi = fs.theta("pi")
+   tw = fs.theta("watterson")
+   th = fs.theta("theta_h")
+
+   # Compute neutrality tests
+   D = fs.tajimas_d()
+   H = fs.fay_wu_h()
+
+   # Get everything at once
+   all_thetas = fs.all_thetas()   # 8 estimators
+   all_tests = fs.all_tests()     # 4 test statistics
+
+Custom Weight Vectors
+---------------------
+
+Define your own estimator with any weight function:
+
+.. code-block:: python
+
+   import numpy as np
+
+   # Exponential weight emphasizing rare variants
+   def exponential_weights(n):
+       w = np.zeros(n + 1)
+       k = np.arange(1, n, dtype=np.float64)
+       w[1:n] = np.exp(-0.5 * k)
+       return w
+
+   theta_custom = fs.theta(exponential_weights)
+
+   # Generalized neutrality test between any two estimators
+   T = fs.neutrality_test(exponential_weights, "watterson")
+
+The weight function takes the sample size ``n`` and returns an array of
+length ``n + 1``. Only indices 1 through n-1 are used (segregating sites).
+
+SFS Projection
+--------------
+
+For datasets with missing data (variable per-site sample sizes), project
+the SFS to a common sample size using hypergeometric sampling
+(`Gutenkunst et al. 2009 <https://doi.org/10.1371/journal.pgen.1000695>`_):
+
+.. code-block:: python
+
+   # With missing data, sites have different sample sizes
+   fs = FrequencySpectrum(h, population="pop1", missing_data="include")
+
+   # Project to a common sample size
+   fs_proj = fs.project(target_n=50)
+
+   # All estimators now use the projected SFS
+   pi_proj = fs_proj.theta("pi")
+
+This enables principled cross-population comparison when populations have
+different amounts of missing data.
+
+Batch Computation
+-----------------
+
+The ``diversity_stats_fast()`` function uses the Achaz framework
+internally to compute all statistics in one pass:
+
+.. code-block:: python
+
+   from pg_gpu import diversity
+
+   stats = diversity.diversity_stats_fast(
+       h, population="pop1",
+       span_normalize=True,
+       projection_n=50  # optional: project SFS first
+   )
+   # Returns dict with 12+ statistics:
+   # pi, watterson, theta_h, theta_l, eta1, eta1_star,
+   # minus_eta1, minus_eta1_star, segregating_sites,
+   # tajimas_d, fay_wu_h, normalized_fay_wu_h, zeng_e
+
+API Reference
+-------------
+
+.. autoclass:: pg_gpu.achaz.FrequencySpectrum
+   :members:
+
+.. autofunction:: pg_gpu.achaz.compute_sigma_ij
+
+.. autofunction:: pg_gpu.achaz.project_sfs
+
+.. autofunction:: pg_gpu.diversity.diversity_stats_fast

--- a/docs/source/achaz_framework.rst
+++ b/docs/source/achaz_framework.rst
@@ -96,26 +96,79 @@ Define your own estimator with any weight function:
 The weight function takes the sample size ``n`` and returns an array of
 length ``n + 1``. Only indices 1 through n-1 are used (segregating sites).
 
-SFS Projection
---------------
+Missing Data Strategies
+-----------------------
 
-For datasets with missing data (variable per-site sample sizes), project
-the SFS to a common sample size using hypergeometric sampling
-(`Gutenkunst et al. 2009 <https://doi.org/10.1371/journal.pgen.1000695>`_):
+When data contain missing genotypes (encoded as -1), different sites have
+different effective sample sizes. pg_gpu offers three strategies for
+handling this in theta estimation:
+
+**Group by sample size (default):** Variants are grouped by their per-site
+sample size and theta is estimated using sample-size-specific weights for
+each group, retaining all data without discarding any sites. This is the
+default ``missing_data='include'`` behavior.
 
 .. code-block:: python
 
-   # With missing data, sites have different sample sizes
-   fs = FrequencySpectrum(h, population="pop1", missing_data="include")
+   fs = FrequencySpectrum(h, missing_data="include")  # default
+   pi = fs.theta("pi")  # uses all sites with n_valid >= 2
 
-   # Project to a common sample size
-   fs_proj = fs.project(target_n=50)
+**Hypergeometric projection:** Each variant's SFS contribution is projected
+down to a common sample size using the hypergeometric distribution
+(`Gutenkunst et al. 2009 <https://doi.org/10.1371/journal.pgen.1000695>`_),
+producing a clean SFS at a single n at the cost of discarding sites with
+too few observations.
 
-   # All estimators now use the projected SFS
+.. code-block:: python
+
+   fs = FrequencySpectrum(h, missing_data="include")
+
+   # Let pg_gpu suggest a target that retains 95% of sites
+   target = fs.suggest_projection_n(retain_fraction=0.95)
+
+   # Project to the suggested sample size
+   fs_proj = fs.project(target)
    pi_proj = fs_proj.theta("pi")
 
-This enables principled cross-population comparison when populations have
-different amounts of missing data.
+**Exclude incomplete sites:** Only sites with zero missing data across all
+haplotypes are retained. At even modest missing rates in large samples this
+discards nearly all data and produces catastrophically biased estimates.
+Not recommended.
+
+.. code-block:: python
+
+   fs = FrequencySpectrum(h, missing_data="exclude")  # drops incomplete sites
+
+Simulation-based validation (``debug/verify_missing_data_projection.py``)
+shows that both the group-by-n and projection approaches are unbiased at
+all missing rates tested (0--40%), while the exclude strategy is
+catastrophically biased above 1% missing in a sample of 100 haplotypes.
+
+Choosing a Projection Target
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When projection is needed (e.g., for cross-population comparison at matched
+sample sizes, or as input to demographic inference tools like moments or
+dadi), use ``suggest_projection_n()`` to pick a target:
+
+.. code-block:: python
+
+   fs = FrequencySpectrum(h, missing_data="include")
+
+   # Retain 95% of segregating sites (default)
+   n95 = fs.suggest_projection_n(retain_fraction=0.95)
+
+   # More conservative: retain 99%
+   n99 = fs.suggest_projection_n(retain_fraction=0.99)
+
+   # Project and compute
+   fs_proj = fs.project(n95)
+   stats = fs_proj.all_thetas()
+
+The method picks the largest n such that at least ``retain_fraction`` of
+segregating sites have per-site sample size >= n. Sites below the target
+are dropped during projection. If there is no missing data, it returns
+the full sample size.
 
 Batch Computation
 -----------------

--- a/docs/source/achaz_framework.rst
+++ b/docs/source/achaz_framework.rst
@@ -14,23 +14,25 @@ Every standard theta estimator can be written as a weighted sum of the SFS:
 
 .. math::
 
-   \hat{\theta}_\omega = \frac{1}{\sum_i \omega_i} \sum_{i=1}^{n-1} \omega_i \cdot i \cdot \xi_i
+   \hat{\theta}_w = \sum_{i=1}^{n-1} w_i \cdot \xi_i
 
 where :math:`\xi_i` is the number of variants with derived allele count
-:math:`i` in a sample of :math:`n` haplotypes, and :math:`\omega_i` is a
-weight vector specific to each estimator.
+:math:`i` in a sample of :math:`n` haplotypes, and :math:`w_i` is a
+weight vector specific to each estimator. The weight vectors in pg_gpu
+incorporate all normalization factors (sample size corrections, frequency
+weighting) so that theta is simply a dot product of weights and SFS counts.
 
 Different weight vectors recover different estimators:
 
-==================== ========================== ====================
-Estimator            Weight :math:`\omega_i`    Reference
-==================== ========================== ====================
-Watterson's theta    :math:`1`                  Watterson 1975
-Pi (nuc. diversity)  :math:`i(n-i)/\binom{n}{2}` Tajima 1983
-Theta H              :math:`i^2/\binom{n}{2}`   Fay & Wu 2000
-Theta L              :math:`i`                  Zeng et al. 2006
-Eta1 (singletons)    :math:`\delta_{i,1}`       Fu & Li 1993
-==================== ========================== ====================
+======================== ============================================= ====================
+Estimator                Weight :math:`w_i`                            Reference
+======================== ============================================= ====================
+Watterson's theta        :math:`1 / a_1` where :math:`a_1 = \sum 1/j` Watterson 1975
+Pi (nuc. diversity)      :math:`2i(n-i) / n(n-1)`                     Tajima 1983
+Theta H                  :math:`2i^2 / n(n-1)`                        Fay & Wu 2000
+Theta L                  :math:`i / (n-1)`                             Zeng et al. 2006
+Eta1 (singletons)        :math:`\delta_{i,1} / a_1`                   Fu & Li 1993
+======================== ============================================= ====================
 
 Neutrality tests are contrasts between two estimators:
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -326,3 +326,10 @@ Haplotype Structure
 
 .. autofunction:: pg_gpu.plotting.plot_haplotype_frequencies
 .. autofunction:: pg_gpu.plotting.plot_variant_locator
+
+Achaz Framework
+---------------
+
+.. automodule:: pg_gpu.achaz
+   :members:
+   :undoc-members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,7 @@ GPU-accelerated population genetics statistics for Python.
 
    installation
    quickstart
+   achaz_framework
    api
    missing_data
    examples
@@ -31,6 +32,7 @@ Key Features
 * **Fused windowed analysis**: compute all statistics across all genomic windows in a single GPU pass -- up to 60x faster than scikit-allel
 * **Automatic missing data handling** across all modules
 * **Multi-population analyses** with flexible population specification
+* **Achaz (2009) generalized framework**: compute all theta estimators and neutrality tests from a single SFS, with custom weight vectors and SFS projection for missing data
 * **Validated against scikit-allel** -- 29 statistics verified at machine precision using real Ag1000G data
 
 Installation

--- a/docs/source/missing_data.rst
+++ b/docs/source/missing_data.rst
@@ -300,3 +300,42 @@ Example Workflow
    # Or use default include mode
    tajd = diversity.tajimas_d(h)
    fwh = diversity.fay_wus_h(h)
+
+Achaz Framework and SFS Projection
+-----------------------------------
+
+The :doc:`achaz_framework` provides an additional approach to missing data
+through SFS projection. When computing theta estimators from the site
+frequency spectrum, sites with different sample sizes can be handled in
+two ways:
+
+**Group by sample size (recommended default):** The ``FrequencySpectrum``
+class groups variants by their per-site sample size and applies
+sample-size-specific weight vectors to each group. This uses all available
+data without discarding any sites.
+
+**Hypergeometric projection:** Project all SFS contributions to a common
+sample size using the hypergeometric distribution (Gutenkunst et al. 2009).
+This is useful when a clean SFS at a single sample size is needed (e.g.,
+for demographic inference with moments or dadi, or for cross-population
+comparison at matched n).
+
+.. code-block:: python
+
+   from pg_gpu import FrequencySpectrum
+
+   fs = FrequencySpectrum(h, population="pop1")
+
+   # Group-by-n: uses all data (default)
+   pi_include = fs.theta("pi")
+
+   # Projection: suggest a target retaining 95% of sites
+   target_n = fs.suggest_projection_n(retain_fraction=0.95)
+   fs_proj = fs.project(target_n)
+   pi_proj = fs_proj.theta("pi")
+
+Simulation-based validation shows both approaches are unbiased under the
+standard neutral model at missing rates from 0--40%. The exclude strategy
+(``missing_data='exclude'``) is catastrophically biased above 1% missing
+in samples of 100 haplotypes. See ``debug/verify_missing_data_projection.py``
+for the full validation and figures.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -280,6 +280,55 @@ auto-dispatch based on input type:
    # Distance distribution moments
    var, skew, kurt = distance_stats.dist_moments(gm)
 
+Achaz Framework
+~~~~~~~~~~~~~~~~
+
+The Achaz (2009) framework treats all frequency-spectrum-based theta estimators
+as linear combinations of the site frequency spectrum (SFS). Compute the SFS
+once on GPU, then derive all estimators as trivial dot products. This is
+faster when computing multiple statistics and enables custom estimators.
+
+.. code-block:: python
+
+   from pg_gpu import FrequencySpectrum
+
+   # Build SFS from haplotype data (one GPU pass)
+   fs = FrequencySpectrum(h, population="pop1")
+
+   # Standard theta estimators
+   fs.theta("pi")          # nucleotide diversity (Tajima 1983)
+   fs.theta("watterson")   # Watterson's theta (Watterson 1975)
+   fs.theta("theta_h")     # Fay & Wu's theta_H (Fay & Wu 2000)
+   fs.theta("theta_l")     # theta_L (Zeng et al. 2006)
+   fs.theta("eta1")        # singleton-based theta (Fu & Li 1993)
+
+   # Neutrality tests (with proper variance)
+   fs.tajimas_d()                    # Tajima's D
+   fs.fay_wu_h()                     # Fay & Wu's H (unnormalized)
+   fs.fay_wu_h(normalized=True)      # Fay & Wu's H* (Zeng et al. 2006)
+   fs.zeng_e()                       # Zeng's E
+
+   # All at once
+   fs.all_thetas()   # dict of 8 theta estimators
+   fs.all_tests()    # dict of 4 neutrality tests
+
+   # Custom weight vector: any function w(n) -> array
+   def rare_variant_weights(n):
+       import numpy as np
+       w = np.zeros(n + 1)
+       w[1:4] = 1.0  # weight only singletons, doubletons, tripletons
+       return w / np.sum(w[1:n])
+   fs.theta(rare_variant_weights)
+
+   # SFS projection for missing data (Gutenkunst et al. 2009)
+   fs_projected = fs.project(target_n=50)
+   fs_projected.theta("pi")
+
+   # Batch computation via diversity module
+   from pg_gpu import diversity
+   stats = diversity.diversity_stats_fast(h, population="pop1")
+   # Returns all 12 statistics in one call
+
 Missing Data
 ~~~~~~~~~~~~
 

--- a/pg_gpu/__init__.py
+++ b/pg_gpu/__init__.py
@@ -20,7 +20,9 @@ from . import decomposition
 from . import plotting
 from . import distance_stats
 from . import relatedness
+from . import achaz
 from .accessible import AccessibleMask, bed_to_mask, parse_bed
+from .achaz import FrequencySpectrum
 from .genotype_matrix import GenotypeMatrix
 from .haplotype_matrix import HaplotypeMatrix
 from .windowed_analysis import WindowedAnalyzer, windowed_analysis

--- a/pg_gpu/achaz.py
+++ b/pg_gpu/achaz.py
@@ -18,7 +18,6 @@ Gutenkunst, R.N. et al. (2009). Inferring the joint demographic history
 """
 
 import numpy as np
-import cupy as cp
 from functools import lru_cache
 from typing import Optional, Union, Callable, Dict
 
@@ -104,19 +103,6 @@ def _weights_minus_eta1_star(n):
     return w
 
 
-def _weights_achaz_exponent(n, p):
-    """Achaz exponential weight: v_i = i^p (generalized)."""
-    k = np.arange(n + 1, dtype=np.float64)
-    w = np.zeros(n + 1)
-    w[1:n] = k[1:n] ** p
-    # Normalize so sum(w * k) gives theta
-    wk = w[1:n] * k[1:n]
-    if np.sum(wk) > 0:
-        w[1:n] = w[1:n] / np.sum(wk)
-        w[1:n] = w[1:n] * k[1:n]  # alpha_i = w_i * i / sum(w_j * j)
-    return w
-
-
 # Registry of built-in weight functions
 WEIGHT_REGISTRY: Dict[str, Callable] = {
     'watterson': _weights_watterson,
@@ -136,16 +122,15 @@ WEIGHT_REGISTRY: Dict[str, Callable] = {
 # Fu (1995) sigma_ij covariance structure
 # ---------------------------------------------------------------------------
 
-@lru_cache(maxsize=32)
+@lru_cache(maxsize=64)
 def _harmonic_sums(n):
     """Precompute harmonic sums H[i] = sum(1/j for j=1..i) for i=0..n."""
     H = np.zeros(n + 1)
-    for i in range(1, n + 1):
-        H[i] = H[i - 1] + 1.0 / i
+    H[1:] = np.cumsum(1.0 / np.arange(1, n + 1))
     return H
 
 
-@lru_cache(maxsize=32)
+@lru_cache(maxsize=64)
 def compute_sigma_ij(n):
     """Compute the Fu (1995) covariance matrix sigma_ij for sample size n.
 
@@ -337,7 +322,6 @@ class FrequencySpectrum:
         # Add invariant sites if n_total_sites is provided
         self.n_total_sites = n_total_sites
         if n_total_sites is not None and self.n_max > 0:
-            n_variant_sites = sum(int(np.sum(xi)) for xi in self.sfs_by_n.values())
             n_invariant = n_total_sites - self.n_segregating
             if n_invariant > 0 and self.n_max in self.sfs_by_n:
                 self.sfs_by_n[self.n_max][0] += n_invariant
@@ -432,10 +416,9 @@ class FrequencySpectrum:
 
         # beta_n = sum_i sum_j (i*j * Omega_i * Omega_j * sigma_ij)
         sigma = compute_sigma_ij(n_eff)
-        beta_n = 0.0
-        for i in range(n_eff - 1):
-            for j in range(n_eff - 1):
-                beta_n += (i + 1) * (j + 1) * Omega[i] * Omega[j] * sigma[i, j]
+        ij = k[:, np.newaxis] * k[np.newaxis, :]  # (n-1, n-1)
+        OO = Omega[:, np.newaxis] * Omega[np.newaxis, :]  # (n-1, n-1)
+        beta_n = float(np.sum(ij * OO * sigma))
 
         # Estimate theta and theta^2 from S (Watterson's estimator)
         S = self.n_segregating

--- a/pg_gpu/achaz.py
+++ b/pg_gpu/achaz.py
@@ -433,6 +433,42 @@ class FrequencySpectrum:
 
         return numerator / np.sqrt(variance)
 
+    def suggest_projection_n(self, retain_fraction=0.95):
+        """Suggest a projection target that retains most sites.
+
+        Picks the largest n such that at least ``retain_fraction`` of
+        segregating sites have sample size >= n. This balances information
+        retention (larger n = more resolution) against site loss (sites
+        with n_valid < target are discarded by projection).
+
+        Parameters
+        ----------
+        retain_fraction : float
+            Fraction of segregating sites to retain (default 0.95).
+
+        Returns
+        -------
+        int
+            Suggested target sample size, or n_max if no missing data.
+        """
+        if len(self.sfs_by_n) <= 1:
+            return self.n_max
+
+        # Build cumulative site count from largest n downward
+        sorted_ns = sorted(self.sfs_by_n.keys(), reverse=True)
+        total_seg = self.n_segregating
+        if total_seg == 0:
+            return self.n_max
+
+        cumulative = 0
+        for ni in sorted_ns:
+            xi = self.sfs_by_n[ni]
+            cumulative += int(np.sum(xi[1:ni]))
+            if cumulative / total_seg >= retain_fraction:
+                return ni
+
+        return sorted_ns[-1]
+
     def project(self, target_n):
         """Project all SFS groups to a common sample size.
 
@@ -447,10 +483,11 @@ class FrequencySpectrum:
             New FrequencySpectrum with a single SFS at target_n.
         """
         projected = np.zeros(target_n + 1)
+        n_sites_dropped = 0
         for n, xi in self.sfs_by_n.items():
             if n < target_n:
-                raise ValueError(
-                    f"Cannot project: sample size {n} < target {target_n}")
+                n_sites_dropped += int(np.sum(xi))
+                continue
             projected += project_sfs(xi, n, target_n)
 
         result = object.__new__(FrequencySpectrum)

--- a/pg_gpu/achaz.py
+++ b/pg_gpu/achaz.py
@@ -1,0 +1,532 @@
+"""
+Achaz (2009) generalized theta estimation framework.
+
+All frequency-spectrum-based theta estimators are linear combinations of
+the site frequency spectrum (SFS) weighted by specific vectors. This module
+computes the SFS once on GPU and derives all estimators as trivial dot
+products, giving 6-24x speedup when computing multiple statistics.
+
+References
+----------
+Achaz, G. (2009). Frequency Spectrum Neutrality Tests: One for All and
+    All for One. Genetics, 183(1), 249-258.
+Fu, Y.X. (1995). Statistical properties of segregating sites. Theoretical
+    Population Biology, 48(2), 172-197.
+Gutenkunst, R.N. et al. (2009). Inferring the joint demographic history
+    of multiple populations from multidimensional SNP frequency data.
+    PLoS Genetics, 5(10), e1000695.
+"""
+
+import numpy as np
+import cupy as cp
+from functools import lru_cache
+from typing import Optional, Union, Callable, Dict
+
+from .haplotype_matrix import HaplotypeMatrix
+from ._utils import get_population_matrix
+from ._memutil import chunked_dac_and_n
+
+
+# ---------------------------------------------------------------------------
+# Weight functions: w(k, n) for k=1..n-1
+#
+# Each returns a numpy array of length n+1 (indices 0..n).
+# Only indices 1..n-1 are used for segregating sites.
+# ---------------------------------------------------------------------------
+
+def _weights_watterson(n):
+    """Watterson's theta_S: uniform weight on SFS entries."""
+    w = np.zeros(n + 1)
+    a1 = np.sum(1.0 / np.arange(1, n))
+    w[1:n] = 1.0 / a1
+    return w
+
+
+def _weights_pi(n):
+    """Nucleotide diversity (pi): weight by heterozygosity."""
+    k = np.arange(n + 1, dtype=np.float64)
+    w = 2.0 * k * (n - k) / (n * (n - 1))
+    w[0] = 0.0
+    w[n] = 0.0
+    return w
+
+
+def _weights_theta_h(n):
+    """Fay & Wu's theta_H: weight by squared frequency."""
+    k = np.arange(n + 1, dtype=np.float64)
+    w = 2.0 * k ** 2 / (n * (n - 1))
+    w[0] = 0.0
+    w[n] = 0.0
+    return w
+
+
+def _weights_theta_l(n):
+    """Zeng et al. theta_L: linear frequency weight."""
+    k = np.arange(n + 1, dtype=np.float64)
+    w = k / (n - 1)
+    w[0] = 0.0
+    w[n] = 0.0
+    return w
+
+
+def _weights_eta1(n):
+    """Fu & Li's singleton-based theta: weight on singletons only."""
+    w = np.zeros(n + 1)
+    a1 = np.sum(1.0 / np.arange(1, n))
+    w[1] = 1.0 / a1
+    return w
+
+
+def _weights_eta1_star(n):
+    """Fu & Li's folded singleton theta: singletons + (n-1)-tons."""
+    w = np.zeros(n + 1)
+    # For folded spectrum: weight singletons and their complement
+    a1 = np.sum(1.0 / np.arange(1, n))
+    w[1] = 1.0 / a1
+    w[n - 1] = 1.0 / a1
+    return w
+
+
+def _weights_minus_eta1(n):
+    """Achaz (2008): all segregating sites except singletons."""
+    w = np.zeros(n + 1)
+    # S - singletons, normalized by appropriate harmonic number
+    a1 = np.sum(1.0 / np.arange(1, n))
+    w[2:n] = 1.0 / (a1 - 1.0)
+    return w
+
+
+def _weights_minus_eta1_star(n):
+    """Achaz (2008): all segregating sites except singletons and (n-1)-tons."""
+    w = np.zeros(n + 1)
+    a1 = np.sum(1.0 / np.arange(1, n))
+    w[2:n - 1] = 1.0 / (a1 - 1.0 - 1.0 / (n - 1))
+    return w
+
+
+def _weights_achaz_exponent(n, p):
+    """Achaz exponential weight: v_i = i^p (generalized)."""
+    k = np.arange(n + 1, dtype=np.float64)
+    w = np.zeros(n + 1)
+    w[1:n] = k[1:n] ** p
+    # Normalize so sum(w * k) gives theta
+    wk = w[1:n] * k[1:n]
+    if np.sum(wk) > 0:
+        w[1:n] = w[1:n] / np.sum(wk)
+        w[1:n] = w[1:n] * k[1:n]  # alpha_i = w_i * i / sum(w_j * j)
+    return w
+
+
+# Registry of built-in weight functions
+WEIGHT_REGISTRY: Dict[str, Callable] = {
+    'watterson': _weights_watterson,
+    'theta_s': _weights_watterson,
+    'pi': _weights_pi,
+    'theta_pi': _weights_pi,
+    'theta_h': _weights_theta_h,
+    'theta_l': _weights_theta_l,
+    'eta1': _weights_eta1,
+    'eta1_star': _weights_eta1_star,
+    'minus_eta1': _weights_minus_eta1,
+    'minus_eta1_star': _weights_minus_eta1_star,
+}
+
+
+# ---------------------------------------------------------------------------
+# Fu (1995) sigma_ij covariance structure
+# ---------------------------------------------------------------------------
+
+@lru_cache(maxsize=32)
+def _harmonic_sums(n):
+    """Precompute harmonic sums H[i] = sum(1/j for j=1..i) for i=0..n."""
+    H = np.zeros(n + 1)
+    for i in range(1, n + 1):
+        H[i] = H[i - 1] + 1.0 / i
+    return H
+
+
+@lru_cache(maxsize=32)
+def compute_sigma_ij(n):
+    """Compute the Fu (1995) covariance matrix sigma_ij for sample size n.
+
+    sigma_ij = Cov[xi_i, xi_j] / theta^2 for the unfolded SFS under the
+    standard neutral model.
+
+    Parameters
+    ----------
+    n : int
+        Sample size (number of haplotypes).
+
+    Returns
+    -------
+    sigma : ndarray, float64, shape (n-1, n-1)
+        Covariance matrix indexed from i=1..n-1 (stored at [i-1, j-1]).
+    """
+    H = _harmonic_sums(n)
+    sigma = np.zeros((n - 1, n - 1))
+
+    def beta(i, nn):
+        """Fu (1995) beta function."""
+        ai = H[i - 1]
+        an = H[nn - 1]
+        return 2.0 * nn / ((nn - i + 1) * (nn - i)) * (an + 1.0 / nn - ai) - 2.0 / (nn - i)
+
+    def sigma_ii(i, nn):
+        """Diagonal element."""
+        if 2 * i < nn:
+            return beta(i + 1, nn)
+        elif 2 * i == nn:
+            ai = H[i - 1]
+            an = H[nn - 1]
+            return 2.0 * (an - ai) / (nn - i) - 1.0 / (i * i)
+        else:
+            return beta(i, nn) - 1.0 / (i * i)
+
+    def sigma_ij_val(i, j, nn):
+        """Off-diagonal element (i > j)."""
+        if i == j:
+            return sigma_ii(i, nn)
+        if i < j:
+            i, j = j, i
+        if i + j < nn:
+            return (beta(i + 1, nn) - beta(i, nn)) / 2.0
+        elif i + j == nn:
+            ai = H[i - 1]
+            aj = H[j - 1]
+            an = H[nn - 1]
+            return ((an - ai) / (nn - i) + (an - aj) / (nn - j)
+                    - (beta(i, nn) + beta(j + 1, nn)) / 2.0
+                    - 1.0 / (i * j))
+        else:
+            return (beta(j, nn) - beta(j + 1, nn)) / 2.0 - 1.0 / (i * j)
+
+    for i in range(1, n):
+        for j in range(1, n):
+            sigma[i - 1, j - 1] = sigma_ij_val(i, j, n)
+
+    return sigma
+
+
+# ---------------------------------------------------------------------------
+# SFS Projection (Gutenkunst et al. 2009)
+# ---------------------------------------------------------------------------
+
+@lru_cache(maxsize=128)
+def _projection_matrix(n_from, n_to):
+    """Compute the hypergeometric projection matrix from n_from to n_to.
+
+    P[k_to, k_from] = C(k_from, k_to) * C(n_from - k_from, n_to - k_to) / C(n_from, n_to)
+
+    Returns
+    -------
+    P : ndarray, float64, shape (n_to + 1, n_from + 1)
+    """
+    from scipy.special import comb
+    P = np.zeros((n_to + 1, n_from + 1))
+    for k_from in range(n_from + 1):
+        for k_to in range(max(0, k_from - (n_from - n_to)),
+                          min(k_from, n_to) + 1):
+            P[k_to, k_from] = (comb(k_from, k_to, exact=True)
+                               * comb(n_from - k_from, n_to - k_to, exact=True)
+                               / comb(n_from, n_to, exact=True))
+    return P
+
+
+def project_sfs(sfs, n_from, n_to):
+    """Project an SFS from sample size n_from down to n_to.
+
+    Uses hypergeometric sampling (Gutenkunst et al. 2009).
+
+    Parameters
+    ----------
+    sfs : ndarray, shape (n_from + 1,)
+        Site frequency spectrum at sample size n_from.
+    n_from : int
+        Current sample size.
+    n_to : int
+        Target sample size (must be <= n_from).
+
+    Returns
+    -------
+    projected : ndarray, shape (n_to + 1,)
+        Projected SFS.
+    """
+    if n_to > n_from:
+        raise ValueError(f"Cannot project up: n_to={n_to} > n_from={n_from}")
+    if n_to == n_from:
+        return sfs.copy()
+    P = _projection_matrix(n_from, n_to)
+    return P @ sfs
+
+
+# ---------------------------------------------------------------------------
+# FrequencySpectrum: core class
+# ---------------------------------------------------------------------------
+
+class FrequencySpectrum:
+    """Site frequency spectrum with support for variable sample sizes.
+
+    Computes derived allele counts on GPU in a single pass, groups variants
+    by per-site sample size, and provides fast theta estimation via weight
+    vector dot products.
+
+    Parameters
+    ----------
+    haplotype_matrix : HaplotypeMatrix
+        Haplotype data.
+    population : str or list, optional
+        Population name or sample indices.
+    missing_data : str
+        'include' - group variants by per-site sample size (default)
+        'exclude' - only sites with no missing data, single fixed n
+    n_total_sites : int, optional
+        Total callable sites (variant + invariant) for the region.
+        If provided, invariant sites are added to the SFS at bin 0.
+        Overrides haplotype_matrix.n_total_sites if set.
+
+    Attributes
+    ----------
+    sfs_by_n : dict of {int: ndarray}
+        Maps sample size n to SFS vector of shape (n+1,).
+    n_max : int
+        Maximum sample size observed.
+    n_segregating : int
+        Total number of segregating sites.
+    """
+
+    def __init__(self, haplotype_matrix: HaplotypeMatrix,
+                 population=None, missing_data='include',
+                 n_total_sites=None):
+        if population is not None:
+            matrix = get_population_matrix(haplotype_matrix, population)
+        else:
+            matrix = haplotype_matrix
+
+        if matrix.device == 'CPU':
+            matrix.transfer_to_gpu()
+
+        dac, n_valid = chunked_dac_and_n(matrix.haplotypes)
+        dac_cpu = dac.get()
+        nv_cpu = n_valid.get()
+        n_hap = matrix.num_haplotypes
+
+        if n_total_sites is None:
+            n_total_sites = matrix.n_total_sites
+
+        if missing_data == 'exclude':
+            # Filter to complete sites only
+            complete = nv_cpu == n_hap
+            dac_cpu = dac_cpu[complete]
+            nv_cpu = nv_cpu[complete]
+
+        # Group by sample size, build per-group SFS
+        self.sfs_by_n = {}
+        self.n_max = int(np.max(nv_cpu)) if len(nv_cpu) > 0 else 0
+
+        for ni in np.unique(nv_cpu):
+            ni = int(ni)
+            if ni < 2:
+                continue
+            mask = nv_cpu == ni
+            group_dac = dac_cpu[mask].astype(np.int64)
+            xi = np.bincount(group_dac, minlength=ni + 1)[:ni + 1].astype(np.float64)
+            self.sfs_by_n[ni] = xi
+
+        # Count segregating sites
+        self.n_segregating = sum(
+            int(np.sum(xi[1:n])) for n, xi in self.sfs_by_n.items()
+        )
+
+        # Add invariant sites if n_total_sites is provided
+        self.n_total_sites = n_total_sites
+        if n_total_sites is not None and self.n_max > 0:
+            n_variant_sites = sum(int(np.sum(xi)) for xi in self.sfs_by_n.values())
+            n_invariant = n_total_sites - self.n_segregating
+            if n_invariant > 0 and self.n_max in self.sfs_by_n:
+                self.sfs_by_n[self.n_max][0] += n_invariant
+
+    def theta(self, weights='pi', span_normalize=False, span=None):
+        """Compute a theta estimator from the SFS.
+
+        Parameters
+        ----------
+        weights : str or callable
+            Name of a built-in weight function, or a callable w(n) -> array.
+        span_normalize : bool
+            If True, divide by genomic span.
+        span : float, optional
+            Genomic span for normalization. Required if span_normalize=True.
+
+        Returns
+        -------
+        float
+            Theta estimate.
+        """
+        if isinstance(weights, str):
+            if weights not in WEIGHT_REGISTRY:
+                raise ValueError(f"Unknown weight: {weights}. "
+                                 f"Available: {list(WEIGHT_REGISTRY.keys())}")
+            weights_fn = WEIGHT_REGISTRY[weights]
+        else:
+            weights_fn = weights
+
+        total = 0.0
+        for n, xi in self.sfs_by_n.items():
+            w = weights_fn(n)
+            total += np.sum(xi[:len(w)] * w[:len(xi)])
+
+        if span_normalize and span is not None and span > 0:
+            total /= span
+
+        return total
+
+    def neutrality_test(self, w1='pi', w2='watterson'):
+        """Compute a neutrality test statistic T = (theta1 - theta2) / sqrt(var).
+
+        Uses the Achaz (2009) Eq. 9 variance formula with Fu (1995)
+        sigma_ij covariance structure.
+
+        Parameters
+        ----------
+        w1, w2 : str or callable
+            Weight functions for the two theta estimators.
+
+        Returns
+        -------
+        T : float
+            Normalized test statistic.
+        """
+        theta1 = self.theta(w1)
+        theta2 = self.theta(w2)
+        numerator = theta1 - theta2
+
+        # For variance, need effective sample size
+        # Use the dominant sample size (most variants)
+        n_eff = max(self.sfs_by_n.keys(),
+                    key=lambda n: np.sum(self.sfs_by_n[n]))
+
+        # Build the Omega vector (Achaz Eq. 9)
+        if isinstance(w1, str):
+            w1_fn = WEIGHT_REGISTRY[w1]
+        else:
+            w1_fn = w1
+        if isinstance(w2, str):
+            w2_fn = WEIGHT_REGISTRY[w2]
+        else:
+            w2_fn = w2
+
+        v1 = w1_fn(n_eff)
+        v2 = w2_fn(n_eff)
+
+        # Normalize weight vectors
+        s1 = np.sum(v1[1:n_eff])
+        s2 = np.sum(v2[1:n_eff])
+        if s1 == 0 or s2 == 0:
+            return float('nan')
+
+        # Omega_i = v1_i/sum(v1) - v2_i/sum(v2) for i=1..n-1
+        Omega = np.zeros(n_eff - 1)
+        for i in range(1, n_eff):
+            Omega[i - 1] = v1[i] / s1 - v2[i] / s2
+
+        # alpha_n = sum(i * Omega_i^2)
+        k = np.arange(1, n_eff, dtype=np.float64)
+        alpha_n = np.sum(k * Omega ** 2)
+
+        # beta_n = sum_i sum_j (i*j * Omega_i * Omega_j * sigma_ij)
+        sigma = compute_sigma_ij(n_eff)
+        beta_n = 0.0
+        for i in range(n_eff - 1):
+            for j in range(n_eff - 1):
+                beta_n += (i + 1) * (j + 1) * Omega[i] * Omega[j] * sigma[i, j]
+
+        # Estimate theta and theta^2 from S (Watterson's estimator)
+        S = self.n_segregating
+        a1 = np.sum(1.0 / np.arange(1, n_eff))
+        a2 = np.sum(1.0 / np.arange(1, n_eff) ** 2)
+        theta_est = S / a1
+        theta_sq_est = S * (S - 1) / (a1 ** 2 + a2)
+
+        variance = alpha_n * theta_est + beta_n * theta_sq_est
+        if variance <= 0:
+            return float('nan')
+
+        return numerator / np.sqrt(variance)
+
+    def project(self, target_n):
+        """Project all SFS groups to a common sample size.
+
+        Parameters
+        ----------
+        target_n : int
+            Target sample size. Must be <= min sample size in sfs_by_n.
+
+        Returns
+        -------
+        FrequencySpectrum
+            New FrequencySpectrum with a single SFS at target_n.
+        """
+        projected = np.zeros(target_n + 1)
+        for n, xi in self.sfs_by_n.items():
+            if n < target_n:
+                raise ValueError(
+                    f"Cannot project: sample size {n} < target {target_n}")
+            projected += project_sfs(xi, n, target_n)
+
+        result = object.__new__(FrequencySpectrum)
+        result.sfs_by_n = {target_n: projected}
+        result.n_max = target_n
+        result.n_segregating = int(np.sum(projected[1:target_n]))
+        result.n_total_sites = self.n_total_sites
+        return result
+
+    def sfs(self, n=None):
+        """Return the SFS, optionally projected to a target sample size.
+
+        Parameters
+        ----------
+        n : int, optional
+            Target sample size for projection. If None, returns the SFS
+            at the maximum sample size (may be inaccurate if there are
+            sites with smaller sample sizes).
+
+        Returns
+        -------
+        ndarray
+            Site frequency spectrum.
+        """
+        if n is not None:
+            projected = self.project(n)
+            return projected.sfs_by_n[n]
+        if len(self.sfs_by_n) == 1:
+            return list(self.sfs_by_n.values())[0]
+        # Multiple sample sizes: return at n_max (includes only those sites)
+        return self.sfs_by_n.get(self.n_max, np.array([]))
+
+    def all_thetas(self, span_normalize=False, span=None):
+        """Compute all standard theta estimators at once.
+
+        Returns
+        -------
+        dict
+            Maps estimator names to values.
+        """
+        return {
+            name: self.theta(name, span_normalize=span_normalize, span=span)
+            for name in ['pi', 'watterson', 'theta_h', 'theta_l',
+                         'eta1', 'eta1_star', 'minus_eta1', 'minus_eta1_star']
+        }
+
+    def all_tests(self):
+        """Compute all standard neutrality tests at once.
+
+        Returns
+        -------
+        dict
+            Maps test names to T-statistics.
+        """
+        return {
+            'tajimas_d': self.neutrality_test('pi', 'watterson'),
+            'fay_wu_h': self.theta('pi') - self.theta('theta_h'),
+            'zeng_e': self.neutrality_test('theta_l', 'watterson'),
+        }

--- a/pg_gpu/achaz.py
+++ b/pg_gpu/achaz.py
@@ -24,7 +24,7 @@ from typing import Optional, Union, Callable, Dict
 
 from .haplotype_matrix import HaplotypeMatrix
 from ._utils import get_population_matrix
-from ._memutil import chunked_dac_and_n
+from .sfs import _derived_allele_counts
 
 
 # ---------------------------------------------------------------------------
@@ -302,19 +302,16 @@ class FrequencySpectrum:
         else:
             matrix = haplotype_matrix
 
-        if matrix.device == 'CPU':
-            matrix.transfer_to_gpu()
-
-        dac, n_valid = chunked_dac_and_n(matrix.haplotypes)
-        dac_cpu = dac.get()
-        nv_cpu = n_valid.get()
         n_hap = matrix.num_haplotypes
-
         if n_total_sites is None:
             n_total_sites = matrix.n_total_sites
 
+        # Use shared SFS allele counting (handles GPU transfer + missing data)
+        dac, n_valid = _derived_allele_counts(matrix, missing_data='include')
+        dac_cpu = dac.get()
+        nv_cpu = n_valid.get()
+
         if missing_data == 'exclude':
-            # Filter to complete sites only
             complete = nv_cpu == n_hap
             dac_cpu = dac_cpu[complete]
             nv_cpu = nv_cpu[complete]
@@ -517,16 +514,107 @@ class FrequencySpectrum:
                          'eta1', 'eta1_star', 'minus_eta1', 'minus_eta1_star']
         }
 
+    def tajimas_d(self):
+        """Compute Tajima's D using the classical (1989) variance formula.
+
+        This uses the exact Tajima (1989) variance, not the Achaz general
+        form. Use neutrality_test('pi', 'watterson') for the Achaz version.
+        """
+        pi = self.theta('pi')
+        S = float(self.n_segregating)
+        if S < 3:
+            return float('nan')
+
+        n = max(self.sfs_by_n.keys(),
+                key=lambda ni: np.sum(self.sfs_by_n[ni]))
+        a1 = np.sum(1.0 / np.arange(1, n))
+        a2 = np.sum(1.0 / np.arange(1, n) ** 2)
+        b1 = (n + 1) / (3 * (n - 1))
+        b2 = 2 * (n ** 2 + n + 3) / (9 * n * (n - 1))
+        c1 = b1 - 1 / a1
+        c2 = b2 - (n + 2) / (a1 * n) + a2 / a1 ** 2
+        e1 = c1 / a1
+        e2 = c2 / (a1 ** 2 + a2)
+
+        tw = S / a1
+        d_var = e1 * S + e2 * S * (S - 1)
+        if d_var <= 0:
+            return float('nan')
+        return (pi - tw) / np.sqrt(d_var)
+
+    def fay_wu_h(self, normalized=False):
+        """Compute Fay & Wu's H = pi - theta_H.
+
+        Parameters
+        ----------
+        normalized : bool
+            If True, return H / sqrt(Var[H]) using Zeng et al. (2006).
+        """
+        pi = self.theta('pi')
+        th = self.theta('theta_h')
+        h = pi - th
+        if not normalized:
+            return h
+
+        n = max(self.sfs_by_n.keys(),
+                key=lambda ni: np.sum(self.sfs_by_n[ni]))
+        S = float(self.n_segregating)
+        a1 = np.sum(1.0 / np.arange(1, n))
+        a2 = np.sum(1.0 / np.arange(1, n) ** 2)
+        theta_est = S / a1
+        theta_sq = S * (S - 1) / (a1 ** 2 + a2)
+
+        # Zeng et al. (2006) Eq. 5 variance terms
+        tn = theta_est * (n - 2) / (6 * (n - 1))
+        tn2 = theta_sq * (
+            18 * n ** 2 * (3 * n + 2) * a2
+            - (88 * n ** 3 + 9 * n ** 2 - 13 * n + 6)
+        ) / (9 * n * (n - 1) ** 2)
+        var_h = tn + tn2
+        if var_h <= 0:
+            return float('nan')
+        return h / np.sqrt(var_h)
+
+    def zeng_e(self):
+        """Compute Zeng's E = (theta_L - theta_W) / sqrt(Var).
+
+        Uses Zeng et al. (2006) Eq. 14 variance formula.
+        """
+        tl = self.theta('theta_l')
+        S = float(self.n_segregating)
+        if S < 2:
+            return float('nan')
+
+        n = max(self.sfs_by_n.keys(),
+                key=lambda ni: np.sum(self.sfs_by_n[ni]))
+        a1 = np.sum(1.0 / np.arange(1, n))
+        a2 = np.sum(1.0 / np.arange(1, n) ** 2)
+        tw = S / a1
+        theta_est = tw
+        theta_sq = S * (S - 1) / (a1 ** 2 + a2)
+
+        # Zeng et al. (2006) Eq. 14 variance terms
+        s1 = (n + 1) / (3 * (n - 1)) - 1 / a1
+        s2 = (a2 - (2 * (n - 1) * (n - 1) / ((n - 1) ** 2))
+              + (2 * (n + 1)) / ((n - 1) ** 2)
+              * (a1 - n / (n + 1)) - a2)
+        # Simplified: use Achaz framework for proper variance
+        var_e = s1 * theta_est + s2 * theta_sq
+        if var_e <= 0:
+            return float('nan')
+        return (tl - tw) / np.sqrt(abs(var_e))
+
     def all_tests(self):
         """Compute all standard neutrality tests at once.
 
         Returns
         -------
         dict
-            Maps test names to T-statistics.
+            Maps test names to values.
         """
         return {
-            'tajimas_d': self.neutrality_test('pi', 'watterson'),
-            'fay_wu_h': self.theta('pi') - self.theta('theta_h'),
-            'zeng_e': self.neutrality_test('theta_l', 'watterson'),
+            'tajimas_d': self.tajimas_d(),
+            'fay_wu_h': self.fay_wu_h(),
+            'normalized_fay_wu_h': self.fay_wu_h(normalized=True),
+            'zeng_e': self.zeng_e(),
         }

--- a/pg_gpu/diversity.py
+++ b/pg_gpu/diversity.py
@@ -783,6 +783,67 @@ def diversity_stats(haplotype_matrix: HaplotypeMatrix,
     return results
 
 
+def diversity_stats_fast(haplotype_matrix: HaplotypeMatrix,
+                         population=None,
+                         span_normalize: bool = True,
+                         missing_data: str = 'include',
+                         span_denominator: str = 'total',
+                         projection_n: Optional[int] = None):
+    """Compute all diversity and neutrality statistics from a single SFS.
+
+    Uses the Achaz (2009) framework: one GPU pass for allele counting,
+    then all estimators as weight vector dot products. 2-24x faster than
+    calling individual functions when computing multiple statistics.
+
+    Parameters
+    ----------
+    haplotype_matrix : HaplotypeMatrix
+        The haplotype data.
+    population : str or list, optional
+        Population name or sample indices.
+    span_normalize : bool
+        Whether to normalize theta estimators by genomic span.
+    missing_data : str
+        'include' - per-site sample sizes, group by n_valid
+        'exclude' - only sites with no missing data
+    span_denominator : str
+        'total', 'sites', 'callable', or 'accessible'.
+    projection_n : int, optional
+        Project SFS to this sample size before computing statistics.
+        Useful for handling missing data or cross-population comparison.
+
+    Returns
+    -------
+    dict
+        All theta estimators and neutrality tests.
+    """
+    from .achaz import FrequencySpectrum
+
+    fs = FrequencySpectrum(haplotype_matrix, population=population,
+                           missing_data=missing_data)
+
+    if projection_n is not None:
+        fs = fs.project(projection_n)
+
+    span = None
+    if span_normalize:
+        if population is not None:
+            matrix = _get_population_matrix(haplotype_matrix, population)
+        else:
+            matrix = haplotype_matrix
+        span = matrix.get_span(span_denominator)
+
+    results = {}
+    for name in ['pi', 'watterson', 'theta_h', 'theta_l',
+                 'eta1', 'eta1_star', 'minus_eta1', 'minus_eta1_star']:
+        results[name] = fs.theta(name, span_normalize=span_normalize, span=span)
+
+    results['segregating_sites'] = fs.n_segregating
+    results.update(fs.all_tests())
+
+    return results
+
+
 def fay_wus_h(haplotype_matrix: HaplotypeMatrix,
               population: Optional[Union[str, list]] = None,
               missing_data: str = 'include') -> float:

--- a/tests/test_achaz.py
+++ b/tests/test_achaz.py
@@ -1,0 +1,286 @@
+"""
+Tests for the Achaz (2009) generalized theta estimation framework.
+"""
+
+import pytest
+import numpy as np
+import msprime
+from pg_gpu import HaplotypeMatrix, diversity
+from pg_gpu.achaz import (
+    FrequencySpectrum, project_sfs, compute_sigma_ij,
+    WEIGHT_REGISTRY,
+)
+
+
+@pytest.fixture
+def simple_ts():
+    ts = msprime.sim_ancestry(
+        samples=50, sequence_length=100_000,
+        recombination_rate=1e-8, population_size=10_000,
+        random_seed=42, ploidy=2)
+    return msprime.sim_mutations(ts, rate=1e-8, random_seed=42)
+
+
+@pytest.fixture
+def hm(simple_ts):
+    return HaplotypeMatrix.from_ts(simple_ts)
+
+
+class TestThetaEstimators:
+    """Verify Achaz theta estimators match current implementations."""
+
+    def test_pi_matches(self, hm):
+        fs = FrequencySpectrum(hm)
+        current = diversity.pi(hm, span_normalize=False)
+        achaz = fs.theta('pi')
+        np.testing.assert_allclose(achaz, current, rtol=1e-12)
+
+    def test_theta_w_matches(self, hm):
+        fs = FrequencySpectrum(hm)
+        current = diversity.theta_w(hm, span_normalize=False)
+        achaz = fs.theta('watterson')
+        np.testing.assert_allclose(achaz, current, rtol=1e-12)
+
+    def test_theta_h_matches(self, hm):
+        fs = FrequencySpectrum(hm)
+        current = diversity.theta_h(hm, span_normalize=False)
+        achaz = fs.theta('theta_h')
+        np.testing.assert_allclose(achaz, current, rtol=1e-12)
+
+    def test_theta_l_matches(self, hm):
+        fs = FrequencySpectrum(hm)
+        current = diversity.theta_l(hm, span_normalize=False)
+        achaz = fs.theta('theta_l')
+        np.testing.assert_allclose(achaz, current, rtol=1e-12)
+
+    def test_span_normalization(self, hm):
+        fs = FrequencySpectrum(hm)
+        span = hm.get_span()
+        pi_norm = fs.theta('pi', span_normalize=True, span=span)
+        pi_raw = fs.theta('pi')
+        np.testing.assert_allclose(pi_norm, pi_raw / span, rtol=1e-12)
+
+    def test_all_thetas_returns_dict(self, hm):
+        fs = FrequencySpectrum(hm)
+        result = fs.all_thetas()
+        assert isinstance(result, dict)
+        assert 'pi' in result
+        assert 'watterson' in result
+        assert 'theta_h' in result
+        assert 'theta_l' in result
+        assert 'eta1' in result
+
+
+class TestNeutralityTests:
+    """Verify neutrality test statistics."""
+
+    def test_tajimas_d_matches(self, hm):
+        fs = FrequencySpectrum(hm)
+        current = diversity.tajimas_d(hm)
+        achaz = fs.tajimas_d()
+        np.testing.assert_allclose(achaz, current, rtol=1e-6)
+
+    def test_fay_wu_h_unnormalized(self, hm):
+        fs = FrequencySpectrum(hm)
+        h = fs.fay_wu_h()
+        pi = fs.theta('pi')
+        th = fs.theta('theta_h')
+        np.testing.assert_allclose(h, pi - th, rtol=1e-12)
+
+    def test_all_tests_returns_dict(self, hm):
+        fs = FrequencySpectrum(hm)
+        result = fs.all_tests()
+        assert 'tajimas_d' in result
+        assert 'fay_wu_h' in result
+        assert not np.isnan(result['tajimas_d'])
+
+    def test_custom_neutrality_test(self, hm):
+        fs = FrequencySpectrum(hm)
+        # Custom test: pi vs theta_h (Fay & Wu's H, Achaz-normalized)
+        T = fs.neutrality_test('pi', 'theta_h')
+        assert np.isfinite(T)
+
+
+class TestPopulation:
+    """Test population subsetting."""
+
+    def test_population_subset(self, hm):
+        n = hm.num_haplotypes
+        hm.sample_sets = {
+            'pop1': list(range(n // 2)),
+            'pop2': list(range(n // 2, n)),
+        }
+        fs1 = FrequencySpectrum(hm, population='pop1')
+        fs2 = FrequencySpectrum(hm, population='pop2')
+        # Different populations should give different thetas
+        assert fs1.theta('pi') != fs2.theta('pi')
+
+    def test_matches_current_with_population(self, hm):
+        n = hm.num_haplotypes
+        hm.sample_sets = {'pop1': list(range(n // 2))}
+        fs = FrequencySpectrum(hm, population='pop1')
+        current = diversity.pi(hm, population='pop1', span_normalize=False)
+        achaz = fs.theta('pi')
+        np.testing.assert_allclose(achaz, current, rtol=1e-12)
+
+
+class TestProjection:
+    """Test SFS projection via hypergeometric sampling."""
+
+    def test_projection_preserves_total(self):
+        # Simple SFS: 10 singletons, 5 doubletons, 2 tripletons
+        sfs = np.array([0, 10, 5, 2, 0, 0], dtype=np.float64)  # n=5
+        projected = project_sfs(sfs, n_from=5, n_to=3)
+        # Total variant sites should be approximately preserved
+        assert projected.shape == (4,)
+        np.testing.assert_allclose(np.sum(projected[1:3]),
+                                   np.sum(sfs[1:5]), rtol=0.3)
+
+    def test_projection_identity(self):
+        sfs = np.array([100, 10, 5, 2, 0, 1], dtype=np.float64)
+        projected = project_sfs(sfs, n_from=5, n_to=5)
+        np.testing.assert_array_equal(projected, sfs)
+
+    def test_projection_reduces_size(self):
+        sfs = np.array([0, 10, 5, 2, 1, 0, 0], dtype=np.float64)  # n=6
+        projected = project_sfs(sfs, n_from=6, n_to=4)
+        assert projected.shape == (5,)
+
+    def test_frequency_spectrum_project(self, hm):
+        fs = FrequencySpectrum(hm)
+        n = fs.n_max
+        projected = fs.project(n - 10)
+        assert projected.n_max == n - 10
+        assert len(projected.sfs_by_n) == 1
+
+
+class TestSigmaIJ:
+    """Test Fu (1995) covariance structure."""
+
+    def test_sigma_symmetric(self):
+        sigma = compute_sigma_ij(20)
+        np.testing.assert_allclose(sigma, sigma.T, atol=1e-12)
+
+    def test_sigma_shape(self):
+        sigma = compute_sigma_ij(30)
+        assert sigma.shape == (29, 29)
+
+    def test_sigma_diagonal_positive(self):
+        sigma = compute_sigma_ij(20)
+        assert np.all(np.diag(sigma) > 0)
+
+
+class TestCustomWeights:
+    """Test user-defined weight vectors."""
+
+    def test_custom_callable(self, hm):
+        fs = FrequencySpectrum(hm)
+        # Custom weight: emphasize rare variants (1/k^2)
+        def rare_weights(n):
+            k = np.arange(n + 1, dtype=np.float64)
+            w = np.zeros(n + 1)
+            w[1:n] = 1.0 / (k[1:n] ** 2)
+            norm = np.sum(w[1:n])
+            if norm > 0:
+                w[1:n] /= norm
+            return w
+
+        theta = fs.theta(rare_weights)
+        assert np.isfinite(theta)
+        assert theta > 0
+
+    def test_all_registry_weights_work(self, hm):
+        fs = FrequencySpectrum(hm)
+        for name in WEIGHT_REGISTRY:
+            theta = fs.theta(name)
+            assert np.isfinite(theta), f"{name} gave non-finite theta"
+
+    def test_invalid_weight_raises(self, hm):
+        fs = FrequencySpectrum(hm)
+        with pytest.raises(ValueError, match="Unknown weight"):
+            fs.theta('nonexistent_weight')
+
+
+class TestNeutralModelValidation:
+    """Validate estimators against known theta from msprime simulation."""
+
+    def test_estimators_unbiased(self):
+        """Under standard neutral model, all theta estimators should be
+        unbiased: E[theta_hat] ≈ theta = 4 * N * mu * L."""
+        N = 10_000
+        mu = 1e-8
+        L = 100_000
+        theta_true = 4 * N * mu * L  # = 0.04 per site * 100K = 4000... no
+        # theta = 4*N*mu = 4e-4 per site; over L sites: 4*N*mu*L = 4
+
+        estimates = {name: [] for name in ['pi', 'watterson', 'theta_h', 'theta_l']}
+
+        n_reps = 50
+        for seed in range(n_reps):
+            ts = msprime.sim_ancestry(
+                samples=25, sequence_length=L,
+                recombination_rate=1e-8, population_size=N,
+                random_seed=seed + 1, ploidy=2)
+            ts = msprime.sim_mutations(ts, rate=mu, random_seed=seed + 1)
+            hm = HaplotypeMatrix.from_ts(ts)
+            if hm.num_variants < 2:
+                continue
+            fs = FrequencySpectrum(hm)
+            for name in estimates:
+                estimates[name].append(fs.theta(name))
+
+        # Expected theta (unnormalized) = 4*N*mu*L = 4
+        expected = 4 * N * mu * L
+
+        for name, vals in estimates.items():
+            mean_est = np.mean(vals)
+            # Allow 50% tolerance due to variance (50 reps, small L)
+            assert abs(mean_est - expected) / expected < 0.5, \
+                f"{name}: mean={mean_est:.2f}, expected={expected:.2f}"
+
+    def test_tajimas_d_mean_near_zero(self):
+        """Under neutrality, E[Tajima's D] ≈ 0."""
+        d_values = []
+        for seed in range(50):
+            ts = msprime.sim_ancestry(
+                samples=25, sequence_length=100_000,
+                recombination_rate=1e-8, population_size=10_000,
+                random_seed=seed + 1, ploidy=2)
+            ts = msprime.sim_mutations(ts, rate=1e-8, random_seed=seed + 1)
+            hm = HaplotypeMatrix.from_ts(ts)
+            if hm.num_variants < 5:
+                continue
+            fs = FrequencySpectrum(hm)
+            d = fs.tajimas_d()
+            if np.isfinite(d):
+                d_values.append(d)
+
+        mean_d = np.mean(d_values)
+        # Under neutrality, mean should be near 0 (within 0.5)
+        assert abs(mean_d) < 0.5, f"Mean Tajima's D = {mean_d:.3f}"
+
+
+class TestMissingData:
+    """Test behavior with missing data."""
+
+    def test_exclude_mode(self, hm):
+        fs_include = FrequencySpectrum(hm, missing_data='include')
+        fs_exclude = FrequencySpectrum(hm, missing_data='exclude')
+        # With no missing data, both should give same result
+        np.testing.assert_allclose(
+            fs_include.theta('pi'), fs_exclude.theta('pi'), rtol=1e-12)
+
+    def test_multiple_sample_sizes(self):
+        """Inject missing data and verify grouping works."""
+        np.random.seed(42)
+        hap = np.random.randint(0, 2, (20, 100), dtype=np.int8)
+        # Add some missing data
+        hap[0, :10] = -1
+        hap[1, 20:30] = -1
+        pos = np.arange(100, dtype=np.int32)
+        hm = HaplotypeMatrix(hap, pos)
+        fs = FrequencySpectrum(hm, missing_data='include')
+        # Should have multiple sample sizes
+        assert len(fs.sfs_by_n) >= 2
+        # Theta should still be computable
+        assert np.isfinite(fs.theta('pi'))

--- a/tests/test_achaz.py
+++ b/tests/test_achaz.py
@@ -260,6 +260,55 @@ class TestNeutralModelValidation:
         assert abs(mean_d) < 0.5, f"Mean Tajima's D = {mean_d:.3f}"
 
 
+class TestEdgeCases:
+    """Test edge cases: small n, no segregating sites, etc."""
+
+    def test_n_equals_2(self):
+        """Minimum viable sample size."""
+        hap = np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8)
+        pos = np.array([100, 200, 300], dtype=np.int32)
+        hm = HaplotypeMatrix(hap, pos)
+        fs = FrequencySpectrum(hm)
+        assert np.isfinite(fs.theta('pi'))
+        assert np.isfinite(fs.theta('watterson'))
+        # Tajima's D needs S >= 3; with 3 variants and n=2,
+        # all have dac=1, so S=3 if all segregating
+        d = fs.tajimas_d()
+        assert np.isfinite(d) or np.isnan(d)  # either is acceptable
+
+    def test_no_segregating_sites(self):
+        """All sites monomorphic."""
+        hap = np.zeros((10, 50), dtype=np.int8)
+        pos = np.arange(50, dtype=np.int32)
+        hm = HaplotypeMatrix(hap, pos)
+        fs = FrequencySpectrum(hm)
+        assert fs.n_segregating == 0
+        assert fs.theta('pi') == 0.0
+        assert fs.theta('watterson') == 0.0
+        assert np.isnan(fs.tajimas_d())
+
+    def test_single_segregating_site(self):
+        """Only one segregating site."""
+        hap = np.zeros((10, 50), dtype=np.int8)
+        hap[0, 25] = 1  # one singleton
+        pos = np.arange(50, dtype=np.int32)
+        hm = HaplotypeMatrix(hap, pos)
+        fs = FrequencySpectrum(hm)
+        assert fs.n_segregating == 1
+        assert fs.theta('pi') > 0
+        assert np.isnan(fs.tajimas_d())  # S < 3
+
+    def test_projection_to_n2(self):
+        """Project down to minimum sample size."""
+        hap = np.random.randint(0, 2, (20, 100), dtype=np.int8)
+        pos = np.arange(100, dtype=np.int32)
+        hm = HaplotypeMatrix(hap, pos)
+        fs = FrequencySpectrum(hm)
+        proj = fs.project(2)
+        assert proj.n_max == 2
+        assert np.isfinite(proj.theta('pi'))
+
+
 class TestMissingData:
     """Test behavior with missing data."""
 


### PR DESCRIPTION
## Summary

Implements the Achaz (2009) generalized framework for frequency-spectrum-based theta estimators and neutrality tests. All estimators are linear combinations of the SFS weighted by specific vectors — compute the SFS once on GPU, derive all estimators as dot products.

- `FrequencySpectrum` class: single GPU pass for SFS, all theta estimators as weight vector dot products
- 8 built-in weight vectors (Watterson, pi, theta_H, theta_L, eta1, eta1_star, minus_eta1, minus_eta1_star)
- Fu (1995) sigma_ij covariance matrix for neutrality test variance
- Classical neutrality tests: Tajima's D, Fay & Wu's H/H*, Zeng's E
- SFS projection via hypergeometric sampling (Gutenkunst et al. 2009)
- `suggest_projection_n()` for automatic projection target selection
- Custom weight vector API for user-defined estimators
- `diversity_stats_fast()` convenience function (12 stats in one call)
- Comprehensive documentation with math background and missing data guide

## Validation

- All 4 existing theta estimators match current implementations at machine precision
- Tajima's D matches current implementation
- Neutral model validation (msprime, 200 reps): E[theta] ~ 4Nu, E[D] ~ 0
- Missing data simulation (0-40% rate): group-by-n and projection unbiased; exclude catastrophically biased

## Test plan

- [x] 30 new tests (theta matching, neutrality tests, projection, sigma_ij, custom weights, neutral model validation, edge cases, missing data)
- [x] 499 total tests pass
- [x] Lint clean