### PR TITLE
feat(ld): default to unbiased sigma_d2 estimator on HaplotypeMatrix

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -192,7 +192,12 @@ Missing Data Handling
   sites). Simulation testing confirms ``include`` is unbiased under
   MCAR.
 * LD projection estimator available via ``estimator='sigma_d2'`` on
-  ``zns`` / ``omega``.
+  ``zns`` / ``omega``. The default is ``estimator='auto'``, which
+  resolves to ``'sigma_d2'`` on ``HaplotypeMatrix`` inputs (the
+  recommended path; uses the unbiased Ragsdale & Gravel 2019
+  estimators) and falls back to ``'r2'`` for pre-computed r² arrays
+  or ``GenotypeMatrix`` inputs. ``windowed_analysis`` follows the
+  same default for windowed ``zns`` and ``omega``.
 
 Moments Integration
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -166,11 +166,14 @@ Linkage Disequilibrium
      - Two-locus nucleotide diversity
      - Ragsdale & Gravel (2019)
    * - ``zns``
-     - Kelly's ZnS (mean pairwise r-squared)
-     - Kelly (1997)
+     - Kelly's ZnS (mean pairwise LD); defaults to the unbiased
+       :math:`\sigma_D^2` estimator on ``HaplotypeMatrix`` inputs,
+       falls back to naive :math:`r^2` for pre-computed arrays.
+     - Kelly (1997); Ragsdale & Gravel (2019)
    * - ``omega``
-     - Kim & Nielsen's Omega (partitioned LD)
-     - Kim & Nielsen (2004)
+     - Kim & Nielsen's Omega (partitioned LD); same default policy
+       as ``zns``.
+     - Kim & Nielsen (2004); Ragsdale & Gravel (2019)
    * - ``mu_ld``
      - Haplotype pattern exclusivity (RAiSD LD component)
      - Alachiotis & Pavlidis (2018)

--- a/docs/source/missing_data.rst
+++ b/docs/source/missing_data.rst
@@ -130,21 +130,31 @@ LD Estimator Choice
 For LD statistics, ``zns()`` and ``omega()`` accept an ``estimator``
 parameter independent of missing data handling:
 
-* ``estimator='r2'`` (default): naive r-squared.
-* ``estimator='sigma_d2'``: unbiased multinomial projection estimators
-  (Ragsdale & Gravel 2019), computing sigma_D^2 = D^2/pi^2 with
-  falling-factorial corrections. More robust with small or variable
-  sample sizes.
+* ``estimator='auto'`` (default): use the unbiased ``sigma_d2``
+  estimator when the input is a ``HaplotypeMatrix``, and fall back to
+  naive ``r2`` for pre-computed r² arrays or ``GenotypeMatrix`` inputs
+  (where ``sigma_d2`` is not available).
+* ``estimator='r2'``: always use naive r-squared. Convenient when you
+  want the "classical" estimator regardless of input type.
+* ``estimator='sigma_d2'``: always use the unbiased multinomial
+  projection estimators (Ragsdale & Gravel 2019), computing
+  :math:`\sigma_D^2 = D^2 / \pi_2` with falling-factorial corrections.
+  More robust with small or variable sample sizes; requires a
+  ``HaplotypeMatrix``.
 
 .. code-block:: python
 
    from pg_gpu import ld_statistics
 
-   # Default: naive r-squared
+   # Default 'auto': unbiased sigma_d2 when given a HaplotypeMatrix
    zns = ld_statistics.zns(h)
 
-   # Unbiased estimator
-   zns_unbiased = ld_statistics.zns(h, estimator='sigma_d2')
+   # Force naive r²
+   zns_naive = ld_statistics.zns(h, estimator='r2')
+
+   # Pre-computed r² array: 'auto' falls back to 'r2'
+   r2 = h.pairwise_r2()
+   zns_from_array = ld_statistics.zns(r2)
 
 Haplotype Identity and Missing Data
 ------------------------------------
@@ -372,9 +382,13 @@ Best Practices
    when you want proper handling of variable sample sizes via group-by-n
    or SFS projection.
 
-4. **Use estimator='sigma_d2'** for LD statistics (ZnS, Omega) when
-   sample sizes are small or variable. The unbiased estimators correct
-   the upward bias inherent in naive r^2.
+4. **The default ``estimator='auto'`` for ``zns()`` and ``omega()``
+   uses the unbiased ``sigma_d2`` estimator on ``HaplotypeMatrix``
+   inputs**, which corrects the upward bias inherent in naive
+   :math:`r^2` -- particularly important with small or variable
+   sample sizes. Pass ``estimator='r2'`` explicitly if you want the
+   classical naive estimator instead (e.g. for backward comparison
+   with a previous analysis).
 
 5. **Check missingness patterns** before analysis with
    ``summarize_missing_data()`` and consider filtering sites with

--- a/pg_gpu/ld_statistics.py
+++ b/pg_gpu/ld_statistics.py
@@ -341,6 +341,24 @@ def _tile_sigma_d2(hi, vi, hj, vj):
     return sigma_d2, valid
 
 
+def _resolve_ld_estimator(estimator: str, is_hap_matrix: bool) -> str:
+    """Resolve an LD estimator string, including the ``'auto'`` policy.
+
+    ``'auto'`` -> ``'sigma_d2'`` when the input is a ``HaplotypeMatrix``
+    (the recommended path; uses the unbiased Ragsdale & Gravel 2019
+    estimators), and ``'r2'`` otherwise (the only thing that works for
+    pre-computed r² arrays or ``GenotypeMatrix`` inputs). Explicit
+    ``'r2'`` and ``'sigma_d2'`` pass through unchanged.
+    """
+    if estimator == 'auto':
+        return 'sigma_d2' if is_hap_matrix else 'r2'
+    if estimator not in ('r2', 'sigma_d2'):
+        raise ValueError(
+            f"Unknown estimator: {estimator!r} "
+            f"(expected one of 'auto', 'r2', 'sigma_d2')")
+    return estimator
+
+
 def _zns_tiled(mat, missing_data='include', tile_size=512):
     """Compute ZnS without materializing the full r² matrix.
 
@@ -486,7 +504,7 @@ def _zns_from_precomputed(hap_clean, valid_mask, col_start, col_end,
     return total / (m * (m - 1))
 
 
-def zns(r2_matrix_or_matrix, missing_data='include', estimator='r2'):
+def zns(r2_matrix_or_matrix, missing_data='include', estimator='auto'):
     """Kelly's ZnS: mean pairwise r-squared across all SNP pairs.
 
     Parameters
@@ -500,24 +518,31 @@ def zns(r2_matrix_or_matrix, missing_data='include', estimator='r2'):
         ``'include'`` (default) uses per-site valid data for frequency
         computation. ``'exclude'`` filters to sites with no missing data.
     estimator : str
-        ``'r2'`` (default) computes naive r-squared.
-        ``'sigma_d2'`` uses unbiased multinomial projection estimators
-        (Ragsdale & Gravel 2019), computing mean sigma_D^2 = D^2/pi^2
-        per pair with falling-factorial corrections. Requires
-        HaplotypeMatrix input.
+        ``'auto'`` (default) uses the unbiased ``sigma_d2`` estimator
+        when the input is a ``HaplotypeMatrix``, and falls back to
+        naive ``r2`` for pre-computed r² arrays or ``GenotypeMatrix``
+        inputs (where ``sigma_d2`` is not available).
+        ``'r2'`` always computes naive r-squared.
+        ``'sigma_d2'`` always uses the unbiased multinomial projection
+        estimators (Ragsdale & Gravel 2019), computing mean
+        :math:`\\sigma_D^2 = D^2/\\pi_2` per pair with falling-factorial
+        corrections. Requires ``HaplotypeMatrix`` input.
 
     Returns
     -------
     float
-        Mean r-squared (or mean sigma_D^2 for estimator='sigma_d2').
+        Mean r-squared (or mean sigma_D^2 when sigma_d2 is selected).
     """
     from .haplotype_matrix import HaplotypeMatrix
+
+    is_hm = isinstance(r2_matrix_or_matrix, HaplotypeMatrix)
+    estimator = _resolve_ld_estimator(estimator, is_hm)
 
     # Map estimator to internal missing_data for backward compat with _zns_tiled
     _md = 'project' if estimator == 'sigma_d2' else missing_data
 
     # Streaming path for HaplotypeMatrix: O(B²) memory instead of O(m²)
-    if isinstance(r2_matrix_or_matrix, HaplotypeMatrix):
+    if is_hm:
         return _zns_tiled(r2_matrix_or_matrix, _md)
 
     if estimator == 'sigma_d2':
@@ -561,7 +586,7 @@ def _build_sigma_d2_matrix(mat, missing_data='include'):
     return result
 
 
-def omega(r2_matrix_or_matrix, missing_data='include', estimator='r2'):
+def omega(r2_matrix_or_matrix, missing_data='include', estimator='auto'):
     """Kim and Nielsen's Omega: max ratio of within-partition to
     cross-partition mean LD.
 
@@ -582,9 +607,14 @@ def omega(r2_matrix_or_matrix, missing_data='include', estimator='r2'):
         ``'include'`` (default) uses per-site valid data for frequency
         computation. ``'exclude'`` filters to sites with no missing data.
     estimator : str
-        ``'r2'`` (default) computes naive r-squared.
-        ``'sigma_d2'`` uses unbiased sigma_D^2 = D^2/pi^2
-        (Ragsdale & Gravel 2019). Requires HaplotypeMatrix input.
+        ``'auto'`` (default) uses the unbiased ``sigma_d2`` estimator
+        when the input is a ``HaplotypeMatrix``, and falls back to
+        naive ``r2`` for pre-computed r² arrays or ``GenotypeMatrix``
+        inputs (where ``sigma_d2`` is not available).
+        ``'r2'`` always computes naive r-squared.
+        ``'sigma_d2'`` always uses unbiased
+        :math:`\\sigma_D^2 = D^2/\\pi_2` (Ragsdale & Gravel 2019).
+        Requires ``HaplotypeMatrix`` input.
 
     Returns
     -------
@@ -593,8 +623,11 @@ def omega(r2_matrix_or_matrix, missing_data='include', estimator='r2'):
     """
     from .haplotype_matrix import HaplotypeMatrix
 
+    is_hm = isinstance(r2_matrix_or_matrix, HaplotypeMatrix)
+    estimator = _resolve_ld_estimator(estimator, is_hm)
+
     if estimator == 'sigma_d2':
-        if not isinstance(r2_matrix_or_matrix, HaplotypeMatrix):
+        if not is_hm:
             raise ValueError(
                 "estimator='sigma_d2' requires a HaplotypeMatrix")
         r2_matrix = _build_sigma_d2_matrix(r2_matrix_or_matrix,

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -2033,9 +2033,13 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
                 continue
 
             if 'zns' in stat_arrays:
+                # Per-window zns defaults to the unbiased sigma_d2
+                # estimator (Ragsdale & Gravel 2019), matching the new
+                # default of ld_statistics.zns(estimator='auto') on
+                # HaplotypeMatrix inputs.
                 stat_arrays['zns'][wi] = ld_statistics._zns_from_precomputed(
                     hap_clean, valid_mask, s, e,
-                    use_projection=False)
+                    use_projection=True)
 
             if need_winmat:
                 win_mat = HaplotypeMatrix(matrix.haplotypes[:, s:e],

--- a/tests/test_diploshic_stats.py
+++ b/tests/test_diploshic_stats.py
@@ -149,6 +149,40 @@ class TestZnSOmega:
         o = ld_statistics.omega_diploid(geno_data)
         assert o >= 0
 
+    def test_zns_default_is_sigma_d2_for_haplotype_matrix(self, hap_data):
+        # Default 'auto' should resolve to sigma_d2 for HaplotypeMatrix
+        # inputs, matching an explicit estimator='sigma_d2' call.
+        z_default = ld_statistics.zns(hap_data)
+        z_sigma_d2 = ld_statistics.zns(hap_data, estimator='sigma_d2')
+        z_r2 = ld_statistics.zns(hap_data, estimator='r2')
+        assert z_default == z_sigma_d2
+        # The unbiased estimator is generally smaller than naive r²,
+        # but at minimum the two are not numerically identical for any
+        # realistic dataset (they differ in their finite-sample bias).
+        assert z_default != z_r2
+
+    def test_zns_default_falls_back_to_r2_for_array(self, hap_data):
+        # Pre-computed r² array: 'auto' must fall back to 'r2' since
+        # sigma_d2 needs the haplotype data.
+        r2 = hap_data.pairwise_r2()
+        z_auto = ld_statistics.zns(r2)
+        z_r2 = ld_statistics.zns(r2, estimator='r2')
+        assert z_auto == z_r2
+
+    def test_zns_sigma_d2_requires_haplotype_matrix(self, hap_data):
+        r2 = hap_data.pairwise_r2()
+        with pytest.raises(ValueError, match="HaplotypeMatrix"):
+            ld_statistics.zns(r2, estimator='sigma_d2')
+
+    def test_omega_default_is_sigma_d2_for_haplotype_matrix(self, hap_data):
+        o_default = ld_statistics.omega(hap_data)
+        o_sigma_d2 = ld_statistics.omega(hap_data, estimator='sigma_d2')
+        assert o_default == o_sigma_d2
+
+    def test_zns_unknown_estimator_raises(self, hap_data):
+        with pytest.raises(ValueError, match="Unknown estimator"):
+            ld_statistics.zns(hap_data, estimator='nonsense')
+
 
 # ---------------------------------------------------------------------------
 # mu_ld


### PR DESCRIPTION
## Summary

Flips the default `estimator` argument on `ld_statistics.zns` and
`ld_statistics.omega` from `'r2'` to a new `'auto'` policy that picks
the unbiased Ragsdale & Gravel (2019) estimator wherever it is
available.

| Input | `estimator='auto'` resolves to |
| --- | --- |
| `HaplotypeMatrix` | `'sigma_d2'` (unbiased; falling-factorial-corrected multinomial projection) |
| Pre-computed r² array | `'r2'` (only option once per-sample data is gone) |
| `GenotypeMatrix` | `'r2'` (sigma_d2 not implemented for genotype data) |

Explicit `estimator='r2'` and `estimator='sigma_d2'` still work as
before; unknown strings now raise `ValueError`.

`windowed_analysis` follows the same default: per-window `zns` now
passes `use_projection=True` to `_zns_from_precomputed`, and the
windowed `omega` path already calls `omega(win_mat)` so it picks up
the new default automatically.

## Why

Nate's doc-review comment on #76:

> Why is naive r2 the default if it is biased? Why not always choose
> the unbiased option? Does sigma_D2 have any limitations? This is
> the preference under "best practices" ...

The naive r² estimator carries an upward bias that's particularly
costly with small or variable sample sizes -- exactly the regime where
ZnS / Omega scans are typically most useful. Making the unbiased
version the default for the recommended call (HaplotypeMatrix in,
scalar out) puts the better statistic in front of users by default
without breaking pre-computed-r² or GenotypeMatrix call sites.

## Tests

5 new tests in `tests/test_diploshic_stats.py` covering:
- `'auto'` → `'sigma_d2'` on a HaplotypeMatrix (matches explicit
  `'sigma_d2'`, differs from explicit `'r2'`).
- `'auto'` → `'r2'` on a pre-computed r² array.
- `'sigma_d2'` requires a HaplotypeMatrix (raises otherwise).
- `'auto'` → `'sigma_d2'` on `omega` for a HaplotypeMatrix.
- Unknown estimator raises `ValueError`.

The existing 6 tests still pass: they pass pre-computed r² arrays or
a GenotypeMatrix, both of which hit the `'r2'` fall-through under
the new default.

## Docs

- `missing_data.rst`: rewrote the "LD Estimator Choice" section and
  Best Practice #4 to describe `'auto'` as the new default and what
  it resolves to.
- `features.rst`: zns/omega entries flag the new default policy.
- `changelog.rst`: v0.1.0 LD section now mentions the `'auto'`
  default and that `windowed_analysis` follows it.

## Test plan

- [x] `pixi run pytest tests/ -n 8` passes (616 passed, 55 skipped;
      pre-existing perf-test flake aside)
- [x] `pixi run ruff check pg_gpu/ tests/ examples/` clean
- [x] `make -C docs html` clean (no warnings)

Knocks off the "Why is naive r² the default if it is biased?" item
from #76.