### PR TITLE
chore: gitignore docs/superpowers/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ commit_message.txt
 CLAUDE.md
 TODO_*.md
 
+# Local-only design specs and brainstorming notes
+docs/superpowers/
+
 # vim for the cool kids
 *.swp
 *.swo


### PR DESCRIPTION
Local-only design specs and brainstorming notes from the superpowers toolchain. We do not want them committed alongside the code they describe.