### PR TITLE
doc cleanup: reorder toctree, fix RTD mocks

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx
 sphinx-rtd-theme
+numpy

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,17 +4,40 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('../..'))
 
-# Mock GPU dependencies for RTD builds (no GPU on build server)
+# Mock GPU dependencies for RTD builds (no GPU on build server).
+# When cupy is unavailable, pg_gpu.__init__ raises RuntimeError.
+# Mock cupy so all pg_gpu modules can be imported by autodoc.
 autodoc_mock_imports = [
-    'cupy', 'cupy.cuda', 'cupy._core',
-    'cupy_backends', 'cupy_backends.cuda',
+    'cupy',
+    'cupy.cuda',
+    'cupy.cuda.memory',
+    'cupy.cuda.runtime',
+    'cupy._core',
+    'cupy._core.core',
+    'cupy_backends',
+    'cupy_backends.cuda',
+    'cupy_backends.cuda.api',
+    'cupy_backends.cuda.libs',
+    'allel',
+    'tskit',
+    'zarr',
+    'scipy',
+    'scipy.special',
+    'scipy.spatial',
+    'scipy.spatial.distance',
 ]
 
-try:
-    import pg_gpu
-    release = pg_gpu.__version__
-except Exception:
+on_rtd = os.environ.get('READTHEDOCS') == 'True'
+
+if on_rtd:
+    # On RTD, pg_gpu can't be imported (no GPU). Set version manually.
     release = '0.1.0'
+else:
+    try:
+        import pg_gpu
+        release = pg_gpu.__version__
+    except Exception:
+        release = '0.1.0'
 
 # Project information
 project = 'pg_gpu'

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,9 +9,9 @@ GPU-accelerated population genetics statistics for Python.
 
    installation
    quickstart
-   achaz_framework
    api
    missing_data
+   achaz_framework
    examples
    moments_integration
    changelog


### PR DESCRIPTION
Reorder achaz_framework after missing_data. Expand autodoc mocks for RTD builds. Add numpy to docs requirements.