### PR TITLE
perf: stream LD variant pairs via GPU generator

### DIFF
--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -1552,63 +1552,39 @@ class HaplotypeMatrix:
             n_haps = self.num_haplotypes
             chunk_size = _estimate_ld_chunk_size(n_haps)
 
-        # Generate distance-filtered pair indices
-        idx_i, idx_j = _generate_pairs_within_distance(pos, max_dist)
-        total_pairs = len(idx_i)
-
-        if total_pairs == 0:
-            # No pairs within distance - return zeros for all bins
-            out = {}
-            for i in range(n_bins):
-                out[(float(bp_bins[i]), float(bp_bins[i + 1]))] = (0.0, 0.0, 0.0)
-            return out
-
-        # Compute distances for all pairs
-        distances = pos[idx_j] - pos[idx_i]
-
-        # Bin assignment
+        # Bin assignment constants
         bp_bins_cp = cp.array(bp_bins)
-        bin_inds = cp.digitize(distances, bp_bins_cp) - 1
 
         # Initialize accumulators: sums and counts per bin
         # 3 statistics: DD, Dz, pi2
         bin_sums = cp.zeros((n_bins, 3), dtype=cp.float64)
         bin_counts = cp.zeros(n_bins, dtype=cp.float64)
 
-        # Process in chunks
-        for chunk_start in range(0, total_pairs, chunk_size):
-            chunk_end = min(chunk_start + chunk_size, total_pairs)
+        # Stream distance-filtered pair chunks
+        for chunk_idx_i, chunk_idx_j in _iter_pairs_within_distance(
+                pos, max_dist, chunk_size):
+            distances = pos[chunk_idx_j] - pos[chunk_idx_i]
+            chunk_bin_inds = cp.digitize(distances, bp_bins_cp) - 1
+            del distances
 
-            # Get chunk indices
-            chunk_idx_i = idx_i[chunk_start:chunk_end]
-            chunk_idx_j = idx_j[chunk_start:chunk_end]
-            chunk_bin_inds = bin_inds[chunk_start:chunk_end]
-
-            # Compute haplotype counts for this chunk (no population filter)
             counts, n_valid = _compute_counts_for_pairs(
                 self.haplotypes, chunk_idx_i, chunk_idx_j, pop_indices=None
             )
 
-            # Compute all 3 statistics for this chunk
             chunk_stats = _compute_single_pop_statistics_batch(
                 counts, n_valid, ld_statistics
             )
 
-            # Accumulate into bins using scatter_add
             valid_mask = (chunk_bin_inds >= 0) & (chunk_bin_inds < n_bins)
             valid_bin_inds = chunk_bin_inds[valid_mask]
             valid_stats = chunk_stats[valid_mask]
 
-            # Accumulate sums
             for stat_idx in range(3):
                 cp.add.at(bin_sums[:, stat_idx], valid_bin_inds, valid_stats[:, stat_idx])
 
-            # Accumulate counts
             cp.add.at(bin_counts, valid_bin_inds, cp.ones(len(valid_bin_inds), dtype=cp.float64))
 
-            # Free chunk memory
-            del counts, n_valid, chunk_stats
-            del chunk_idx_i, chunk_idx_j, valid_stats
+            del counts, n_valid, chunk_stats, chunk_bin_inds, valid_stats
 
         # Build output dictionary
         out = {}
@@ -1717,49 +1693,24 @@ class HaplotypeMatrix:
             n_haps = max(len(pop1_indices), len(pop2_indices))
             chunk_size = _estimate_ld_chunk_size(n_haps)
 
-        # Generate distance-filtered pair indices
-        idx_i, idx_j = _generate_pairs_within_distance(pos, max_dist)
-        total_pairs = len(idx_i)
-
-        if total_pairs == 0:
-            # No pairs within distance - return zeros for all bins
-            out = {}
-            for i in range(n_bins):
-                out[(float(bp_bins[i]), float(bp_bins[i + 1]))] = OrderedDict([
-                    ('DD_0_0', 0.0), ('DD_0_1', 0.0), ('DD_1_1', 0.0),
-                    ('Dz_0_0_0', 0.0), ('Dz_0_0_1', 0.0), ('Dz_0_1_1', 0.0),
-                    ('Dz_1_0_0', 0.0), ('Dz_1_0_1', 0.0), ('Dz_1_1_1', 0.0),
-                    ('pi2_0_0_0_0', 0.0), ('pi2_0_0_0_1', 0.0), ('pi2_0_0_1_1', 0.0),
-                    ('pi2_0_1_0_1', 0.0), ('pi2_0_1_1_1', 0.0), ('pi2_1_1_1_1', 0.0)
-                ])
-            return out
-
-        # Compute distances for all pairs
-        distances = pos[idx_j] - pos[idx_i]
-
-        # Bin assignment
+        # Bin assignment constants
         bp_bins_cp = cp.array(bp_bins)
-        bin_inds = cp.digitize(distances, bp_bins_cp) - 1
 
-        # Initialize accumulators: sums and counts per bin
         stat_names = [
             'DD_0_0', 'DD_0_1', 'DD_1_1',
             'Dz_0_0_0', 'Dz_0_0_1', 'Dz_0_1_1', 'Dz_1_0_0', 'Dz_1_0_1', 'Dz_1_1_1',
             'pi2_0_0_0_0', 'pi2_0_0_0_1', 'pi2_0_0_1_1', 'pi2_0_1_0_1', 'pi2_0_1_1_1', 'pi2_1_1_1_1'
         ]
         bin_sums = cp.zeros((n_bins, 15), dtype=cp.float64)
-        bin_counts = cp.zeros(n_bins, dtype=cp.float64)  # float64 for scatter_add compatibility
+        bin_counts = cp.zeros(n_bins, dtype=cp.float64)
 
-        # Process in chunks
-        for chunk_start in range(0, total_pairs, chunk_size):
-            chunk_end = min(chunk_start + chunk_size, total_pairs)
+        # Stream distance-filtered pair chunks
+        for chunk_idx_i, chunk_idx_j in _iter_pairs_within_distance(
+                pos, max_dist, chunk_size):
+            distances = pos[chunk_idx_j] - pos[chunk_idx_i]
+            chunk_bin_inds = cp.digitize(distances, bp_bins_cp) - 1
+            del distances
 
-            # Get chunk indices
-            chunk_idx_i = idx_i[chunk_start:chunk_end]
-            chunk_idx_j = idx_j[chunk_start:chunk_end]
-            chunk_bin_inds = bin_inds[chunk_start:chunk_end]
-
-            # Compute haplotype counts for this chunk
             counts_pop1, n_valid1 = _compute_counts_for_pairs(
                 self.haplotypes, chunk_idx_i, chunk_idx_j, pop1_indices
             )
@@ -1767,26 +1718,21 @@ class HaplotypeMatrix:
                 self.haplotypes, chunk_idx_i, chunk_idx_j, pop2_indices
             )
 
-            # Compute all 15 statistics for this chunk
             chunk_stats = _compute_two_pop_statistics_batch(
                 counts_pop1, counts_pop2, n_valid1, n_valid2, ld_statistics
             )
 
-            # Accumulate into bins using scatter_add
             valid_mask = (chunk_bin_inds >= 0) & (chunk_bin_inds < n_bins)
             valid_bin_inds = chunk_bin_inds[valid_mask]
             valid_stats = chunk_stats[valid_mask]
 
-            # Accumulate sums per bin
             for stat_idx in range(15):
                 cp.add.at(bin_sums[:, stat_idx], valid_bin_inds, valid_stats[:, stat_idx])
 
-            # Accumulate counts
             cp.add.at(bin_counts, valid_bin_inds, cp.ones(len(valid_bin_inds), dtype=cp.float64))
 
-            # Free chunk memory
             del counts_pop1, counts_pop2, n_valid1, n_valid2, chunk_stats
-            del chunk_idx_i, chunk_idx_j, valid_stats
+            del chunk_bin_inds, valid_stats
 
         # Build output dictionary
         out = {}
@@ -1821,7 +1767,7 @@ class HaplotypeMatrix:
 # =============================================================================
 from .ld_pipeline import (  # noqa: E402, F401
     estimate_ld_chunk_size as _estimate_ld_chunk_size,
-    generate_pairs_within_distance as _generate_pairs_within_distance,
+    iter_pairs_within_distance as _iter_pairs_within_distance,
     compute_counts_for_pairs as _compute_counts_for_pairs,
     compute_genotype_counts_for_pairs as _compute_genotype_counts_for_pairs,
     compute_two_pop_statistics_batch as _compute_two_pop_statistics_batch,

--- a/pg_gpu/ld_pipeline.py
+++ b/pg_gpu/ld_pipeline.py
@@ -54,55 +54,72 @@ def estimate_ld_chunk_size(n_haplotypes_per_pop, available_memory_bytes=None,
 # ---------------------------------------------------------------------------
 
 
-def generate_pairs_within_distance(positions, max_dist):
+def iter_pairs_within_distance(positions, max_dist, chunk_size):
     """
-    Generate (i, j) pair indices for all variant pairs where pos[j] - pos[i] <= max_dist.
+    Yield GPU chunks of variant pair indices (i, j) with pos[j] - pos[i] <= max_dist.
 
-    Uses binary search for O(n log n) complexity instead of O(n^2).
-    Assumes positions are sorted.
+    Fully GPU-native: no CPU materialization of the full pair list. Variants
+    are partitioned into contiguous anchor blocks whose cumulative pair count
+    is close to ``chunk_size``; each block's pairs are emitted as a single
+    chunk. Overshoot above ``chunk_size`` per chunk is bounded by
+    ``max(pairs_per_variant) ~= density * max_dist``.
 
     Parameters
     ----------
     positions : cp.ndarray
-        Sorted variant positions on GPU
+        Sorted variant positions on GPU.
     max_dist : float
-        Maximum distance between variants to include
+        Maximum distance between variants to include.
+    chunk_size : int
+        Target pairs per chunk (actual chunk size may slightly exceed this).
 
-    Returns
-    -------
-    idx_i : cp.ndarray[int32]
-        First index of each pair
-    idx_j : cp.ndarray[int32]
-        Second index of each pair
+    Yields
+    ------
+    idx_i, idx_j : cp.ndarray[int32]
+        First and second variant index of each pair in the chunk.
     """
     n = len(positions)
+    if n < 2:
+        return
 
     upper_bounds = positions + max_dist
     j_max = cp.searchsorted(positions, upper_bounds, side='right')
-
     variant_indices = cp.arange(n, dtype=cp.int64)
     pairs_per_variant = cp.maximum(0, j_max - variant_indices - 1)
-    total_pairs = int(cp.sum(pairs_per_variant).get())
-
+    cumulative = cp.cumsum(pairs_per_variant)
+    total_pairs = int(cumulative[-1].get())
     if total_pairs == 0:
-        return cp.array([], dtype=cp.int32), cp.array([], dtype=cp.int32)
+        return
 
-    pairs_per_variant_cpu = pairs_per_variant.get().astype(np.int64)
-    j_max_cpu = j_max.get()
+    chunk_size = max(1, int(chunk_size))
+    n_chunks = (total_pairs + chunk_size - 1) // chunk_size
+    targets = cp.minimum(
+        cp.arange(1, n_chunks + 1, dtype=cp.int64) * chunk_size,
+        total_pairs)
+    # Exclusive upper variant for each chunk: smallest v with cumulative[v] >= target.
+    v_his = (cp.searchsorted(cumulative, targets, side='left') + 1).get()
+    v_his = np.minimum(v_his, n)
 
-    idx_i_cpu = np.empty(total_pairs, dtype=np.int32)
-    idx_j_cpu = np.empty(total_pairs, dtype=np.int32)
-
-    offset = 0
-    for i in range(n):
-        n_pairs_i = int(pairs_per_variant_cpu[i])
-        if n_pairs_i > 0:
-            idx_i_cpu[offset:offset + n_pairs_i] = i
-            idx_j_cpu[offset:offset + n_pairs_i] = np.arange(
-                i + 1, j_max_cpu[i], dtype=np.int32)
-            offset += n_pairs_i
-
-    return cp.array(idx_i_cpu), cp.array(idx_j_cpu)
+    v_lo = 0
+    for v_hi in v_his:
+        v_hi = int(v_hi)
+        if v_hi <= v_lo:
+            continue
+        counts_slice = pairs_per_variant[v_lo:v_hi]
+        cum_local = cp.cumsum(counts_slice)
+        n_pairs_chunk = int(cum_local[-1].get())
+        if n_pairs_chunk == 0:
+            v_lo = v_hi
+            continue
+        flat = cp.arange(n_pairs_chunk, dtype=cp.int64)
+        var_pos = cp.searchsorted(cum_local, flat, side='right')
+        offsets = cp.concatenate(
+            [cp.zeros(1, dtype=cum_local.dtype), cum_local[:-1]])
+        within_var = flat - offsets[var_pos]
+        idx_i = (v_lo + var_pos).astype(cp.int32)
+        idx_j = idx_i + 1 + within_var.astype(cp.int32)
+        yield idx_i, idx_j
+        v_lo = v_hi
 
 
 # ---------------------------------------------------------------------------

--- a/pg_gpu/ld_pipeline.py
+++ b/pg_gpu/ld_pipeline.py
@@ -113,9 +113,9 @@ def iter_pairs_within_distance(positions, max_dist, chunk_size):
             continue
         flat = cp.arange(n_pairs_chunk, dtype=cp.int64)
         var_pos = cp.searchsorted(cum_local, flat, side='right')
-        offsets = cp.concatenate(
-            [cp.zeros(1, dtype=cum_local.dtype), cum_local[:-1]])
-        within_var = flat - offsets[var_pos]
+        # Exclusive prefix-sum: inclusive cumsum minus the addend at each index.
+        exclusive = cum_local - counts_slice
+        within_var = flat - exclusive[var_pos]
         idx_i = (v_lo + var_pos).astype(cp.int32)
         idx_j = idx_i + 1 + within_var.astype(cp.int32)
         yield idx_i, idx_j

--- a/pg_gpu/moments_ld.py
+++ b/pg_gpu/moments_ld.py
@@ -22,7 +22,7 @@ import cupy as cp
 
 from .haplotype_matrix import HaplotypeMatrix
 from .ld_pipeline import (
-    generate_pairs_within_distance as _generate_pairs_within_distance,
+    iter_pairs_within_distance as _iter_pairs_within_distance,
     compute_counts_for_pairs as _compute_counts_for_pairs,
     compute_genotype_counts_for_pairs as _compute_genotype_counts_for_pairs,
     compute_two_pop_statistics_batch as _compute_two_pop_statistics_batch,
@@ -296,30 +296,23 @@ def _compute_ld_sums(mat, pops, bins, gen_dists_gpu, max_bp_dist,
     ld_stat_names = _ld_names(num_pops)
     n_ld = len(ld_stat_names)
 
-    idx_i, idx_j = _generate_pairs_within_distance(pos, max_bp_dist)
-    if len(idx_i) == 0:
-        return np.zeros((n_bins, n_ld), dtype=np.float64)
-
+    # Genetic-distance lookup: filter once outside the loop so fancy-indexing
+    # on the keep-mask doesn't repeat per chunk.
     if gen_dists_gpu is not None:
-        if use_genotypes:
-            filtered_gen_dists = gen_dists_gpu[keep_idx]
-            distances = cp.abs(filtered_gen_dists[idx_j] - filtered_gen_dists[idx_i])
-        else:
-            distances = cp.abs(gen_dists_gpu[idx_j] - gen_dists_gpu[idx_i])
+        gen_dists_lookup = gen_dists_gpu[keep_idx] if use_genotypes else gen_dists_gpu
     else:
-        distances = pos[idx_j] - pos[idx_i]
-    bin_inds = cp.digitize(distances, bins_gpu) - 1
-    del distances
+        gen_dists_lookup = None
 
     bin_sums = cp.zeros((n_bins, n_ld), dtype=cp.float64)
-    total_pairs = len(idx_i)
     stat_specs = _generate_stat_specs(num_pops) if (num_pops != 2 or use_genotypes) else None
 
-    for chunk_start in range(0, total_pairs, chunk_size):
-        chunk_end = min(chunk_start + chunk_size, total_pairs)
-        ci = idx_i[chunk_start:chunk_end]
-        cj = idx_j[chunk_start:chunk_end]
-        cb = bin_inds[chunk_start:chunk_end]
+    for ci, cj in _iter_pairs_within_distance(pos, max_bp_dist, chunk_size):
+        if gen_dists_lookup is not None:
+            distances = cp.abs(gen_dists_lookup[cj] - gen_dists_lookup[ci])
+        else:
+            distances = pos[cj] - pos[ci]
+        cb = cp.digitize(distances, bins_gpu) - 1
+        del distances
 
         counts_list = []
         n_valid_list = []
@@ -345,9 +338,8 @@ def _compute_ld_sums(mat, pops, bins, gen_dists_gpu, max_bp_dist,
         flat_idx = vb[:, None] * n_ld + cp.arange(n_ld)[None, :]
         cp.add.at(bin_sums.ravel(), flat_idx.ravel(), vs.ravel())
 
-        del counts_list, n_valid_list, stats
+        del counts_list, n_valid_list, stats, cb
 
-    del idx_i, idx_j, bin_inds
     return bin_sums.get()
 
 

--- a/tests/test_ld_pair_iteration.py
+++ b/tests/test_ld_pair_iteration.py
@@ -1,0 +1,115 @@
+"""Unit tests for pg_gpu.ld_pipeline.iter_pairs_within_distance."""
+import cupy as cp
+import numpy as np
+import pytest
+
+from pg_gpu.ld_pipeline import iter_pairs_within_distance
+
+
+def _collect(positions_gpu, max_dist, chunk_size):
+    """Run the generator and return concatenated (idx_i, idx_j) as numpy arrays."""
+    ii_parts = []
+    jj_parts = []
+    for ci, cj in iter_pairs_within_distance(positions_gpu, max_dist, chunk_size):
+        ii_parts.append(ci.get())
+        jj_parts.append(cj.get())
+    if not ii_parts:
+        return np.empty(0, dtype=np.int32), np.empty(0, dtype=np.int32)
+    return np.concatenate(ii_parts), np.concatenate(jj_parts)
+
+
+def _naive_pairs(positions, max_dist):
+    """CPU oracle: exhaustive (i, j) enumeration with i < j and pos[j]-pos[i] <= max_dist."""
+    n = len(positions)
+    pairs = set()
+    for i in range(n):
+        for j in range(i + 1, n):
+            if positions[j] - positions[i] <= max_dist:
+                pairs.add((i, j))
+    return pairs
+
+
+@pytest.mark.parametrize("n", [2, 10, 50])
+@pytest.mark.parametrize("max_dist_factor", [0.1, 0.5, 1.0, 10.0])
+def test_matches_naive_oracle(n, max_dist_factor):
+    rng = np.random.default_rng(seed=(n * 997 + int(max_dist_factor * 1000)))
+    # Sorted integer positions with gaps.
+    positions = np.sort(rng.integers(0, 10 * n, size=n)).astype(np.int64)
+    positions = np.unique(positions)
+    if len(positions) < 2:
+        pytest.skip("duplicates collapsed input")
+    span = positions[-1] - positions[0]
+    max_dist = max(1, int(span * max_dist_factor))
+
+    pos_gpu = cp.asarray(positions)
+    idx_i, idx_j = _collect(pos_gpu, max_dist, chunk_size=7)
+
+    got = set(zip(idx_i.tolist(), idx_j.tolist()))
+    expected = _naive_pairs(positions, max_dist)
+    assert got == expected
+    # All pairs have i < j
+    assert np.all(idx_i < idx_j)
+    # All within distance
+    assert np.all(positions[idx_j] - positions[idx_i] <= max_dist)
+
+
+def test_chunk_size_independence():
+    rng = np.random.default_rng(seed=12345)
+    positions = np.sort(rng.integers(0, 100_000, size=500)).astype(np.int64)
+    positions = np.unique(positions)
+    pos_gpu = cp.asarray(positions)
+    max_dist = 5000
+
+    def collect_sorted(cs):
+        idx_i, idx_j = _collect(pos_gpu, max_dist, chunk_size=cs)
+        order = np.lexsort((idx_j, idx_i))
+        return idx_i[order], idx_j[order]
+
+    refs = collect_sorted(1)
+    for cs in (1, 100, 10_000, 1_000_000):
+        got = collect_sorted(cs)
+        np.testing.assert_array_equal(got[0], refs[0])
+        np.testing.assert_array_equal(got[1], refs[1])
+
+
+def test_empty_inputs():
+    # n=0
+    empty = cp.asarray(np.empty(0, dtype=np.int64))
+    assert list(iter_pairs_within_distance(empty, 100, 10)) == []
+    # n=1
+    single = cp.asarray(np.array([42], dtype=np.int64))
+    assert list(iter_pairs_within_distance(single, 100, 10)) == []
+
+
+def test_max_dist_zero_admits_no_pairs_when_positions_unique():
+    positions = cp.asarray(np.arange(10, dtype=np.int64))
+    idx_i, idx_j = _collect(positions, max_dist=0, chunk_size=4)
+    assert idx_i.size == 0 and idx_j.size == 0
+
+
+def test_max_dist_huge_admits_every_pair():
+    n = 25
+    positions = cp.asarray(np.arange(n, dtype=np.int64) * 10)
+    idx_i, idx_j = _collect(positions, max_dist=10**9, chunk_size=7)
+    assert idx_i.size == n * (n - 1) // 2
+    got = set(zip(idx_i.tolist(), idx_j.tolist()))
+    expected = {(i, j) for i in range(n) for j in range(i + 1, n)}
+    assert got == expected
+
+
+def test_total_pair_count_matches_cumulative():
+    rng = np.random.default_rng(seed=99)
+    positions = np.sort(rng.integers(0, 50_000, size=300)).astype(np.int64)
+    positions = np.unique(positions)
+    pos_gpu = cp.asarray(positions)
+    max_dist = 2500
+
+    n = len(positions)
+    upper = pos_gpu + max_dist
+    j_max = cp.searchsorted(pos_gpu, upper, side='right')
+    pairs_per_variant = cp.maximum(0, j_max - cp.arange(n, dtype=cp.int64) - 1)
+    expected_total = int(cp.sum(pairs_per_variant).get())
+
+    total = sum(int(ci.size) for ci, _ in
+                iter_pairs_within_distance(pos_gpu, max_dist, chunk_size=250))
+    assert total == expected_total


### PR DESCRIPTION
## Summary
- Replace `generate_pairs_within_distance` (CPU-side `np.empty` + Python for-loop over variants) with `iter_pairs_within_distance`, a fully cupy-native streaming generator built on `searchsorted` + `cumsum` over variant-aligned chunks. No chunk's pair indices are ever materialized for the full pair set.
- Refactor the three in-repo callers (`moments_ld._compute_ld_sums`, `HaplotypeMatrix.compute_ld_statistics_gpu_single_pop`, `..._two_pops`) to consume chunks in a single loop, and fold per-chunk distance + bin assignment into that same loop. Drops the all-pair `pos[idx_j] - pos[idx_i]` intermediate along with the pair list.
- **Unblocks 10 kb+ `max_dist` regimes** that OOM'd on a 32 GB V100S before — the old pair-list stage needed 22 GB of int32 indices alone for a 4 Mb / 1 M-variant chromosome at 10 kb.

## A/B vs main (Tesla V100S 32 GB)

| Workload | main | this branch | Δ |
|---|---|---|---|
| 4 Mb gamb.X chrom, 1 M variants, 1 kb bp_bins, 2-pop haplotype | 49.75 s / 10.49 GB | **43.26 s / 10.19 GB** | −13 % wall, −3 % mem |
| `examples/multipop_ld_genotype_benchmark.py 2` (3 × 1 Mb sim, up to 1 Mb bp_bins, genotype) | 1.673 s | **1.532 s** | −8 % wall |
| 10 kb bp_bins, same gamb.X chrom | OOM | runs | — |

Numerical parity between branches on the 1 kb sums: max relative err `2.77e-15`, max absolute err `4.55e-12` — float64 epsilon, from `cp.add.at` reassociating over a different chunk traversal. Parity vs the `moments` oracle is unchanged (max rel err `1.83e-11` on both branches).

## Signature break
`generate_pairs_within_distance` is removed. Its three in-package callers are all updated. Not used by any `tests/` or `examples/` code.

## Test plan
- [x] `pixi run pytest tests/test_ld_pair_iteration.py -v` — 17 new unit tests (exact enumeration vs naive oracle, chunk-size independence, edge cases, total-pair count)
- [x] `pixi run -e moments pytest tests/test_moments_ld.py -v` — 23 passed, 1/2/3/4-pop parity with `moments.LD.Parsing.compute_ld_statistics`
- [x] `pixi run -e moments pytest tests/test_ld_{statistics_comparison,validation_full,statistics_gpu,statistics_gpu_single_pop,missing_data,missing_data_detailed,r_squared}.py tests/test_moments_ld.py -v` — 113 passed
- [x] `examples/multipop_ld_genotype_benchmark.py 2` numerical output unchanged (correlation 1.0, max rel err 1.83e-11)