### PR TITLE
fix: treat chrom_start=0 as set in windowed_analysis

### DIFF
--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -671,8 +671,10 @@ def _windowed_thetas_scatter(haplotype_matrix, window_size, step_size,
         pos_cpu = np.asarray(pos)
 
     # Window boundaries
-    chrom_start = matrix.chrom_start or int(pos_cpu[0])
-    chrom_end = matrix.chrom_end or int(pos_cpu[-1])
+    chrom_start = (matrix.chrom_start if matrix.chrom_start is not None
+                   else int(pos_cpu[0]))
+    chrom_end = (matrix.chrom_end if matrix.chrom_end is not None
+                 else int(pos_cpu[-1]))
     win_starts = np.arange(int(chrom_start), int(chrom_end), step_size,
                            dtype=np.float64)
     win_stops = win_starts + window_size
@@ -883,8 +885,12 @@ def _windowed_twopop_scatter(haplotype_matrix, window_size, step_size,
         pos_cpu = np.asarray(pos)
 
     # Window boundaries (same pattern as _windowed_thetas_scatter)
-    chrom_start = haplotype_matrix.chrom_start or int(pos_cpu[0])
-    chrom_end = haplotype_matrix.chrom_end or int(pos_cpu[-1])
+    chrom_start = (haplotype_matrix.chrom_start
+                   if haplotype_matrix.chrom_start is not None
+                   else int(pos_cpu[0]))
+    chrom_end = (haplotype_matrix.chrom_end
+                 if haplotype_matrix.chrom_end is not None
+                 else int(pos_cpu[-1]))
     win_starts = np.arange(int(chrom_start), int(chrom_end), step_size,
                            dtype=np.float64)
     win_stops = win_starts + window_size

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -562,3 +562,58 @@ class TestFusedMissingData:
             "pop2": list(range(n_hap // 2, n_hap)),
         }
         self._compare_fused_vs_scatter(hm)
+
+
+class TestChromStartZero:
+    """Windows must be anchored at chrom_start=0, not the first variant position.
+
+    Regression: `chrom_start or int(pos_cpu[0])` used truthy-check, which
+    treats an explicit chrom_start of 0 as unset and falls back to the first
+    variant. Windows then start at pos[0] instead of 0, mis-aligning every
+    user-provided interval (BED boundaries, accessibility masks, exon
+    coordinates, etc.) against the reported window boundaries.
+    """
+
+    def _simple_hm(self, seq_len=100_000, first_pos=243):
+        """Haplotype matrix with chrom_start=0 and a first variant > 0."""
+        rng = np.random.RandomState(7)
+        positions = np.concatenate([
+            [first_pos],
+            np.sort(rng.choice(
+                np.arange(first_pos + 1, seq_len), size=499, replace=False)),
+        ])
+        hap = rng.randint(0, 2, (20, len(positions)), dtype=np.int8)
+        return HaplotypeMatrix(hap, positions,
+                               chrom_start=0, chrom_end=seq_len)
+
+    def test_single_pop_windows_start_at_zero(self):
+        hm = self._simple_hm()
+        df = windowed_analysis(hm, window_size=10_000, step_size=10_000,
+                               statistics=["pi"])
+        assert int(df["start"].iloc[0]) == 0, (
+            f"first window start should be chrom_start=0, got "
+            f"{int(df['start'].iloc[0])} (likely the first variant position)")
+        # Windows should tile [0, 100_000) exactly: 10 windows, step=10k
+        assert list(df["start"]) == list(range(0, 100_000, 10_000))
+
+    def test_twopop_windows_start_at_zero(self):
+        hm = self._simple_hm()
+        hm.sample_sets = {"a": list(range(0, 10)), "b": list(range(10, 20))}
+        df = windowed_analysis(hm, window_size=10_000, step_size=10_000,
+                               statistics=["fst", "dxy"],
+                               populations=["a", "b"])
+        assert int(df["start"].iloc[0]) == 0
+        assert list(df["start"]) == list(range(0, 100_000, 10_000))
+
+    def test_non_zero_chrom_start_still_honored(self):
+        """chrom_start=50_000 should anchor windows at 50_000."""
+        rng = np.random.RandomState(11)
+        positions = np.sort(rng.choice(
+            np.arange(50_100, 150_000), size=500, replace=False))
+        hap = rng.randint(0, 2, (20, len(positions)), dtype=np.int8)
+        hm = HaplotypeMatrix(hap, positions,
+                             chrom_start=50_000, chrom_end=150_000)
+        df = windowed_analysis(hm, window_size=10_000, step_size=10_000,
+                               statistics=["pi"])
+        assert int(df["start"].iloc[0]) == 50_000
+        assert list(df["start"]) == list(range(50_000, 150_000, 10_000))


### PR DESCRIPTION
## Summary

`windowed_analysis` was using `chrom_start = matrix.chrom_start or int(pos_cpu[0])` to anchor window boundaries. The truthy-check treats `chrom_start=0` as unset and falls through to the first variant position, so windows started at `pos[0]` (e.g. 243) instead of 0. This mis-aligned every user-supplied genomic interval — accessibility-mask boundaries, exon coordinates, BED intervals — against the reported window edges.

`HaplotypeMatrix.from_ts` sets `chrom_start = 0` by default, so this affected every tree-sequence-based pipeline.

## Symptom that surfaced it

While writing `examples/accessibility_mask.py` (PR #61): a window that should have been `[590_000, 600_000]` became `[590_243, 600_243]`, giving it a 243-bp sliver of accessible territory spilling across the mask boundary and a near-zero π estimate rendered inside the shaded exon region.

## Fix

Replace the truthy check with `if matrix.chrom_start is not None else …` in both `_windowed_thetas_scatter` and `_windowed_twopop_scatter`. `chrom_end` has the same code pattern — swept along for symmetry, though that side is rarely affected in practice because `sequence_length` is typically > 0.

## Test plan

- [x] New `TestChromStartZero` class with three regression cases (single-pop, two-pop, non-zero chrom_start sanity).
- [x] All 21 existing `tests/test_windowed_analysis.py` tests pass.
- [x] `ruff` clean.

```
$ pixi run pytest tests/test_windowed_analysis.py -v
======================== 21 passed, 1 skipped in 6.34s =========================
```

## Notes

The other windowed-analysis bug surfaced this week (#64, overlapping-window scaling and span-clamp NaN behavior) is independent of this fix and remains open. Both are in the same module but have different root causes and warrant separate review.