### PR TITLE
install all deps on RTD, fix API layout

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,10 @@ sphinx
 sphinx-rtd-theme
 numpy
 scipy
+matplotlib
+seaborn
+cupy
+scikit-allel
+tskit
+msprime
+zarr

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -9,6 +9,14 @@ HaplotypeMatrix
    :undoc-members:
    :show-inheritance:
 
+GenotypeMatrix
+--------------
+
+.. autoclass:: pg_gpu.GenotypeMatrix
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 LD Statistics
 -------------
 
@@ -250,14 +258,6 @@ Legacy Functions
 ~~~~~~~~~~~~~~~~
 
 .. autofunction:: pg_gpu.windowed_analysis.windowed_statistics
-
-GenotypeMatrix
---------------
-
-.. autoclass:: pg_gpu.GenotypeMatrix
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
 Moments Integration (LD Inference)
 -----------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,21 +4,8 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('../..'))
 
-# Mock GPU/genomics dependencies for RTD (no CUDA on build server).
-# autodoc_mock_imports lets Sphinx parse source without importing these.
-autodoc_mock_imports = [
-    'cupy', 'cupy.cuda', 'cupy.cuda.memory', 'cupy.cuda.runtime',
-    'cupy._core', 'cupy._core.core',
-    'cupy_backends', 'cupy_backends.cuda', 'cupy_backends.cuda.api',
-    'cupy_backends.cuda.libs',
-    'allel', 'tskit', 'msprime', 'zarr',
-]
-
-try:
-    import pg_gpu
-    release = pg_gpu.__version__
-except Exception:
-    release = '0.1.0'
+import pg_gpu
+release = pg_gpu.__version__
 
 # Project information
 project = 'pg_gpu'

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -8,20 +8,28 @@ from .accessible import AccessibleMask, bed_to_mask, resolve_accessible_mask
 
 
 class HaplotypeMatrix:
-    """
-    Represents a haplotype matrix, which is a matrix of haplotypes across multiple variants.
-    This class provides methods for manipulating and analyzing the haplotype matrix, including
-    extracting subsets based on positions, calculating allele frequency spectra, and computing
-    nucleotide diversity (π).
-    """
-    """
-    A class for representing a haplotype matrix.
+    """Haplotype matrix for population genetics analysis.
 
-    Attributes:
-        haplotypes (cp.ndarray): The genotype/haplotype matrix.
-        positions (cp.ndarray): The array of variant positions.
-        chrom_start (int): Chromosome start position.
-        chrom_end (int): Chromosome end position.
+    Stores phased haplotype data with variant positions and population
+    labels. Supports GPU-accelerated computation of diversity, divergence,
+    selection, and LD statistics.
+
+    Parameters
+    ----------
+    genotypes : ndarray, shape (n_haplotypes, n_variants)
+        Haplotype data (0/1 with -1 for missing).
+    positions : ndarray, shape (n_variants,)
+        Variant positions.
+    chrom_start, chrom_end : int, optional
+        Chromosome boundaries for span normalization.
+    sample_sets : dict, optional
+        Maps population names to lists of haplotype indices.
+    n_total_sites : int, optional
+        Total callable sites for pairwise-mode normalization.
+    samples : list, optional
+        Diploid sample names (from VCF).
+    accessible_mask : AccessibleMask, optional
+        Genome accessibility mask.
     """
     def __init__(self,
                  genotypes,


### PR DESCRIPTION
Install cupy and all dependencies on RTD so autodoc can import all modules. Remove mock workarounds. Move GenotypeMatrix next to HaplotypeMatrix.