### PR TITLE
skip moments tests in default env, update install docs

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -61,5 +61,13 @@ Running Tests
 
 .. code-block:: bash
 
-   pixi run test              # all tests
+   pixi run test              # all tests (moments-dependent tests auto-skip)
    pixi run test-parallel     # parallel execution
+
+Tests that validate against the `moments` library will be automatically
+skipped if moments is not installed. To run the full test suite including
+moments validation tests:
+
+.. code-block:: bash
+
+   pixi run -e moments test   # includes moments LD validation tests

--- a/tests/test_ld_missing_data.py
+++ b/tests/test_ld_missing_data.py
@@ -10,6 +10,7 @@ import numpy as np
 import tempfile
 import os
 import allel
+pytest.importorskip("moments.LD")
 import moments.LD.Parsing as mParsing
 from pg_gpu.haplotype_matrix import HaplotypeMatrix
 from collections import OrderedDict

--- a/tests/test_ld_missing_data_detailed.py
+++ b/tests/test_ld_missing_data_detailed.py
@@ -7,6 +7,7 @@ import numpy as np
 import tempfile
 import os
 import allel
+pytest.importorskip("moments.LD")
 import moments.LD.Parsing as mParsing
 from pg_gpu.haplotype_matrix import HaplotypeMatrix
 

--- a/tests/test_ld_statistics_comparison.py
+++ b/tests/test_ld_statistics_comparison.py
@@ -7,12 +7,14 @@ implementations, checking that they agree within numerical tolerance.
 """
 
 import os
+import tempfile
+
 import numpy as np
 import pytest
-from pg_gpu.haplotype_matrix import HaplotypeMatrix
-import moments.LD.stats_from_haplotype_counts as moments_shc
-import tempfile
 import allel
+from pg_gpu.haplotype_matrix import HaplotypeMatrix
+
+moments_shc = pytest.importorskip("moments.LD.stats_from_haplotype_counts")
 
 
 class TestLDStatisticsComparison:

--- a/tests/test_ld_statistics_gpu.py
+++ b/tests/test_ld_statistics_gpu.py
@@ -13,6 +13,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'moments'))
 import numpy as np
 import pytest
 from pg_gpu.haplotype_matrix import HaplotypeMatrix
+pytest.importorskip("moments.LD")
 import moments.LD.Parsing as mParsing
 import tempfile
 import allel

--- a/tests/test_ld_statistics_gpu_single_pop.py
+++ b/tests/test_ld_statistics_gpu_single_pop.py
@@ -3,6 +3,7 @@ import numpy as np
 import tempfile
 import os
 import allel
+pytest.importorskip("moments.LD")
 import moments.LD.Parsing as mParsing
 from pg_gpu.haplotype_matrix import HaplotypeMatrix
 

--- a/tests/test_ld_validation_full.py
+++ b/tests/test_ld_validation_full.py
@@ -11,6 +11,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'moments'))
 
 import numpy as np
 import pytest
+pytest.importorskip("moments.LD")
 import moments.LD.Parsing as mParsing
 from pg_gpu.haplotype_matrix import HaplotypeMatrix
 import allel

--- a/tests/test_ld_validation_synthetic.py
+++ b/tests/test_ld_validation_synthetic.py
@@ -11,7 +11,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'moments'))
 
 import numpy as np
 import pytest
-import moments.LD
+pytest.importorskip("moments.LD")
 from pg_gpu.haplotype_matrix import HaplotypeMatrix
 import tempfile
 import msprime


### PR DESCRIPTION
## Summary
- Add `pytest.importorskip("moments.LD")` guards to 7 test files that import moments at module level
- Tests auto-skip cleanly in the default pixi env (no moments), run normally in the moments env
- Update installation docs to clarify test commands

Fixes the issue where `pixi run test` fails with `ModuleNotFoundError: No module named 'moments.LD'` in the default environment.

## Test plan
- `pixi run test` -- 502 passed, 54 skipped (moments tests skip cleanly)
- `pixi run -e moments test` -- full suite including moments validation