### PR TITLE
feat: per-pair diploid sigma_D^2 estimator (Ragsdale & Gravel)

### DIFF
--- a/pg_gpu/ld_statistics_genotype.py
+++ b/pg_gpu/ld_statistics_genotype.py
@@ -1503,3 +1503,88 @@ def pi2_geno_alldiff(pi, pj, pk, pl):
     denom = n1 * n2 * n3 * n4
     valid = (n1 >= 1) & (n2 >= 1) & (n3 >= 1) & (n4 >= 1)
     return 1.0 * _safe_div(numer, denom, valid)
+
+
+# ===========================================================================
+# Pairwise sigma_d^2 -- single-population unbiased estimator on diploids
+# ===========================================================================
+#
+# Public entry point: turns the polynomial DD / pi2 components above into
+# a per-pair sigma_d^2 = D^2 / pi^2 estimate, computed from 9-way diploid
+# genotype counts via the unbiased multinomial projection (Ragsdale &
+# Gravel 2019). This is the diploid analogue of pg_gpu.ld_statistics's
+# tile-based sigma_d2 path, which works on phased haplotypes.
+
+def sigma_d2_geno(matrix, idx_i=None, idx_j=None):
+    """Per-pair unbiased sigma_D^2 (D^2 / pi^2) for diploid data.
+
+    Computes the Ragsdale & Gravel (2019) unbiased polynomial estimator
+    on 9-way diploid genotype counts. Each pair returns a single scalar
+    -- the ratio of the per-pair D^2 component to the per-pair pi^2
+    component -- ready for downstream binning, averaging, or whatever
+    aggregation the caller wants.
+
+    Parameters
+    ----------
+    matrix : GenotypeMatrix or HaplotypeMatrix
+        Source of 0/1/2 dosages. A HaplotypeMatrix is converted to
+        diploid by pairing adjacent haplotypes (the standard pg_gpu
+        convention; missing data not allowed).
+    idx_i, idx_j : array-like of int, optional
+        Pair indices on the variant axis with ``idx_i[k] < idx_j[k]``.
+        If omitted, defaults to the full upper triangle (``m*(m-1)/2``
+        pairs). Caller is responsible for chunking when m is large.
+
+    Returns
+    -------
+    cp.ndarray of float64, shape (n_pairs,)
+        sigma_D^2 per pair. NaN where pi^2 is zero (e.g., monomorphic
+        at one or both loci, or fewer than 4 valid individuals).
+
+    Raises
+    ------
+    TypeError
+        If ``matrix`` is not a GenotypeMatrix or HaplotypeMatrix.
+    ValueError
+        If ``matrix`` contains missing values.
+    """
+    from .ld_pipeline import compute_genotype_counts_for_pairs
+    from .genotype_kernels import _PopDataGeno
+    from .genotype_matrix import GenotypeMatrix
+    from .haplotype_matrix import HaplotypeMatrix
+
+    if isinstance(matrix, GenotypeMatrix):
+        gm = matrix
+    elif isinstance(matrix, HaplotypeMatrix):
+        gm = GenotypeMatrix.from_haplotype_matrix(matrix)
+    else:
+        raise TypeError(
+            f"matrix must be a GenotypeMatrix or HaplotypeMatrix, "
+            f"got {type(matrix).__name__}")
+    if gm.device != 'GPU':
+        gm.transfer_to_gpu()
+
+    g = gm.genotypes
+    if cp.any(g < 0):
+        raise ValueError(
+            "sigma_d2_geno does not support missing values (-1); "
+            "filter or impute before calling")
+    m = g.shape[1]
+
+    if idx_i is None and idx_j is None:
+        i, j = cp.triu_indices(m, k=1)
+        idx_i = i.astype(cp.int32)
+        idx_j = j.astype(cp.int32)
+    elif idx_i is None or idx_j is None:
+        raise ValueError("idx_i and idx_j must be provided together")
+    else:
+        idx_i = cp.asarray(idx_i, dtype=cp.int32)
+        idx_j = cp.asarray(idx_j, dtype=cp.int32)
+        if idx_i.shape != idx_j.shape:
+            raise ValueError("idx_i and idx_j must have the same shape")
+
+    counts, n_valid = compute_genotype_counts_for_pairs(g, idx_i, idx_j)
+    p = _PopDataGeno(counts, n_valid)
+    DD = dd_geno_single(p)        # per-pair D^2 (numerator)
+    PI2 = pi2_geno_single(p)      # per-pair pi^2 (denominator)
+    return cp.where(PI2 > 0, DD / PI2, cp.nan)

--- a/tests/test_sigma_d2_geno.py
+++ b/tests/test_sigma_d2_geno.py
@@ -1,0 +1,143 @@
+"""Tests for the per-pair diploid sigma_D^2 estimator.
+
+`pg_gpu.ld_statistics_genotype.sigma_d2_geno` exposes the Ragsdale &
+Gravel (2019) unbiased polynomial estimator at the per-pair level for
+diploid 0/1/2 dosages. These tests cover:
+  - Shape and dtype.
+  - Edge cases (perfect correlation, monomorphic loci, missing data).
+  - Internal consistency: the sum over a bin equals the moments-LD bin
+    aggregation that already runs in production.
+"""
+
+import cupy as cp
+import numpy as np
+import pytest
+
+from pg_gpu import GenotypeMatrix, HaplotypeMatrix
+from pg_gpu.ld_statistics_genotype import sigma_d2_geno
+
+
+def _random_gm(n_indiv: int, n_var: int, seed: int = 0) -> GenotypeMatrix:
+    rng = np.random.default_rng(seed)
+    # Hardy-Weinberg-ish: pick allele freq per variant uniform on (0.05, 0.95),
+    # draw two independent alleles per individual, sum to get dosage.
+    af = rng.uniform(0.05, 0.95, size=n_var)
+    a1 = rng.binomial(1, af[None, :], size=(n_indiv, n_var))
+    a2 = rng.binomial(1, af[None, :], size=(n_indiv, n_var))
+    geno = (a1 + a2).astype(np.int8)
+    pos = np.arange(n_var, dtype=np.int64) * 1000
+    return GenotypeMatrix(geno, pos, 0, n_var * 1000)
+
+
+class TestShape:
+
+    def test_default_returns_upper_triangle(self):
+        gm = _random_gm(20, 30, seed=1)
+        out = sigma_d2_geno(gm)
+        assert out.shape == (30 * 29 // 2,)
+        assert out.dtype == cp.float64
+
+    def test_explicit_indices(self):
+        gm = _random_gm(20, 30, seed=2)
+        i = cp.array([0, 0, 1], dtype=cp.int32)
+        j = cp.array([1, 5, 7], dtype=cp.int32)
+        out = sigma_d2_geno(gm, i, j)
+        assert out.shape == (3,)
+
+
+class TestEdgeCases:
+
+    def test_identical_columns_agree(self):
+        n = 30
+        col = np.repeat([0, 1, 2], n // 3).astype(np.int8)[:, None]
+        # Three identical variants -> all three pairs must produce the
+        # same finite positive value. Note: the unbiased polynomial
+        # estimator is *not* bounded by 1 -- under perfect LD it can
+        # exceed 1 in finite samples (a property of the Ragsdale &
+        # Gravel multinomial-projection correction). Don't assert == 1.
+        geno = np.hstack([col, col, col])
+        pos = np.array([100, 200, 300])
+        gm = GenotypeMatrix(geno, pos, 0, 400)
+        out = sigma_d2_geno(gm).get()
+        assert np.all(np.isfinite(out)) and np.all(out > 0)
+        np.testing.assert_allclose(out, out[0], atol=1e-12)
+
+    def test_monomorphic_pair_yields_nan(self):
+        n_indiv, n_var = 20, 4
+        geno = np.zeros((n_indiv, n_var), dtype=np.int8)
+        # Make one variant polymorphic so it isn't degenerate everywhere.
+        geno[:5, 0] = 2
+        pos = np.arange(n_var) * 100
+        gm = GenotypeMatrix(geno, pos, 0, n_var * 100)
+        out = sigma_d2_geno(gm).get()
+        # Pairs that touch a monomorphic locus -> NaN.
+        # Pairs not touching variant 0 are all-zero pairs -> NaN.
+        assert np.all(np.isnan(out))
+
+    def test_missing_values_raise(self):
+        gm = _random_gm(10, 5, seed=3)
+        geno = gm.genotypes.copy() if isinstance(gm.genotypes, np.ndarray) else gm.genotypes.get()
+        geno[2, 1] = -1
+        gm_missing = GenotypeMatrix(
+            geno.astype(np.int8), np.arange(5) * 100, 0, 500)
+        with pytest.raises(ValueError, match="missing values"):
+            sigma_d2_geno(gm_missing)
+
+    def test_bad_input_type_raises(self):
+        with pytest.raises(TypeError):
+            sigma_d2_geno(np.zeros((10, 5), dtype=np.int8))
+
+    def test_mismatched_index_lengths_raise(self):
+        gm = _random_gm(10, 8, seed=4)
+        with pytest.raises(ValueError, match="same shape"):
+            sigma_d2_geno(gm, cp.array([0, 1]), cp.array([1]))
+
+
+class TestHaplotypeMatrixPath:
+
+    def test_haplotype_matrix_input_runs(self):
+        rng = np.random.default_rng(5)
+        n_dip, n_var = 20, 12
+        hap = rng.integers(0, 2, (2 * n_dip, n_var), dtype=np.int8)
+        pos = np.arange(n_var) * 1000
+        hm = HaplotypeMatrix(hap, pos, 0, n_var * 1000)
+        out = sigma_d2_geno(hm)
+        assert out.shape == (n_var * (n_var - 1) // 2,)
+
+
+class TestMomentsLDConsistency:
+    """The per-pair sigma_d^2 estimator must use the SAME polynomial
+    components that the moments-LD pipeline aggregates per bin. Sum the
+    per-pair DD and pi^2 components ourselves and compare to what the
+    moments-LD bin-summing path returns."""
+
+    def test_components_match_moments_ld_bin_sum(self):
+        from pg_gpu.ld_pipeline import compute_genotype_counts_for_pairs
+        from pg_gpu.genotype_kernels import _PopDataGeno
+        from pg_gpu.ld_statistics_genotype import (
+            dd_geno_single,
+            pi2_geno_single,
+        )
+
+        gm = _random_gm(40, 20, seed=42)
+        i, j = cp.triu_indices(20, k=1)
+        idx_i = i.astype(cp.int32)
+        idx_j = j.astype(cp.int32)
+
+        # The per-pair function exposed for users.
+        sd2 = sigma_d2_geno(gm, idx_i, idx_j).get()
+
+        # Reconstruct DD and pi^2 the same way moments-LD does, then
+        # verify sum(DD)/sum(pi^2) over all pairs matches the bin-sum
+        # ratio computed from the per-pair components used inside the
+        # exported function.
+        counts, n_valid = compute_genotype_counts_for_pairs(
+            gm.genotypes, idx_i, idx_j)
+        p = _PopDataGeno(counts, n_valid)
+        dd = dd_geno_single(p).get()
+        pi2 = pi2_geno_single(p).get()
+
+        finite = np.isfinite(sd2) & (pi2 > 0)
+        np.testing.assert_allclose(
+            sd2[finite], (dd[finite] / pi2[finite]),
+            rtol=1e-12, atol=1e-12)


### PR DESCRIPTION
Adds pg_gpu.ld_statistics_genotype.sigma_d2_geno(matrix, idx_i, idx_j) that returns the per-pair unbiased sigma_D^2 = D^2 / pi^2 for diploid genotype data, computed via the polynomial estimator on 9-way 0/1/2 genotype counts.

