### PR TITLE
docs: drop "Verify Installation" section

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -75,28 +75,6 @@ environment that has both libraries installed:
 See :doc:`tutorials/moments_integration` for the full
 demographic-inference walk-through.
 
-Verify Installation
--------------------
-
-``import pg_gpu`` performs a CUDA-availability check at import time
-and raises a diagnostic error if CuPy is missing or no usable CUDA
-device is detected. So the verification is just:
-
-.. code-block:: bash
-
-   pixi run python -c "import pg_gpu; print(pg_gpu.__version__)"
-
-If you see the version printed, you are set up correctly. If the
-import fails, the error message will name the underlying cause -- the
-most common one being a mismatch between the system CUDA driver and
-the toolkit pixi installed; ``nvidia-smi`` should show a driver
-version that supports CUDA 12.
-
-For docs builds, static analysis, type checking, or any other context
-where you want to import ``pg_gpu`` without exercising the GPU, set
-``PG_GPU_SKIP_CUDA_CHECK=1`` to bypass the check. (The
-``READTHEDOCS=True`` environment variable is auto-detected.)
-
 Running Tests
 -------------
 


### PR DESCRIPTION
The import-time CUDA check (added in #81) makes a successful
``import pg_gpu`` the verification on its own: there is nothing the
user can do between installing and importing that the import itself
doesn't already check. The diagnostic error message names the same
things the section was repeating in prose (``nvidia-smi``, the
toolkit/driver mismatch case, the ``PG_GPU_SKIP_CUDA_CHECK`` escape
hatch), so the section is pure restatement.

Per Nate's review on #76 ("Also why is this section needed?").

22 lines deleted, no other references in the docs tree.

## Test plan

- [x] No remaining references to "Verify Installation" anywhere in
      ``docs/source/``
- [x] ``make -C docs html`` clean (no warnings)