### PR TITLE
fix: return NaN for fully-inaccessible windows in windowed_analysis

### DIFF
--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -709,9 +709,14 @@ def _windowed_thetas_scatter(haplotype_matrix, window_size, step_size,
             spans = (win_stops - win_starts) * matrix.n_total_sites / total_span
         else:
             spans = np.minimum(win_stops, chrom_end) - win_starts
+        # Windows with zero span (fully inaccessible) divide to NaN rather
+        # than 0 — the per-base rate is undefined, not zero. Clamp for
+        # safe division and carry the zero-span mask for post-processing.
+        zero_span = spans <= 0
         spans = np.maximum(spans, 1.0)
     else:
         spans = np.ones(n_windows)
+        zero_span = np.zeros(n_windows, dtype=bool)
 
     stats_set = set(statistics)
 
@@ -793,6 +798,13 @@ def _windowed_thetas_scatter(haplotype_matrix, window_size, step_size,
         H = (raw['pi'] - raw['theta_h']).get() / spans
         results['zeng_dh'] = np.where(
             (tajd < 0) & (H < 0), tajd * H, 0.0)
+
+    # Windows with no accessible bases get NaN for every per-base rate.
+    if zero_span.any():
+        for name in ('pi', 'theta_w', 'theta_h', 'theta_l',
+                     'fay_wu_h', 'zeng_dh'):
+            if name in results:
+                results[name] = np.where(zero_span, np.nan, results[name])
 
     return pd.DataFrame(results)
 
@@ -922,9 +934,14 @@ def _windowed_twopop_scatter(haplotype_matrix, window_size, step_size,
             spans = (win_stops - win_starts) * haplotype_matrix.n_total_sites / total_span
         else:
             spans = np.minimum(win_stops, chrom_end) - win_starts
+        # Windows with zero span (fully inaccessible) divide to NaN rather
+        # than 0 — the per-base rate is undefined, not zero. Clamp for
+        # safe division and carry the zero-span mask for post-processing.
+        zero_span = spans <= 0
         spans = np.maximum(spans, 1.0)
     else:
         spans = np.ones(n_windows)
+        zero_span = np.zeros(n_windows, dtype=bool)
 
     # Compute per-site components (single pass over the data)
     mpd1, mpd2, between = _twopop_site_components(hap1, hap2)
@@ -958,6 +975,12 @@ def _windowed_twopop_scatter(haplotype_matrix, window_size, step_size,
 
     if 'da' in stats_set:
         results['da'] = ((between_sum - (pi1_sum + pi2_sum) / 2.0) / spans_gpu).get()
+
+    # Windows with no accessible bases get NaN for every per-base rate.
+    if zero_span.any():
+        for name in ('dxy', 'da'):
+            if name in results:
+                results[name] = np.where(zero_span, np.nan, results[name])
 
     return pd.DataFrame(results)
 
@@ -1798,7 +1821,11 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
             s, e = int(ws_np[wi]), int(we_np[wi])
             if e - s < 2:
                 if e - s == 1:
-                    mu_var_arr[wi] = 1.0 / window_bases[wi] if per_base and window_bases[wi] > 0 else 1.0
+                    if per_base:
+                        mu_var_arr[wi] = (1.0 / window_bases[wi]
+                                          if window_bases[wi] > 0 else np.nan)
+                    else:
+                        mu_var_arr[wi] = 1.0
                 continue
             win_pos = pos_cpu[s:e]
             gaps = np.diff(win_pos).astype(np.float64)
@@ -1806,7 +1833,11 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
             sd_var[wi] = np.var(gaps)
             sd_min[wi] = np.min(gaps)
             sd_max[wi] = np.max(gaps)
-            mu_var_arr[wi] = len(win_pos) / window_bases[wi] if per_base and window_bases[wi] > 0 else float(len(win_pos))
+            if per_base:
+                mu_var_arr[wi] = (len(win_pos) / window_bases[wi]
+                                  if window_bases[wi] > 0 else np.nan)
+            else:
+                mu_var_arr[wi] = float(len(win_pos))
 
         for stat, arr in [('snp_dist_mean', sd_mean), ('snp_dist_var', sd_var),
                           ('snp_dist_min', sd_min), ('snp_dist_max', sd_max),

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -617,3 +617,86 @@ class TestChromStartZero:
                                statistics=["pi"])
         assert int(df["start"].iloc[0]) == 50_000
         assert list(df["start"]) == list(range(50_000, 150_000, 10_000))
+
+
+class TestFullyMaskedWindowNaN:
+    """Windows with zero accessible bases must return NaN per-base rates.
+
+    Regression: `spans = np.maximum(spans, 1.0)` clamped the denominator
+    to 1.0 for fully-masked windows, so the output was 0 (numerator also
+    0 after variant filtering). A per-base rate with zero accessible
+    territory is undefined, not zero.
+    """
+
+    def _build_hm_with_mask(self, seq_len=100_000, mask_start=40_000,
+                            mask_end=60_000):
+        """HM with a contiguous inaccessible region in the middle."""
+        rng = np.random.RandomState(13)
+        positions = np.sort(rng.choice(np.arange(1, seq_len), size=400,
+                                        replace=False))
+        hap = rng.randint(0, 2, (20, len(positions)), dtype=np.int8)
+        hm = HaplotypeMatrix(hap, positions,
+                             chrom_start=0, chrom_end=seq_len)
+        mask = np.ones(seq_len, dtype=bool)
+        mask[mask_start:mask_end] = False
+        hm.set_accessible_mask(mask)
+        return hm, mask_start, mask_end
+
+    def test_pi_is_nan_for_fully_masked_windows(self):
+        hm, ms, me = self._build_hm_with_mask()
+        df = windowed_analysis(hm, window_size=10_000, step_size=10_000,
+                               statistics=["pi", "theta_w"])
+        fully_masked = (df["start"] >= ms) & (df["stop"] <= me)
+        assert fully_masked.sum() > 0, "test needs at least one fully-masked window"
+        assert df.loc[fully_masked, "pi"].isna().all(), (
+            "fully-masked windows must report pi = NaN, got "
+            f"{df.loc[fully_masked, 'pi'].tolist()}")
+        assert df.loc[fully_masked, "theta_w"].isna().all()
+
+    def test_accessible_windows_unaffected(self):
+        hm, ms, me = self._build_hm_with_mask()
+        df = windowed_analysis(hm, window_size=10_000, step_size=10_000,
+                               statistics=["pi"])
+        # Windows entirely outside the mask should have finite pi.
+        accessible = (df["stop"] <= ms) | (df["start"] >= me)
+        assert accessible.sum() > 0
+        assert df.loc[accessible, "pi"].notna().all()
+        assert (df.loc[accessible, "pi"] > 0).all()
+
+    def test_segregating_sites_stays_zero_not_nan(self):
+        """Raw-count stats remain 0 (not NaN) for fully-masked windows."""
+        hm, ms, me = self._build_hm_with_mask()
+        df = windowed_analysis(hm, window_size=10_000, step_size=10_000,
+                               statistics=["segregating_sites"])
+        fully_masked = (df["start"] >= ms) & (df["stop"] <= me)
+        assert (df.loc[fully_masked, "segregating_sites"] == 0).all()
+
+    def test_twopop_dxy_is_nan_for_fully_masked_windows(self):
+        hm, ms, me = self._build_hm_with_mask()
+        hm.sample_sets = {"a": list(range(0, 10)), "b": list(range(10, 20))}
+        df = windowed_analysis(hm, window_size=10_000, step_size=10_000,
+                               statistics=["dxy", "da"],
+                               populations=["a", "b"])
+        fully_masked = (df["start"] >= ms) & (df["stop"] <= me)
+        assert fully_masked.sum() > 0
+        assert df.loc[fully_masked, "dxy"].isna().all()
+        assert df.loc[fully_masked, "da"].isna().all()
+
+    def test_mu_var_is_nan_for_fully_masked_windows(self):
+        """Fused snp_dist path: mu_var should be NaN, not 1.0 or count."""
+        from pg_gpu.windowed_analysis import windowed_statistics_fused
+
+        hm, ms, me = self._build_hm_with_mask()
+        hm.transfer_to_gpu()
+        bp_bins = np.arange(0, 100_001, 10_000, dtype=np.float64)
+        r = windowed_statistics_fused(
+            hm, bp_bins=bp_bins, statistics=("mu_var",),
+            per_base=True)
+
+        starts = r["window_start"]
+        stops = r["window_stop"]
+        fully_masked = (starts >= ms) & (stops <= me)
+        assert fully_masked.sum() > 0
+        assert np.isnan(r["mu_var"][fully_masked]).all(), (
+            "fully-masked windows must report mu_var = NaN, got "
+            f"{r['mu_var'][fully_masked]}")


### PR DESCRIPTION
## Summary

`windowed_analysis` clamped per-window span denominators to a minimum of 1.0 (`np.maximum(spans, 1.0)`) to avoid div-by-zero, then divided the zero numerator by 1 — reporting `pi = theta_w = dxy = … = 0.0` for any window whose accessible-base count was zero. A per-base rate over zero accessible territory is undefined, not zero. Users scanning with an accessibility mask saw a "flat zero" stretch indistinguishable from a selective sweep.

Addresses the span-clamp half of #64. The overlapping-window scaling half (Part A there) is independent and stays open.

## Fix

**Scatter paths** (`_windowed_thetas_scatter`, `_windowed_divergence_scatter`): Track zero-span windows separately before clamping, keep the clamp for safe division, and post-process every per-base output — `pi`, `theta_w`, `theta_h`, `theta_l`, `fay_wu_h`, `zeng_dh`, `dxy`, `da` — to NaN for those windows. Raw-count stats (`segregating_sites`, `singletons`, `max_daf`) remain 0, which is correct: a count over zero accessible bases is still a valid 0.

**Fused snp_dist path** (`windowed_statistics_fused`): same bug class — `mu_var` fell through to `1.0` / `float(len(win_pos))` when `window_bases` was 0 instead of NaN. The other fused stats (pi, theta_w, dxy, etc.) already used the `np.where(window_bases > 0, …, np.nan)` pattern correctly.

## Audit done before merging

Confirmed all other windowed entry points are clean — no other instances of this bug class:

- `windowed_statistics_fused_chunked`: delegates `snp_dist_stats` to `windowed_statistics_fused`, so the `mu_var` fix covers both.
- `windowed_statistics` (line 2512): all stats already use `np.where(window_bases > 0, …, np.nan)`.
- `moving_garud_h`, `moving_patterson_f3/d`, `pbs`: variant-index windowed, no span/mask concept.
- `ihs`, `nsl`, `xpehh`: per-variant scans, no windowing.
- `windowed_r_squared`: distance-bin based, no per-base normalization.

## Test plan

`TestFullyMaskedWindowNaN` covers:
- `pi` and `theta_w` NaN for fully-masked windows (single-pop scatter).
- `dxy` and `da` NaN for fully-masked windows (two-pop scatter).
- `mu_var` NaN for fully-masked windows (fused snp_dist).
- `segregating_sites` preserved at 0 (not turned to NaN).
- Neighboring fully-accessible windows remain finite and non-zero.

```
$ pixi run pytest tests/test_windowed_analysis.py -v
======================== 26 passed, 1 skipped in 6.28s =========================
```

## Downstream

Once merged, `examples/accessibility_mask.py` (PR #61) can drop its `if hm.has_accessible_mask: ... pi = NaN` post-processing block — those lines exist only to work around this bug.
