### PR TITLE
fix docstring formatting for Sphinx

### DIFF
--- a/pg_gpu/divergence.py
+++ b/pg_gpu/divergence.py
@@ -465,10 +465,9 @@ def dxy(haplotype_matrix: HaplotypeMatrix,
     per_site : bool
         If True, return per-site values; if False, return mean
     missing_data : str
-        'include' - Use all sites, calculate from available data per site
-        'exclude' - Only use sites with no missing data
-        'pairwise' - Comparison-counting normalization (pixy-style):
-            dxy = sum(diffs) / sum(comps) across all sites.
+        ``'include'`` (default) uses per-site valid data.
+        ``'exclude'`` filters to sites with no missing data.
+        ``'pairwise'`` uses comparison-counting normalization (pixy-style).
     span_denominator : bool
         If True, normalize by total sites; if False, normalize by sites with data
     return_components : bool

--- a/pg_gpu/diversity.py
+++ b/pg_gpu/diversity.py
@@ -114,12 +114,12 @@ def pi(haplotype_matrix: HaplotypeMatrix,
     span_normalize : bool
         If True, normalize by genomic span; if False, return raw diversity
     missing_data : str
-        'include' - Use all sites, calculate pi from available data per site
-        'exclude' - Only use sites with no missing data
-        'pairwise' - Comparison-counting normalization (pixy-style):
-            pi = sum(diffs) / sum(comps) across all sites.
-            Sites with more observed data contribute proportionally more.
-            Invariant sites are included in the denominator when available.
+        ``'include'`` (default) uses per-site valid data.
+        ``'exclude'`` filters to sites with no missing data.
+        ``'pairwise'`` uses comparison-counting normalization (pixy-style):
+        pi = sum(diffs) / sum(comps) across all sites, where sites with
+        more observed data contribute proportionally more and invariant
+        sites are included in the denominator when available.
     span_denominator : str
         'total' - Use total genomic span (chrom_end - chrom_start)
         'sites' - Use number of sites analyzed
@@ -228,10 +228,10 @@ def theta_w(haplotype_matrix: HaplotypeMatrix,
     span_normalize : bool
         If True, normalize by genomic span; if False, return raw theta
     missing_data : str
-        'include' - Use all sites, calculate from available data per site
-        'exclude' - Only use sites with no missing data
-        'pairwise' - Per-site 1/a(n_i) for segregating sites, normalized
-            by n_total_sites when invariant info is available.
+        ``'include'`` (default) uses per-site valid data.
+        ``'exclude'`` filters to sites with no missing data.
+        ``'pairwise'`` uses per-site 1/a(n_i) for segregating sites,
+        normalized by n_total_sites when invariant info is available.
     span_denominator : str
         'total' - Use total genomic span (chrom_end - chrom_start)
         'sites' - Use number of sites analyzed
@@ -371,11 +371,11 @@ def tajimas_d(haplotype_matrix: HaplotypeMatrix,
     population : str or list, optional
         Population name or list of sample indices. If None, uses all samples
     missing_data : str
-        'include' - Use all sites, calculate from available data per site.
-            Uses harmonic mean of per-site sample sizes for variance terms.
-        'exclude' - Only use sites with no missing data.
-        'pairwise' - Uses pairwise pi and per-site theta_w with harmonic
-            mean sample sizes for variance terms.
+        ``'include'`` (default) uses per-site valid data with harmonic
+        mean of per-site sample sizes for variance terms.
+        ``'exclude'`` filters to sites with no missing data.
+        ``'pairwise'`` uses pairwise pi and per-site theta_w with
+        harmonic mean sample sizes for variance terms.
 
     Returns
     -------
@@ -1205,9 +1205,9 @@ def normalized_fay_wus_h(haplotype_matrix: HaplotypeMatrix,
     haplotype_matrix : HaplotypeMatrix
     population : str or list, optional
     missing_data : str
-        'include' or 'pairwise' - per-site sample sizes, harmonic mean n
-            for variance terms
-        'exclude' - only sites with no missing data
+        ``'include'`` (default) or ``'pairwise'`` uses per-site sample
+        sizes with harmonic mean n for variance terms.
+        ``'exclude'`` filters to sites with no missing data.
 
     Returns
     -------
@@ -1278,9 +1278,9 @@ def zeng_e(haplotype_matrix: HaplotypeMatrix,
     haplotype_matrix : HaplotypeMatrix
     population : str or list, optional
     missing_data : str
-        'include' or 'pairwise' - per-site sample sizes, harmonic mean n
-            for variance terms
-        'exclude' - only sites with no missing data
+        ``'include'`` (default) or ``'pairwise'`` uses per-site sample
+        sizes with harmonic mean n for variance terms.
+        ``'exclude'`` filters to sites with no missing data.
 
     Returns
     -------

--- a/pg_gpu/ld_statistics.py
+++ b/pg_gpu/ld_statistics.py
@@ -456,18 +456,16 @@ def zns(r2_matrix_or_matrix, missing_data='include'):
         When a HaplotypeMatrix is passed, uses tiled computation to
         avoid materializing the full m×m r² matrix.
     missing_data : str
-        'include' - per-site valid data for frequency computation
-        'exclude' - filter to sites with no missing data
-        'project' - unbiased multinomial projection estimators, computing
-          mean σ_D² = D²/π² per pair using falling-factorial corrections
-          for finite sample size. Requires HaplotypeMatrix input.
-          See: Ragsdale & Gravel (2019) "Unbiased estimation of linkage
-          disequilibrium from unphased data", MBE 37(3):923-932.
+        ``'include'`` (default) uses per-site valid data for frequency
+        computation. ``'exclude'`` filters to sites with no missing data.
+        ``'project'`` uses unbiased multinomial projection estimators,
+        computing mean sigma_D^2 = D^2/pi^2 per pair with falling-factorial
+        corrections (Ragsdale & Gravel 2019). Requires HaplotypeMatrix input.
 
     Returns
     -------
     float
-        Mean r-squared (or mean σ_D² for 'project' mode).
+        Mean r-squared (or mean sigma_D^2 for 'project' mode).
     """
     from .haplotype_matrix import HaplotypeMatrix
 
@@ -534,12 +532,10 @@ def omega(r2_matrix_or_matrix, missing_data='include'):
         Square r-squared matrix, or a matrix object (dispatches to
         haploid or diploid r-squared computation automatically).
     missing_data : str
-        'include' - per-site valid data for frequency computation
-        'exclude' - filter to sites with no missing data
-        'project' - unbiased multinomial projection estimators, using
-          σ_D² = D²/π² instead of naive r². Requires HaplotypeMatrix input.
-          See: Ragsdale & Gravel (2019) "Unbiased estimation of linkage
-          disequilibrium from unphased data", MBE 37(3):923-932.
+        ``'include'`` (default) uses per-site valid data for frequency
+        computation. ``'exclude'`` filters to sites with no missing data.
+        ``'project'`` uses unbiased sigma_D^2 = D^2/pi^2 instead of naive
+        r^2 (Ragsdale & Gravel 2019). Requires HaplotypeMatrix input.
 
     Returns
     -------

--- a/pg_gpu/relatedness.py
+++ b/pg_gpu/relatedness.py
@@ -106,8 +106,8 @@ def ibs(genotype_matrix_or_haplotype_matrix,
     between all pairs of individuals. Equivalent to PLINK's --distance
     ibs matrix.
 
-    For each site, IBS between individuals i and j is:
-        IBS = (2 - |g_i - g_j|) / 2
+    For each site, IBS between individuals i and j is
+    ``IBS = (2 - abs(g_i - g_j)) / 2``.
 
     The matrix contains the mean IBS across all jointly-called sites.
 


### PR DESCRIPTION
Fix 10 Sphinx errors from malformed missing_data parameter descriptions and RST substitution references. Build now produces 0 errors, 0 warnings.