### PR TITLE
feat: public pg_gpu.resampling module (block_jackknife, block_bootstrap)

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -176,6 +176,19 @@ Scaling and Folding Utilities
 .. autofunction:: pg_gpu.sfs.fold_sfs
 .. autofunction:: pg_gpu.sfs.fold_joint_sfs
 
+Resampling (Block Jackknife and Bootstrap)
+------------------------------------------
+
+General-purpose block-resampling estimators for calibrated SE / CI on any
+scalar genome-wide statistic. Both accept pre-binned per-block values
+(single 1D array or tuple of arrays for ratio-of-sums statistics) and a
+callable ``statistic``. See ``examples/sweep_tajimas_d_bootstrap.py`` for
+an end-to-end CI on Tajima's D under a completed sweep.
+
+.. autofunction:: pg_gpu.resampling.block_jackknife
+
+.. autofunction:: pg_gpu.resampling.block_bootstrap
+
 Admixture and F-Statistics
 --------------------------
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -93,6 +93,19 @@ Admixture / F-Statistics
 * Block-jackknife with SE: ``average_patterson_f3``,
   ``average_patterson_d``.
 
+Resampling
+~~~~~~~~~~
+
+* Public ``pg_gpu.resampling`` module with ``block_jackknife`` and
+  ``block_bootstrap`` for block-resampled SE / CIs on any scalar
+  genome-wide statistic (genome-wide mean Tajima's D, ratio-of-sums
+  estimators, etc.). Promotes the previously private ``_jackknife`` helper
+  from ``admixture``. The weighted jackknife follows the Busing et al.
+  (1999) delete-:math:`m_j` formulation for unequal block sizes.
+* ``examples/sweep_tajimas_d_bootstrap.py`` -- 95% bootstrap CI on
+  Tajima's D under a completed sweep, showing sweep-local vs distal mean
+  difference CIs that exclude zero.
+
 Dimensionality Reduction and Distance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -130,6 +130,22 @@ SFS and Admixture
    )
    print(f"D = {d:.4f}, SE = {se:.4f}, Z = {z:.2f}")
 
+Bootstrap CI on Tajima's D under a Sweep
+-----------------------------------------
+
+``examples/sweep_tajimas_d_bootstrap.py`` simulates a 10 Mb chromosome
+with msprime's ``SweepGenicSelection`` targeting fixation at the midpoint,
+computes windowed Tajima's D, and uses ``block_bootstrap`` to obtain 95%
+confidence intervals for the mean Tajima's D in the sweep-local region,
+and the distal region. Under a completed sweep the
+sweep-local CI excludes zero; the distal CI
+brackets the neutral expectation.
+
+.. code-block:: bash
+
+   pixi run python examples/sweep_tajimas_d_bootstrap.py
+   pixi run python examples/sweep_tajimas_d_bootstrap.py --seed 7 --n-replicates 5000
+
 Admixture Detection (end-to-end)
 --------------------------------
 

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -280,6 +280,28 @@ Admixture and F-Statistics
      - D with block-jackknife standard error
      - Patterson et al. (2012)
 
+Resampling (Block Jackknife and Bootstrap)
+-------------------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 45 30
+
+   * - Function
+     - Description
+     - Reference
+   * - ``block_jackknife``
+     - Delete-1 block jackknife SE; supports unequal block sizes
+     - Busing et al. (1999)
+   * - ``block_bootstrap``
+     - Block bootstrap SE and replicate distribution
+     - Efron & Tibshirani (1993)
+
+Both operate on pre-binned per-block values and a user-supplied statistic,
+so any scalar aggregate (genome-wide mean Tajima's D, per-population π,
+ratio-of-sums estimators like normed F3 / D) can get a calibrated SE / CI
+with a single call.
+
 FrequencySpectrum (Power-User SFS Interface)
 ---------------------------------------------
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -226,6 +226,39 @@ Admixture / F-Statistics
        h, 'popA', 'popB', 'popC', 'popD', blen=100
    )
 
+Resampling (Block Jackknife and Bootstrap)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Both estimators take pre-binned per-block values and a callable ``statistic``.
+For ratio-of-sums statistics, pass a tuple ``(num, den)`` and have
+``statistic`` consume both — the same block indices are applied to each
+entry (required invariant).
+
+.. code-block:: python
+
+   import numpy as np
+   from pg_gpu import block_jackknife, block_bootstrap, windowed_analysis
+
+   # 1) Jackknife SE of a windowed mean. windowed_analysis gives per-window
+   #    Tajima's D; treat each window as a block and take the mean.
+   df = windowed_analysis(h, window_size=50_000, step_size=25_000,
+                          statistics=['tajimas_d'], window_type='bp')
+   tajd = df['tajimas_d'].to_numpy()
+   tajd = tajd[np.isfinite(tajd)]
+   est, se, _ = block_jackknife(tajd, statistic=np.mean)
+
+   # 2) Bootstrap 95% CI on the same mean.
+   est, se, reps = block_bootstrap(tajd, statistic=np.mean,
+                                   n_replicates=2000, rng=0)
+   lo, hi = np.quantile(reps, [0.025, 0.975])
+
+   # 3) Ratio-of-sums pattern (same as average_patterson_d).
+   est, se, reps = block_bootstrap(
+       (num_blocks, den_blocks),
+       statistic=lambda n, d: np.sum(n) / np.sum(d),
+       n_replicates=2000, rng=0,
+   )
+
 PCA and Distance
 ~~~~~~~~~~~~~~~~
 

--- a/examples/sweep_tajimas_d_bootstrap.py
+++ b/examples/sweep_tajimas_d_bootstrap.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python
+"""
+Block-bootstrap confidence intervals for Tajima's D under a completed sweep.
+
+Pipeline:
+    1. Simulate a 10 Mb chromosome with msprime using
+       `SweepGenicSelection` at the midpoint, targeting a final sweep
+       allele frequency of 1.0 (i.e. a completed sweep). The sweep
+        drives Tajima's D sharply negative in the local region.
+    2. `windowed_analysis` with `statistic='tajimas_d'` in bp windows along
+       the chromosome produces per-window Tajima's D values.
+    3. Partition windows into
+         * sweep-local  (|center - focal| <= local_radius)
+         * distal       (|center - focal| >  distal_radius)
+    4. `block_bootstrap` on each regime separately for the 95% CI of its
+       mean Tajima's D. Under a completed sweep the sweep-local CI excludes
+       zero while the distal CI brackets zero — the calibrated CIs are what
+       make that statement defensible.
+
+Usage
+-----
+    pixi run python examples/sweep_tajimas_d_bootstrap.py
+    pixi run python examples/sweep_tajimas_d_bootstrap.py --seed 7
+    pixi run python examples/sweep_tajimas_d_bootstrap.py --no-plot
+"""
+
+import argparse
+import pathlib
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import msprime
+import numpy as np
+
+# The three pg_gpu entry points used in this example:
+#   HaplotypeMatrix    — the core phased-data container; everything else
+#                        takes one of these as input.
+#   windowed_analysis  — GPU-fused per-window statistics, returns a pandas
+#                        DataFrame with one row per window.
+#   block_bootstrap    — generic block-resampling CIs on any scalar stat
+#                        computed over pre-binned per-block values.
+from pg_gpu import HaplotypeMatrix, block_bootstrap, windowed_analysis
+
+
+SEQ_LEN = 10_000_000
+SWEEP_POS = 5_000_000
+NE = 10_000
+MU = 1e-8
+RECOMB_RATE = 1e-8
+
+
+def _simulate(n_diploids: int, s: float, seed: int):
+    """Completed genic-selection sweep at the chromosome midpoint.
+
+    msprime's ``SweepGenicSelection`` requires ``end_frequency < 1``; using
+    ``1 - 1/(2 Ne)`` corresponds to the final copy reaching fixation.
+    """
+    sweep = msprime.SweepGenicSelection(
+        position=SWEEP_POS,
+        start_frequency=1.0 / (2 * NE),
+        end_frequency=1.0 - 1.0 / (2 * NE),
+        s=s,
+        dt=1e-6,
+    )
+    ts = msprime.sim_ancestry(
+        samples=n_diploids,
+        sequence_length=SEQ_LEN,
+        recombination_rate=RECOMB_RATE,
+        population_size=NE,
+        model=[sweep, msprime.StandardCoalescent()],
+        random_seed=seed,
+    )
+    ts = msprime.sim_mutations(ts, rate=MU, random_seed=seed)
+    hap = ts.genotype_matrix().T.astype(np.int8)
+    positions = ts.tables.sites.position.astype(np.int64)
+    for i in range(1, len(positions)):
+        if positions[i] <= positions[i - 1]:
+            positions[i] = positions[i - 1] + 1
+    return hap, positions
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--seed", type=int, default=1)
+    p.add_argument("--window", type=int, default=50_000,
+                   help="Window size (bp)")
+    p.add_argument("--step", type=int, default=25_000,
+                   help="Window step (bp)")
+    p.add_argument("--local-radius", type=int, default=500_000,
+                   help="Half-width of sweep-local region around focal site")
+    p.add_argument("--distal-radius", type=int, default=2_000_000,
+                   help="Minimum distance from focal site for distal set")
+    p.add_argument("--n-diploids", type=int, default=50)
+    p.add_argument("--s", type=float, default=0.1,
+                   help="Selection coefficient for the sweep")
+    p.add_argument("--n-replicates", type=int, default=2000)
+    p.add_argument("--out", type=pathlib.Path,
+                   default=pathlib.Path(__file__).with_suffix(".png"))
+    p.add_argument("--no-plot", action="store_true")
+    args = p.parse_args()
+
+    print(f"Simulating completed sweep at {SWEEP_POS:,} bp "
+          f"(seed={args.seed}, n_diploids={args.n_diploids}, "
+          f"s={args.s}) ...")
+    hap, positions = _simulate(args.n_diploids, args.s, args.seed)
+    print(f"  n_haplotypes={hap.shape[0]}  n_variants={hap.shape[1]}")
+
+    # Build a HaplotypeMatrix from raw numpy. The constructor takes the
+    # (n_haplotypes, n_variants) matrix, variant positions, and the genomic
+    # region bounds [start, stop). For real data, prefer the loader class
+    # methods: HaplotypeMatrix.from_vcf / from_zarr / from_ts. 
+    hm = HaplotypeMatrix(hap, positions, 0, SEQ_LEN)
+
+    # windowed_analysis runs one fused GPU kernel across all windows and
+    # returns a pandas DataFrame with one row per window. Columns include
+    # 'start', 'stop', 'center', plus one column per requested statistic
+    # (here just 'tajimas_d'). window_type='bp' uses base-pair windows;
+    # pass 'snp' for fixed-SNP-count windows instead. `step_size` less than
+    # `window_size` produces overlapping windows.
+    print(f"Windowed Tajima's D (window={args.window:,} bp, "
+          f"step={args.step:,} bp) ...")
+    df = windowed_analysis(
+        hm, window_size=args.window, step_size=args.step,
+        statistics=['tajimas_d'], window_type='bp',
+    )
+    centers = df['center'].to_numpy()
+    tajd = df['tajimas_d'].to_numpy()
+    # Tajima's D is undefined on windows with <2 segregating sites, which
+    # show up as NaN. Drop them before downstream analysis.
+    finite = np.isfinite(tajd)
+    centers, tajd = centers[finite], tajd[finite]
+    print(f"  n_windows={len(tajd)}  (finite)")
+
+    dist = np.abs(centers - SWEEP_POS)
+    sweep_mask = dist <= args.local_radius
+    distal_mask = dist > args.distal_radius
+    d_sweep = tajd[sweep_mask]
+    d_distal = tajd[distal_mask]
+    print(f"  sweep-local windows: {sweep_mask.sum()}  "
+          f"distal windows: {distal_mask.sum()}")
+
+    # block_bootstrap takes pre-binned per-block values (here one Tajima's D
+    # value per genomic window) and a callable `statistic`, draws
+    # `n_replicates` with-replacement resamples of the block indices, and
+    # returns the plug-in point estimate, SE of the replicates, and the raw
+    # replicate distribution. Passing `rng=<int>` makes the draw reproducible.
+    # Extract percentile CIs from the replicate array directly.
+    print(f"Block bootstrap (n_replicates={args.n_replicates}) ...")
+    est_s, se_s, reps_s = block_bootstrap(
+        d_sweep, statistic=np.mean,
+        n_replicates=args.n_replicates, rng=args.seed,
+    )
+    est_d, se_d, reps_d = block_bootstrap(
+        d_distal, statistic=np.mean,
+        n_replicates=args.n_replicates, rng=args.seed + 1,
+    )
+    lo_s, hi_s = np.quantile(reps_s, [0.025, 0.975])
+    lo_d, hi_d = np.quantile(reps_d, [0.025, 0.975])
+
+    def fmt(est, se, lo, hi):
+        return f"{est:+.3f} ± {se:.3f}  (95% CI [{lo:+.3f}, {hi:+.3f}])"
+
+    print(f"  sweep-local  mean D = {fmt(est_s, se_s, lo_s, hi_s)}")
+    print(f"  distal       mean D = {fmt(est_d, se_d, lo_d, hi_d)}")
+
+    if args.no_plot:
+        return
+
+    fig, (ax_top, ax_bot) = plt.subplots(
+        2, 1, figsize=(10, 6),
+        gridspec_kw={'height_ratios': [2.2, 1.0], 'hspace': 0.35},
+    )
+
+    ax_top.plot(centers / 1e6, tajd, color='steelblue', lw=1.2,
+                label="Tajima's D (per window)")
+    ax_top.axhline(0, color='gray', lw=0.8, alpha=0.6)
+    ax_top.axvline(SWEEP_POS / 1e6, color='orange', linestyle='--',
+                   alpha=0.7, label='sweep focal site')
+    ax_top.axvspan((SWEEP_POS - args.local_radius) / 1e6,
+                   (SWEEP_POS + args.local_radius) / 1e6,
+                   color='#D94E4E', alpha=0.12, label='sweep-local region')
+    ax_top.axvspan(0, (SWEEP_POS - args.distal_radius) / 1e6,
+                   color='#4C9AFF', alpha=0.10, label='distal region')
+    ax_top.axvspan((SWEEP_POS + args.distal_radius) / 1e6, SEQ_LEN / 1e6,
+                   color='#4C9AFF', alpha=0.10)
+    ax_top.set_xlabel("chromosome position (Mb)")
+    ax_top.set_ylabel("Tajima's D")
+    ax_top.set_xlim(0, SEQ_LEN / 1e6)
+    ax_top.set_title("Windowed Tajima's D along a chromosome with a completed sweep")
+    ax_top.legend(loc='best', fontsize=8)
+
+    labels = ['sweep-local', 'distal']
+    ests = [est_s, est_d]
+    los = [lo_s, lo_d]
+    his = [hi_s, hi_d]
+    colors = ['#D94E4E', '#4C9AFF']
+    y = np.arange(len(labels))
+    for i, (e, lo, hi, c) in enumerate(zip(ests, los, his, colors)):
+        ax_bot.plot([lo, hi], [y[i], y[i]], color=c, lw=3,
+                    solid_capstyle='round')
+        ax_bot.plot(e, y[i], 'o', color=c, markersize=7,
+                    markeredgecolor='white')
+    ax_bot.axvline(0, color='gray', lw=0.8, alpha=0.6)
+    ax_bot.set_yticks(y)
+    ax_bot.set_yticklabels(labels)
+    ax_bot.set_xlabel("mean Tajima's D  (95% block-bootstrap CI)")
+    ax_bot.set_title(f"Per-regime mean  (n_replicates={args.n_replicates})")
+    ax_bot.invert_yaxis()
+
+    fig.savefig(args.out, dpi=130, bbox_inches='tight')
+    print(f"Saved {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pg_gpu/__init__.py
+++ b/pg_gpu/__init__.py
@@ -23,6 +23,7 @@ from . import decomposition
 from . import plotting
 from . import distance_stats
 from . import relatedness
+from . import resampling
 from .accessible import AccessibleMask, bed_to_mask, parse_bed
 from .diversity import FrequencySpectrum
 from .genotype_matrix import GenotypeMatrix
@@ -35,7 +36,8 @@ from .decomposition import (
     pc_dist,
     corners,
 )
+from .resampling import block_jackknife, block_bootstrap
 
-__all__ = ['ld_statistics', 'diversity', 'divergence', 'windowed_analysis', 'selection', 'sfs', 'admixture', 'decomposition', 'plotting', 'distance_stats', 'HaplotypeMatrix', 'GenotypeMatrix', 'WindowedAnalyzer', 'windowed_analysis', 'AccessibleMask', 'bed_to_mask', 'parse_bed', 'LocalPCAResult', 'local_pca', 'local_pca_jackknife', 'pc_dist', 'corners']
+__all__ = ['ld_statistics', 'diversity', 'divergence', 'windowed_analysis', 'selection', 'sfs', 'admixture', 'decomposition', 'plotting', 'distance_stats', 'resampling', 'HaplotypeMatrix', 'GenotypeMatrix', 'WindowedAnalyzer', 'windowed_analysis', 'AccessibleMask', 'bed_to_mask', 'parse_bed', 'LocalPCAResult', 'local_pca', 'local_pca_jackknife', 'pc_dist', 'corners', 'block_jackknife', 'block_bootstrap']
 
 __version__ = '0.1.0'

--- a/pg_gpu/admixture.py
+++ b/pg_gpu/admixture.py
@@ -10,6 +10,7 @@ import cupy as cp
 from typing import Union, Optional, Tuple
 from .haplotype_matrix import HaplotypeMatrix
 from ._utils import get_population_matrix as _get_population_matrix
+from .resampling import block_jackknife, _moving_nansum, _moving_nanmean
 
 
 def _allele_freq(haplotype_matrix):
@@ -55,110 +56,6 @@ def _allele_freq_and_het(haplotype_matrix):
 
     return freq, h, an
 
-
-
-def _moving_nansum(values, size, start=0, stop=None, step=None):
-    """Windowed nansum on GPU via cumulative sums.
-
-    Parameters
-    ----------
-    values : cupy.ndarray, shape (n,)
-    size, start, stop, step : int
-
-    Returns
-    -------
-    cupy.ndarray, shape (n_windows,)
-    """
-    n = len(values)
-    if stop is None:
-        stop = n
-    if step is None:
-        step = size
-
-    v = cp.where(cp.isfinite(values), values, 0.0)
-    cs = cp.concatenate([cp.zeros(1, dtype=cp.float64), cp.cumsum(v)])
-    w_starts = cp.arange(start, stop - size + 1, step)
-    return cs[w_starts + size] - cs[w_starts]
-
-
-def _moving_nanmean(values, size, start=0, stop=None, step=None):
-    """Windowed nanmean on GPU via cumulative sums.
-
-    Parameters
-    ----------
-    values : cupy.ndarray, shape (n,)
-    size, start, stop, step : int
-
-    Returns
-    -------
-    cupy.ndarray, shape (n_windows,)
-    """
-    n = len(values)
-    if stop is None:
-        stop = n
-    if step is None:
-        step = size
-
-    finite = cp.isfinite(values)
-    v = cp.where(finite, values, 0.0)
-    cs = cp.concatenate([cp.zeros(1, dtype=cp.float64), cp.cumsum(v)])
-    cn = cp.concatenate([cp.zeros(1, dtype=cp.float64),
-                         cp.cumsum(finite.astype(cp.float64))])
-    w_starts = cp.arange(start, stop - size + 1, step)
-    sums = cs[w_starts + size] - cs[w_starts]
-    counts = cn[w_starts + size] - cn[w_starts]
-    return cp.where(counts > 0, sums / counts, cp.nan)
-
-
-def _jackknife(values, statistic):
-    """Block-jackknife for standard error estimation.
-
-    Parameters
-    ----------
-    values : ndarray or tuple of ndarrays
-        Block-level values.
-    statistic : callable
-        Statistic to compute from values.
-
-    Returns
-    -------
-    m : float
-        Mean of jackknife estimates.
-    se : float
-        Standard error estimate.
-    vj : ndarray
-        Per-iteration jackknife values.
-    """
-    if isinstance(values, tuple):
-        n = len(values[0])
-        masked = [np.ma.asarray(v) for v in values]
-        for m in masked:
-            m.mask = np.zeros(m.shape, dtype=bool)
-    else:
-        n = len(values)
-        masked = np.ma.asarray(values)
-        masked.mask = np.zeros(masked.shape, dtype=bool)
-
-    vj = []
-    for i in range(n):
-        if isinstance(values, tuple):
-            for m in masked:
-                m.mask[i] = True
-            x = statistic(*masked)
-            for m in masked:
-                m.mask[i] = False
-        else:
-            masked.mask[i] = True
-            x = statistic(masked)
-            masked.mask[i] = False
-        vj.append(x)
-
-    vj = np.array(vj)
-    m = vj.mean()
-    sv = ((n - 1) / n) * np.sum((vj - m) ** 2)
-    se = np.sqrt(sv)
-
-    return m, se, vj
 
 
 # ---------------------------------------------------------------------------
@@ -464,7 +361,7 @@ def average_patterson_f3(haplotype_matrix: HaplotypeMatrix,
         T_bsum = _moving_nansum(T, blen).get()
         B_bsum = _moving_nansum(B, blen).get()
         vb = T_bsum / B_bsum
-        _, se, vj = _jackknife(
+        _, se, vj = block_jackknife(
             (T_bsum, B_bsum),
             statistic=lambda t, b: np.sum(t) / np.sum(b)
         )
@@ -472,7 +369,7 @@ def average_patterson_f3(haplotype_matrix: HaplotypeMatrix,
         finite = cp.isfinite(T)
         f3 = float((cp.sum(cp.where(finite, T, 0.0)) / cp.sum(finite)).get())
         vb = _moving_nanmean(T, blen).get()
-        _, se, vj = _jackknife(vb, statistic=np.mean)
+        _, se, vj = block_jackknife(vb, statistic=np.mean)
 
     z = f3 / se
     return f3, se, z, vb, vj
@@ -519,7 +416,7 @@ def average_patterson_d(haplotype_matrix: HaplotypeMatrix,
     den_bsum = _moving_nansum(den, blen).get()
     vb = num_bsum / den_bsum
 
-    _, se, vj = _jackknife(
+    _, se, vj = block_jackknife(
         (num_bsum, den_bsum),
         statistic=lambda n, d: np.sum(n) / np.sum(d)
     )

--- a/pg_gpu/resampling.py
+++ b/pg_gpu/resampling.py
@@ -1,0 +1,256 @@
+"""
+Block-resampling utilities for calibrated SE / CI on genome-wide statistics.
+
+This module provides general-purpose resampling estimators that operate on
+pre-binned per-block values:
+
+* :func:`block_jackknife` — delete-1 block jackknife SE, including the
+  Busing et al. (1999) weighted variant for unequal block sizes.
+* :func:`block_bootstrap` — block bootstrap: resample blocks with replacement
+  to obtain an empirical SE and replicate distribution.
+
+Both accept either a single 1D array of per-block values or a tuple of
+1D arrays (one entry per block), plus a callable ``statistic`` that maps
+the block values to a scalar. The tuple form is intended for ratio-of-sums
+estimators (normed F3, Patterson D, windowed Tajima's D means, etc.), where
+the numerator and denominator share the same block indexing.
+
+References
+----------
+Busing, F. M. T. A., Meijer, E., & Van der Leeden, R. (1999). Delete-m
+jackknife for unequal m. *Statistics and Computing*, 9, 3-8.
+
+Efron, B., & Tibshirani, R. J. (1993). *An Introduction to the Bootstrap*,
+Chapter 6. Chapman & Hall/CRC.
+
+Notes
+-----
+Future work: delete-m jackknife (contiguous block deletion for m > 1),
+jackknife-after-bootstrap, and BCa confidence intervals. Input block values
+are expected on host (NumPy); the companion CuPy helpers
+``_moving_nansum`` / ``_moving_nanmean`` in this module produce them from
+per-variant arrays.
+"""
+
+import numpy as np
+import cupy as cp
+
+
+def _moving_nansum(values, size, start=0, stop=None, step=None):
+    """Windowed nansum on GPU via cumulative sums.
+
+    Parameters
+    ----------
+    values : cupy.ndarray, shape (n,)
+    size, start, stop, step : int
+
+    Returns
+    -------
+    cupy.ndarray, shape (n_windows,)
+    """
+    n = len(values)
+    if stop is None:
+        stop = n
+    if step is None:
+        step = size
+
+    v = cp.where(cp.isfinite(values), values, 0.0)
+    cs = cp.concatenate([cp.zeros(1, dtype=cp.float64), cp.cumsum(v)])
+    w_starts = cp.arange(start, stop - size + 1, step)
+    return cs[w_starts + size] - cs[w_starts]
+
+
+def _moving_nanmean(values, size, start=0, stop=None, step=None):
+    """Windowed nanmean on GPU via cumulative sums.
+
+    Parameters
+    ----------
+    values : cupy.ndarray, shape (n,)
+    size, start, stop, step : int
+
+    Returns
+    -------
+    cupy.ndarray, shape (n_windows,)
+    """
+    n = len(values)
+    if stop is None:
+        stop = n
+    if step is None:
+        step = size
+
+    finite = cp.isfinite(values)
+    v = cp.where(finite, values, 0.0)
+    cs = cp.concatenate([cp.zeros(1, dtype=cp.float64), cp.cumsum(v)])
+    cn = cp.concatenate([cp.zeros(1, dtype=cp.float64),
+                         cp.cumsum(finite.astype(cp.float64))])
+    w_starts = cp.arange(start, stop - size + 1, step)
+    sums = cs[w_starts + size] - cs[w_starts]
+    counts = cn[w_starts + size] - cn[w_starts]
+    return cp.where(counts > 0, sums / counts, cp.nan)
+
+
+def _as_tuple(values):
+    """Normalise a single array or tuple of arrays to a tuple."""
+    if isinstance(values, tuple):
+        arrays = tuple(np.asarray(v) for v in values)
+        n = len(arrays[0])
+        for a in arrays:
+            if len(a) != n:
+                raise ValueError(
+                    "all arrays in `values` tuple must have the same length"
+                )
+        return arrays, n, True
+    arr = np.asarray(values)
+    return (arr,), len(arr), False
+
+
+def block_jackknife(values, statistic, *, weights=None):
+    """Block-jackknife standard error for a statistic over pre-binned blocks.
+
+    Implements the delete-1 block jackknife: for each block ``j``, the
+    statistic is recomputed on the remaining blocks; the spread of those
+    leave-one-out estimates gives a calibrated SE. When ``weights`` is
+    provided, the Busing et al. (1999) weighted delete-:math:`m_j`
+    formulation is used so unequal block sizes do not skew the SE.
+
+    Parameters
+    ----------
+    values : ndarray or tuple of ndarrays
+        Per-block values. Use a single 1D array for statistics of the form
+        ``statistic(vb)``; use a tuple ``(num, den, ...)`` for ratio-of-sums
+        statistics where multiple per-block arrays are consumed by
+        ``statistic``. All arrays in the tuple must have the same length.
+    statistic : callable
+        ``statistic(*values) -> float``. Called once on the full data and
+        once per block with that block masked out.
+    weights : ndarray, optional
+        Length-``n`` array of block sizes (e.g., SNPs per block). When
+        ``None`` (default), blocks are treated as equally weighted and the
+        formula reduces to the unweighted block jackknife. See Notes.
+
+    Returns
+    -------
+    estimate : float
+        Point estimate. Unweighted case: mean of leave-one-out values
+        (matches the current admixture jackknife). Weighted case: mean of
+        the Busing pseudo-values.
+    se : float
+        Jackknife standard error.
+    per_iter : ndarray, shape (n,)
+        Per-block leave-one-out statistic values.
+
+    Notes
+    -----
+    For uniform block sizes the weighted formulation reduces exactly to
+    ``sqrt(((n-1)/n) * sum((vj - mean(vj))**2))``.
+
+    Weighted formulation (Busing 1999 eq. 4-5):
+
+    .. math::
+
+        h_j = N / m_j, \\qquad \\phi_j = h_j \\hat\\theta - (h_j - 1) \\hat\\theta_{-j}
+
+        \\tilde\\theta = \\frac{1}{g} \\sum_j \\phi_j, \\qquad
+        \\mathrm{Var}(\\tilde\\theta) = \\frac{1}{g} \\sum_j
+            \\frac{(\\phi_j - \\tilde\\theta)^2}{h_j - 1}
+
+    where ``g`` is the number of blocks, ``m_j`` is the size of block ``j``,
+    and ``N = sum(m_j)``.
+
+    References
+    ----------
+    Busing, F. M. T. A., Meijer, E., & Van der Leeden, R. (1999). Delete-m
+    jackknife for unequal m. *Statistics and Computing*, 9, 3-8.
+    """
+    arrays, n, is_tuple = _as_tuple(values)
+
+    def _eval(mask):
+        if is_tuple:
+            masked = [a[mask] for a in arrays]
+            return float(statistic(*masked))
+        return float(statistic(arrays[0][mask]))
+
+    keep = np.ones(n, dtype=bool)
+    per_iter = np.empty(n, dtype=np.float64)
+    for i in range(n):
+        keep[i] = False
+        per_iter[i] = _eval(keep)
+        keep[i] = True
+
+    if weights is None:
+        m = per_iter.mean()
+        sv = ((n - 1) / n) * np.sum((per_iter - m) ** 2)
+        return m, float(np.sqrt(sv)), per_iter
+
+    w = np.asarray(weights, dtype=np.float64)
+    if w.shape != (n,):
+        raise ValueError(
+            f"`weights` must have length {n}; got shape {w.shape}"
+        )
+    if np.any(w <= 0):
+        raise ValueError("`weights` must be strictly positive")
+
+    theta_hat = _eval(np.ones(n, dtype=bool))
+    h = w.sum() / w
+    phi = h * theta_hat - (h - 1.0) * per_iter
+    estimate = float(phi.mean())
+    var = float(np.mean((phi - estimate) ** 2 / (h - 1.0)))
+    return estimate, float(np.sqrt(var)), per_iter
+
+
+def block_bootstrap(values, statistic, *, n_replicates=1000, rng=None):
+    """Block-bootstrap distribution for a statistic over pre-binned blocks.
+
+    Resamples block indices with replacement ``n_replicates`` times and
+    evaluates ``statistic`` on each resample. When ``values`` is a tuple,
+    the **same** sampled indices are applied to every array — required for
+    ratio-of-sums statistics where numerator and denominator share block
+    indexing (e.g. normed Patterson F3, Patterson D). To bootstrap two
+    *independent* arrays, call ``block_bootstrap`` on each separately.
+
+    Parameters
+    ----------
+    values : ndarray or tuple of ndarrays
+        Per-block values. Tuple entries must have the same length.
+    statistic : callable
+        ``statistic(*values) -> float``.
+    n_replicates : int, default 1000
+        Number of bootstrap replicates.
+    rng : int, numpy.random.Generator, or None
+        Seed or Generator for reproducibility. ``None`` uses fresh entropy.
+
+    Returns
+    -------
+    estimate : float
+        Plug-in point estimate ``statistic(*values)`` on the full data.
+        This follows Efron & Tibshirani (1993) §6.2: the bootstrap mean is
+        a noisy estimate of the plug-in estimate, not a replacement for it.
+    se : float
+        Bootstrap standard error, ``std(replicates, ddof=1)``.
+    replicates : ndarray, shape (n_replicates,)
+        Bootstrap replicate values. Use e.g. ``np.quantile(replicates,
+        [0.025, 0.975])`` for a percentile 95% CI.
+
+    References
+    ----------
+    Efron, B., & Tibshirani, R. J. (1993). *An Introduction to the
+    Bootstrap*. Chapman & Hall/CRC.
+    """
+    arrays, n, is_tuple = _as_tuple(values)
+    gen = np.random.default_rng(rng)
+
+    if is_tuple:
+        estimate = float(statistic(*arrays))
+    else:
+        estimate = float(statistic(arrays[0]))
+
+    replicates = np.empty(n_replicates, dtype=np.float64)
+    for r in range(n_replicates):
+        idx = gen.integers(0, n, size=n)
+        if is_tuple:
+            replicates[r] = float(statistic(*(a[idx] for a in arrays)))
+        else:
+            replicates[r] = float(statistic(arrays[0][idx]))
+
+    se = float(replicates.std(ddof=1)) if n_replicates > 1 else float("nan")
+    return estimate, se, replicates

--- a/tests/test_resampling.py
+++ b/tests/test_resampling.py
@@ -1,0 +1,169 @@
+"""
+Tests for pg_gpu.resampling: block_jackknife and block_bootstrap.
+"""
+
+import numpy as np
+import pytest
+from scipy import stats
+
+from pg_gpu.resampling import block_jackknife, block_bootstrap
+
+
+# -----------------------------------------------------------------------------
+# block_jackknife
+# -----------------------------------------------------------------------------
+
+
+class TestBlockJackknife:
+    def test_mean_closed_form_se(self):
+        """For statistic=mean, jackknife SE equals sample_std / sqrt(n)."""
+        rng = np.random.default_rng(42)
+        x = rng.normal(size=200)
+        est, se, per_iter = block_jackknife(x, statistic=np.mean)
+
+        assert per_iter.shape == (200,)
+        # Unweighted point estimate is mean of leave-one-out means, which
+        # equals the full-sample mean for a linear statistic.
+        assert est == pytest.approx(x.mean(), abs=1e-12)
+        # Closed-form: delete-1 jackknife SE of the mean is s/sqrt(n) with
+        # the ((n-1)/n) * sum((...)**2) formula → equals sample-std / sqrt(n)
+        # with the usual n-1 sample-std denominator.
+        expected_se = x.std(ddof=1) / np.sqrt(len(x))
+        assert se == pytest.approx(expected_se, rel=1e-10)
+
+    def test_tuple_ratio_matches_handwritten(self):
+        """Tuple-input ratio-of-sums matches an explicit delete-1 loop."""
+        rng = np.random.default_rng(0)
+        num = rng.normal(1.0, 0.5, size=30)
+        den = rng.normal(2.0, 0.5, size=30)
+
+        def stat(a, b):
+            return np.sum(a) / np.sum(b)
+        est, se, per_iter = block_jackknife((num, den), statistic=stat)
+
+        # Reference: explicit leave-one-out loop
+        vj_ref = np.array([stat(np.delete(num, i), np.delete(den, i))
+                           for i in range(len(num))])
+        assert np.allclose(per_iter, vj_ref)
+        n = len(num)
+        se_ref = np.sqrt(((n - 1) / n) * np.sum((vj_ref - vj_ref.mean()) ** 2))
+        assert se == pytest.approx(se_ref, rel=1e-12)
+        assert est == pytest.approx(vj_ref.mean(), abs=1e-12)
+
+    def test_weighted_reduces_to_unweighted_when_uniform(self):
+        """Uniform weights must give identical SE to unweighted case."""
+        rng = np.random.default_rng(7)
+        x = rng.normal(size=40)
+        _, se_u, _ = block_jackknife(x, statistic=np.mean)
+        _, se_w, _ = block_jackknife(x, statistic=np.mean,
+                                     weights=np.full(40, 250.0))
+        assert se_w == pytest.approx(se_u, rel=1e-12)
+
+    def test_weighted_busing_handcomputed(self):
+        """Weighted jackknife SE against an explicit Busing 1999 implementation."""
+        x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        w = np.array([10.0, 20.0, 10.0, 40.0, 20.0], dtype=np.float64)
+
+        est, se, per_iter = block_jackknife(x, statistic=np.sum, weights=w)
+
+        # Reference: explicit Busing 1999 pseudo-values + weighted variance.
+        g = len(x)
+        theta_hat = x.sum()
+        theta_neg = np.array([np.delete(x, i).sum() for i in range(g)])
+        h = w.sum() / w
+        phi = h * theta_hat - (h - 1.0) * theta_neg
+        est_ref = phi.mean()
+        var_ref = np.mean((phi - est_ref) ** 2 / (h - 1.0))
+        se_ref = np.sqrt(var_ref)
+
+        assert np.allclose(per_iter, theta_neg)
+        assert est == pytest.approx(est_ref, rel=1e-12)
+        assert se == pytest.approx(se_ref, rel=1e-12)
+
+    def test_weights_validated(self):
+        with pytest.raises(ValueError):
+            block_jackknife(np.arange(5.0), statistic=np.mean,
+                            weights=np.ones(4))
+        with pytest.raises(ValueError):
+            block_jackknife(np.arange(5.0), statistic=np.mean,
+                            weights=np.array([1.0, 1.0, 0.0, 1.0, 1.0]))
+
+    def test_tuple_length_mismatch_raises(self):
+        with pytest.raises(ValueError):
+            block_jackknife((np.arange(5.0), np.arange(6.0)),
+                            statistic=lambda a, b: a.sum() / b.sum())
+
+
+# -----------------------------------------------------------------------------
+# block_bootstrap
+# -----------------------------------------------------------------------------
+
+
+class TestBlockBootstrap:
+    def test_replicates_shape_and_estimate(self):
+        rng = np.random.default_rng(11)
+        x = rng.normal(size=50)
+
+        est, se, reps = block_bootstrap(x, statistic=np.mean,
+                                        n_replicates=500, rng=0)
+        # Plug-in estimate equals the sample mean exactly — not the
+        # replicate mean.
+        assert est == pytest.approx(x.mean(), abs=1e-12)
+        assert reps.shape == (500,)
+        assert se > 0
+
+    def test_seed_reproducibility(self):
+        x = np.arange(20.0)
+        _, se1, reps1 = block_bootstrap(x, statistic=np.mean,
+                                        n_replicates=200, rng=123)
+        _, se2, reps2 = block_bootstrap(x, statistic=np.mean,
+                                        n_replicates=200, rng=123)
+        assert se1 == se2
+        assert np.array_equal(reps1, reps2)
+
+    def test_agreement_with_scipy_bootstrap(self):
+        """SE should agree with scipy.stats.bootstrap on a simple mean."""
+        rng = np.random.default_rng(2024)
+        x = rng.normal(size=100)
+        _, se_ours, _ = block_bootstrap(x, statistic=np.mean,
+                                        n_replicates=4000, rng=1)
+        res = stats.bootstrap(
+            (x,), statistic=np.mean, n_resamples=4000,
+            method="percentile",
+            random_state=np.random.default_rng(1),
+        )
+        assert se_ours == pytest.approx(res.standard_error, rel=0.1)
+
+    def test_tuple_same_indices_invariant(self):
+        """Same block indices apply across tuple entries.
+
+        If resampling were independent across entries, a statistic that
+        consumes (a, b) as paired blocks would not reproduce any relation
+        between them. Here we use b = 2 * a, so every replicate of
+        np.sum(b)/np.sum(a) must equal exactly 2 regardless of the draw.
+        """
+        a = np.arange(1.0, 21.0)
+        b = 2.0 * a
+        est, se, reps = block_bootstrap(
+            (a, b), statistic=lambda x, y: np.sum(y) / np.sum(x),
+            n_replicates=300, rng=42,
+        )
+        assert est == pytest.approx(2.0)
+        assert np.allclose(reps, 2.0)
+        # With perfectly collinear entries, bootstrap SE is exactly zero.
+        assert se == pytest.approx(0.0, abs=1e-12)
+
+    def test_patterson_d_style_ratio_bootstrap(self):
+        """Ratio-of-sums bootstrap SE is in the same ballpark as jackknife SE."""
+        rng = np.random.default_rng(9)
+        num = rng.normal(0.1, 0.05, size=60)
+        den = rng.normal(0.3, 0.05, size=60)
+
+        def stat(n, d):
+            return np.sum(n) / np.sum(d)
+
+        _, se_jk, _ = block_jackknife((num, den), statistic=stat)
+        _, se_bs, _ = block_bootstrap((num, den), statistic=stat,
+                                      n_replicates=2000, rng=0)
+        # Not equal — but should agree to within a factor of ~1.5-2.
+        assert 0.5 * se_jk < se_bs < 2.0 * se_jk


### PR DESCRIPTION
## Summary

- Promotes the private ``_jackknife`` helper out of ``admixture`` into a public ``pg_gpu.resampling`` module, and adds a ``block_bootstrap`` companion. ``block_jackknife`` gains a Busing et al. (1999) weighted delete-:math:\`m_j\` variant for unequal block sizes.
- Relocates ``_moving_nansum`` / ``_moving_nanmean`` into the new module; ``admixture`` imports them back. ``average_patterson_f3`` / ``average_patterson_d`` call ``block_jackknife`` and return identical SEs byte-for-byte.
- New example ``examples/sweep_tajimas_d_bootstrap.py``: completed msprime sweep, windowed Tajima's D, block_bootstrap CIs for sweep-local vs distal mean Tajima's D. Sweep-local CI excludes zero; distal CI brackets the neutral expectation. New Sphinx docs section (api, features, quickstart, examples, changelog).

## Test plan

- [x] ``pixi run pytest tests/test_resampling.py -v`` — 11 new tests pass (closed-form SE, Busing hand-computation, scipy parity, paired-tuple invariant)
- [x] ``pixi run pytest tests/test_admixture_allel_comparison.py -v`` — 9 admixture parity tests still pass
- [x] Full suite: 550 passed, 55 skipped
- [x] ``pixi run ruff check pg_gpu/ tests/ examples/`` — clean
- [x] ``pixi run python examples/sweep_tajimas_d_bootstrap.py`` — runs end to end; sweep-local CI excludes 0
- [x] ``pixi run python examples/admixture_detection.py`` — null CI brackets 0 (Z=-0.09), admixed CI excludes 0 (Z=-5.11) — no regression

Closes #63