### PR TITLE
fix references and doc examples

### DIFF
--- a/docs/source/missing_data.rst
+++ b/docs/source/missing_data.rst
@@ -287,7 +287,7 @@ Example Workflow
 
    # Inspect missing data
    summary = h.summarize_missing_data()
-   print(f"Missing: {summary['fraction_missing']:.1%}")
+   print(f"Missing: {summary['missing_freq_overall']:.1%}")
 
    # Filter extreme missingness
    h = h.filter_variants_by_missing(max_missing_freq=0.5)

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -354,6 +354,6 @@ Missing data is encoded as -1 and handled automatically:
 .. code-block:: python
 
    # Different missing data strategies
-   pi_include = diversity.pi(h, missing_data='include')
-   pi_exclude = diversity.pi(h, missing_data='exclude')
-   pi_ignore = diversity.pi(h, missing_data='ignore')
+   pi_include = diversity.pi(h, missing_data='include')   # default: per-site valid data
+   pi_exclude = diversity.pi(h, missing_data='exclude')   # only fully genotyped sites
+   pi_pairwise = diversity.pi(h, missing_data='pairwise') # pixy-style comparison counting

--- a/pg_gpu/divergence.py
+++ b/pg_gpu/divergence.py
@@ -1213,8 +1213,10 @@ def dd(haplotype_matrix: HaplotypeMatrix,
 
     References
     ----------
-    Schrider, D.R. et al. (2018). Supervised Machine Learning for
-    Population Genetics: A New Paradigm. Trends in Genetics, 34(4).
+    Schrider, D.R., Ayroles, J., Matute, D.R. & Kern, A.D. (2018).
+    Supervised machine learning reveals introgressed loci in the genomes
+    of Drosophila simulans and D. sechellia. PLoS Genetics, 14(4),
+    e1007341. https://doi.org/10.1371/journal.pgen.1007341
     """
     from . import diversity
 
@@ -1261,8 +1263,10 @@ def dd_rank(haplotype_matrix: HaplotypeMatrix,
 
     References
     ----------
-    Schrider, D.R. et al. (2018). Supervised Machine Learning for
-    Population Genetics: A New Paradigm. Trends in Genetics, 34(4).
+    Schrider, D.R., Ayroles, J., Matute, D.R. & Kern, A.D. (2018).
+    Supervised machine learning reveals introgressed loci in the genomes
+    of Drosophila simulans and D. sechellia. PLoS Genetics, 14(4),
+    e1007341. https://doi.org/10.1371/journal.pgen.1007341
     """
     dist_between, dist_within1, dist_within2 = _resolve_distance_matrices(
         haplotype_matrix, pop1, pop2, missing_data, distance_matrices)
@@ -1302,8 +1306,10 @@ def zx(haplotype_matrix: HaplotypeMatrix,
 
     References
     ----------
-    Schrider, D.R. et al. (2018). Supervised Machine Learning for
-    Population Genetics: A New Paradigm. Trends in Genetics, 34(4).
+    Schrider, D.R., Ayroles, J., Matute, D.R. & Kern, A.D. (2018).
+    Supervised machine learning reveals introgressed loci in the genomes
+    of Drosophila simulans and D. sechellia. PLoS Genetics, 14(4),
+    e1007341. https://doi.org/10.1371/journal.pgen.1007341
     """
     from . import ld_statistics
     from ._utils import get_population_matrix


### PR DESCRIPTION
## Summary
- Fix three Schrider et al. citations from the Trends in Genetics review to the correct FILET paper (PLoS Genetics, e1007341)
- Replace deprecated `missing_data='ignore'` with `missing_data='pairwise'` in quickstart

## Test plan
- [ ] RTD build renders correctly
- [ ] All code examples in docs verified to run