### PR TITLE
fix windowed FST: per-site valid counts in fused kernel, KeyError on mixed stats

### DIFF
--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -1263,35 +1263,39 @@ void fused_windowed_twopop(const signed char* hap1_t,
         return;
     }
 
-    double dn1 = (double)n_hap1;
-    double dn2 = (double)n_hap2;
-
-    // Weir-Cockerham constants (haploid, r=2, constant sample sizes)
-    double n_total = dn1 + dn2;
-    double n_bar = n_total / 2.0;
-    double n_C = (n_total - (dn1*dn1 + dn2*dn2) / n_total);  // r-1 = 1
-
     double t_fst_num = 0.0, t_fst_den = 0.0;
     double t_dxy = 0.0, t_pi1 = 0.0, t_pi2 = 0.0;
     double t_wc_a = 0.0, t_wc_ab = 0.0;
 
+    // n_hap1 and n_hap2 are used only for array indexing (row stride);
+    // per-site valid counts (dn1, dn2) are computed inside the loop.
+
     for (int vi = threadIdx.x; vi < n_vars; vi += blockDim.x) {
         int v = v_start + vi;
 
-        int ac1_1 = 0, ac2_1 = 0;
+        // Count valid (non-missing) samples and alt alleles per site
+        int ac1_1 = 0, valid1 = 0;
         const signed char* row1 = hap1_t + (long long)v * n_hap1;
         for (int h = 0; h < n_hap1; h++) {
-            if (row1[h] > 0) ac1_1++;
+            signed char a = row1[h];
+            if (a >= 0) { valid1++; if (a > 0) ac1_1++; }
         }
+        int ac2_1 = 0, valid2 = 0;
         const signed char* row2 = hap2_t + (long long)v * n_hap2;
         for (int h = 0; h < n_hap2; h++) {
-            if (row2[h] > 0) ac2_1++;
+            signed char a = row2[h];
+            if (a >= 0) { valid2++; if (a > 0) ac2_1++; }
         }
 
+        double dn1 = (double)valid1;
+        double dn2 = (double)valid2;
         double ac1_0 = dn1 - ac1_1;
         double ac2_0 = dn2 - ac2_1;
         double d_ac1_1 = (double)ac1_1;
         double d_ac2_1 = (double)ac2_1;
+
+        // Skip sites with no valid samples in either population
+        if (valid1 == 0 || valid2 == 0) continue;
 
         // Hudson: within-pop mean pairwise difference
         double n1_pairs = dn1 * (dn1 - 1.0) / 2.0;
@@ -1315,7 +1319,10 @@ void fused_windowed_twopop(const signed char* hap1_t,
         t_pi1 += mpd1;
         t_pi2 += mpd2;
 
-        // Weir-Cockerham (haploid, h_bar=0, r=2)
+        // Weir-Cockerham (haploid, h_bar=0, r=2, per-site sample sizes)
+        double n_total = dn1 + dn2;
+        double n_bar = n_total / 2.0;
+        double n_C = (n_total - (dn1*dn1 + dn2*dn2) / n_total);
         double p1 = d_ac1_1 / dn1;
         double p2 = d_ac2_1 / dn2;
         double p_bar = (dn1 * p1 + dn2 * p2) / n_total;
@@ -1666,9 +1673,9 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
         if pop1 is None or pop2 is None:
             raise ValueError("pop1 and pop2 required for fst/dxy/da")
 
-        # Use filtered matrix so inaccessible variants are excluded
-        m1 = get_population_matrix(matrix, pop1)
-        m2 = get_population_matrix(matrix, pop2)
+        # Use the original (unsubsetted) matrix for population lookup
+        m1 = get_population_matrix(haplotype_matrix, pop1)
+        m2 = get_population_matrix(haplotype_matrix, pop2)
         if m1.device == 'CPU':
             m1.transfer_to_gpu()
         if m2.device == 'CPU':
@@ -2068,9 +2075,9 @@ def windowed_statistics_fused_chunked(haplotype_matrix: HaplotypeMatrix,
         if pop1 is None or pop2 is None:
             raise ValueError("pop1 and pop2 required for fst/dxy/da")
 
-        # Get population haplotype indices for GPU slicing
-        pop1_idx = matrix.sample_sets[pop1]
-        pop2_idx = matrix.sample_sets[pop2]
+        # Get population haplotype indices from the original (unsubsetted) matrix
+        pop1_idx = haplotype_matrix.sample_sets[pop1]
+        pop2_idx = haplotype_matrix.sample_sets[pop2]
         n1 = len(pop1_idx)
         n2 = len(pop2_idx)
         # Chunk size based on the larger population
@@ -2651,9 +2658,9 @@ def windowed_statistics(haplotype_matrix: HaplotypeMatrix,
         if pop1 is None or pop2 is None:
             raise ValueError("pop1 and pop2 required for fst/dxy")
 
-        # Use filtered matrix so inaccessible variants are excluded
-        m1 = get_population_matrix(matrix, pop1)
-        m2 = get_population_matrix(matrix, pop2)
+        # Use the original (unsubsetted) matrix for population lookup
+        m1 = get_population_matrix(haplotype_matrix, pop1)
+        m2 = get_population_matrix(haplotype_matrix, pop2)
         if m1.device == 'CPU':
             m1.transfer_to_gpu()
         if m2.device == 'CPU':

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -459,3 +459,106 @@ class TestChunkedFused:
         for k in ('fst', 'fst_wc', 'dxy', 'da'):
             np.testing.assert_allclose(r1[k], r2[k], rtol=1e-12, equal_nan=True,
                                        err_msg=f"Mismatch in {k}")
+
+    def test_mixed_single_twopop_chunked(self, matrix_with_pops):
+        """Mixed single+two-pop stats should not crash (KeyError regression)."""
+        from pg_gpu.windowed_analysis import windowed_statistics_fused_chunked
+        from pg_gpu import _memutil
+
+        hm = matrix_with_pops
+        hm.transfer_to_gpu()
+
+        bp_bins = np.arange(0, 500_001, 50_000, dtype=np.float64)
+
+        orig = _memutil.estimate_fused_chunk_size
+        _memutil.estimate_fused_chunk_size = lambda n, memory_fraction=0.35: 500
+        try:
+            r = windowed_statistics_fused_chunked(
+                hm, bp_bins=bp_bins,
+                statistics=('pi', 'theta_w', 'fst', 'fst_wc', 'dxy'),
+                population='pop1', pop1='pop1', pop2='pop2')
+        finally:
+            _memutil.estimate_fused_chunk_size = orig
+
+        for k in ('pi', 'theta_w', 'fst', 'fst_wc', 'dxy'):
+            assert k in r, f"Missing {k}"
+            assert len(r[k]) > 0
+
+
+class TestFusedMissingData:
+    """Fused two-pop kernel must use per-site valid counts under missingness."""
+
+    @pytest.fixture
+    def matrix_with_missing(self):
+        """Two-pop matrix where ~50% of sites have missing data in one pop."""
+        rng = np.random.RandomState(123)
+        n_hap, n_var = 40, 2000
+        hap = rng.randint(0, 2, (n_hap, n_var), dtype=np.int8)
+        # Inject missing data: ~50% of pop1 entries at odd-indexed variants
+        for v in range(0, n_var, 2):
+            for h in range(n_hap // 2):
+                if rng.random() < 0.5:
+                    hap[h, v] = -1
+        pos = np.arange(1, n_var + 1) * 100
+        hm = HaplotypeMatrix(hap, pos, 0, (n_var + 1) * 100)
+        hm.sample_sets = {
+            "pop1": list(range(n_hap // 2)),
+            "pop2": list(range(n_hap // 2, n_hap)),
+        }
+        return hm
+
+    def _compare_fused_vs_scatter(self, hm):
+        """Compare fused kernel FST with scatter-add FST using aligned windows.
+
+        Uses windowed_analysis() which routes to scatter-add for pure two-pop,
+        vs calling windowed_statistics_fused() directly.
+        Both paths use the same window boundaries via the convenience function.
+        """
+        from pg_gpu.windowed_analysis import windowed_statistics_fused
+
+        hm.transfer_to_gpu()
+
+        # Use windowed_analysis to get scatter-add results (pure two-pop request)
+        r_scatter = windowed_analysis(
+            hm, window_size=50_000,
+            statistics=["fst", "dxy"],
+            populations=["pop1", "pop2"],
+            span_normalize=False)
+
+        # Build the same windows the scatter path used
+        ws = r_scatter['start'].values.astype(np.float64)
+        we = r_scatter['stop'].values.astype(np.float64)
+        bp_bins = np.concatenate([ws, [we[-1]]])
+
+        # Fused kernel path with identical windows
+        r_fused = windowed_statistics_fused(
+            hm, bp_bins=bp_bins,
+            statistics=('fst', 'dxy'),
+            pop1='pop1', pop2='pop2',
+            _win_starts=ws, _win_stops=we,
+            per_base=False)
+
+        both_valid = np.isfinite(r_fused['fst']) & np.isfinite(r_scatter['fst'].values)
+        assert np.sum(both_valid) > 0, "No valid FST values to compare"
+        np.testing.assert_allclose(
+            r_fused['fst'][both_valid],
+            r_scatter['fst'].values[both_valid],
+            rtol=1e-10,
+            err_msg="Fused kernel FST disagrees with scatter-add")
+
+    def test_fused_twopop_missing_matches_scatter(self, matrix_with_missing):
+        """Fused kernel FST must match scatter-add FST under missingness."""
+        self._compare_fused_vs_scatter(matrix_with_missing)
+
+    def test_fused_twopop_no_missing_matches_scatter(self, matrix_with_missing):
+        """Sanity: without missing data, fused and scatter should agree."""
+        rng = np.random.RandomState(456)
+        n_hap, n_var = 40, 2000
+        hap = rng.randint(0, 2, (n_hap, n_var), dtype=np.int8)
+        pos = np.arange(1, n_var + 1) * 100
+        hm = HaplotypeMatrix(hap, pos, 0, (n_var + 1) * 100)
+        hm.sample_sets = {
+            "pop1": list(range(n_hap // 2)),
+            "pop2": list(range(n_hap // 2, n_hap)),
+        }
+        self._compare_fused_vs_scatter(hm)


### PR DESCRIPTION
## Summary

- Fix fused two-pop CUDA kernel to count valid (non-missing) samples per site instead of using fixed `n_hap1`/`n_hap2` — missing data was treated as reference allele 0, inflating denominators
- Fix `windowed_statistics_fused` and `windowed_statistics_fused_chunked` to look up population names on the original matrix, not a single-pop-subsetted matrix (caused `KeyError` on mixed single+two-pop stat requests like `["pi", "fst_wc", "dxy"]`)

## Test plan

- [x] All 19 windowed analysis tests pass (18 passed, 1 skipped)
- [x] New `TestChunkedFused.test_mixed_single_twopop_chunked` — catches the KeyError regression
- [x] New `TestFusedMissingData.test_fused_twopop_missing_matches_scatter` — verifies fused kernel matches scatter-add FST under 50% missingness (rtol=1e-10)
- [x] New `TestFusedMissingData.test_fused_twopop_no_missing_matches_scatter` — same for complete data
- [x] "Windowed all 7" on Ag1000G 3R (10.9M variants) no longer crashes
- [x] Ruff lint clean

Closes #52