### PR TITLE
fix GRM/IBS OOM on large datasets

### DIFF
--- a/pg_gpu/relatedness.py
+++ b/pg_gpu/relatedness.py
@@ -41,21 +41,27 @@ def grm(genotype_matrix_or_haplotype_matrix,
         Symmetric GRM. Diagonal entries are individual inbreeding
         coefficients + 1. Off-diagonal entries are pairwise relatedness.
     """
-    from ._memutil import estimate_variant_chunk_size, dac_and_n
+    from ._memutil import estimate_variant_chunk_size
 
-    hap, n_ind = _get_haplotype_data(genotype_matrix_or_haplotype_matrix,
-                                       population)
-    n_hap, n_var = hap.shape
+    geno, n_ind = _get_genotype_data(genotype_matrix_or_haplotype_matrix,
+                                      population)
+    n_var = geno.shape[1]
 
-    # Allele frequency: p = sum(alleles) / n_haplotypes = sum(genotypes) / (2*n_ind)
-    # DAC sums all haplotype alleles; n_valid counts valid haplotypes.
-    # For diploid p: divide by n_valid (not 2*n_valid).
-    dac, n_valid = dac_and_n(hap)
-    p = cp.where(n_valid > 0, dac.astype(cp.float64) / n_valid.astype(cp.float64), 0.0)
+    # Allele frequency from genotypes, chunked to avoid large temporaries.
+    dac = cp.zeros(n_var, dtype=cp.int32)
+    n_valid = cp.zeros(n_var, dtype=cp.int32)
+    freq_chunk = max(1, n_var // 20)
+    for s in range(0, n_var, freq_chunk):
+        e = min(s + freq_chunk, n_var)
+        gc = geno[:, s:e]
+        v = gc >= 0
+        n_valid[s:e] = cp.sum(v, axis=0)
+        dac[s:e] = cp.sum(cp.where(v, gc, 0), axis=0)
+        del gc, v
+    p = cp.where(n_valid > 0, dac.astype(cp.float64) / (2.0 * n_valid.astype(cp.float64)), 0.0)
 
-    # Filter monomorphic and exclude-missing sites
     if missing_data == 'exclude':
-        complete = n_valid == n_hap
+        complete = n_valid == n_ind
         poly = complete & (p > 0) & (p < 1)
     else:
         poly = (p > 0) & (p < 1)
@@ -66,11 +72,13 @@ def grm(genotype_matrix_or_haplotype_matrix,
         return np.zeros((n_ind, n_ind), dtype=np.float64)
 
     p_poly = p[poly_idx]
+    del p, dac, n_valid, poly
 
     # Chunked GRM: accumulate (std_chunk @ std_chunk.T) over variant chunks.
-    # Construct diploid genotypes on-the-fly per chunk to avoid full matrix.
+    # Peak per-chunk: 1 float64 array (standardized genotypes) + matmul workspace.
     chunk_size = estimate_variant_chunk_size(n_ind, bytes_per_element=8,
-                                             n_intermediates=3)
+                                             n_intermediates=3,
+                                             memory_fraction=0.25)
     A = cp.zeros((n_ind, n_ind), dtype=cp.float64)
 
     for start in range(0, n_snps_used, chunk_size):
@@ -78,20 +86,19 @@ def grm(genotype_matrix_or_haplotype_matrix,
         idx = poly_idx[start:end]
         p_chunk = p_poly[start:end]
 
-        # Build diploid genotypes for this chunk from haplotypes
-        h1 = hap[:n_ind, :][:, idx].astype(cp.float64)
-        h2 = hap[n_ind:, :][:, idx].astype(cp.float64)
-        # Handle missing: if either haplotype is missing, genotype is invalid
-        valid1 = h1 >= 0
-        valid2 = h2 >= 0
-        g_chunk = cp.where(valid1 & valid2, cp.maximum(h1, 0) + cp.maximum(h2, 0), 0.0)
-        v_chunk = (valid1 & valid2).astype(cp.float64)
+        g_chunk = geno[:, idx]
+        valid = (g_chunk >= 0)
+        g = cp.where(valid, g_chunk, 0).astype(cp.float64)
+        del g_chunk
 
-        centered = (g_chunk - 2.0 * p_chunk) * v_chunk
         scale = cp.sqrt(2.0 * p_chunk * (1.0 - p_chunk))
-        std_chunk = centered / scale
-        A += std_chunk @ std_chunk.T
-        del h1, h2, g_chunk, centered, std_chunk
+        # std = (g - 2p) * valid / scale, computed in-place
+        g -= 2.0 * p_chunk
+        g *= valid
+        g /= scale
+        del valid, scale
+        A += g @ g.T
+        del g
 
     A /= n_snps_used
     return A.get()
@@ -129,11 +136,13 @@ def ibs(genotype_matrix_or_haplotype_matrix,
     """
     from ._memutil import estimate_variant_chunk_size
 
-    hap, n_ind = _get_haplotype_data(genotype_matrix_or_haplotype_matrix,
-                                       population)
-    n_hap, n_var = hap.shape
+    geno, n_ind = _get_genotype_data(genotype_matrix_or_haplotype_matrix,
+                                      population)
+    n_var = geno.shape[1]
+    # Peak per-chunk: 1 float64 indicator + matmul workspace.
     chunk_size = estimate_variant_chunk_size(n_ind, bytes_per_element=8,
-                                             n_intermediates=4)
+                                             n_intermediates=3,
+                                             memory_fraction=0.25)
 
     ibs2 = cp.zeros((n_ind, n_ind), dtype=cp.float64)
     ibs1 = cp.zeros((n_ind, n_ind), dtype=cp.float64)
@@ -141,25 +150,31 @@ def ibs(genotype_matrix_or_haplotype_matrix,
 
     for start in range(0, n_var, chunk_size):
         end = min(start + chunk_size, n_var)
-        # Build diploid genotypes on-the-fly from haplotype chunks
-        h1 = hap[:n_ind, start:end]
-        h2 = hap[n_ind:, start:end]
-        valid = ((h1 >= 0) & (h2 >= 0)).astype(cp.float64)
-        g = (cp.maximum(h1, 0) + cp.maximum(h2, 0)).astype(cp.float64) * valid
+        g_chunk = geno[:, start:end]
+        valid = (g_chunk >= 0).astype(cp.float64)
+        g = cp.where(g_chunk >= 0, g_chunk, 0).astype(cp.float64)
+        del g_chunk
 
         if missing_data == 'exclude':
             site_complete = cp.all(valid > 0, axis=0)
             valid = valid[:, site_complete]
             g = g[:, site_complete]
 
-        i0 = (g == 0) * valid
-        i1 = (g == 1) * valid
-        i2 = (g == 2) * valid
-
-        ibs2 += i0 @ i0.T + i1 @ i1.T + i2 @ i2.T
-        ibs1 += i0 @ i1.T + i1 @ i0.T + i1 @ i2.T + i2 @ i1.T
         n_joint += valid @ valid.T
-        del h1, h2, g, i0, i1, i2
+
+        # Compute ibs2 and ibs1 one indicator at a time to avoid
+        # materializing i0, i1, i2 simultaneously.
+        for gval in (0, 1, 2):
+            ind = (g == gval) * valid
+            ibs2 += ind @ ind.T
+            if gval < 2:
+                ind_next = (g == (gval + 1)) * valid
+                cross = ind @ ind_next.T
+                ibs1 += cross + cross.T
+                del ind_next
+            del ind
+
+        del g, valid
 
     ibs_mat = cp.where(n_joint > 0,
                         (2.0 * ibs2 + ibs1) / (2.0 * n_joint),
@@ -172,6 +187,38 @@ def ibs(genotype_matrix_or_haplotype_matrix,
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+def _get_genotype_data(matrix, population=None):
+    """Get diploid genotype matrix (n_individuals, n_variants) on GPU.
+
+    Returns genotypes directly from GenotypeMatrix, or builds them from
+    HaplotypeMatrix by summing paired haplotypes. Avoids the memory cost
+    of round-tripping through an intermediate haplotype representation.
+    """
+    from .haplotype_matrix import HaplotypeMatrix
+    from .genotype_matrix import GenotypeMatrix
+    from ._utils import get_population_matrix
+
+    if population is not None:
+        matrix = get_population_matrix(matrix, population)
+
+    if hasattr(matrix, 'device') and matrix.device == 'CPU':
+        matrix.transfer_to_gpu()
+
+    if isinstance(matrix, GenotypeMatrix):
+        return matrix.genotypes, matrix.genotypes.shape[0]
+    elif isinstance(matrix, HaplotypeMatrix):
+        hap = matrix.haplotypes
+        n_ind = hap.shape[0] // 2
+        h1 = hap[:n_ind, :]
+        h2 = hap[n_ind:, :]
+        missing = (h1 < 0) | (h2 < 0)
+        geno = (cp.maximum(h1, 0) + cp.maximum(h2, 0)).astype(cp.int8)
+        geno[missing] = -1
+        return geno, n_ind
+    else:
+        raise TypeError(f"Expected HaplotypeMatrix or GenotypeMatrix, got {type(matrix)}")
+
 
 def _get_haplotype_data(matrix, population=None):
     """Get haplotype matrix and number of diploid individuals.


### PR DESCRIPTION
## Summary

- Work directly with genotypes instead of converting back to haplotypes (eliminates 32 GB intermediate)
- Chunk allele frequency computation to avoid 16 GB temporaries
- Compute standardized genotypes in-place (1 float64 array instead of 5-6)
- Process IBS indicators one at a time instead of materializing i0/i1/i2 simultaneously
- Reduce `memory_fraction` from 0.4 to 0.25 for conservative chunking

## Results

GRM and IBS now complete on Ag1000G 3R (1470 diploids x 10.9M variants) with **only 3.6 GB free GPU memory**:
- GRM: 4.2s
- IBS: 17.7s

Previously both OOM'd, requiring ~50-58 GB.

## Test plan

- [x] All 13 relatedness tests pass
- [x] GRM and IBS complete on full Ag1000G 3R (1470 samples x 10.9M variants)
- [x] Ruff lint clean