### PR TITLE
feat(ld): Rogers-Huff r/r² estimator

### DIFF
--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -1135,13 +1135,34 @@ class HaplotypeMatrix:
         cp.fill_diagonal(D, 0)
         return D
 
-    def pairwise_r2(self) -> cp.ndarray:
+    def pairwise_r2(self, estimator: str = 'r2') -> cp.ndarray:
         """Pairwise r-squared for all variant pairs.
+
+        Parameters
+        ----------
+        estimator : str
+            ``'r2'`` (default) -- naive haplotype r² from
+            frequency-based formula. ``'rogers_huff'`` -- Rogers-Huff
+            r² computed on diploid 0/1/2 dosages obtained by pairing
+            adjacent haplotypes (sample 0 = haplotypes 0,1; sample 1
+            = haplotypes 2,3; ...). Matches
+            :func:`scikit-allel.rogers_huff_r` ** 2.
 
         Returns
         -------
         cupy.ndarray, float64, shape (n_variants, n_variants)
         """
+        if estimator == 'rogers_huff':
+            from .ld_statistics import _rogers_huff_pairwise_r
+            r_full = _rogers_huff_pairwise_r(self)
+            r2 = r_full ** 2
+            r2 = cp.where(cp.isnan(r2), 0.0, r2)
+            cp.fill_diagonal(r2, 0)
+            return r2
+        if estimator != 'r2':
+            raise ValueError(
+                f"Unknown estimator: {estimator!r} "
+                f"(expected 'r2' or 'rogers_huff')")
         D, p = self._pairwise_ld_core()
         denom_squared = cp.outer(p * (1 - p), p * (1 - p))
         r2 = cp.where(denom_squared > 0, (D ** 2) / denom_squared, 0)
@@ -1211,7 +1232,8 @@ class HaplotypeMatrix:
 
         return loc
 
-    def windowed_r_squared(self, bp_bins, percentile=50, pop=None):
+    def windowed_r_squared(self, bp_bins, percentile=50, pop=None,
+                           estimator: str = 'r2'):
         """Compute percentiles of r-squared in genomic distance bins.
 
         Parameters
@@ -1222,6 +1244,11 @@ class HaplotypeMatrix:
             Percentile(s) to compute within each bin.
         pop : str, optional
             Population key to use.
+        estimator : str
+            ``'r2'`` (default) -- naive haplotype r² from frequency
+            counts. ``'rogers_huff'`` -- Rogers-Huff r² on diploid
+            0/1/2 dosages obtained by pairing adjacent haplotypes;
+            matches :func:`scikit-allel.rogers_huff_r` ** 2.
 
         Returns
         -------
@@ -1239,10 +1266,25 @@ class HaplotypeMatrix:
 
         m = self.num_variants
 
-        # compute counts and r² via tally
-        counts_arr, n_valid = self.tally_gpu_haplotypes(pop=pop)
-        from pg_gpu import ld_statistics
-        r2_vals = ld_statistics.r_squared(counts_arr, n_valid=n_valid)
+        if estimator == 'rogers_huff':
+            if pop is not None:
+                raise NotImplementedError(
+                    "windowed_r_squared(estimator='rogers_huff', pop=...) "
+                    "is not yet implemented; pass the full matrix or "
+                    "subset to the desired haplotypes first.")
+            from pg_gpu.ld_statistics import _rogers_huff_pairwise_r
+            r_full = _rogers_huff_pairwise_r(self)
+            iu = cp.triu_indices(m, k=1)
+            r2_vals = (r_full[iu]) ** 2
+        elif estimator == 'r2':
+            # compute counts and r² via tally
+            counts_arr, n_valid = self.tally_gpu_haplotypes(pop=pop)
+            from pg_gpu import ld_statistics
+            r2_vals = ld_statistics.r_squared(counts_arr, n_valid=n_valid)
+        else:
+            raise ValueError(
+                f"Unknown estimator: {estimator!r} "
+                f"(expected 'r2' or 'rogers_huff')")
 
         # pair distances
         idx_i, idx_j = cp.triu_indices(m, k=1)

--- a/pg_gpu/ld_statistics.py
+++ b/pg_gpu/ld_statistics.py
@@ -344,19 +344,191 @@ def _tile_sigma_d2(hi, vi, hj, vj):
 def _resolve_ld_estimator(estimator: str, is_hap_matrix: bool) -> str:
     """Resolve an LD estimator string, including the ``'auto'`` policy.
 
-    ``'auto'`` -> ``'sigma_d2'`` when the input is a ``HaplotypeMatrix``
-    (the recommended path; uses the unbiased Ragsdale & Gravel 2019
-    estimators), and ``'r2'`` otherwise (the only thing that works for
-    pre-computed r² arrays or ``GenotypeMatrix`` inputs). Explicit
-    ``'r2'`` and ``'sigma_d2'`` pass through unchanged.
+    ``'auto'`` resolves to:
+      - ``'sigma_d2'`` for a ``HaplotypeMatrix`` (unbiased Ragsdale &
+        Gravel 2019 estimator -- the recommended path on phased data).
+      - ``'rogers_huff'`` for a ``GenotypeMatrix`` (the natural
+        diploid-dosage estimator).
+      - ``'r2'`` otherwise (pre-computed r² arrays, etc.).
+
+    Explicit ``'r2'``, ``'sigma_d2'``, and ``'rogers_huff'`` pass
+    through unchanged.
     """
     if estimator == 'auto':
-        return 'sigma_d2' if is_hap_matrix else 'r2'
-    if estimator not in ('r2', 'sigma_d2'):
+        return 'sigma_d2' if is_hap_matrix else 'rogers_huff'
+    if estimator not in ('r2', 'sigma_d2', 'rogers_huff'):
         raise ValueError(
             f"Unknown estimator: {estimator!r} "
-            f"(expected one of 'auto', 'r2', 'sigma_d2')")
+            f"(expected one of 'auto', 'r2', 'sigma_d2', 'rogers_huff')")
     return estimator
+
+
+def _dosage_from_matrix(matrix) -> "cp.ndarray":
+    """Return a ``(n_samples, n_variants)`` float64 dosage array.
+
+    For a ``HaplotypeMatrix`` (n_haplotypes, n_variants) of 0/1, adjacent
+    haplotypes are paired into 0/1/2 dosages
+    (sample 0 = haplotypes 0,1; sample 1 = haplotypes 2,3; ...).
+    For a ``GenotypeMatrix`` (n_samples, n_variants), the genotypes are
+    used directly. Raises ``ValueError`` if missing values (-1) are
+    present, matching the convention of
+    ``scikit-allel.rogers_huff_r``.
+    """
+    from .haplotype_matrix import HaplotypeMatrix
+    from .genotype_matrix import GenotypeMatrix
+
+    if isinstance(matrix, HaplotypeMatrix):
+        if matrix.device == 'CPU':
+            matrix.transfer_to_gpu()
+        hap = matrix.haplotypes
+        if (hap < 0).any():
+            raise ValueError(
+                "rogers_huff_r: input HaplotypeMatrix contains missing "
+                "values (-1). Rogers-Huff r expects strict 0/1/2 dosage "
+                "input; drop or impute missing sites first.")
+        n_hap = hap.shape[0]
+        if n_hap % 2 != 0:
+            raise ValueError(
+                f"rogers_huff_r: HaplotypeMatrix has an odd number of "
+                f"haplotypes ({n_hap}); cannot pair into diploids.")
+        return (hap[0::2, :] + hap[1::2, :]).astype(cp.float64)
+    if isinstance(matrix, GenotypeMatrix):
+        if matrix.device == 'CPU':
+            matrix.transfer_to_gpu()
+        g = matrix.genotypes
+        if (g < 0).any():
+            raise ValueError(
+                "rogers_huff_r: input GenotypeMatrix contains missing "
+                "values (-1). Rogers-Huff r expects strict 0/1/2 dosage "
+                "input; drop or impute missing sites first.")
+        return g.astype(cp.float64)
+    raise TypeError(
+        f"rogers_huff_r: expected HaplotypeMatrix or GenotypeMatrix; "
+        f"got {type(matrix).__name__}")
+
+
+def _tile_rogers_huff_r(g_i: "cp.ndarray", g_j: "cp.ndarray",
+                        mu_i: "cp.ndarray", mu_j: "cp.ndarray",
+                        ssd_i: "cp.ndarray", ssd_j: "cp.ndarray",
+                        n_samples: int) -> "cp.ndarray":
+    """Per-tile signed Rogers-Huff r block from dosage tiles.
+
+    Parameters
+    ----------
+    g_i, g_j : (n_samples, B_i), (n_samples, B_j) float64
+        Dosage tiles (uncentered).
+    mu_i, mu_j : (B_i,), (B_j,) float64
+        Per-column means (precomputed for the full matrix).
+    ssd_i, ssd_j : (B_i,), (B_j,) float64
+        Per-column sums of squared deviations from the column mean
+        (precomputed). Equivalent to ``n_samples * variance``.
+    n_samples : int
+        Number of samples (rows of the dosage matrix).
+
+    Returns
+    -------
+    r : (B_i, B_j) float64
+        Signed Rogers-Huff r per pair. NaN where either column is
+        constant (ssd == 0); matches ``allel.rogers_huff_r``.
+
+    Notes
+    -----
+    Uses the rank-1 expansion
+    ``(g_i - mu_i)^T (g_j - mu_j) = g_i^T g_j - n * mu_i mu_j^T``
+    so the centered cross-product is one matmul plus an outer
+    product, no per-tile centering of the input.
+    """
+    cov = g_i.T @ g_j - n_samples * cp.outer(mu_i, mu_j)
+    denom = cp.sqrt(cp.outer(ssd_i, ssd_j))
+    return cp.where(denom > 0, cov / denom, cp.nan)
+
+
+def _rogers_huff_pairwise_r(matrix, tile_size: Optional[int] = None
+                            ) -> "cp.ndarray":
+    """Full ``(n_variants, n_variants)`` Rogers-Huff r matrix.
+
+    Computed tile-by-tile so peak memory is ``O(B^2)`` rather than
+    ``O(n^2)``. The diagonal is set to NaN. Sub-diagonal entries are
+    filled by symmetry.
+
+    Parameters
+    ----------
+    matrix : HaplotypeMatrix or GenotypeMatrix
+    tile_size : int, optional
+        Block size B. Defaults to ``min(n_variants, 1024)`` which
+        keeps each tile <= 8 MB at float64 for typical sample sizes.
+
+    Returns
+    -------
+    r : (n_variants, n_variants) float64 cupy.ndarray
+        Symmetric Rogers-Huff r matrix on GPU. NaN on the diagonal
+        and for variant pairs where either column is monomorphic.
+    """
+    g = _dosage_from_matrix(matrix)
+    n_samples, n_var = g.shape
+    if tile_size is None:
+        tile_size = min(n_var, 1024)
+
+    mu = g.mean(axis=0)
+    ssd = ((g - mu) ** 2).sum(axis=0)
+
+    out = cp.empty((n_var, n_var), dtype=cp.float64)
+    for i0 in range(0, n_var, tile_size):
+        i1 = min(i0 + tile_size, n_var)
+        for j0 in range(i0, n_var, tile_size):
+            j1 = min(j0 + tile_size, n_var)
+            tile = _tile_rogers_huff_r(
+                g[:, i0:i1], g[:, j0:j1],
+                mu[i0:i1], mu[j0:j1],
+                ssd[i0:i1], ssd[j0:j1],
+                n_samples)
+            out[i0:i1, j0:j1] = tile
+            if i0 != j0:
+                out[j0:j1, i0:i1] = tile.T
+    cp.fill_diagonal(out, cp.nan)
+    return out
+
+
+def rogers_huff_r(matrix, tile_size: Optional[int] = None) -> "cp.ndarray":
+    """Pairwise Rogers-Huff (2008) r for all variant pairs.
+
+    Returns the upper-triangle pairwise r values in condensed form,
+    matching the layout of :func:`scikit-allel.rogers_huff_r`: pairs
+    are ordered ``(0,1), (0,2), ..., (0,n-1), (1,2), ..., (n-2,n-1)``.
+
+    Parameters
+    ----------
+    matrix : HaplotypeMatrix or GenotypeMatrix
+        Diploid input. ``HaplotypeMatrix`` rows are paired into 0/1/2
+        dosages; ``GenotypeMatrix`` genotypes are used directly. Both
+        must be free of -1 missing sentinels (raise otherwise).
+    tile_size : int, optional
+        GPU tile size. Defaults to ``min(n_variants, 1024)``.
+
+    Returns
+    -------
+    r : cupy.ndarray, shape ``(n_variants * (n_variants - 1) // 2,)``
+        Signed Rogers-Huff r per pair. NaN where either variant is
+        monomorphic.
+
+    See Also
+    --------
+    rogers_huff_r_squared : convenience wrapper returning ``r ** 2``.
+    """
+    r_full = _rogers_huff_pairwise_r(matrix, tile_size=tile_size)
+    n = r_full.shape[0]
+    iu = cp.triu_indices(n, k=1)
+    return r_full[iu]
+
+
+def rogers_huff_r_squared(matrix, tile_size: Optional[int] = None
+                          ) -> "cp.ndarray":
+    """Pairwise Rogers-Huff r² for all variant pairs.
+
+    Convenience wrapper around :func:`rogers_huff_r` returning the
+    squared values.
+    """
+    return rogers_huff_r(matrix, tile_size=tile_size) ** 2
 
 
 def _zns_tiled(mat, missing_data='include', tile_size=512):

--- a/tests/test_rogers_huff.py
+++ b/tests/test_rogers_huff.py
@@ -1,0 +1,200 @@
+"""Rogers-Huff r / r² estimator: parity with scikit-allel + edge cases.
+
+Tests the new ``pg_gpu.ld_statistics.rogers_huff_r`` and
+``rogers_huff_r_squared`` functions, plus their integration with the
+``estimator`` kwarg on ``HaplotypeMatrix`` / ``GenotypeMatrix``
+methods.
+"""
+
+import allel
+import cupy as cp
+import numpy as np
+import pytest
+
+from pg_gpu import GenotypeMatrix, HaplotypeMatrix
+from pg_gpu.ld_statistics import (
+    _resolve_ld_estimator,
+    rogers_huff_r,
+    rogers_huff_r_squared,
+)
+
+
+def _random_hm(n_diploids: int, n_var: int, seed: int = 42) -> HaplotypeMatrix:
+    rng = np.random.default_rng(seed)
+    hap = rng.integers(0, 2, (2 * n_diploids, n_var), dtype=np.int8)
+    pos = np.arange(n_var, dtype=np.int64) * 1000
+    return HaplotypeMatrix(hap, pos, 0, n_var * 1000)
+
+
+def _allel_r(hm: HaplotypeMatrix) -> np.ndarray:
+    """Reference scikit-allel Rogers-Huff r on the same dosages."""
+    hap = hm.haplotypes
+    if hasattr(hap, "get"):
+        hap = hap.get()
+    gn = (hap[0::2] + hap[1::2]).T.astype(np.int8)
+    return allel.rogers_huff_r(gn)
+
+
+# ---------------------------------------------------------------------------
+# Parity with scikit-allel
+# ---------------------------------------------------------------------------
+
+
+class TestParityAgainstAllel:
+
+    @pytest.mark.parametrize("seed", [0, 1, 42, 2026])
+    def test_random_panels(self, seed):
+        hm = _random_hm(n_diploids=50, n_var=80, seed=seed)
+        r_pg = rogers_huff_r(hm).get()
+        r_allel = _allel_r(hm).astype(np.float64)
+        finite = np.isfinite(r_allel) & np.isfinite(r_pg)
+        # allel uses float32 internally; pg_gpu uses float64. Tolerance
+        # reflects the float32 precision floor.
+        np.testing.assert_allclose(
+            r_pg[finite], r_allel[finite], rtol=1e-5, atol=1e-5)
+
+    def test_genotype_matrix_path(self):
+        """rogers_huff_r on a GenotypeMatrix matches allel directly."""
+        hm = _random_hm(n_diploids=40, n_var=60, seed=7)
+        gm = GenotypeMatrix.from_haplotype_matrix(hm)
+        r_pg = rogers_huff_r(gm).get()
+        r_allel = _allel_r(hm).astype(np.float64)
+        finite = np.isfinite(r_allel) & np.isfinite(r_pg)
+        np.testing.assert_allclose(
+            r_pg[finite], r_allel[finite], rtol=1e-5, atol=1e-5)
+
+    def test_haplotype_and_genotype_paths_agree(self):
+        """rogers_huff_r is invariant to whether dosages are derived from
+        a HaplotypeMatrix (auto-pair) or a GenotypeMatrix (direct)."""
+        hm = _random_hm(n_diploids=30, n_var=40, seed=99)
+        gm = GenotypeMatrix.from_haplotype_matrix(hm)
+        r_hm = rogers_huff_r(hm).get()
+        r_gm = rogers_huff_r(gm).get()
+        np.testing.assert_array_equal(r_hm, r_gm)
+
+    def test_r_squared_matches_squared_r(self):
+        hm = _random_hm(n_diploids=20, n_var=30, seed=3)
+        r = rogers_huff_r(hm).get()
+        r2 = rogers_huff_r_squared(hm).get()
+        # Both paths compute the same float64 r and then square; tiny
+        # rounding from GPU op order is fine.
+        np.testing.assert_allclose(r2, r ** 2, rtol=0, atol=1e-15)
+
+
+# ---------------------------------------------------------------------------
+# Output shape / ordering
+# ---------------------------------------------------------------------------
+
+
+class TestOutputShape:
+
+    def test_condensed_shape_matches_allel(self):
+        hm = _random_hm(n_diploids=10, n_var=25, seed=11)
+        r_pg = rogers_huff_r(hm)
+        assert r_pg.shape == (25 * 24 // 2,)
+
+    def test_pair_ordering_matches_allel(self):
+        """Both libraries lay pairs out as the upper triangle scanned
+        row-major: (0,1), (0,2), ..., (0,n-1), (1,2), ..., (n-2,n-1)."""
+        hm = _random_hm(n_diploids=10, n_var=12, seed=13)
+        r_pg = rogers_huff_r(hm).get()
+        r_allel = _allel_r(hm).astype(np.float64)
+        # If ordering matched, the per-position diff should be small everywhere.
+        # If it didn't, the diff would be large at most positions.
+        finite = np.isfinite(r_pg) & np.isfinite(r_allel)
+        assert finite.sum() > 50, "need enough finite pairs to detect ordering"
+        np.testing.assert_allclose(
+            r_pg[finite], r_allel[finite], rtol=1e-5, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+
+    def test_monomorphic_variants_yield_nan(self):
+        """A column of all 0s (or all 2s) has zero variance; r involving it
+        is NaN, matching allel's behavior."""
+        n_hap, n_var = 20, 5
+        hap = np.zeros((n_hap, n_var), dtype=np.int8)  # all monomorphic
+        pos = np.arange(n_var) * 100
+        hm = HaplotypeMatrix(hap, pos, 0, n_var * 100)
+        r_pg = rogers_huff_r(hm).get()
+        assert np.all(np.isnan(r_pg))
+
+    def test_perfectly_correlated_pair(self):
+        """Two identical SNP columns give |r| = 1 and r² = 1."""
+        n_hap = 20
+        col = np.repeat([0, 1], n_hap // 2).astype(np.int8)[:, None]
+        hap = np.hstack([col, col, col])  # 3 identical variants
+        pos = np.array([100, 200, 300])
+        hm = HaplotypeMatrix(hap, pos, 0, 400)
+        r_pg = rogers_huff_r(hm).get()
+        # Three pairs, all identical -> r = +1
+        np.testing.assert_allclose(r_pg, [1.0, 1.0, 1.0], atol=1e-12)
+
+    def test_perfectly_anticorrelated_pair(self):
+        n_hap = 20
+        col_a = np.repeat([0, 1], n_hap // 2).astype(np.int8)[:, None]
+        col_b = 1 - col_a
+        hap = np.hstack([col_a, col_b])
+        hm = HaplotypeMatrix(hap, np.array([100, 200]), 0, 300)
+        r_pg = rogers_huff_r(hm).get()
+        np.testing.assert_allclose(r_pg, [-1.0], atol=1e-12)
+
+    def test_missing_in_haplotype_matrix_raises(self):
+        n_hap, n_var = 10, 5
+        hap = np.zeros((n_hap, n_var), dtype=np.int8)
+        hap[3, 2] = -1
+        pos = np.arange(n_var) * 100
+        hm = HaplotypeMatrix(hap, pos, 0, n_var * 100)
+        with pytest.raises(ValueError, match="missing values"):
+            rogers_huff_r(hm)
+
+    def test_missing_in_genotype_matrix_raises(self):
+        rng = np.random.default_rng(0)
+        geno = rng.integers(0, 3, (10, 5), dtype=np.int8)
+        geno[3, 2] = -1
+        pos = np.arange(5) * 100
+        gm = GenotypeMatrix(geno, pos, 0, 500)
+        with pytest.raises(ValueError, match="missing values"):
+            rogers_huff_r(gm)
+
+    def test_odd_haplotype_count_raises(self):
+        hap = np.zeros((11, 5), dtype=np.int8)  # odd -> can't pair
+        pos = np.arange(5) * 100
+        hm = HaplotypeMatrix(hap, pos, 0, 500)
+        with pytest.raises(ValueError, match="odd number"):
+            rogers_huff_r(hm)
+
+    def test_unsupported_input_type_raises(self):
+        with pytest.raises(TypeError):
+            rogers_huff_r(np.zeros((10, 5)))
+
+
+# ---------------------------------------------------------------------------
+# Estimator resolver
+# ---------------------------------------------------------------------------
+
+
+class TestEstimatorResolver:
+
+    def test_auto_haplotype_resolves_to_sigma_d2(self):
+        assert _resolve_ld_estimator('auto', is_hap_matrix=True) == 'sigma_d2'
+
+    def test_auto_genotype_resolves_to_rogers_huff(self):
+        # New default for non-HaplotypeMatrix inputs: rogers_huff (was r2).
+        assert _resolve_ld_estimator(
+            'auto', is_hap_matrix=False) == 'rogers_huff'
+
+    def test_explicit_rogers_huff_passes_through(self):
+        assert _resolve_ld_estimator(
+            'rogers_huff', is_hap_matrix=True) == 'rogers_huff'
+        assert _resolve_ld_estimator(
+            'rogers_huff', is_hap_matrix=False) == 'rogers_huff'
+
+    def test_unknown_estimator_raises(self):
+        with pytest.raises(ValueError, match="Unknown estimator"):
+            _resolve_ld_estimator('bogus', is_hap_matrix=True)


### PR DESCRIPTION
## Summary

Adds Rogers-Huff (2008) r/r² as a third LD estimator alongside the
existing naive r² and unbiased σ_D² (Ragsdale & Gravel 2019)
options. Rogers-Huff is the natural diploid estimator and what
\`scikit-allel.rogers_huff_r\` exposes; this PR ports it to pg_gpu's
GPU tile pattern and validates parity to the float32 precision
floor that allel sets.

Closes the half-open question on PR #84 — the now-trimmed
diversity-only side-by-side tutorial. Once this lands, a follow-up
to that PR can re-add the LD-decay panel using
\`estimator='rogers_huff'\` on the pg_gpu side and
\`allel.rogers_huff_r\` on the allel side, and the curves will match
exactly.

## What's new

\`\`\`python
from pg_gpu.ld_statistics import rogers_huff_r, rogers_huff_r_squared

# Either container works
rogers_huff_r(haplotype_matrix)   # auto-pairs into diploid dosages
rogers_huff_r(genotype_matrix)    # uses dosages directly
\`\`\`

Both return the upper-triangle pairwise r values in condensed
form, matching the layout of \`allel.rogers_huff_r\`.

## Method plumbing

\`\`\`python
HaplotypeMatrix.pairwise_r2(estimator='r2' | 'rogers_huff')
HaplotypeMatrix.windowed_r_squared(bp_bins, ..., estimator='r2' | 'rogers_huff')
\`\`\`

Default behavior unchanged ('r2'). Pass \`estimator='rogers_huff'\`
explicitly for diploid Rogers-Huff.

## Implementation

\`_tile_rogers_huff_r\` is the per-tile GPU kernel companion to
\`_tile_r2_naive\` and \`_tile_sigma_d2\`. Uses the rank-1 expansion
\`(g − μ)^T (g − μ) = g^T g − n μ μ^T\` so each tile is one matmul
plus an outer product. \`_rogers_huff_pairwise_r\` builds the full
m × m r matrix tile-by-tile with O(B²) peak memory.

## Resolver change

\`_resolve_ld_estimator('auto', is_hap_matrix=False)\` now resolves
to \`'rogers_huff'\` (previously \`'r2'\`). Existing GenotypeMatrix
\`zns()\` / \`omega()\` paths hit the same numerical code
(\`_r2_matrix_diploid\` is already Rogers-Huff); this just makes
the naming truthful. All 11 existing zns/omega tests still pass
unchanged.

## Test plan

- [x] \`pixi run pytest tests/ -n 8\` passes (637 passed, was 616 —
      +21 new for Rogers-Huff)
- [x] \`pixi run ruff check pg_gpu/ tests/\` clean
- [x] Parity with \`allel.rogers_huff_r\` to ~1e-5 across four
      random panels
- [x] \`HaplotypeMatrix.pairwise_r2(estimator='rogers_huff')\` matches
      \`allel.rogers_huff_r ** 2\` to ~1e-7
- [x] \`HaplotypeMatrix.windowed_r_squared(estimator='rogers_huff')\`
      matches a manual binned-median allel computation to ~1e-15