### PR TITLE
hide string span_normalize options from public API

### DIFF
--- a/docs/source/missing_data.rst
+++ b/docs/source/missing_data.rst
@@ -156,16 +156,13 @@ Rate estimators (pi, theta_w, dxy, etc.) accept a ``span_normalize``
 parameter that controls *how results are expressed*. This is orthogonal
 to missing data handling.
 
-``span_normalize`` accepts:
+``span_normalize`` accepts ``True`` or ``False``:
 
 * ``True`` (default): auto-detect the best denominator. If an accessible
   mask is set, divides by accessible bases. Otherwise divides by genomic
   span (chrom_end - chrom_start).
 * ``False``: return raw sum (used internally by composite statistics like
   Tajima's D, and by advanced users who need custom normalization).
-* ``'per_base'``: explicit genomic span.
-* ``'accessible'``: explicit accessible base count (error if no mask).
-* ``'per_variant'``: divide by number of variant sites.
 
 .. code-block:: python
 
@@ -178,9 +175,6 @@ to missing data handling.
 
    # Raw sum (no normalization)
    pi_raw = diversity.pi(h, span_normalize=False)
-
-   # Explicit mode
-   pi_var = diversity.pi(h, span_normalize='per_variant')
 
 Test statistics (Tajima's D, Fay-Wu's H, FST) do not accept
 ``span_normalize`` — they are dimensionless by definition.

--- a/pg_gpu/achaz.py
+++ b/pg_gpu/achaz.py
@@ -334,12 +334,12 @@ class FrequencySpectrum:
         ----------
         weights : str or callable
             Name of a built-in weight function, or a callable w(n) -> array.
-        span_normalize : bool or str
+        span_normalize : bool
             ``True``: auto-detect best denominator from source matrix.
             ``False`` (default): return raw sum.
-            String values select an explicit denominator.
         span : float, optional
             Explicit span for normalization. Overrides auto-detection.
+            For internal use.
 
         Returns
         -------

--- a/pg_gpu/divergence.py
+++ b/pg_gpu/divergence.py
@@ -408,10 +408,9 @@ def dxy(haplotype_matrix: HaplotypeMatrix,
     missing_data : str
         ``'include'`` (default) uses per-site valid data.
         ``'exclude'`` filters to sites with no missing data.
-    span_normalize : bool or str
+    span_normalize : bool
         ``True`` (default): auto-detect best denominator.
         ``False``: return raw sum / sites-with-data average.
-        String values select an explicit denominator.
 
     Returns
     -------
@@ -484,7 +483,7 @@ def da(haplotype_matrix: HaplotypeMatrix,
     missing_data : str
         'include' - Use all sites, calculate from available data per site
         'exclude' - Only use sites with no missing data
-    span_normalize : bool or str
+    span_normalize : bool
         ``True`` (default): auto-detect best denominator.
         ``False``: return raw sum / sites-with-data average.
 
@@ -526,7 +525,7 @@ def pi_within_population(haplotype_matrix: HaplotypeMatrix,
         Population name or list of indices
     missing_data : str
         'include' or 'exclude'
-    span_normalize : bool or str
+    span_normalize : bool
         ``True`` (default): auto-detect. ``False``: raw sum.
 
     Returns
@@ -560,7 +559,7 @@ def divergence_stats(haplotype_matrix: HaplotypeMatrix,
     missing_data : str
         'include' - Use all sites, calculate from available data per site
         'exclude' - Only use sites with no missing data
-    span_normalize : bool or str
+    span_normalize : bool
         ``True`` (default): auto-detect. ``False``: raw sum / per-site average.
 
     Returns

--- a/pg_gpu/diversity.py
+++ b/pg_gpu/diversity.py
@@ -25,7 +25,7 @@ def _apply_span_normalize(value, matrix, span_normalize):
         Source matrix (for get_span).
     span_normalize : bool or str
         True: auto-detect best span. False: return raw value.
-        String: explicit mode passed to get_span().
+        String: explicit mode passed to get_span() (internal use).
     """
     if span_normalize is False:
         return float(value.get() if hasattr(value, 'get') else value)
@@ -125,12 +125,10 @@ def pi(haplotype_matrix: HaplotypeMatrix,
         The haplotype data
     population : str or list, optional
         Population name or list of sample indices. If None, uses all samples
-    span_normalize : bool or str
+    span_normalize : bool
         ``True`` (default): auto-detect best denominator (accessible
         bases if mask set, else genomic span).
-        ``False``: return raw sum of per-site diversity.
-        String values (``'per_base'``, ``'accessible'``, ``'per_variant'``)
-        select an explicit denominator.
+        ``False``: return raw sum.
     missing_data : str
         ``'include'`` (default) uses per-site valid data.
         ``'exclude'`` filters to sites with no missing data.
@@ -196,10 +194,9 @@ def theta_w(haplotype_matrix: HaplotypeMatrix,
         The haplotype data
     population : str or list, optional
         Population name or list of sample indices. If None, uses all samples
-    span_normalize : bool or str
+    span_normalize : bool
         ``True`` (default): auto-detect best denominator.
         ``False``: return raw sum.
-        String values select an explicit denominator.
     missing_data : str
         ``'include'`` (default) uses per-site valid data.
         ``'exclude'`` filters to sites with no missing data.
@@ -576,7 +573,7 @@ def diversity_stats(haplotype_matrix: HaplotypeMatrix,
         Population name or list of sample indices. If None, uses all samples
     statistics : list
         List of statistics to compute
-    span_normalize : bool or str
+    span_normalize : bool
         ``True`` (default): auto-detect best denominator.
         ``False``: return raw sums.
     missing_data : str
@@ -632,7 +629,7 @@ def diversity_stats_fast(haplotype_matrix: HaplotypeMatrix,
         The haplotype data.
     population : str or list, optional
         Population name or sample indices.
-    span_normalize : bool or str
+    span_normalize : bool
         ``True`` (default): auto-detect best denominator.
         ``False``: return raw sums.
         String values select an explicit denominator.
@@ -857,7 +854,7 @@ def theta_h(haplotype_matrix: HaplotypeMatrix,
     ----------
     haplotype_matrix : HaplotypeMatrix
     population : str or list, optional
-    span_normalize : bool or str
+    span_normalize : bool
         ``True`` (default): auto-detect best denominator.
         ``False``: return raw sum.
     missing_data : str
@@ -915,7 +912,7 @@ def theta_l(haplotype_matrix: HaplotypeMatrix,
     ----------
     haplotype_matrix : HaplotypeMatrix
     population : str or list, optional
-    span_normalize : bool or str
+    span_normalize : bool
         ``True`` (default): auto-detect best denominator.
         ``False``: return raw sum.
     missing_data : str

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -508,10 +508,9 @@ class WindowedAnalyzer:
         missing_data : str
             'include' - Use all sites, calculate from available data per site
             'exclude' - Only use sites with no missing data
-        span_normalize : bool or str
+        span_normalize : bool
             ``True`` (default): auto-detect best denominator per window.
             ``False``: return raw sums.
-            String values select an explicit denominator.
         """
         self.window_params = WindowParams(
             window_type=window_type,
@@ -666,7 +665,7 @@ def windowed_analysis(haplotype_matrix: HaplotypeMatrix,
     missing_data : str
         'include' - Use all sites, calculate from available data per site
         'exclude' - Only use sites with no missing data
-    span_normalize : bool or str
+    span_normalize : bool
         ``True`` (default): auto-detect best denominator per window.
         ``False``: return raw sums.
     accessible_bed : str, optional

--- a/tests/test_accessible_mask.py
+++ b/tests/test_accessible_mask.py
@@ -589,7 +589,7 @@ class TestWindowedScatterAddWithMask:
 
 class TestWindowedAnalysisConvenience:
     def test_accessible_span_normalize(self):
-        """windowed_analysis with span_normalize='accessible' uses mask."""
+        """windowed_analysis with mask set auto-normalizes by accessible bases."""
         from pg_gpu.windowed_analysis import windowed_analysis
 
         hm = _make_windowed_matrix()
@@ -598,9 +598,9 @@ class TestWindowedAnalysisConvenience:
         mask[2000:3000] = False  # 1000 inaccessible in some windows
         hm.set_accessible_mask(mask)
 
+        # span_normalize=True (default) auto-detects accessible mask
         df = windowed_analysis(
-            hm, window_size=5000, statistics=['pi'],
-            span_normalize='accessible')
+            hm, window_size=5000, statistics=['pi'])
 
         assert len(df) > 0
         assert 'pi' in df.columns


### PR DESCRIPTION
Docstrings and docs now document span_normalize as bool only (True/False). String modes remain functional internally but are not advertised.