### PR TITLE
fix: from_ts auto-populates sample_sets from ts.populations()

### DIFF
--- a/examples/admixture_detection.py
+++ b/examples/admixture_detection.py
@@ -94,24 +94,6 @@ def simulate(demography, length, n_diploids, seed):
     return ts
 
 
-def load_and_label(ts) -> HaplotypeMatrix:
-    """Build a HaplotypeMatrix from the ts and assign sample_sets by pop name."""
-    # from_ts does NOT carry over msprime population labels, so we rebuild
-    # the {name: [row indices]} mapping from the tskit sample nodes ourselves.
-    # (GPU transfer is automatic on the first stat call, no device= needed.)
-    hm = HaplotypeMatrix.from_ts(ts)
-    sample_idx = {int(s): i for i, s in enumerate(ts.samples())}
-    sample_sets = {}
-    for pop in ts.populations():
-        name = pop.metadata.get("name") if pop.metadata else None
-        if name is None or name not in POPS:
-            continue
-        sample_sets[name] = [sample_idx[int(s)]
-                             for s in ts.samples(population=pop.id)]
-    hm.sample_sets = sample_sets
-    return hm
-
-
 # ── D test ──────────────────────────────────────────────────────────────────
 
 def run_d_test(hm, scenario, label, blen=None):
@@ -226,7 +208,9 @@ def main():
         with_pulse = scenario == "admixed"
         print(f"\nSimulating {label!r} (seed={seed})...")
         ts = simulate(build_demography(with_pulse), args.length, args.samples, seed)
-        hm = load_and_label(ts)
+        # from_ts auto-populates hm.sample_sets from the ts population metadata,
+        # so the A/B/C/D labels flow through without an extra loop here.
+        hm = HaplotypeMatrix.from_ts(ts)
         print(f"  {ts.num_sites:,} variants, {hm.num_haplotypes} haplotypes across "
               f"{len(hm.sample_sets)} populations")
         results.append(run_d_test(hm, scenario, label, blen=args.blen))

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -476,6 +476,15 @@ class HaplotypeMatrix:
 
         Returns:
             HaplotypeMatrix: A new HaplotypeMatrix instance
+
+        Notes:
+            Populations declared in the tree sequence (with a name in
+            metadata) are automatically registered in ``sample_sets``:
+            each pop name maps to the haplotype row indices of its
+            samples. The no-demography case (``sim_ancestry(samples=N)``
+            with a single unnamed population) leaves ``sample_sets``
+            unset. Users who need custom groupings can overwrite
+            ``hm.sample_sets`` after construction.
         """
         # Convert ts to haplotype matrix
         haplotypes = ts.genotype_matrix().T
@@ -493,6 +502,19 @@ class HaplotypeMatrix:
                  n_total_sites=n_total_sites)
         if accessible_bed is not None:
             hm.set_accessible_mask(accessible_bed, chrom=chrom)
+
+        sample_sets = {}
+        sample_idx = {s: i for i, s in enumerate(ts.samples())}
+        for pop in ts.populations():
+            name = pop.metadata.get("name") if pop.metadata else None
+            if name is None:
+                continue
+            nodes = ts.samples(population=pop.id)
+            if len(nodes):
+                sample_sets[name] = [sample_idx[s] for s in nodes]
+        if sample_sets:
+            hm.sample_sets = sample_sets
+
         return hm
 
     def get_matrix(self) -> cp.ndarray:

--- a/tests/test_haplotype_matrix.py
+++ b/tests/test_haplotype_matrix.py
@@ -75,6 +75,66 @@ def test_from_ts(sample_ts):
     assert cp.allclose(D, D.T)  # Check symmetry
     assert cp.all(cp.abs(D) <= 0.25)  # D is bounded by ±0.25
 
+
+def test_from_ts_default_population(sample_ts):
+    """sim_ancestry(samples=N) with no explicit Demography -> msprime
+    still names a default 'pop_0' population; hm.sample_sets exposes it."""
+    hm = HaplotypeMatrix.from_ts(sample_ts)
+    assert list(hm.sample_sets.keys()) == ["pop_0"]
+    assert len(hm.sample_sets["pop_0"]) == hm.num_haplotypes
+
+
+def test_from_ts_populates_sample_sets_from_demography():
+    """Named populations in the tree sequence auto-register as sample_sets."""
+    demography = msprime.Demography()
+    demography.add_population(name="A", initial_size=10_000)
+    demography.add_population(name="B", initial_size=10_000)
+    demography.add_population(name="AB", initial_size=10_000)
+    demography.add_population_split(time=5_000, derived=["A", "B"],
+                                    ancestral="AB")
+    ts = msprime.sim_ancestry(
+        samples={"A": 12, "B": 8},
+        sequence_length=100_000,
+        recombination_rate=1e-8,
+        demography=demography,
+        random_seed=42, ploidy=2)
+    ts = msprime.sim_mutations(ts, rate=1e-8, random_seed=42)
+
+    hm = HaplotypeMatrix.from_ts(ts)
+
+    # Extant pops A and B should be present; the ancestral AB has no living
+    # samples and should NOT appear.
+    assert set(hm.sample_sets.keys()) == {"A", "B"}
+    assert len(hm.sample_sets["A"]) == 2 * 12
+    assert len(hm.sample_sets["B"]) == 2 * 8
+
+    # Row indices must actually refer to samples drawn from that population
+    # in the tree sequence, not just any rows.
+    all_samples = list(ts.samples())
+    a_nodes = set(int(s) for s in ts.samples(population=0))
+    b_nodes = set(int(s) for s in ts.samples(population=1))
+    assert set(all_samples[i] for i in hm.sample_sets["A"]) == a_nodes
+    assert set(all_samples[i] for i in hm.sample_sets["B"]) == b_nodes
+
+
+def test_from_ts_user_can_overwrite_sample_sets():
+    """Callers who want custom groupings can still reassign the dict."""
+    demography = msprime.Demography()
+    demography.add_population(name="P", initial_size=10_000)
+    ts = msprime.sim_ancestry(samples={"P": 20},
+                              sequence_length=50_000,
+                              demography=demography,
+                              random_seed=7, ploidy=2)
+    ts = msprime.sim_mutations(ts, rate=1e-8, random_seed=7)
+    hm = HaplotypeMatrix.from_ts(ts)
+    assert list(hm.sample_sets.keys()) == ["P"]
+
+    n = hm.num_haplotypes
+    hm.sample_sets = {"left": list(range(n // 2)),
+                      "right": list(range(n // 2, n))}
+    assert set(hm.sample_sets.keys()) == {"left", "right"}
+
+
 def test_shape(sample_vcf):
     """Test the shape property."""
     hap_matrix = HaplotypeMatrix.from_vcf(sample_vcf)

--- a/tests/test_missing_data_bias.py
+++ b/tests/test_missing_data_bias.py
@@ -40,12 +40,8 @@ def _simulate(seed):
 
 
 def _ts_to_hm(ts):
-    hm = HaplotypeMatrix.from_ts(ts)
-    hm.sample_sets = {
-        "pop1": list(range(0, N_HAPS_PER_POP)),
-        "pop2": list(range(N_HAPS_PER_POP, 2 * N_HAPS_PER_POP)),
-    }
-    return hm
+    # sample_sets are auto-populated from the named populations in ts.
+    return HaplotypeMatrix.from_ts(ts)
 
 
 def _add_missing(hm, rate, rng):


### PR DESCRIPTION
## Summary

`HaplotypeMatrix.from_ts` now auto-populates `hm.sample_sets` from the population metadata the tree sequence already carries. Every caller who wanted population-aware stats (FST, Patterson's D, joint SFS, etc.) previously had to rebuild the `{name: [row indices]}` mapping by hand — the same 6-10 line loop showed up in at least four places.

Closes #62.

## Behavior

- Each named population with at least one living sample is registered in `hm.sample_sets`.
- Ancestral populations declared in the demography but with no living samples are skipped automatically (`len(ts.samples(population=id)) == 0`).
- `sim_ancestry(samples=N)` with no explicit `Demography` gets msprime's default `"pop_0"` name.
- Callers who need custom groupings (e.g. splitting one pop in half, as some tests do) can still overwrite `hm.sample_sets` after construction.

## Simplifications downstream

- `examples/admixture_detection.py`: `load_and_label` helper removed entirely; `from_ts` alone produces the A/B/C/D mapping used by the D test. Output unchanged.
- `tests/test_missing_data_bias.py`: `_ts_to_hm` collapses to `return HaplotypeMatrix.from_ts(ts)`.

## Test plan

Three new regression tests in `tests/test_haplotype_matrix.py`:
- `test_from_ts_default_population` — no-demography sim returns `{'pop_0': [all haps]}`.
- `test_from_ts_populates_sample_sets_from_demography` — multi-pop sim returns correct row indices, ancestral pops filtered out.
- `test_from_ts_user_can_overwrite_sample_sets` — reassignment after construction still works.

```
$ pixi run pytest tests/ -q
516 passed, 54 skipped in 87.84s
```

`pixi run ruff check` clean.