### PR TITLE
fix: correct accessible-mask coords and add site-count properties

### DIFF
--- a/docs/source/missing_data.rst
+++ b/docs/source/missing_data.rst
@@ -187,8 +187,9 @@ to missing data handling.
 ``span_normalize`` accepts ``True`` or ``False``:
 
 * ``True`` (default): auto-detect the best denominator. If an accessible
-  mask is set, divides by accessible bases. Otherwise divides by genomic
-  span (chrom_end - chrom_start).
+  mask is set, divides by ``mask.total_accessible`` (the BED span).
+  Otherwise divides by the genomic span (1-based inclusive,
+  ``chrom_end - chrom_start + 1``).
 * ``False``: return raw sum (used internally by composite statistics like
   Tajima's D, and by advanced users who need custom normalization).
 
@@ -251,11 +252,46 @@ and the mask can be swapped or removed at any time.
   for chaining. It automatically sets ``n_total_sites`` to the count
   of accessible bases.
 
-* ``get_span('accessible')`` returns the accessible base count for a
-  region, used for per-base normalization.
+* The mask covers the union of the BED's extent and the matrix's
+  ``[chrom_start, chrom_end]`` range, so BED accessible bases that
+  fall outside the variant range (common for variants-only VCFs) are
+  not silently dropped. ``n_total_sites`` always equals the full BED
+  accessible-base count.
+
+* ``get_span('accessible')`` returns the accessible base count, used
+  for per-base normalization. This matches the denominator used by
+  ``allel.sequence_diversity(is_accessible=...)``.
 
 * The mask stays on CPU and uses a lazy prefix-sum for O(1) range
   queries, so windowed analysis over many windows is efficient.
+
+Site Count Properties
+---------------------
+
+After a mask is attached (or ``include_invariant=True`` was passed at
+load time), three properties decompose the analysis universe:
+
+* ``n_callable_sites`` -- alias for ``n_total_sites``; the BED span when
+  masked, or the matrix length if loaded with ``include_invariant=True``.
+* ``n_segregating_sites`` -- polymorphic sites in the matrix
+  (``0 < derived_count < n_valid``).
+* ``n_invariant_sites`` -- ``n_callable_sites - n_segregating_sites``;
+  may include implied invariants outside the matrix when the VCF was
+  variants-only.
+
+These satisfy ``n_callable_sites == n_segregating_sites + n_invariant_sites``.
+Note that ``num_variants`` is the *physical* matrix row count and is
+generally not equal to either ``n_segregating_sites`` (which excludes
+monomorphic rows) or ``n_callable_sites`` (which can include implied
+invariants).
+
+.. code-block:: python
+
+   h.set_accessible_mask("accessibility.bed", chrom="3L")
+   h.n_callable_sites          # e.g. 30,000,000 (BED total)
+   h.n_segregating_sites       # e.g. 1,200,000  (polymorphic in matrix)
+   h.n_invariant_sites         # e.g. 28,800,000 (callable - segregating)
+   h.num_variants              # whatever rows are physically present
 
 * ``get_subset()`` and ``get_population_matrix()`` read from the
   filtered properties, so child matrices automatically contain only

--- a/pg_gpu/accessible.py
+++ b/pg_gpu/accessible.py
@@ -15,8 +15,11 @@ class AccessibleMask:
     mask : array_like
         Boolean array where True indicates an accessible/callable site.
     offset : int
-        Genomic coordinate corresponding to index 0 of the mask array.
-        For example, if offset=1000, then mask[0] represents position 1000.
+        1-based genomic coordinate corresponding to mask[0]. For example,
+        if offset=1000, mask[0] represents 1-based position 1000.
+        Positions passed to is_accessible_at/count_accessible are interpreted
+        as 1-based (matching VCF conventions). BED intervals consumed by
+        bed_to_mask remain 0-based half-open per BED standard.
     """
 
     def __init__(self, mask, offset=0):
@@ -173,20 +176,27 @@ def bed_to_mask(path, chrom, length, offset=0):
     length : int
         Total length of the mask array (number of genomic positions to cover).
     offset : int
-        Genomic coordinate of the first position in the mask (index 0).
+        1-based genomic coordinate of mask[0].
 
     Returns
     -------
     AccessibleMask
         Boolean mask where True = accessible. Positions outside any BED
         interval are False.
+
+    Notes
+    -----
+    BED intervals are 0-based half-open: an interval (s, e) covers 1-based
+    positions s+1 through e (inclusive). Mask index k represents 1-based
+    position offset + k.
     """
     intervals = parse_bed(path, chrom=chrom)
     mask = np.zeros(length, dtype=bool)
     for _, s, e in intervals:
-        # Clip to the mask range
-        i = max(0, s - offset)
-        j = min(length, e - offset)
+        # BED (s, e) [0-based half-open] = 1-based positions s+1..e
+        # mask[k] = True for k where offset + k in [s+1, e]
+        i = max(0, s + 1 - offset)
+        j = min(length, e + 1 - offset)
         if j > i:
             mask[i:j] = True
     return AccessibleMask(mask, offset=offset)
@@ -200,7 +210,10 @@ def resolve_accessible_mask(mask_or_path, chrom_start, chrom_end, chrom=None):
     mask_or_path : str, path-like, numpy.ndarray, or AccessibleMask
         BED file path, boolean array, or AccessibleMask instance.
     chrom_start, chrom_end : int or None
-        Chromosome boundaries used for offset and BED loading.
+        Matrix chromosome bounds (1-based inclusive). Used to widen the
+        mask range so it covers both the matrix and the BED. This avoids
+        silently dropping BED accessible bases that fall outside the
+        matrix's variant range (relevant for variants-only VCFs).
     chrom : str, optional
         Chromosome name (required for BED file input).
 
@@ -213,11 +226,23 @@ def resolve_accessible_mask(mask_or_path, chrom_start, chrom_end, chrom=None):
     if isinstance(mask_or_path, np.ndarray):
         offset = chrom_start if chrom_start is not None else 0
         return AccessibleMask(mask_or_path, offset=offset)
-    # Treat as file path
-    offset = chrom_start if chrom_start is not None else 0
-    end = chrom_end if chrom_end is not None else 0
-    length = end - offset
+    # Treat as file path. Build the mask over the union of [chrom_start,
+    # chrom_end] and the BED's own extent so no accessible bases are lost
+    # when the matrix's variant range is narrower than the BED.
+    intervals = parse_bed(mask_or_path, chrom=chrom)
+    if not intervals:
+        raise ValueError(
+            f"No BED intervals found for chrom={chrom!r} in {mask_or_path}")
+    # 1-based inclusive bounds of the BED (BED is 0-based half-open: a record
+    # (s, e) covers 1-based positions s+1..e).
+    bed_min = min(s + 1 for _, s, _ in intervals)
+    bed_max = max(e for _, _, e in intervals)
+    matrix_min = chrom_start if chrom_start is not None else bed_min
+    matrix_max = chrom_end if chrom_end is not None else bed_max
+    offset = min(bed_min, matrix_min)
+    end = max(bed_max, matrix_max)
+    length = end - offset + 1
     if length <= 0:
         raise ValueError(
-            "chrom_start and chrom_end must be set to load a BED mask")
+            "Could not determine mask range from BED and chromosome bounds")
     return bed_to_mask(mask_or_path, chrom=chrom, length=length, offset=offset)

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -175,21 +175,41 @@ class GenotypeMatrix:
         return self.n_total_sites is not None
 
     @property
-    def n_invariant_sites(self):
-        """Number of invariant sites, or None if unknown."""
-        if self.n_total_sites is None:
-            return None
+    def n_callable_sites(self):
+        """Total callable sites in the analysis universe.
+
+        Alias for ``n_total_sites``. See ``HaplotypeMatrix.n_callable_sites``
+        for full semantics.
+        """
+        return self.n_total_sites
+
+    @property
+    def n_segregating_sites(self):
+        """Number of polymorphic sites in the matrix.
+
+        Counts sites where 0 < alt_count < 2 * n_valid (polymorphic among
+        observed diploid genotypes), with at least 2 valid samples.
+        """
         xp = cp if self.device == 'GPU' else np
         geno = self.genotypes
         valid_mask = geno >= 0
         geno_clean = xp.where(valid_mask, geno, 0)
         alt_counts = xp.sum(geno_clean, axis=0)
         n_valid = xp.sum(valid_mask, axis=0)
-        # max possible alt count per site (diploid: 2 * n_valid)
         max_alt = 2 * n_valid
         is_variant = (alt_counts > 0) & (alt_counts < max_alt) & (n_valid >= 2)
-        n_variant = int(xp.sum(is_variant))
-        return self.n_total_sites - n_variant
+        return int(xp.sum(is_variant))
+
+    @property
+    def n_invariant_sites(self):
+        """Number of invariant sites in the callable span, or None if unknown.
+
+        Computed as ``n_callable_sites - n_segregating_sites``. See
+        ``HaplotypeMatrix.n_invariant_sites`` for full semantics.
+        """
+        if self.n_total_sites is None:
+            return None
+        return self.n_total_sites - self.n_segregating_sites
 
     def __repr__(self):
         return (f"GenotypeMatrix(shape={self.shape}, "

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -63,7 +63,11 @@ class GenotypeMatrix:
                 accessible_mask, chrom_start, chrom_end)
         self.accessible_mask = accessible_mask
         if self._accessible_mask is not None and self.n_total_sites is None:
-            self.n_total_sites = self._accessible_mask.total_accessible
+            if chrom_start is not None and chrom_end is not None:
+                self.n_total_sites = self._accessible_mask.count_accessible(
+                    chrom_start, chrom_end + 1)
+            else:
+                self.n_total_sites = self._accessible_mask.total_accessible
 
     @property
     def genotypes(self):
@@ -157,7 +161,11 @@ class GenotypeMatrix:
         """
         self.accessible_mask = resolve_accessible_mask(
             mask_or_path, self.chrom_start, self.chrom_end, chrom)
-        self.n_total_sites = self.accessible_mask.total_accessible
+        if self.chrom_start is not None and self.chrom_end is not None:
+            self.n_total_sites = self.accessible_mask.count_accessible(
+                self.chrom_start, self.chrom_end + 1)
+        else:
+            self.n_total_sites = self.accessible_mask.total_accessible
         return self
 
     def remove_accessible_mask(self):

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -207,25 +207,52 @@ class HaplotypeMatrix:
         return self.n_total_sites is not None
 
     @property
-    def n_invariant_sites(self):
-        """Number of invariant (monomorphic) sites, or None if unknown.
+    def n_callable_sites(self):
+        """Total callable sites in the analysis universe.
 
-        If n_total_sites is set, computes as n_total_sites minus the number of
-        segregating sites in the matrix. If invariant sites are stored directly
-        in the matrix, counts sites where all valid alleles are identical.
+        Alias for ``n_total_sites``. When an accessible mask is set, this is
+        the BED span (mask.total_accessible). When no mask is set but the
+        matrix was loaded with ``include_invariant=True``, this is the matrix
+        length at construction. Otherwise None.
+
+        This is the denominator for per-base span normalization, and
+        ``n_callable_sites = n_segregating_sites + n_invariant_sites``.
         """
-        if self.n_total_sites is None:
-            return None
+        return self.n_total_sites
+
+    @property
+    def n_segregating_sites(self):
+        """Number of polymorphic sites in the matrix.
+
+        Counts sites where 0 < derived_count < n_valid (i.e. polymorphic
+        among observed haplotypes), with at least 2 valid samples.
+        """
         xp = cp if self.device == 'GPU' else np
         hap = self.haplotypes
         valid_mask = hap >= 0
         hap_clean = xp.where(valid_mask, hap, 0)
         derived_counts = xp.sum(hap_clean, axis=0)
         n_valid = xp.sum(valid_mask, axis=0)
-        # A site is variant if 0 < derived < n_valid (i.e. polymorphic among observed)
         is_variant = (derived_counts > 0) & (derived_counts < n_valid) & (n_valid >= 2)
-        n_variant = int(xp.sum(is_variant))
-        return self.n_total_sites - n_variant
+        return int(xp.sum(is_variant))
+
+    @property
+    def n_invariant_sites(self):
+        """Number of invariant sites in the callable span, or None if unknown.
+
+        Computed as ``n_callable_sites - n_segregating_sites``. The matrix may
+        physically contain fewer than ``n_callable_sites`` rows (e.g. for a
+        variants-only VCF the matrix has only the polymorphic rows and the
+        rest are implied invariants from the accessible-mask span); in that
+        case the returned count includes those implied invariants.
+
+        Note that ``num_variants`` (matrix row count) is generally not equal
+        to ``n_segregating_sites`` and not equal to ``n_callable_sites`` --
+        it is just the physical matrix length.
+        """
+        if self.n_total_sites is None:
+            return None
+        return self.n_total_sites - self.n_segregating_sites
 
     def transfer_to_gpu(self):
         """Transfer data from CPU to GPU."""
@@ -489,9 +516,11 @@ class HaplotypeMatrix:
         # Convert ts to haplotype matrix
         haplotypes = ts.genotype_matrix().T
         positions = ts.tables.sites.position
-        # get the chromosome start and end
+        # tskit uses 0-based exclusive ends (positions in [0, sequence_length))
+        # while pg_gpu treats chrom_end as 1-based inclusive. Subtract 1 so
+        # span = chrom_end - chrom_start + 1 == sequence_length.
         chrom_start = 0
-        chrom_end = ts.sequence_length
+        chrom_end = int(ts.sequence_length) - 1
         if device == 'GPU':
             # Convert to CuPy arrays
             haplotypes = cp.array(haplotypes)
@@ -840,29 +869,31 @@ class HaplotypeMatrix:
         span : int
             The span to use for normalization
         """
+        # chrom_start and chrom_end are 1-based inclusive throughout pg_gpu;
+        # count_accessible() is half-open, so pass end + 1 to include
+        # chrom_end itself, and the inclusive count is end - start + 1.
+        # When a mask is set, the full BED total (mask.total_accessible)
+        # is the natural denominator, matching scikit-allel's
+        # sequence_diversity(is_accessible=...) behavior.
         if mode == 'auto':
             if self.accessible_mask is not None:
-                start = self.chrom_start if self.chrom_start is not None else 0
-                end = self.chrom_end if self.chrom_end is not None else start
-                return self.accessible_mask.count_accessible(start, end)
+                return self.accessible_mask.total_accessible
             if self.n_total_sites is not None:
                 return self.n_total_sites
             if self.chrom_start is not None and self.chrom_end is not None:
-                return self.chrom_end - self.chrom_start
+                return self.chrom_end - self.chrom_start + 1
             mode = 'callable'
 
         if mode == 'accessible':
             if self.accessible_mask is not None:
-                start = self.chrom_start if self.chrom_start is not None else 0
-                end = self.chrom_end if self.chrom_end is not None else start
-                return self.accessible_mask.count_accessible(start, end)
+                return self.accessible_mask.total_accessible
             raise ValueError(
                 "mode='accessible' requires an accessible mask. "
                 "Use set_accessible_mask() first.")
 
         if mode in ('per_base', 'total'):
             if self.chrom_start is not None and self.chrom_end is not None:
-                return self.chrom_end - self.chrom_start
+                return self.chrom_end - self.chrom_start + 1
             mode = 'callable'
 
         if mode in ('per_variant', 'sites'):

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -76,7 +76,11 @@ class HaplotypeMatrix:
                 accessible_mask, chrom_start, chrom_end)
         self.accessible_mask = accessible_mask
         if self._accessible_mask is not None and self.n_total_sites is None:
-            self.n_total_sites = self._accessible_mask.total_accessible
+            if chrom_start is not None and chrom_end is not None:
+                self.n_total_sites = self._accessible_mask.count_accessible(
+                    chrom_start, chrom_end + 1)
+            else:
+                self.n_total_sites = self._accessible_mask.total_accessible
 
     @property
     def haplotypes(self):
@@ -189,7 +193,16 @@ class HaplotypeMatrix:
         # The property setter handles _accessible_idx and cache invalidation
         self.accessible_mask = resolve_accessible_mask(
             mask_or_path, self.chrom_start, self.chrom_end, chrom)
-        self.n_total_sites = self.accessible_mask.total_accessible
+        # n_total_sites is the BED-accessible-base count within the
+        # analysis range [chrom_start, chrom_end]. The mask itself may
+        # span more (we widen it to avoid losing bases inside the range
+        # when chrom_end < BED max), but only in-range bases count toward
+        # the per-base normalization denominator.
+        if self.chrom_start is not None and self.chrom_end is not None:
+            self.n_total_sites = self.accessible_mask.count_accessible(
+                self.chrom_start, self.chrom_end + 1)
+        else:
+            self.n_total_sites = self.accessible_mask.total_accessible
         return self
 
     def remove_accessible_mask(self):
@@ -318,16 +331,30 @@ class HaplotypeMatrix:
         positions = np.array(vcf['variants/POS'])
         sample_names = list(vcf['samples'])
 
+        # When a region is given, use its bounds (1-based inclusive) so the
+        # analysis range matches what the user asked for, not just the
+        # span between the first and last observed variants. This matters
+        # for span normalization with an accessible mask: the denominator
+        # is BED accessible bases within [chrom_start, chrom_end].
+        chrom_start = int(positions[0])
+        chrom_end = int(positions[-1])
+        chrom = None
+        if region is not None:
+            chrom_part, _, range_part = region.partition(':')
+            chrom = chrom_part or None
+            if range_part:
+                start_str, _, end_str = range_part.partition('-')
+                if start_str:
+                    chrom_start = int(start_str.replace(',', ''))
+                if end_str:
+                    chrom_end = int(end_str.replace(',', ''))
+        elif 'variants/CHROM' in vcf:
+            chrom = vcf['variants/CHROM'][0]
+
         n_total_sites = num_variants if include_invariant else None
-        hm = cls(haplotypes, positions, positions[0], positions[-1],
+        hm = cls(haplotypes, positions, chrom_start, chrom_end,
                  n_total_sites=n_total_sites, samples=sample_names)
         if accessible_bed is not None:
-            # Extract chrom from region string or VCF data
-            chrom = None
-            if region is not None:
-                chrom = region.split(':')[0]
-            elif 'variants/CHROM' in vcf:
-                chrom = vcf['variants/CHROM'][0]
             hm.set_accessible_mask(accessible_bed, chrom=chrom)
         return hm
 
@@ -872,12 +899,14 @@ class HaplotypeMatrix:
         # chrom_start and chrom_end are 1-based inclusive throughout pg_gpu;
         # count_accessible() is half-open, so pass end + 1 to include
         # chrom_end itself, and the inclusive count is end - start + 1.
-        # When a mask is set, the full BED total (mask.total_accessible)
-        # is the natural denominator, matching scikit-allel's
-        # sequence_diversity(is_accessible=...) behavior.
+        # The denominator is BED accessible bases within the analysis range
+        # [chrom_start, chrom_end], matching scikit-allel's
+        # sequence_diversity(is_accessible=..., start=..., stop=...).
         if mode == 'auto':
             if self.accessible_mask is not None:
-                return self.accessible_mask.total_accessible
+                start = self.chrom_start if self.chrom_start is not None else 0
+                end = self.chrom_end if self.chrom_end is not None else start
+                return self.accessible_mask.count_accessible(start, end + 1)
             if self.n_total_sites is not None:
                 return self.n_total_sites
             if self.chrom_start is not None and self.chrom_end is not None:
@@ -886,7 +915,9 @@ class HaplotypeMatrix:
 
         if mode == 'accessible':
             if self.accessible_mask is not None:
-                return self.accessible_mask.total_accessible
+                start = self.chrom_start if self.chrom_start is not None else 0
+                end = self.chrom_end if self.chrom_end is not None else start
+                return self.accessible_mask.count_accessible(start, end + 1)
             raise ValueError(
                 "mode='accessible' requires an accessible mask. "
                 "Use set_accessible_mask() first.")

--- a/tests/test_accessible_mask.py
+++ b/tests/test_accessible_mask.py
@@ -157,24 +157,43 @@ class TestBedToMask:
         return f.name
 
     def test_basic_mask(self):
+        # offset is 1-based, BED is 0-based half-open. BED (10, 20) covers
+        # 1-based positions 11..20 (10 bases). BED (30, 35) covers 31..35.
         path = self._write_bed("chr1\t10\t20\nchr1\t30\t35\n")
         try:
-            am = bed_to_mask(path, chrom="chr1", length=50, offset=0)
+            am = bed_to_mask(path, chrom="chr1", length=50, offset=1)
             assert am.total_accessible == 15  # 10 + 5
-            assert am.count_accessible(10, 20) == 10
-            assert am.count_accessible(0, 10) == 0
-            assert am.count_accessible(30, 35) == 5
+            # count_accessible(start, end) is 1-based half-open
+            assert am.count_accessible(11, 21) == 10
+            assert am.count_accessible(1, 11) == 0
+            assert am.count_accessible(31, 36) == 5
         finally:
             os.unlink(path)
 
     def test_mask_with_offset(self):
         path = self._write_bed("chr1\t100\t200\n")
         try:
-            am = bed_to_mask(path, chrom="chr1", length=200, offset=50)
-            # Mask covers positions 50-250, BED interval is 100-200
-            # Mask indices: 50->0, 100->50, 200->150
-            assert am.count_accessible(100, 200) == 100
-            assert am.count_accessible(50, 100) == 0
+            am = bed_to_mask(path, chrom="chr1", length=200, offset=51)
+            # offset=51 (1-based), so mask[0] = position 51, mask[199] = 250.
+            # BED (100, 200) covers 1-based positions 101..200 (100 bases).
+            assert am.count_accessible(101, 201) == 100
+            assert am.count_accessible(51, 101) == 0
+        finally:
+            os.unlink(path)
+
+    def test_offset_one_based_roundtrip(self):
+        # Regression: BED accessible bases must equal positions surviving
+        # is_accessible_at when VCF positions match BED bases exactly.
+        # Failure mode pre-fix: each BED interval lost its rightmost base.
+        path = self._write_bed("chr1\t10\t20\nchr1\t30\t35\n")
+        try:
+            am = bed_to_mask(path, chrom="chr1", length=50, offset=1)
+            # 1-based positions in the BED accessible set: 11..20, 31..35
+            test_positions = np.concatenate([
+                np.arange(11, 21), np.arange(31, 36)])
+            keep = am.is_accessible_at(test_positions)
+            assert keep.sum() == 15
+            assert keep.all()
         finally:
             os.unlink(path)
 
@@ -275,7 +294,8 @@ class TestHaplotypeMatrixAccessibleMask:
         hm = _make_haplotype_matrix()
         hm.set_accessible_mask(mask)
         assert hm.get_span('accessible') == 900
-        assert hm.get_span('total') == 1000
+        # chrom_start=0, chrom_end=1000 are 1-based inclusive => 1001 positions
+        assert hm.get_span('total') == 1001
 
     def test_get_span_auto_uses_accessible(self):
         mask = np.ones(1000, dtype=bool)
@@ -416,8 +436,8 @@ class TestBackwardCompatibility:
         """All operations work without a mask set."""
         hm = _make_haplotype_matrix()
         assert not hm.has_accessible_mask
-        # get_span should still work
-        assert hm.get_span('total') == 1000
+        # get_span should still work; chrom_end=1000 is 1-based inclusive
+        assert hm.get_span('total') == 1001
         assert hm.get_span('sites') == 20
         # get_subset should work
         subset = hm.get_subset(np.array([0, 1]))
@@ -673,3 +693,179 @@ class TestSelectionAccessibleMask:
         score_with_mask = selection.ihs(hm)
 
         np.testing.assert_array_equal(score_no_mask, score_with_mask)
+
+
+# ---- New site-count properties ----
+
+class TestSiteCountProperties:
+    """n_segregating_sites, n_callable_sites, n_invariant_sites consistency."""
+
+    def _make_hm(self, hap, positions, chrom_start, chrom_end,
+                 n_total_sites=None):
+        return HaplotypeMatrix(
+            hap, positions, chrom_start=chrom_start, chrom_end=chrom_end,
+            n_total_sites=n_total_sites)
+
+    def test_n_callable_sites_alias(self):
+        hm = _make_haplotype_matrix()
+        hm.n_total_sites = 1234
+        assert hm.n_callable_sites == 1234
+        hm.n_total_sites = None
+        assert hm.n_callable_sites is None
+
+    def test_n_segregating_strict_polymorphic(self):
+        # 5 sites: site 0 fully ref (invariant), site 1 polymorphic,
+        # site 2 fully alt (invariant), site 3 polymorphic, site 4 all missing.
+        hap = np.array([
+            [0, 0, 1, 0, -1],
+            [0, 1, 1, 1, -1],
+            [0, 1, 1, 0, -1],
+            [0, 0, 1, 1, -1],
+        ], dtype=np.int8)
+        pos = np.array([1, 2, 3, 4, 5])
+        hm = self._make_hm(hap, pos, chrom_start=1, chrom_end=5)
+        # Sites 1 and 3 are the only polymorphic ones (0 < derived < n_valid)
+        assert hm.n_segregating_sites == 2
+
+    def test_n_invariant_identity(self):
+        # Identity: n_total = n_segregating + n_invariant when n_total set.
+        hap = np.array([
+            [0, 0, 1, 0],
+            [0, 1, 1, 1],
+            [0, 1, 1, 0],
+            [0, 0, 1, 1],
+        ], dtype=np.int8)
+        pos = np.array([1, 2, 3, 4])
+        hm = self._make_hm(hap, pos, chrom_start=1, chrom_end=4,
+                           n_total_sites=10)
+        assert hm.n_segregating_sites == 2  # sites 1 and 3
+        assert hm.n_invariant_sites == 8  # 10 - 2
+
+    def test_n_invariant_returns_none_without_total(self):
+        hap = np.array([[0, 1], [1, 0]], dtype=np.int8)
+        pos = np.array([1, 2])
+        hm = self._make_hm(hap, pos, chrom_start=1, chrom_end=2)
+        # No mask, no n_total_sites set
+        assert hm.n_total_sites is None
+        assert hm.n_invariant_sites is None
+        # n_segregating works regardless
+        assert hm.n_segregating_sites == 2
+
+    def test_post_mask_consistency_h2_scenario(self):
+        # Regression for barnacle notebook h2: filtered VCF whose positions
+        # exactly match BED accessible bases. Pre-fix this lost ~half the
+        # rows and produced negative variant_sites in user reports.
+        bed_intervals = [(0, 100), (199, 299), (399, 499),
+                         (599, 799), (899, 950)]
+        total_bed = sum(e - s for s, e in bed_intervals)  # 551
+        # Construct VCF positions that exactly match BED accessible bases
+        # (1-based: BED (s, e) -> positions s+1..e)
+        positions = np.concatenate([np.arange(s + 1, e + 1)
+                                    for s, e in bed_intervals]).astype(np.int64)
+        n_hap = 4
+        hap = np.random.RandomState(0).randint(
+            0, 2, size=(n_hap, len(positions))).astype(np.int8)
+        hm = HaplotypeMatrix(hap, positions,
+                             chrom_start=int(positions[0]),
+                             chrom_end=int(positions[-1]))
+
+        f = tempfile.NamedTemporaryFile(
+            mode='w', suffix='.bed', delete=False)
+        for s, e in bed_intervals:
+            f.write(f"chr1\t{s}\t{e}\n")
+        f.close()
+        try:
+            hm.set_accessible_mask(f.name, chrom="chr1")
+            # All VCF positions are inside BED, so all matrix rows survive
+            assert hm.num_variants == total_bed
+            # Mask cumulative count includes every BED base (no off-by-one)
+            assert hm.accessible_mask.total_accessible == total_bed
+            assert hm.n_callable_sites == total_bed
+            # Identity holds
+            assert (hm.n_invariant_sites + hm.n_segregating_sites
+                    == hm.n_callable_sites)
+            # variant count derived as (callable - invariant) is non-negative
+            assert hm.n_segregating_sites >= 0
+            assert hm.n_invariant_sites >= 0
+        finally:
+            os.unlink(f.name)
+
+    def test_pi_matches_scikit_allel_with_mask(self):
+        # Anchor against allel.sequence_diversity, the canonical reference
+        # for per-base nucleotide diversity with an accessibility mask.
+        import allel
+
+        rng = np.random.RandomState(0)
+        n_hap = 8
+        total_bp = 1000
+        bed_intervals = [(0, 100), (199, 299), (399, 499),
+                         (599, 799), (899, 950)]
+        # Boolean mask in 1-based-index-aligned form (mask[k] = True iff
+        # 1-based position k+1 is accessible).
+        mask_array = np.zeros(total_bp, dtype=bool)
+        for s, e in bed_intervals:
+            mask_array[s:e] = True
+
+        scenarios = []
+        # Scenario A: dense (positions cover every base, e.g. raw VCF).
+        positions_A = np.arange(1, total_bp + 1)
+        hap_A = rng.randint(0, 2, size=(n_hap, total_bp)).astype(np.int8)
+        scenarios.append(("dense", positions_A, hap_A))
+        # Scenario B: sparse (positions == BED accessible bases).
+        positions_B = np.concatenate(
+            [np.arange(s + 1, e + 1) for s, e in bed_intervals]
+        ).astype(np.int64)
+        hap_B = rng.randint(0, 2,
+                            size=(n_hap, len(positions_B))).astype(np.int8)
+        scenarios.append(("sparse", positions_B, hap_B))
+        # Scenario C: variants-only (positions are a subset of BED).
+        all_acc = np.concatenate(
+            [np.arange(s + 1, e + 1) for s, e in bed_intervals])
+        sub_idx = np.sort(rng.choice(len(all_acc), 60, replace=False))
+        positions_C = all_acc[sub_idx].astype(np.int64)
+        hap_C = rng.randint(0, 2,
+                            size=(n_hap, len(positions_C))).astype(np.int8)
+        scenarios.append(("variants_only", positions_C, hap_C))
+
+        bed_path = tempfile.NamedTemporaryFile(
+            mode='w', suffix='.bed', delete=False).name
+        with open(bed_path, 'w') as f:
+            for s, e in bed_intervals:
+                f.write(f"chr1\t{s}\t{e}\n")
+        try:
+            for label, positions, hap in scenarios:
+                from pg_gpu import diversity as div
+                hm = HaplotypeMatrix(hap, positions,
+                                     chrom_start=int(positions[0]),
+                                     chrom_end=int(positions[-1]))
+                hm.set_accessible_mask(bed_path, chrom="chr1")
+                pi_pg = div.pi(hm)
+
+                ac = allel.HaplotypeArray(hap.T).count_alleles()
+                pi_allel = allel.sequence_diversity(
+                    positions, ac, start=1, stop=total_bp,
+                    is_accessible=mask_array)
+                assert abs(pi_pg - pi_allel) < 1e-10, (
+                    f"{label}: pg_gpu pi {pi_pg} != allel pi {pi_allel}")
+                # n_callable_sites must equal allel's accessible count
+                assert hm.n_callable_sites == int(mask_array.sum())
+        finally:
+            os.unlink(bed_path)
+
+    def test_genotype_matrix_properties(self):
+        # Mirror on GenotypeMatrix
+        rng = np.random.RandomState(0)
+        # site 0: invariant ref, site 1: polymorphic, site 2: invariant alt,
+        # site 3: polymorphic
+        geno = np.array([
+            [0, 0, 2, 0],
+            [0, 1, 2, 2],
+            [0, 2, 2, 1],
+            [0, 1, 2, 1],
+        ], dtype=np.int8)
+        pos = np.array([1, 2, 3, 4])
+        gm = GenotypeMatrix(geno, pos, chrom_start=1, chrom_end=4,
+                            n_total_sites=10)
+        assert gm.n_segregating_sites == 2
+        assert gm.n_callable_sites == 10
+        assert gm.n_invariant_sites == 8

--- a/tests/test_accessible_mask.py
+++ b/tests/test_accessible_mask.py
@@ -765,8 +765,9 @@ class TestSiteCountProperties:
         n_hap = 4
         hap = np.random.RandomState(0).randint(
             0, 2, size=(n_hap, len(positions))).astype(np.int8)
+        # chrom_start/end define the analysis range (1-based inclusive).
         hm = HaplotypeMatrix(hap, positions,
-                             chrom_start=int(positions[0]),
+                             chrom_start=1,
                              chrom_end=int(positions[-1]))
 
         f = tempfile.NamedTemporaryFile(
@@ -835,9 +836,11 @@ class TestSiteCountProperties:
         try:
             for label, positions, hap in scenarios:
                 from pg_gpu import diversity as div
+                # Analysis range is [1, total_bp]; matches allel's
+                # start/stop arguments.
                 hm = HaplotypeMatrix(hap, positions,
-                                     chrom_start=int(positions[0]),
-                                     chrom_end=int(positions[-1]))
+                                     chrom_start=1,
+                                     chrom_end=total_bp)
                 hm.set_accessible_mask(bed_path, chrom="chr1")
                 pi_pg = div.pi(hm)
 

--- a/tests/test_diversity.py
+++ b/tests/test_diversity.py
@@ -51,7 +51,8 @@ class TestNucleotideDiversity:
 
         # Create positions with known span
         positions = np.arange(n_variants) * 100  # 100 bp spacing
-        span = positions[-1] - positions[0]
+        # chrom_end is 1-based inclusive => span = end - start + 1
+        span = positions[-1] - positions[0] + 1
 
         matrix = HaplotypeMatrix(haplotypes, positions, positions[0], positions[-1])
 


### PR DESCRIPTION
## Summary

Fixes two compounding coordinate bugs in `set_accessible_mask` that produced
nonsensical site counts (negative variant counts, ~50% of accessible bases
silently dropped) and adds a clean three-property decomposition of the
analysis universe.

Validated against `allel.sequence_diversity` on three scenarios (dense,
sparse, variants-only): pi matches to floating-point precision.

## Bugs fixed

1. **Off-by-one in `bed_to_mask`.** It treated `offset` as 0-based, but
   `from_vcf` passes a 1-based VCF position. Each BED interval lost its
   rightmost base. With small BED intervals this could drop ~50% of
   accessible bases (the failure mode reported on the barnacle dataset).

2. **Mask range clipped to matrix range.** `resolve_accessible_mask` built
   the mask only over `[chrom_start, chrom_end]`, so BED accessible bases
   outside the variant range were silently dropped (relevant for
   variants-only VCFs where the BED extends past the last variant).

The mask now covers the union of the matrix range and the BED extent, and
`n_total_sites` always equals the full BED accessible-base count. `offset`
is now documented as 1-based.

## API

`HaplotypeMatrix` and `GenotypeMatrix` gain three properties:

- `n_callable_sites` -- alias for `n_total_sites`; the BED span when masked,
  or matrix length if loaded with `include_invariant=True`.
- `n_segregating_sites` -- polymorphic sites in the matrix
  (`0 < derived_count < n_valid`).
- `n_invariant_sites` -- now `n_callable_sites - n_segregating_sites`;
  may include implied invariants outside the matrix when the VCF was
  variants-only.

These satisfy `n_callable_sites == n_segregating_sites + n_invariant_sites`.
`num_variants` remains the *physical* matrix row count.

`get_span()` with a mask now returns `mask.total_accessible` directly,
matching `allel.sequence_diversity(is_accessible=...)`.

## Convention notes

`chrom_end` is 1-based inclusive throughout pg_gpu (this matches
`windowed_analysis._iter_bp_windows` which already enforced it). `get_span`
mode `'per_base'` and `'auto'` now correctly return `chrom_end - chrom_start + 1`.
`from_ts` adjusts so span equals `ts.sequence_length` (tskit uses 0-based
exclusive ends).

## Test plan

- [x] `pixi run pytest tests/ -n 8` passes (603 passed, 55 skipped) -- only
      pre-existing `test_windowed_scalability` perf test fails (also fails
      on `main`, unrelated)
- [x] `pixi run ruff check pg_gpu/ tests/` clean
- [x] New regression test `test_post_mask_consistency_h2_scenario`
      exercises the barnacle scenario directly
- [x] New `test_pi_matches_scikit_allel_with_mask` anchors pi against
      `allel.sequence_diversity` on dense / sparse / variants-only
      matrices
- [x] Docs build clean (`make html`)