### PR TITLE
feat(install): improve import-time CUDA check

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -78,27 +78,24 @@ demographic-inference walk-through.
 Verify Installation
 -------------------
 
-Save the following as ``check_pg_gpu.py``:
-
-.. code-block:: python
-
-   # check_pg_gpu.py
-   import pg_gpu
-   import cupy as cp
-
-   print(f"pg_gpu version:  {pg_gpu.__version__}")
-   print(f"GPU available:   {cp.cuda.is_available()}")
-   print(f"GPU device:      {cp.cuda.Device().name}")
-
-then run it via pixi:
+``import pg_gpu`` performs a CUDA-availability check at import time
+and raises a diagnostic error if CuPy is missing or no usable CUDA
+device is detected. So the verification is just:
 
 .. code-block:: bash
 
-   pixi run python check_pg_gpu.py
+   pixi run python -c "import pg_gpu; print(pg_gpu.__version__)"
 
-If the import fails or no GPU is reported, the most common cause is a
-mismatch between the system CUDA driver and the toolkit pixi installed;
-``nvidia-smi`` should show a driver version that supports CUDA 12.
+If you see the version printed, you are set up correctly. If the
+import fails, the error message will name the underlying cause -- the
+most common one being a mismatch between the system CUDA driver and
+the toolkit pixi installed; ``nvidia-smi`` should show a driver
+version that supports CUDA 12.
+
+For docs builds, static analysis, type checking, or any other context
+where you want to import ``pg_gpu`` without exercising the GPU, set
+``PG_GPU_SKIP_CUDA_CHECK=1`` to bypass the check. (The
+``READTHEDOCS=True`` environment variable is auto-detected.)
 
 Running Tests
 -------------

--- a/pg_gpu/__init__.py
+++ b/pg_gpu/__init__.py
@@ -2,15 +2,39 @@
 
 import os
 
-if os.environ.get('READTHEDOCS') != 'True':
+# Import-time CUDA check. Set PG_GPU_SKIP_CUDA_CHECK=1 to skip --
+# useful for docs builds, static analysis, type checking, and other
+# contexts that want to import pg_gpu without exercising the GPU. The
+# Read-the-Docs builder is auto-detected via READTHEDOCS=True.
+if not (os.environ.get('PG_GPU_SKIP_CUDA_CHECK')
+        or os.environ.get('READTHEDOCS') == 'True'):
     try:
-        import cupy as cp
-        cp.cuda.runtime.getDeviceCount()
-    except Exception as e:
+        import cupy as _cp  # noqa: F401  (verifying availability only)
+    except ImportError as _e:
+        raise ImportError(
+            "pg_gpu requires CuPy, but `import cupy` failed:\n"
+            f"  {_e}\n\n"
+            "Install via the project's pixi environment (recommended):\n"
+            "  git clone https://github.com/kr-colab/pg_gpu.git\n"
+            "  cd pg_gpu && pixi install && pixi shell\n\n"
+            "To import pg_gpu without CuPy (e.g. for docs builds or\n"
+            "static analysis), set PG_GPU_SKIP_CUDA_CHECK=1."
+        ) from _e
+    try:
+        if _cp.cuda.runtime.getDeviceCount() < 1:
+            raise RuntimeError("no CUDA devices found")
+    except Exception as _e:
         raise RuntimeError(
-            "pg_gpu requires a CUDA-capable GPU and CuPy installed with "
-            "working CUDA drivers. No usable GPU was detected."
-        ) from e
+            "pg_gpu requires a CUDA-capable NVIDIA GPU. CuPy imported\n"
+            f"successfully, but no usable CUDA device was found: {_e}\n\n"
+            "Common causes:\n"
+            "  - No NVIDIA driver installed; check `nvidia-smi`.\n"
+            "  - CUDA toolkit version mismatch with the system driver.\n"
+            "  - All GPUs are taken by another process (try setting\n"
+            "    CUDA_VISIBLE_DEVICES to a free index).\n\n"
+            "To import pg_gpu without a GPU (e.g. for docs builds or\n"
+            "static analysis), set PG_GPU_SKIP_CUDA_CHECK=1."
+        ) from _e
 
 from . import ld_statistics
 from . import diversity


### PR DESCRIPTION
## Summary

The import-time CUDA check has existed for a while but raised a
generic ``RuntimeError`` that didn't help users diagnose what was
wrong. This PR makes the check informative and replaces the manual
"Verify Installation" docs snippet with the import itself -- which is
what Nate's review on #76 was probing about.

### Code (`pg_gpu/__init__.py`)

- Distinguishes **"CuPy not installed"** (raises `ImportError` with
  pixi install instructions) from **"no usable CUDA device"** (raises
  `RuntimeError` with diagnostic causes).
- Names the most common failure modes (driver not installed,
  toolkit/driver version mismatch, all GPUs allocated) and points at
  `nvidia-smi`.
- Generalizes the escape hatch from the hardcoded `READTHEDOCS=True`
  to a project-specific `PG_GPU_SKIP_CUDA_CHECK=1`. Read-the-Docs is
  still auto-detected.
- Preserves the underlying exception via `raise ... from _e`.

### Docs (`installation.rst`)

The "Verify Installation" section was eight lines of `import pg_gpu`
+ `cupy.cuda.is_available()` + `cupy.cuda.Device().name`. With the
import-time check in place, that's redundant: a successful import
*is* the verification. Replaces the snippet with a one-line
`pixi run python -c "import pg_gpu; print(pg_gpu.__version__)"` and
mentions the escape hatch for docs / static-analysis contexts.

## Verification

- `pixi run python -c "import pg_gpu"` (GPU available): prints
  version successfully.
- `CUDA_VISIBLE_DEVICES="" pixi run python -c "import pg_gpu"`:
  raises with the new diagnostic message naming `nvidia-smi`,
  the toolkit/driver mismatch case, and the escape hatch.
- `PG_GPU_SKIP_CUDA_CHECK=1 CUDA_VISIBLE_DEVICES="" pixi run python
  -c "import pg_gpu"`: import succeeds (escape hatch works).

## Test plan

- [x] `pixi run ruff check pg_gpu/ tests/ examples/` clean
- [x] `make -C docs html` clean (no warnings)
- [x] `pixi run pytest tests/ -n 8` passes (only the pre-existing
      `test_get_subset_from_range` parallel-execution flake fails;
      passes when run solo)

Knocks off the "could we simply check for cuda on init and error out
(so import fails with informative message)?" item from #76.