### PR TITLE
Expose local_pca_jackknife as a windowed_analysis statistic

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -289,6 +289,7 @@ Selection scan statistics:
 Structure / dimensionality reduction:
 
 - ``local_pca`` -- Li & Ralph (2019) local PCA. Vector-valued per window; dispatches to :func:`pg_gpu.decomposition.local_pca` and returns a :class:`~pg_gpu.decomposition.LocalPCAResult` instead of the scalar-stat DataFrame. Can be combined with scalar statistics in the same call; the scalar columns are merged onto ``result.windows``.
+- ``local_pca_jackknife`` -- delete-1 block jackknife SE for local PCA eigenvectors. Returns a :class:`~pg_gpu.decomposition.LocalPCAResult` with the ``jackknife_se`` field populated. When requested alongside ``local_pca``, per-window matrix preparation is shared. Accepts ``n_blocks`` and ``aggregate`` kwargs.
 
 Legacy Functions
 ~~~~~~~~~~~~~~~~

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -150,6 +150,9 @@ non-overlapping windows with ``missing_data='include'``:
   ``mean_nsl``.
 * Structure: ``local_pca`` (returns a ``LocalPCAResult``; scalar stats
   requested alongside are merged onto ``result.windows``).
+* Structure: ``local_pca_jackknife`` computes delete-1 block jackknife
+  SE and populates ``LocalPCAResult.jackknife_se``. When both are
+  requested together, per-window matrix preparation is shared.
 
 Lower-level windowed entry points: ``windowed_statistics`` (scatter-add
 aggregation) and ``windowed_statistics_fused`` (custom bin edges, one

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -220,6 +220,13 @@ Python API:
    mds, _ = pcoa(dist, n_components=2)
    extremes = corners(mds, prop=0.05, k=3)
 
+   # With jackknife SE (shares per-window matrix prep with local_pca)
+   result = windowed_analysis(
+       hm, window_size=500, step_size=250,
+       statistics=['local_pca', 'local_pca_jackknife'],
+       window_type='snp', k=2, n_blocks=10)
+   result.jackknife_se  # (n_windows, k) SE array
+
 LD Block Partitioning (end-to-end)
 ----------------------------------
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -307,14 +307,25 @@ regions). All four steps of the pipeline are available:
    # 4. Extreme-cluster detection in MDS space (Welzl MEC)
    corner_idx = corners(coords, prop=0.05, k=3)
 
-   # Optional: delete-1 block jackknife SE of local PCs
+   # Optional: delete-1 block jackknife SE of local PCs (standalone)
    from pg_gpu.decomposition import local_pca_jackknife
    se = local_pca_jackknife(h, window_size=500, window_type='snp',
                             k=2, n_blocks=10)  # (n_windows, k)
 
-``local_pca`` can also be requested through ``windowed_analysis``; when
-mixed with scalar statistics, the scalar columns are merged onto
-``result.windows`` so you get one object with both kinds of output.
+Both ``local_pca`` and ``local_pca_jackknife`` can be requested through
+``windowed_analysis``.  When both are requested together, per-window
+matrix preparation is shared for efficiency.  Scalar statistics can be
+mixed in the same call; the scalar columns are merged onto
+``result.windows``.
+
+.. code-block:: python
+
+   from pg_gpu import windowed_analysis
+
+   result = windowed_analysis(h, window_size=500, window_type='snp',
+                              statistics=['local_pca', 'local_pca_jackknife'],
+                              k=2, n_blocks=10)
+   result.jackknife_se  # (n_windows, k)
 
 For an end-to-end example with a simulated partial sweep, see
 ``examples/local_pca.py``.

--- a/pg_gpu/decomposition.py
+++ b/pg_gpu/decomposition.py
@@ -753,6 +753,159 @@ def local_pca(haplotype_matrix: "HaplotypeMatrix",
     )
 
 
+def _local_pca_with_jackknife(
+    haplotype_matrix: "HaplotypeMatrix",
+    window_params=None,
+    k: int = 2,
+    n_blocks: int = 10,
+    scaler: Optional[str] = None,
+    missing_data: str = 'include',
+    population: Optional[Union[str, list]] = None,
+    aggregate: Optional[str] = 'mean',
+    batch_size: Optional[int] = None,
+    window_size: Optional[int] = None,
+    step_size: Optional[int] = None,
+    window_type: str = 'snp',
+    regions=None,
+) -> LocalPCAResult:
+    """Local PCA with fused jackknife SE, sharing per-window matrix preparation.
+
+    Iterates windows once; for each valid window calls ``_prepare_matrix`` once
+    and from the same materialized ``X`` computes both the full Gram matrix (for
+    eigvals/eigvecs) and the leave-one-block-out Gram matrices (for jackknife).
+
+    Two-tier validity: windows with enough variants for PCA (``>= max(k, 2)``)
+    but too few for jackknife (``< max(k, 2) * n_blocks``) get valid
+    eigvals/eigvecs but NaN ``jackknife_se``.
+    """
+    from .windowed_analysis import WindowIterator
+
+    window_params = _resolve_window_params(
+        window_params, window_size, step_size, window_type, regions,
+        caller='_local_pca_with_jackknife')
+
+    if population is not None:
+        matrix = _get_population_matrix(haplotype_matrix, population)
+    else:
+        matrix = haplotype_matrix
+    if matrix.device == 'CPU':
+        matrix.transfer_to_gpu()
+
+    n_samples = matrix.num_haplotypes
+    iterator = WindowIterator(matrix, window_params)
+    identity_placeholder = cp.eye(n_samples, dtype=cp.float64)
+    nan_scalar = cp.asarray(np.nan, dtype=cp.float64)
+    identity_blocks = cp.broadcast_to(
+        identity_placeholder, (n_blocks, n_samples, n_samples))
+
+    min_pca = max(k, 2)
+    min_jk = min_pca * n_blocks
+
+    window_meta = []
+    gram_list = []
+    sumsq_list = []
+    jk_gram_list = []
+    valid_pca = []
+    valid_jk = []
+
+    for window in iterator:
+        window_meta.append(window)
+
+        if window.n_variants < min_pca:
+            # Too few variants for PCA or jackknife.
+            gram_list.append(identity_placeholder)
+            sumsq_list.append(nan_scalar)
+            jk_gram_list.append(identity_blocks)
+            valid_pca.append(False)
+            valid_jk.append(False)
+            continue
+
+        X = _prepare_matrix(window.matrix, scaler, population=None,
+                            missing_data=missing_data)
+        X = _materialize_prepared(X)
+        n_var_win = X.shape[1]
+
+        # Full Gram for local_pca.
+        C, sumsq = _window_gram(X, n_var_win)
+        gram_list.append(C)
+        sumsq_list.append(sumsq)
+        valid_pca.append(True)
+
+        # Leave-one-block-out Grams for jackknife.
+        step = n_var_win // n_blocks
+        if n_var_win < min_jk or step < 1:
+            jk_gram_list.append(identity_blocks)
+            valid_jk.append(False)
+            continue
+
+        window_grams = cp.empty((n_blocks, n_samples, n_samples),
+                                dtype=cp.float64)
+        for b in range(n_blocks):
+            lo = b * step
+            hi = (b + 1) * step
+            keep = cp.concatenate([cp.arange(0, lo), cp.arange(hi, n_var_win)])
+            Xk = X[:, keep]
+            Xk = Xk - Xk.mean(axis=1, keepdims=True)
+            denom = max(Xk.shape[1] - 1, 1)
+            window_grams[b] = (Xk @ Xk.T) / denom
+        jk_gram_list.append(window_grams)
+        valid_jk.append(True)
+
+    n_windows = len(window_meta)
+    if n_windows == 0:
+        raise ValueError("WindowIterator produced no windows.")
+
+    # --- Main eigendecomposition (local_pca) ---
+    gram_stack = cp.stack(gram_list, axis=0)
+    eigvals_host, eigvecs_host = _batched_top_k_eigh(gram_stack, k, batch_size)
+    sumsq_host = cp.stack(sumsq_list).get()
+
+    pca_mask = np.array(valid_pca, dtype=bool)
+    eigvals_host[~pca_mask] = np.nan
+    eigvecs_host[~pca_mask] = np.nan
+    sumsq_host[~pca_mask] = np.nan
+
+    # --- Jackknife eigendecomposition ---
+    jk_stack = cp.concatenate(jk_gram_list, axis=0)
+    _, jk_vecs = _batched_top_k_eigh(jk_stack, k, batch_size)
+    jk_vecs_4d = cp.asarray(jk_vecs).reshape(n_windows, n_blocks, k, n_samples)
+    aligned = _sign_align_replicates(jk_vecs_4d)
+    mean = aligned.mean(axis=1, keepdims=True)
+    jackknife_scale = (n_blocks - 1) / n_blocks
+    var = jackknife_scale * cp.sum((aligned - mean) ** 2, axis=1)
+    se_out = cp.sqrt(var).get()  # (n_windows, k, n_samples)
+
+    jk_mask = np.array(valid_jk, dtype=bool)
+    se_out[~jk_mask] = np.nan
+
+    if aggregate == 'mean':
+        jackknife_se = np.nanmean(se_out, axis=2)  # (n_windows, k)
+    elif aggregate is None:
+        jackknife_se = se_out
+    else:
+        raise ValueError(f"Unknown aggregate: {aggregate}")
+
+    windows_df = pd.DataFrame({
+        'chrom': [w.chrom for w in window_meta],
+        'start': [w.start for w in window_meta],
+        'end': [w.end for w in window_meta],
+        'center': [w.center for w in window_meta],
+        'n_variants': [w.n_variants for w in window_meta],
+        'window_id': [w.window_id for w in window_meta],
+    })
+
+    return LocalPCAResult(
+        windows=windows_df,
+        eigvals=eigvals_host,
+        eigvecs=eigvecs_host,
+        sumsq=sumsq_host,
+        k=k,
+        scaler=scaler,
+        missing_data=missing_data,
+        jackknife_se=jackknife_se,
+    )
+
+
 def pc_dist(source, npc: Optional[int] = None,
             normalize: Optional[str] = 'L1',
             w=1) -> np.ndarray:

--- a/pg_gpu/decomposition.py
+++ b/pg_gpu/decomposition.py
@@ -514,6 +514,11 @@ class LocalPCAResult:
         Number of PCs retained.
     scaler : str or None
     missing_data : str
+    jackknife_se : numpy.ndarray or None
+        Delete-1 block jackknife SE of the top-k eigenvectors. Shape
+        ``(n_windows, k)`` with ``aggregate='mean'``, or
+        ``(n_windows, k, n_samples)`` with ``aggregate=None``.
+        ``None`` when jackknife was not computed.
     """
 
     windows: "pd.DataFrame"
@@ -523,6 +528,7 @@ class LocalPCAResult:
     k: int
     scaler: Optional[str]
     missing_data: str
+    jackknife_se: Optional[np.ndarray] = None
 
     @property
     def n_windows(self) -> int:

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -18,10 +18,11 @@ from . import ld_statistics
 from . import divergence
 from . import diversity
 
-# Kwargs that the 'local_pca' dispatch consumes but scalar-stat paths don't
-# accept. Filtered out before the recursive call to scalar windowed_analysis.
+# Kwargs that the 'local_pca' / 'local_pca_jackknife' dispatch consumes but
+# scalar-stat paths don't accept. Filtered out before the recursive call.
 _LOCAL_PCA_ONLY_KWARGS = frozenset(
-    {'k', 'scaler', 'population', 'batch_size', 'window_type', 'regions'})
+    {'k', 'scaler', 'population', 'batch_size', 'window_type', 'regions',
+     'n_blocks', 'aggregate'})
 
 
 def _compute_window_bases(haplotype_matrix, win_starts, win_stops,
@@ -1110,8 +1111,11 @@ def windowed_analysis(haplotype_matrix: HaplotypeMatrix,
     # Local PCA dispatch: vector-valued per-window output; cannot live in the
     # scalar-stat DataFrame pipeline. Return a LocalPCAResult (with scalar
     # stats merged into .windows if requested alongside).
-    if 'local_pca' in statistics:
+    # 'local_pca_jackknife' implies 'local_pca' -- the SE is meaningless
+    # without the base eigendecomposition.
+    if 'local_pca' in statistics or 'local_pca_jackknife' in statistics:
         from . import decomposition
+        want_jackknife = 'local_pca_jackknife' in statistics
         local_pca_kwargs = {
             'k': kwargs.get('k', 2),
             'scaler': kwargs.get('scaler', None),
@@ -1123,8 +1127,15 @@ def windowed_analysis(haplotype_matrix: HaplotypeMatrix,
             'window_type': kwargs.get('window_type', 'bp'),
             'regions': kwargs.get('regions', None),
         }
-        result = decomposition.local_pca(haplotype_matrix, **local_pca_kwargs)
-        other_stats = [s for s in statistics if s != 'local_pca']
+        if want_jackknife:
+            local_pca_kwargs['n_blocks'] = kwargs.get('n_blocks', 10)
+            local_pca_kwargs['aggregate'] = kwargs.get('aggregate', 'mean')
+            result = decomposition._local_pca_with_jackknife(
+                haplotype_matrix, **local_pca_kwargs)
+        else:
+            result = decomposition.local_pca(haplotype_matrix, **local_pca_kwargs)
+        other_stats = [s for s in statistics
+                       if s not in ('local_pca', 'local_pca_jackknife')]
         if other_stats:
             scalar_df = windowed_analysis(
                 haplotype_matrix,

--- a/tests/test_local_pca.py
+++ b/tests/test_local_pca.py
@@ -376,3 +376,53 @@ class TestJackknife:
         V_flipped_aligned = _sign_align_replicates(V_flipped)
         var2 = cp.var(V_flipped_aligned, axis=0).get()
         np.testing.assert_allclose(var1, var2, rtol=1e-10, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Fused local_pca + jackknife
+# ---------------------------------------------------------------------------
+
+
+class TestFusedJackknife:
+
+    def test_fused_matches_separate(self, small_hm):
+        from pg_gpu.decomposition import _local_pca_with_jackknife
+
+        k, n_blocks = 2, 5
+        wkw = dict(window_size=200, window_type='snp', k=k)
+
+        fused = _local_pca_with_jackknife(small_hm, n_blocks=n_blocks,
+                                          aggregate='mean', **wkw)
+        separate_pca = local_pca(small_hm, **wkw)
+        separate_jk = local_pca_jackknife(small_hm, n_blocks=n_blocks,
+                                          aggregate='mean', **wkw)
+
+        assert isinstance(fused, LocalPCAResult)
+        np.testing.assert_allclose(fused.eigvals, separate_pca.eigvals,
+                                   rtol=1e-10)
+        np.testing.assert_allclose(fused.sumsq, separate_pca.sumsq,
+                                   rtol=1e-10)
+        assert fused.jackknife_se is not None
+        np.testing.assert_allclose(fused.jackknife_se, separate_jk,
+                                   rtol=1e-10)
+
+    def test_fused_partial_validity(self):
+        """Windows valid for PCA but not for jackknife."""
+        rng = np.random.default_rng(99)
+        # 12 variants total: with window_size=4 and n_blocks=5, the
+        # jackknife threshold (max(k,2)*n_blocks = 10) exceeds window size
+        # but PCA threshold (max(k,2) = 2) is met.
+        n_hap, n_var = 20, 12
+        hap = rng.integers(0, 2, (n_hap, n_var), dtype=np.int8)
+        pos = np.arange(n_var, dtype=np.int64) * 1000
+        hm = HaplotypeMatrix(hap, pos, 0, n_var * 1000)
+
+        from pg_gpu.decomposition import _local_pca_with_jackknife
+        result = _local_pca_with_jackknife(hm, window_size=4, window_type='snp',
+                                           k=2, n_blocks=5, aggregate='mean')
+
+        # PCA should be valid (4 >= 2)
+        assert np.all(np.isfinite(result.eigvals))
+        # Jackknife should be NaN (4 < 10)
+        assert result.jackknife_se is not None
+        assert np.all(np.isnan(result.jackknife_se))

--- a/tests/test_local_pca.py
+++ b/tests/test_local_pca.py
@@ -303,6 +303,44 @@ class TestWindowedAnalysisDispatch:
         assert isinstance(res, LocalPCAResult)
         assert 'pi' in res.windows.columns
 
+    def test_jackknife_alone(self, small_hm):
+        res = windowed_analysis(small_hm, window_size=200_000,
+                                step_size=200_000,
+                                statistics=['local_pca_jackknife'], k=2,
+                                n_blocks=5, window_type='bp')
+        assert isinstance(res, LocalPCAResult)
+        assert res.jackknife_se is not None
+        assert res.eigvals.shape[0] == res.jackknife_se.shape[0]
+
+    def test_jackknife_with_local_pca(self, small_hm):
+        res = windowed_analysis(small_hm, window_size=200_000,
+                                step_size=200_000,
+                                statistics=['local_pca', 'local_pca_jackknife'],
+                                k=2, n_blocks=5, window_type='bp')
+        assert isinstance(res, LocalPCAResult)
+        assert res.jackknife_se is not None
+        assert np.all(np.isfinite(res.eigvals))
+
+    def test_jackknife_with_scalar_stat(self, small_hm):
+        res = windowed_analysis(small_hm, window_size=200_000,
+                                step_size=200_000,
+                                statistics=['pi', 'local_pca_jackknife'],
+                                k=2, n_blocks=5, window_type='bp')
+        assert isinstance(res, LocalPCAResult)
+        assert 'pi' in res.windows.columns
+        assert res.jackknife_se is not None
+
+    def test_jackknife_aggregate_none(self, small_hm):
+        res = windowed_analysis(small_hm, window_size=200_000,
+                                step_size=200_000,
+                                statistics=['local_pca_jackknife'], k=2,
+                                n_blocks=5, aggregate=None, window_type='bp')
+        assert isinstance(res, LocalPCAResult)
+        assert res.jackknife_se is not None
+        assert res.jackknife_se.ndim == 3
+        assert res.jackknife_se.shape == (
+            res.n_windows, 2, small_hm.num_haplotypes)
+
 
 # ---------------------------------------------------------------------------
 # Corners

--- a/tests/test_local_pca.py
+++ b/tests/test_local_pca.py
@@ -95,6 +95,8 @@ class TestLocalPCAShape:
         assert set(CANONICAL_WINDOW_PREFIX) <= set(res.windows.columns)
         # Eigvals are sorted descending
         assert np.all(res.eigvals[:, 0] >= res.eigvals[:, 1])
+        # jackknife_se is None when jackknife not requested
+        assert res.jackknife_se is None
 
     def test_to_lostruct_matrix(self, small_hm):
         res = local_pca(small_hm, window_size=100, window_type='snp', k=3)


### PR DESCRIPTION
## Summary

Closes #71.

- Add `jackknife_se: Optional[np.ndarray]` field to `LocalPCAResult` (default `None`, backward compatible)
- Implement `_local_pca_with_jackknife()` fused function that iterates windows once and shares `_prepare_matrix` work between the full PCA eigendecomposition and the delete-1 block jackknife, avoiding redundant per-window matrix preparation
- Wire `'local_pca_jackknife'` string dispatch into `windowed_analysis()` -- requesting it alone implicitly computes the full local PCA; combinable with `'local_pca'` and scalar statistics in the same call
- Two-tier validity: windows meeting the PCA variant threshold but not the jackknife threshold get valid eigvals/eigvecs with NaN `jackknife_se`
- Document in quickstart, examples, API reference, and changelog

## Test plan

- [x] 22 tests pass in `tests/test_local_pca.py` (16 existing + 6 new)
- [x] `test_fused_matches_separate` verifies parity between fused and standalone `local_pca()` + `local_pca_jackknife()` calls
- [x] `test_fused_partial_validity` covers windows valid for PCA but not jackknife
- [x] `test_jackknife_alone`, `test_jackknife_with_local_pca`, `test_jackknife_with_scalar_stat`, `test_jackknife_aggregate_none` cover all `windowed_analysis` dispatch paths
- [x] Ruff lint clean