### PR TITLE
feat: scikit-allel tutorial + fused RawKernels for all LD stats

### DIFF
--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -19,6 +19,7 @@ time, see :doc:`examples` instead.
    tutorials/accessibility_mask
    tutorials/local_pca
    tutorials/ld_blocks
+   tutorials/scikit_allel_comparison
    tutorials/moments_integration
 
 Each tutorial follows the same structure:

--- a/docs/source/tutorials/scikit_allel_comparison.rst
+++ b/docs/source/tutorials/scikit_allel_comparison.rst
@@ -55,8 +55,19 @@ What the script does
    two libraries normalize partial windows slightly differently --
    a single-window cosmetic effect, not a real numerical
    disagreement).
-5. Subsamples ``--ld-snps`` (default 10,000) random SNPs and
-   computes a pairwise LD-decay curve on each side. The pg_gpu
+5. Selects a contiguous block of ``--ld-snps`` SNPs (default
+   10,000) centered on the chromosome midpoint, drops variants
+   below ``--ld-mac-min`` (default 10, i.e. MAF 0.05 in n=100
+   diploids), and computes a pairwise LD-decay curve on each side.
+   A contiguous block (vs. a random subsample) gives dense coverage
+   of short pair distances, which is where the LD-decay signal
+   lives -- a random 10k subsample leaves only a handful of pairs
+   in each short-distance bin and the curve washes out into noise.
+   The MAC filter is equally important: pairs of near-singleton
+   variants take a tiny set of tied :math:`r^2` values (e.g., two
+   non-overlapping singletons give exactly :math:`1/(n-1)^2`)
+   regardless of distance, and those tied values pin the per-bin
+   median to a constant -- erasing any decay signal. The pg_gpu
    path is one call:
    ``hm_sub.windowed_r_squared(bp_bins, percentile=50, estimator='rogers_huff')``;
    the scikit-allel path runs ``allel.rogers_huff_r``, squares it,
@@ -86,10 +97,11 @@ multi-statistic windowed analysis. To adapt it:
   diversity-scan resolution; ``--window-size`` accepts any positive
   integer.
 * Tune the LD scan for your scale of interest. ``--ld-snps``
-  controls the random subsample; larger values give a less-noisy
-  decay curve at the cost of quadratic compute. The bin edges
-  (``LD_BP_BINS`` in the script) span 100 bp to 1 kb in 24 log-spaced
-  steps -- appropriate for *Anopheles*-like populations where LD
-  decays within a kilobase. For organisms with longer LD scales
-  (humans, livestock) widen the range; for tighter LD scales
-  (recombining viruses) shrink it.
+  controls the size of the contiguous block (centered on the
+  chromosome midpoint); larger values widen the block's bp footprint
+  and give a less-noisy decay curve at the cost of quadratic compute.
+  The bin edges (``LD_BP_BINS`` in the script) span 100 bp to 10 kb in
+  24 log-spaced steps -- appropriate for *Anopheles*-like populations
+  where LD decays within a few kilobases. For organisms with longer LD
+  scales (humans, livestock) widen the range and use a larger
+  ``--ld-snps``; for tighter LD scales (recombining viruses) shrink it.

--- a/docs/source/tutorials/scikit_allel_comparison.rst
+++ b/docs/source/tutorials/scikit_allel_comparison.rst
@@ -56,12 +56,12 @@ What the script does
    a single-window cosmetic effect, not a real numerical
    disagreement).
 5. Selects a contiguous block of ``--ld-snps`` SNPs (default
-   10,000) centered on the chromosome midpoint, drops variants
-   below ``--ld-mac-min`` (default 10, i.e. MAF 0.05 in n=100
+   500,000) centered on the chromosome midpoint, drops variants
+   below ``--ld-mac-min`` (default 20, i.e. MAF 0.05 in n=100
    diploids), and computes a pairwise LD-decay curve on each side.
    A contiguous block (vs. a random subsample) gives dense coverage
    of short pair distances, which is where the LD-decay signal
-   lives -- a random 10k subsample leaves only a handful of pairs
+   lives -- a random subsample leaves only a handful of pairs
    in each short-distance bin and the curve washes out into noise.
    The MAC filter is equally important: pairs of near-singleton
    variants take a tiny set of tied :math:`r^2` values (e.g., two

--- a/docs/source/tutorials/scikit_allel_comparison.rst
+++ b/docs/source/tutorials/scikit_allel_comparison.rst
@@ -49,12 +49,12 @@ What the script does
    ``allel.windowed_diversity``, ``allel.windowed_watterson_theta``,
    ``allel.windowed_tajima_d``.
 4. Verifies strict numerical agreement on the diversity statistics
-   (NaN-aware, ``rtol=1e-5`` / ``atol=1e-8``). Trailing partial
-   windows (where the chromosome end falls inside a window) are
-   masked out of the comparison: the two libraries normalize the
-   trailing partial window differently (allel divides by actual
-   span; pg_gpu divides by the fixed window size), so a 1-window
-   discrepancy there is uninteresting.
+   (NaN-aware, ``rtol=1e-5`` / ``atol=1e-8``). When the chromosome
+   end isn't an exact multiple of ``window_size``, the trailing
+   partial window is silently NaN-masked from the comparison (the
+   two libraries normalize partial windows slightly differently --
+   a single-window cosmetic effect, not a real numerical
+   disagreement).
 5. Subsamples ``--ld-snps`` (default 10,000) random SNPs and
    computes a pairwise LD-decay curve on each side. The pg_gpu
    path is one call:
@@ -88,7 +88,8 @@ multi-statistic windowed analysis. To adapt it:
 * Tune the LD scan for your scale of interest. ``--ld-snps``
   controls the random subsample; larger values give a less-noisy
   decay curve at the cost of quadratic compute. The bin edges
-  (``LD_BP_BINS`` in the script) span 100 bp to 1 Mb in 24 log-spaced
-  steps -- sensible for chromosomes with LD on the kb-to-Mb scale;
-  for tighter LD scales (e.g. recombining HIV sequences) tighten the
-  range.
+  (``LD_BP_BINS`` in the script) span 100 bp to 1 kb in 24 log-spaced
+  steps -- appropriate for *Anopheles*-like populations where LD
+  decays within a kilobase. For organisms with longer LD scales
+  (humans, livestock) widen the range; for tighter LD scales
+  (recombining viruses) shrink it.

--- a/docs/source/tutorials/scikit_allel_comparison.rst
+++ b/docs/source/tutorials/scikit_allel_comparison.rst
@@ -15,11 +15,14 @@ Background
 ----------
 
 A common workflow on phased haplotype data is a windowed scan
-producing several diversity statistics along a chromosome. In
-``scikit-allel`` this needs three separate calls -- one per statistic
--- each rebuilding its own per-window iteration. ``pg_gpu`` collapses
-the same three statistics into a single ``windowed_analysis(...)``
-call that runs in one GPU kernel pass.
+producing several diversity statistics along a chromosome, plus an
+LD-decay curve summarising linkage disequilibrium as a function of
+physical distance. In ``scikit-allel`` each diversity stat needs a
+separate call, and the LD-decay scan requires manually pairwise-r²,
+distance binning, and median-per-bin aggregation. ``pg_gpu``
+collapses the diversity stats into a single ``windowed_analysis(...)``
+call and exposes the LD-decay path as ``HaplotypeMatrix.windowed_r_squared(estimator='rogers_huff')``,
+both running in single GPU kernel passes.
 
 This tutorial puts the two implementations next to each other on
 real Anopheles gambiae X-chromosome data (n = 100 phased haplotypes,
@@ -45,17 +48,27 @@ What the script does
    'tajimas_d'])``. Three stats from scikit-allel:
    ``allel.windowed_diversity``, ``allel.windowed_watterson_theta``,
    ``allel.windowed_tajima_d``.
-4. Verifies strict numerical agreement on all three statistics
+4. Verifies strict numerical agreement on the diversity statistics
    (NaN-aware, ``rtol=1e-5`` / ``atol=1e-8``). Trailing partial
    windows (where the chromosome end falls inside a window) are
    masked out of the comparison: the two libraries normalize the
    trailing partial window differently (allel divides by actual
    span; pg_gpu divides by the fixed window size), so a 1-window
    discrepancy there is uninteresting.
-5. Plots a 4-panel figure: pi / theta_W / Tajima's D traces overlaid
-   between the two implementations (so agreement = visual identity)
-   plus horizontal timing bars at the bottom annotated with the
-   speedup ratio.
+5. Subsamples ``--ld-snps`` (default 10,000) random SNPs and
+   computes a pairwise LD-decay curve on each side. The pg_gpu
+   path is one call:
+   ``hm_sub.windowed_r_squared(bp_bins, percentile=50, estimator='rogers_huff')``;
+   the scikit-allel path runs ``allel.rogers_huff_r``, squares it,
+   builds a pair-distance array, and bins manually. Both compute
+   the per-distance-bin median Rogers-Huff (2008) :math:`r^2`, so
+   the two curves agree to floating-point precision (the float32
+   precision floor scikit-allel sets internally). Times each side.
+6. Plots a 5-panel figure: pi / theta_W / Tajima's D traces overlaid
+   between the two implementations (agreement = visual identity),
+   the LD-decay curves overlaid on a log distance axis, and a
+   bottom panel of horizontal timing bars annotated with speedup
+   ratios for both the windowed scan and the LD-decay scan.
 
 Why it's useful as a template
 ------------------------------
@@ -72,3 +85,10 @@ multi-statistic windowed analysis. To adapt it:
 * Time at different window sizes. The default 10 kb is a typical
   diversity-scan resolution; ``--window-size`` accepts any positive
   integer.
+* Tune the LD scan for your scale of interest. ``--ld-snps``
+  controls the random subsample; larger values give a less-noisy
+  decay curve at the cost of quadratic compute. The bin edges
+  (``LD_BP_BINS`` in the script) span 100 bp to 1 Mb in 24 log-spaced
+  steps -- sensible for chromosomes with LD on the kb-to-Mb scale;
+  for tighter LD scales (e.g. recombining HIV sequences) tighten the
+  range.

--- a/docs/source/tutorials/scikit_allel_comparison.rst
+++ b/docs/source/tutorials/scikit_allel_comparison.rst
@@ -58,7 +58,28 @@ What the script does
 5. Selects a contiguous block of ``--ld-snps`` SNPs (default
    500,000) centered on the chromosome midpoint, drops variants
    below ``--ld-mac-min`` (default 20, i.e. MAF 0.05 in n=100
-   diploids), and computes a pairwise LD-decay curve on each side.
+   diploids), and computes *three* LD-decay curves on the same
+   pairs:
+
+   - scikit-allel Rogers-Huff :math:`r^2` (``allel.rogers_huff_r``,
+     squared, distance-binned, per-bin median)
+   - pg_gpu Rogers-Huff :math:`r^2` (one call to
+     ``hm_sub.windowed_r_squared(bp_bins, percentile=50, estimator='rogers_huff')``)
+   - pg_gpu unbiased :math:`\sigma_D^2` (Ragsdale & Gravel 2019;
+     one call to ``sigma_d2_geno(hm_sub)`` on the diploid genotype
+     view, distance-binned, per-bin median)
+
+   The first two are the *same* statistic computed by two different
+   libraries -- they agree to floating-point precision (the float32
+   precision floor scikit-allel sets internally) and serve as the
+   parity check. The third is a *different* statistic on the same
+   SNPs: rather than per-pair :math:`r^2 = D^2/\pi^2` where
+   :math:`\pi^2` is computed from the same pair, it's the unbiased
+   moments-LD polynomial estimator that subtracts a finite-sample
+   bias term derived from the multinomial projection. On panmictic
+   data with many rare variants it tracks below :math:`r^2` at
+   short distances and converges to it at long distances.
+
    A contiguous block (vs. a random subsample) gives dense coverage
    of short pair distances, which is where the LD-decay signal
    lives -- a random subsample leaves only a handful of pairs
@@ -67,19 +88,15 @@ What the script does
    variants take a tiny set of tied :math:`r^2` values (e.g., two
    non-overlapping singletons give exactly :math:`1/(n-1)^2`)
    regardless of distance, and those tied values pin the per-bin
-   median to a constant -- erasing any decay signal. The pg_gpu
-   path is one call:
-   ``hm_sub.windowed_r_squared(bp_bins, percentile=50, estimator='rogers_huff')``;
-   the scikit-allel path runs ``allel.rogers_huff_r``, squares it,
-   builds a pair-distance array, and bins manually. Both compute
-   the per-distance-bin median Rogers-Huff (2008) :math:`r^2`, so
-   the two curves agree to floating-point precision (the float32
-   precision floor scikit-allel sets internally). Times each side.
-6. Plots a 5-panel figure: pi / theta_W / Tajima's D traces overlaid
-   between the two implementations (agreement = visual identity),
-   the LD-decay curves overlaid on a log distance axis, and a
-   bottom panel of horizontal timing bars annotated with speedup
-   ratios for both the windowed scan and the LD-decay scan.
+   median to a constant -- erasing any decay signal.
+
+6. Plots a 5-panel figure: pi / theta_W / Tajima's D traces
+   overlaid between the two implementations (agreement = visual
+   identity), the three LD-decay curves overlaid on a log distance
+   axis, and a bottom panel of horizontal timing bars annotated
+   with speedup ratios for both the windowed scan and the LD-decay
+   scan. The :math:`\sigma_D^2` runtime is also reported but isn't
+   on the speedup bar (it has no scikit-allel counterpart).
 
 Why it's useful as a template
 ------------------------------

--- a/docs/source/tutorials/scikit_allel_comparison.rst
+++ b/docs/source/tutorials/scikit_allel_comparison.rst
@@ -1,0 +1,74 @@
+Side-by-Side: scikit-allel vs pg_gpu
+====================================
+
+Packaged script: ``examples/scikit_allel_comparison.py``
+
+Run it from the repo root:
+
+.. code-block:: bash
+
+   pixi run python examples/scikit_allel_comparison.py
+   pixi run python examples/scikit_allel_comparison.py --small
+   pixi run python examples/scikit_allel_comparison.py --no-plot
+
+Background
+----------
+
+A common workflow on phased haplotype data is a windowed scan
+producing several diversity statistics along a chromosome. In
+``scikit-allel`` this needs three separate calls -- one per statistic
+-- each rebuilding its own per-window iteration. ``pg_gpu`` collapses
+the same three statistics into a single ``windowed_analysis(...)``
+call that runs in one GPU kernel pass.
+
+This tutorial puts the two implementations next to each other on
+real Anopheles gambiae X-chromosome data (n = 100 phased haplotypes,
+~1M segregating sites), checks that they agree numerically, and
+reports the wall-clock speedup.
+
+What the script does
+--------------------
+
+1. Loads ``examples/data/gamb.X.phased.n100.zarr`` via
+   ``HaplotypeMatrix.from_zarr`` and builds the views needed
+   downstream: a ``(n_variants, 2)`` allele-count array for
+   ``scikit-allel`` plus the ``HaplotypeMatrix`` itself for
+   ``pg_gpu``.
+2. Pins the windowing by computing the window edges once with
+   ``allel.position_windows``; the resulting window array is passed
+   explicitly to every ``scikit-allel`` call, and the per-window
+   ``start``/``end`` columns of ``windowed_analysis``'s result are
+   asserted to match.
+3. Times both implementations with ``time.perf_counter``, after a
+   warmup run that absorbs CuPy/JIT initialization. Three stats from
+   pg_gpu: ``windowed_analysis(statistics=['pi', 'theta_w',
+   'tajimas_d'])``. Three stats from scikit-allel:
+   ``allel.windowed_diversity``, ``allel.windowed_watterson_theta``,
+   ``allel.windowed_tajima_d``.
+4. Verifies strict numerical agreement on all three statistics
+   (NaN-aware, ``rtol=1e-5`` / ``atol=1e-8``). Trailing partial
+   windows (where the chromosome end falls inside a window) are
+   masked out of the comparison: the two libraries normalize the
+   trailing partial window differently (allel divides by actual
+   span; pg_gpu divides by the fixed window size), so a 1-window
+   discrepancy there is uninteresting.
+5. Plots a 4-panel figure: pi / theta_W / Tajima's D traces overlaid
+   between the two implementations (so agreement = visual identity)
+   plus horizontal timing bars at the bottom annotated with the
+   speedup ratio.
+
+Why it's useful as a template
+------------------------------
+
+The recipe -- *load once, build the right shapes for each library,
+pass identical windows in, compare* -- is the right shape for any
+multi-statistic windowed analysis. To adapt it:
+
+* Swap the statistics list. ``windowed_analysis`` accepts any
+  combination of single-pop summaries; the ``scikit-allel`` side
+  needs one named call per statistic.
+* Run on your own data. The script accepts any zarr store loadable
+  by ``HaplotypeMatrix.from_zarr`` -- point ``ZARR_FULL`` at it.
+* Time at different window sizes. The default 10 kb is a typical
+  diversity-scan resolution; ``--window-size`` accepts any positive
+  integer.

--- a/examples/scikit_allel_comparison.py
+++ b/examples/scikit_allel_comparison.py
@@ -15,7 +15,6 @@ Usage
 """
 
 import argparse
-import sys
 import time
 from pathlib import Path
 
@@ -36,53 +35,6 @@ ZARR_FULL = DATA_DIR / "gamb.X.phased.n100.zarr"
 ZARR_SMALL = DATA_DIR / "gamb.X.8-12Mb.n100.derived.zarr"
 
 
-# -- helpers -----------------------------------------------------------------
-
-def compute_genotype_codes(hm: HaplotypeMatrix) -> np.ndarray:
-    """Build a scikit-allel-style (n_variants, n_samples) int8 genotype
-    array (0 = hom ref, 1 = het, 2 = hom alt).
-
-    Pairs adjacent haplotypes (haplotypes 0,1 = sample 0; 2,3 = sample
-    1; etc.). The gamb X dataset has no missing data; this helper
-    raises if it sees any -1 sentinels.
-    """
-    hap = hm.haplotypes
-    if hasattr(hap, "get"):
-        hap = hap.get()
-    hap = np.asarray(hap, dtype=np.int8)
-    if (hap < 0).any():
-        raise ValueError(
-            "compute_genotype_codes: input haplotypes contain missing "
-            "values (-1).")
-    n_hap, _ = hap.shape
-    if n_hap % 2 != 0:
-        raise ValueError(
-            f"compute_genotype_codes: odd number of haplotypes ({n_hap}); "
-            f"cannot pair into diploids.")
-    paired = hap[0::2, :] + hap[1::2, :]
-    return paired.T.astype(np.int8)
-
-
-def compute_allele_counts(hm: HaplotypeMatrix) -> np.ndarray:
-    """Build a scikit-allel-style (n_variants, 2) allele-count array.
-
-    Counts ref (0) and alt (1) calls per variant, ignoring any -1
-    missing-data sentinels.
-    """
-    hap = hm.haplotypes
-    if hasattr(hap, "get"):  # cupy -> numpy
-        hap = hap.get()
-    hap = np.asarray(hap, dtype=np.int8)
-    ac = np.empty((hap.shape[1], 2), dtype=np.int32)
-    ac[:, 0] = (hap == 0).sum(axis=0)
-    ac[:, 1] = (hap == 1).sum(axis=0)
-    # Sanity: ref + alt should equal the number of non-missing haplotypes.
-    n_called = (hap >= 0).sum(axis=0)
-    assert np.array_equal(ac.sum(axis=1), n_called), (
-        "allele counts do not match called-haplotype counts")
-    return ac
-
-
 def _load_data(small: bool) -> tuple:
     """Load the gamb dataset and build the three views needed for comparison.
 
@@ -90,7 +42,8 @@ def _load_data(small: bool) -> tuple:
     -------
     hm : HaplotypeMatrix
     pos : np.ndarray, shape (n_variants,), 1-based positions
-    ac : np.ndarray, shape (n_variants, 2), allele counts for allel
+    ac : np.ndarray, shape (n_variants, 2), allele counts (allel)
+    gn : np.ndarray, shape (n_variants, n_samples), 0/1/2 dosages (allel)
     """
     path = ZARR_SMALL if small else ZARR_FULL
     if not path.exists():
@@ -111,8 +64,16 @@ def _load_data(small: bool) -> tuple:
     if hasattr(pos, "get"):
         pos = pos.get()
     pos = np.asarray(pos, dtype=np.int64)
-    ac = compute_allele_counts(hm)
-    gn = compute_genotype_codes(hm)
+    # Build the two scikit-allel-shaped views from a single HaplotypeArray.
+    # pg_gpu stores haplotypes as (n_haplotypes, n_variants); allel wants
+    # (n_variants, n_haplotypes). Transposing once and going through allel's
+    # converters keeps us out of the hand-rolled-pairing business.
+    hap = hm.haplotypes
+    if hasattr(hap, "get"):
+        hap = hap.get()
+    ha = allel.HaplotypeArray(np.ascontiguousarray(hap.T))
+    ac = np.asarray(ha.count_alleles())
+    gn = np.asarray(ha.to_genotypes(ploidy=2).to_n_alt())
     return hm, pos, ac, gn
 
 
@@ -371,9 +332,6 @@ def _verify_strict(name: str, allel_arr: np.ndarray,
 
 def main() -> None:
     args = _parse_args()
-    if args.self_test:
-        _run_self_test()
-        return
     hm, pos, ac, gn = _load_data(args.small)
 
     print("Computing windows ...", flush=True)
@@ -470,30 +428,7 @@ def _parse_args() -> argparse.Namespace:
     p.add_argument("-o", "--output", type=Path,
                    default=Path("scikit_allel_comparison.png"),
                    help="Output figure path")
-    p.add_argument("--self-test", action="store_true",
-                   help=argparse.SUPPRESS)
     return p.parse_args()
-
-
-def _run_self_test() -> None:
-    """Quick host-side sanity check on the helpers."""
-    # 4 haplotypes, 3 variants, no missing
-    hap = np.array([
-        [0, 1, 0],
-        [1, 1, 0],
-        [0, 0, 0],
-        [0, 1, 1],
-    ], dtype=np.int8)
-    pos = np.array([100, 200, 300])
-    hm = HaplotypeMatrix(hap, pos, chrom_start=1, chrom_end=300)
-    ac = compute_allele_counts(hm)
-    np.testing.assert_array_equal(ac[:, 0], [3, 1, 3])
-    np.testing.assert_array_equal(ac[:, 1], [1, 3, 1])
-    gn = compute_genotype_codes(hm)
-    assert gn.shape == (3, 2), gn.shape
-    np.testing.assert_array_equal(gn[:, 0], [1, 2, 0])
-    np.testing.assert_array_equal(gn[:, 1], [0, 1, 1])
-    print("self-test OK")
 
 
 if __name__ == "__main__":

--- a/examples/scikit_allel_comparison.py
+++ b/examples/scikit_allel_comparison.py
@@ -109,16 +109,26 @@ def _compute_pg_gpu(hm: HaplotypeMatrix, window_size: int) -> tuple:
 # scikit-allel via allel.rogers_huff_r + manual binning. The two should
 # match numerically up to allel's float32 internal precision.
 
-LD_BP_BINS = np.logspace(2, 3, 25)  # 100 bp .. 1 kb, 24 log-spaced bins
+LD_BP_BINS = np.logspace(2, 4, 25)  # 100 bp .. 10 kb, 24 log-spaced bins
 
 
 def _subsample_for_ld(hm: HaplotypeMatrix,
                       pos: np.ndarray,
                       gn: np.ndarray,
                       n_snps: int,
-                      seed: int) -> tuple:
-    """Pick `n_snps` random SNPs (sorted by position) and build the
-    inputs both libraries need.
+                      mac_min: int) -> tuple:
+    """Pick `n_snps` contiguous SNPs centered on the chromosome midpoint,
+    then drop low-frequency variants below the MAC threshold.
+
+    A contiguous block (vs. a random subsample) gives dense coverage of
+    short pair distances -- which is where the LD-decay signal lives.
+    Anchoring on the midpoint keeps us away from telomere/centromere
+    edge effects. The MAC filter then drops near-singleton variants whose
+    pairwise r^2 is dominated by tied small values (e.g., two singletons
+    that never overlap give r^2 = 1/(n_dip-1)^2 regardless of distance);
+    those tied values pin the per-bin median to a constant and erase any
+    real decay signal. A standard MAF 0.05 floor (MAC >= 10 in n=100
+    diploids) is plenty to recover decay structure.
 
     Returns (hm_sub, pos_sub, gn_sub).
     """
@@ -126,19 +136,34 @@ def _subsample_for_ld(hm: HaplotypeMatrix,
     if n_snps > n_var:
         raise ValueError(
             f"--ld-snps={n_snps} exceeds the dataset size ({n_var})")
-    rng = np.random.RandomState(seed)
-    idx = rng.choice(n_var, size=n_snps, replace=False)
-    idx.sort()
-    pos_sub = pos[idx]
-    gn_sub = gn[idx]
+    midpoint = (hm.chrom_start + hm.chrom_end) // 2
+    center_idx = int(np.searchsorted(pos, midpoint))
+    half = n_snps // 2
+    start = max(0, center_idx - half)
+    end = start + n_snps
+    if end > n_var:
+        end = n_var
+        start = end - n_snps
+    idx = np.arange(start, end)
+    pos_blk = pos[idx]
+    gn_blk = gn[idx]
+    if mac_min > 0:
+        # MAC = minor allele count under a 0/1/2 dosage encoding.
+        n_alt = np.sum(gn_blk, axis=1).astype(np.int64)
+        n_total = 2 * gn_blk.shape[1]
+        mac = np.minimum(n_alt, n_total - n_alt)
+        keep = mac >= mac_min
+        idx = idx[keep]
+        pos_blk = pos_blk[keep]
+        gn_blk = gn_blk[keep]
     hap_full = hm.haplotypes
     if hasattr(hap_full, "get"):
         hap_full = hap_full.get()
     hap_full = np.asarray(hap_full, dtype=np.int8)
     hap_sub = hap_full[:, idx]
     hm_sub = HaplotypeMatrix(
-        hap_sub, pos_sub, hm.chrom_start, hm.chrom_end)
-    return hm_sub, pos_sub, gn_sub
+        hap_sub, pos_blk, hm.chrom_start, hm.chrom_end)
+    return hm_sub, pos_blk, gn_blk
 
 
 def _compute_allel_ld_decay(pos_sub: np.ndarray,
@@ -377,10 +402,14 @@ def main() -> None:
     print(f"  theta_w:   max abs diff = {md_tw:.3e}")
     print(f"  tajimas_d: max abs diff = {md_td:.3e}")
 
-    print(f"Subsampling {args.ld_snps:,} SNPs for LD-decay (seed={args.seed}) ...",
-          flush=True)
+    print(f"Selecting contiguous block of {args.ld_snps:,} SNPs centered "
+          f"on the chromosome midpoint for LD-decay ...", flush=True)
     hm_sub, pos_sub, gn_sub = _subsample_for_ld(
-        hm, pos, gn, args.ld_snps, args.seed)
+        hm, pos, gn, args.ld_snps, args.ld_mac_min)
+    print(f"  block spans {pos_sub[0]:,}-{pos_sub[-1]:,} "
+          f"({(pos_sub[-1] - pos_sub[0]) / 1e3:.1f} kb), "
+          f"{len(pos_sub):,} variants kept (MAC >= {args.ld_mac_min})",
+          flush=True)
     bp_bins = LD_BP_BINS
 
     print(f"Timing LD-decay (n_warmup={args.n_warmup}) ...", flush=True)
@@ -418,11 +447,16 @@ def _parse_args() -> argparse.Namespace:
                    help="Window size in bp (default: 10 kb)")
     p.add_argument("--n-warmup", type=int, default=1,
                    help="Discarded runs before timing (default: 1)")
-    p.add_argument("--ld-snps", type=int, default=10_000,
-                   help="SNPs subsampled for the LD-decay scan "
-                        "(default: 10_000)")
-    p.add_argument("--seed", type=int, default=0,
-                   help="RNG seed for SNP subsampling (default: 0)")
+    p.add_argument("--ld-snps", type=int, default=100_000,
+                   help="Size of the contiguous SNP block (centered on "
+                        "the chromosome midpoint) used for the LD-decay "
+                        "scan, before the MAC filter is applied "
+                        "(default: 100_000)")
+    p.add_argument("--ld-mac-min", type=int, default=10,
+                   help="Drop variants with minor allele count below this "
+                        "threshold from the LD block. Standard MAF 0.05 "
+                        "in n=100 diploids -> 10. Set to 0 to disable. "
+                        "(default: 10)")
     p.add_argument("--no-plot", action="store_true",
                    help="Skip the matplotlib figure")
     p.add_argument("-o", "--output", type=Path,

--- a/examples/scikit_allel_comparison.py
+++ b/examples/scikit_allel_comparison.py
@@ -165,6 +165,33 @@ def _compute_pg_gpu(hm: HaplotypeMatrix, window_size: int) -> tuple:
             df["zns"].to_numpy()), df
 
 
+def _assert_windows_aligned(allel_windows: np.ndarray,
+                            pg_gpu_df) -> None:
+    """Confirm both libraries laid out the same windows.
+
+    scikit-allel returns `windows` as (n_windows, 2) of (start, stop)
+    in 1-based inclusive coordinates. pg_gpu's windowed_analysis
+    returns `start` and `end` columns. We check that they match
+    exactly.
+    """
+    n_allel = allel_windows.shape[0]
+    n_pg = len(pg_gpu_df)
+    if n_allel != n_pg:
+        raise AssertionError(
+            f"window count mismatch: allel={n_allel}, pg_gpu={n_pg}. "
+            f"This means the two libraries laid out different windows "
+            f"for the same input range; the rest of the comparison "
+            f"would be apples-to-oranges. Check that window_size, "
+            f"step_size, and the chromosome range agree.")
+    starts_a = allel_windows[:, 0]
+    starts_g = pg_gpu_df["start"].to_numpy()
+    if not np.array_equal(starts_a, starts_g):
+        bad = np.where(starts_a != starts_g)[0][:5]
+        raise AssertionError(
+            f"window-start mismatch at indices {bad}: "
+            f"allel={starts_a[bad]}, pg_gpu={starts_g[bad]}")
+
+
 def main() -> None:
     args = _parse_args()
     if args.self_test:
@@ -182,7 +209,8 @@ def main() -> None:
     pi_a, tw_a, td_a, ld_a = _compute_allel(pos, ac, gn, windows)
     print("Running pg_gpu ...", flush=True)
     (pi_g, tw_g, td_g, ld_g), df = _compute_pg_gpu(hm, args.window_size)
-    print(f"allel windows: {len(pi_a)}, pg_gpu windows: {len(pi_g)}")
+    _assert_windows_aligned(windows, df)
+    print(f"  {len(pi_a)} aligned windows confirmed")
     return
 
 

--- a/examples/scikit_allel_comparison.py
+++ b/examples/scikit_allel_comparison.py
@@ -123,13 +123,66 @@ def _load_data(small: bool) -> tuple:
     return hm, pos, ac, gn
 
 
+# -- compute paths -----------------------------------------------------------
+
+def _compute_allel(pos: np.ndarray, ac: np.ndarray, gn: np.ndarray,
+                   windows: np.ndarray) -> tuple:
+    """Run scikit-allel's four windowed scans. Returns (pi, theta_w,
+    tajimas_d, ld_median_r2).
+
+    Note: allel.windowed_r_squared crashes in NumPy >= 1.25 when a window
+    contains exactly one variant (rogers_huff_r returns an empty r array
+    and np.percentile raises IndexError on it). We use windowed_statistic
+    directly with a guarded closure to match the intended behaviour.
+    """
+    pi, _, _, _ = allel.windowed_diversity(pos, ac, windows=windows)
+    theta_w, _, _, _ = allel.windowed_watterson_theta(
+        pos, ac, windows=windows)
+    tajd, _, _ = allel.windowed_tajima_d(pos, ac, windows=windows)
+
+    def _median_r2(gnw):
+        r_sq = allel.rogers_huff_r(gnw) ** 2
+        if len(r_sq) == 0:
+            return np.nan
+        return np.percentile(r_sq, 50)
+
+    ld, _, _ = allel.windowed_statistic(
+        pos, gn, _median_r2, windows=windows, fill=np.nan)
+    return pi, theta_w, tajd, ld
+
+
+def _compute_pg_gpu(hm: HaplotypeMatrix, window_size: int) -> tuple:
+    """Run pg_gpu's single fused windowed_analysis call. Returns
+    (pi, theta_w, tajimas_d, zns) plus the result DataFrame so the
+    caller can inspect window edges."""
+    df = windowed_analysis(
+        hm, window_size=window_size, step_size=window_size,
+        statistics=["pi", "theta_w", "tajimas_d", "zns"])
+    cp.cuda.Device().synchronize()
+    return (df["pi"].to_numpy(),
+            df["theta_w"].to_numpy(),
+            df["tajimas_d"].to_numpy(),
+            df["zns"].to_numpy()), df
+
+
 def main() -> None:
     args = _parse_args()
     if args.self_test:
         _run_self_test()
         return
     hm, pos, ac, gn = _load_data(args.small)
-    print(f"shapes: ac={ac.shape}, gn={gn.shape}, pos[0..2]={pos[:3]}")
+
+    print("Computing windows ...", flush=True)
+    windows = allel.position_windows(
+        pos, size=args.window_size, step=args.window_size,
+        start=int(pos[0]), stop=int(pos[-1]))
+    print(f"  {len(windows)} windows of {args.window_size:,} bp")
+
+    print("Running scikit-allel ...", flush=True)
+    pi_a, tw_a, td_a, ld_a = _compute_allel(pos, ac, gn, windows)
+    print("Running pg_gpu ...", flush=True)
+    (pi_g, tw_g, td_g, ld_g), df = _compute_pg_gpu(hm, args.window_size)
+    print(f"allel windows: {len(pi_a)}, pg_gpu windows: {len(pi_g)}")
     return
 
 

--- a/examples/scikit_allel_comparison.py
+++ b/examples/scikit_allel_comparison.py
@@ -145,6 +145,19 @@ def _assert_windows_aligned(allel_windows: np.ndarray,
 
 # -- verify + time -----------------------------------------------------------
 
+def _time(callable_, n_warmup: int) -> tuple:
+    """Run `n_warmup` discarded calls, then one timed call.
+
+    Returns (result, elapsed_seconds).
+    """
+    for _ in range(n_warmup):
+        callable_()
+    t0 = time.perf_counter()
+    result = callable_()
+    elapsed = time.perf_counter() - t0
+    return result, elapsed
+
+
 def _verify_strict(name: str, allel_arr: np.ndarray,
                    pg_arr: np.ndarray,
                    rtol: float = 1e-5, atol: float = 1e-8) -> float:
@@ -188,10 +201,17 @@ def main() -> None:
         start=int(pos[0]), stop=int(pos[-1]))
     print(f"  {len(windows)} windows of {args.window_size:,} bp")
 
-    print("Running scikit-allel ...", flush=True)
-    pi_a, tw_a, td_a = _compute_allel(pos, ac, windows)
-    print("Running pg_gpu ...", flush=True)
-    (pi_g, tw_g, td_g), df = _compute_pg_gpu(hm, args.window_size)
+    print(f"Timing (n_warmup={args.n_warmup}) ...", flush=True)
+    (pi_a, tw_a, td_a), t_allel = _time(
+        lambda: _compute_allel(pos, ac, windows),
+        n_warmup=args.n_warmup)
+    ((pi_g, tw_g, td_g), df), t_pg = _time(
+        lambda: _compute_pg_gpu(hm, args.window_size),
+        n_warmup=args.n_warmup)
+    speedup = t_allel / t_pg
+    print(f"  scikit-allel: {t_allel:6.2f}s")
+    print(f"  pg_gpu:       {t_pg:6.2f}s  ({speedup:.1f}x speedup)")
+
     _assert_windows_aligned(windows, df)
     print(f"  {len(pi_a)} aligned windows confirmed")
 

--- a/examples/scikit_allel_comparison.py
+++ b/examples/scikit_allel_comparison.py
@@ -143,6 +143,63 @@ def _assert_windows_aligned(allel_windows: np.ndarray,
             f"allel={starts_a[bad]}, pg_gpu={starts_g[bad]}")
 
 
+# -- plotting ----------------------------------------------------------------
+
+# Two-color palette: scikit-allel = warm grey, pg_gpu = blue.
+COL_ALLEL = "#9aa1ac"   # light grey-blue
+COL_PG = "#2980b9"      # pg_gpu blue (matches accessibility_mask.py)
+
+
+def _plot_comparison(
+    centers_mb: np.ndarray,
+    pi_a: np.ndarray, pi_g: np.ndarray,
+    tw_a: np.ndarray, tw_g: np.ndarray,
+    td_a: np.ndarray, td_g: np.ndarray,
+    t_allel: float, t_pg: float,
+    outpath: Path,
+) -> None:
+    sns.set_theme(style="whitegrid", context="paper", font_scale=0.95)
+    fig, axes = plt.subplots(
+        4, 1, figsize=(11, 9),
+        gridspec_kw={"height_ratios": [1, 1, 1, 0.5]},
+        sharex=False)
+
+    # Panels 1-3: identical-shape overlays for pi / theta_w / Tajima's D.
+    for ax, (a, g, ylabel) in zip(
+        axes[:3],
+        [(pi_a, pi_g, r"$\pi$"),
+         (tw_a, tw_g, r"$\theta_W$"),
+         (td_a, td_g, r"Tajima's $D$")]):
+        ax.plot(centers_mb, a, color=COL_ALLEL, linewidth=1.6, alpha=0.9)
+        ax.plot(centers_mb, g, color=COL_PG, linewidth=0.8, alpha=0.95)
+        ax.set_ylabel(ylabel)
+
+    # Top-panel legend only.
+    axes[0].plot([], [], color=COL_ALLEL, linewidth=1.6, label="scikit-allel")
+    axes[0].plot([], [], color=COL_PG, linewidth=0.8, label="pg_gpu")
+    axes[0].legend(fontsize=8, loc="upper right", frameon=False)
+
+    axes[2].set_xlabel("Genomic position (Mb)")
+
+    # Panel 4: timing bars.
+    ax_t = axes[3]
+    ax_t.barh([1, 0], [t_allel, t_pg], color=[COL_ALLEL, COL_PG],
+              height=0.6)
+    ax_t.set_yticks([0, 1])
+    ax_t.set_yticklabels(["pg_gpu", "scikit-allel"])
+    ax_t.set_xlabel("seconds")
+    ax_t.text(t_allel, 1, f"  {t_allel:.2f}s",
+              va="center", ha="left", fontsize=9, color="0.2")
+    ax_t.text(t_pg, 0, f"  {t_pg:.2f}s ({t_allel / t_pg:.1f}x)",
+              va="center", ha="left", fontsize=9, color="0.2")
+    ax_t.grid(axis="y", visible=False)
+
+    fig.tight_layout()
+    fig.savefig(outpath, bbox_inches="tight", dpi=150)
+    plt.close(fig)
+    print(f"\nFigure saved to {outpath}")
+
+
 # -- verify + time -----------------------------------------------------------
 
 def _time(callable_, n_warmup: int) -> tuple:
@@ -240,6 +297,14 @@ def main() -> None:
     print(f"  pi:        max abs diff = {md_pi:.3e}")
     print(f"  theta_w:   max abs diff = {md_tw:.3e}")
     print(f"  tajimas_d: max abs diff = {md_td:.3e}")
+
+    if not args.no_plot:
+        centers_mb = (df["start"].to_numpy() + df["end"].to_numpy()) / 2 / 1e6
+        _plot_comparison(
+            centers_mb,
+            pi_a, pi_g, tw_a, tw_g, td_a, td_g,
+            t_allel=t_allel, t_pg=t_pg,
+            outpath=args.output)
     return
 
 

--- a/examples/scikit_allel_comparison.py
+++ b/examples/scikit_allel_comparison.py
@@ -166,16 +166,23 @@ def _subsample_for_ld(hm, pos, gn, n_snps, mac_min):
     gn_blk = gn[idx]
 
     # Drop near-singleton variants. See the docstring for why.
+    # (Formula assumes biallelic, non-missing 0/1/2 dosages -- the
+    # gamb fixture is clean, so we don't validate here.)
     if mac_min > 0:
         n_alt = gn_blk.sum(axis=1)
         mac = np.minimum(n_alt, 2 * gn_blk.shape[1] - n_alt)
         keep = mac >= mac_min
         idx, pos_blk, gn_blk = idx[keep], pos_blk[keep], gn_blk[keep]
 
-    # Build the matching pg_gpu view (haplotypes subset the same way).
-    hap_full = _to_numpy(hm.haplotypes).astype(np.int8, copy=False)
+    # Slice haplotypes on whichever device they live (CPU or GPU)
+    # rather than pulling the full chromosome through host memory.
+    hap = hm.haplotypes
+    if hasattr(hap, "get"):  # CuPy array on GPU
+        hap_sub = hap[:, cp.asarray(idx)]
+    else:
+        hap_sub = hap[:, idx]
     hm_sub = HaplotypeMatrix(
-        hap_full[:, idx], pos_blk, hm.chrom_start, hm.chrom_end)
+        hap_sub, pos_blk, hm.chrom_start, hm.chrom_end)
     return hm_sub, pos_blk, gn_blk
 
 
@@ -347,14 +354,12 @@ def main():
     # When chrom_end isn't a clean multiple of window_size, the last
     # window has fewer than window_size bp. The two libraries normalize
     # that single partial window slightly differently -- a one-window
-    # cosmetic effect, not a real numerical disagreement. Mask it out
+    # cosmetic effect, not a real numerical disagreement. NaN it out
     # of the comparison so it doesn't flag a false failure.
-    arrays = [np.array(a) for a in (pi_a, tw_a, td_a, pi_g, tw_g, td_g)]
     partial = (windows[:, 1] - windows[:, 0] + 1) != args.window_size
-    if partial.any():
-        for arr in arrays:
-            arr[partial] = np.nan
-    pi_a, tw_a, td_a, pi_g, tw_g, td_g = arrays
+    pi_a, tw_a, td_a, pi_g, tw_g, td_g = (
+        np.where(partial, np.nan, np.asarray(a))
+        for a in (pi_a, tw_a, td_a, pi_g, tw_g, td_g))
 
     # Strict numerical agreement on all three diversity stats.
     print("Verifying diversity ...", flush=True)

--- a/examples/scikit_allel_comparison.py
+++ b/examples/scikit_allel_comparison.py
@@ -39,8 +39,102 @@ ZARR_FULL = DATA_DIR / "gamb.X.phased.n100.zarr"
 ZARR_SMALL = DATA_DIR / "gamb.X.8-12Mb.n100.derived.zarr"
 
 
+# -- helpers -----------------------------------------------------------------
+
+def compute_allele_counts(hm: HaplotypeMatrix) -> np.ndarray:
+    """Build a scikit-allel-style (n_variants, 2) allele-count array.
+
+    Counts ref (0) and alt (1) calls per variant, ignoring any -1
+    missing-data sentinels.
+    """
+    hap = hm.haplotypes
+    if hasattr(hap, "get"):  # cupy -> numpy
+        hap = hap.get()
+    hap = np.asarray(hap, dtype=np.int8)
+    ac = np.empty((hap.shape[1], 2), dtype=np.int32)
+    ac[:, 0] = (hap == 0).sum(axis=0)
+    ac[:, 1] = (hap == 1).sum(axis=0)
+    # Sanity: ref + alt should equal the number of non-missing haplotypes.
+    n_called = (hap >= 0).sum(axis=0)
+    assert np.array_equal(ac.sum(axis=1), n_called), (
+        "allele counts do not match called-haplotype counts")
+    return ac
+
+
+def compute_genotype_codes(hm: HaplotypeMatrix) -> np.ndarray:
+    """Build a scikit-allel-style (n_variants, n_samples) int8 genotype
+    array (0 = hom ref, 1 = het, 2 = hom alt).
+
+    Pairs adjacent haplotypes (haplotypes 0,1 = sample 0; 2,3 = sample
+    1; etc.). The gamb X dataset has no missing data; this function
+    asserts that and refuses to silently fabricate codes.
+    """
+    hap = hm.haplotypes
+    if hasattr(hap, "get"):
+        hap = hap.get()
+    hap = np.asarray(hap, dtype=np.int8)
+    if (hap < 0).any():
+        raise ValueError(
+            "compute_genotype_codes: input haplotypes contain missing "
+            "values (-1). scikit-allel's rogers_huff_r expects 0/1/2 "
+            "with no missing sentinels; drop or impute missing sites "
+            "before calling.")
+    n_hap, n_var = hap.shape
+    if n_hap % 2 != 0:
+        raise ValueError(
+            f"compute_genotype_codes: odd number of haplotypes "
+            f"({n_hap}); cannot pair into diploids.")
+    # (n_haps, n_var) -> (n_samples, n_var) by summing pairs, then transpose.
+    paired = hap[0::2, :] + hap[1::2, :]   # (n_samples, n_var) int8
+    return paired.T.astype(np.int8)        # (n_var, n_samples)
+
+
 def main() -> None:
+    args = _parse_args()
+    if args.self_test:
+        _run_self_test()
+        return
     raise NotImplementedError("main not yet wired up")
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Side-by-side scikit-allel vs pg_gpu windowed scan")
+    p.add_argument("--small", action="store_true",
+                   help="Use the 4 Mb gamb.X.8-12Mb subset (fast)")
+    p.add_argument("--window-size", type=int, default=10_000,
+                   help="Window size in bp (default: 10 kb)")
+    p.add_argument("--n-warmup", type=int, default=1,
+                   help="Discarded runs before timing (default: 1)")
+    p.add_argument("--no-plot", action="store_true",
+                   help="Skip the matplotlib figure")
+    p.add_argument("-o", "--output", type=Path,
+                   default=Path("scikit_allel_comparison.png"),
+                   help="Output figure path")
+    p.add_argument("--self-test", action="store_true",
+                   help=argparse.SUPPRESS)
+    return p.parse_args()
+
+
+def _run_self_test() -> None:
+    """Quick host-side sanity check on the two helpers."""
+    # 4 haplotypes, 3 variants, no missing
+    hap = np.array([
+        [0, 1, 0],
+        [1, 1, 0],
+        [0, 0, 0],
+        [0, 1, 1],
+    ], dtype=np.int8)
+    pos = np.array([100, 200, 300])
+    hm = HaplotypeMatrix(hap, pos, chrom_start=1, chrom_end=300)
+    ac = compute_allele_counts(hm)
+    np.testing.assert_array_equal(ac[:, 0], [3, 1, 3])
+    np.testing.assert_array_equal(ac[:, 1], [1, 3, 1])
+    gn = compute_genotype_codes(hm)
+    assert gn.shape == (3, 2), gn.shape
+    np.testing.assert_array_equal(gn[:, 0], [1, 2, 0])
+    np.testing.assert_array_equal(gn[:, 1], [0, 1, 1])
+    print("self-test OK")
 
 
 if __name__ == "__main__":

--- a/examples/scikit_allel_comparison.py
+++ b/examples/scikit_allel_comparison.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+"""
+Side-by-side: scikit-allel vs pg_gpu on a windowed diversity / LD scan.
+
+Loads a real Anopheles gambiae X-chromosome dataset and computes
+windowed pi, theta_w, Tajima's D, and a windowed LD summary using
+both libraries. scikit-allel takes four separate calls; pg_gpu takes
+one. The script verifies numerical agreement (or, for the LD scan,
+high rank correlation) and reports the wall-clock speedup.
+
+Usage
+-----
+    pixi run python examples/scikit_allel_comparison.py
+    pixi run python examples/scikit_allel_comparison.py --small
+    pixi run python examples/scikit_allel_comparison.py --no-plot
+"""
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+import allel
+import cupy as cp
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import seaborn as sns
+from scipy.stats import spearmanr
+
+from pg_gpu import HaplotypeMatrix
+from pg_gpu.windowed_analysis import windowed_analysis
+
+
+# Datasets: full X-chromosome by default; --small uses a 4 Mb subset.
+DATA_DIR = Path(__file__).resolve().parent / "data"
+ZARR_FULL = DATA_DIR / "gamb.X.phased.n100.zarr"
+ZARR_SMALL = DATA_DIR / "gamb.X.8-12Mb.n100.derived.zarr"
+
+
+def main() -> None:
+    raise NotImplementedError("main not yet wired up")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/scikit_allel_comparison.py
+++ b/examples/scikit_allel_comparison.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 """
-Side-by-side: scikit-allel vs pg_gpu on a windowed diversity / LD scan.
+Side-by-side: scikit-allel vs pg_gpu on a windowed diversity scan.
 
 Loads a real Anopheles gambiae X-chromosome dataset and computes
-windowed pi, theta_w, Tajima's D, and a windowed LD summary using
-both libraries. scikit-allel takes four separate calls; pg_gpu takes
-one. The script verifies numerical agreement (or, for the LD scan,
-high rank correlation) and reports the wall-clock speedup.
+windowed pi, theta_w, and Tajima's D using both libraries.
+scikit-allel takes three separate calls; pg_gpu takes one. The script
+verifies numerical agreement and reports the wall-clock speedup.
 
 Usage
 -----
@@ -27,8 +26,6 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
-from scipy.stats import spearmanr
-
 from pg_gpu import HaplotypeMatrix
 from pg_gpu.windowed_analysis import windowed_analysis
 
@@ -61,43 +58,14 @@ def compute_allele_counts(hm: HaplotypeMatrix) -> np.ndarray:
     return ac
 
 
-def compute_genotype_codes(hm: HaplotypeMatrix) -> np.ndarray:
-    """Build a scikit-allel-style (n_variants, n_samples) int8 genotype
-    array (0 = hom ref, 1 = het, 2 = hom alt).
-
-    Pairs adjacent haplotypes (haplotypes 0,1 = sample 0; 2,3 = sample
-    1; etc.). The gamb X dataset has no missing data; this function
-    asserts that and refuses to silently fabricate codes.
-    """
-    hap = hm.haplotypes
-    if hasattr(hap, "get"):
-        hap = hap.get()
-    hap = np.asarray(hap, dtype=np.int8)
-    if (hap < 0).any():
-        raise ValueError(
-            "compute_genotype_codes: input haplotypes contain missing "
-            "values (-1). scikit-allel's rogers_huff_r expects 0/1/2 "
-            "with no missing sentinels; drop or impute missing sites "
-            "before calling.")
-    n_hap, n_var = hap.shape
-    if n_hap % 2 != 0:
-        raise ValueError(
-            f"compute_genotype_codes: odd number of haplotypes "
-            f"({n_hap}); cannot pair into diploids.")
-    # (n_haps, n_var) -> (n_samples, n_var) by summing pairs, then transpose.
-    paired = hap[0::2, :] + hap[1::2, :]   # (n_samples, n_var) int8
-    return paired.T.astype(np.int8)        # (n_var, n_samples)
-
-
 def _load_data(small: bool) -> tuple:
-    """Load the gamb dataset and build all four views.
+    """Load the gamb dataset and build the three views needed for comparison.
 
     Returns
     -------
     hm : HaplotypeMatrix
     pos : np.ndarray, shape (n_variants,), 1-based positions
     ac : np.ndarray, shape (n_variants, 2), allele counts for allel
-    gn : np.ndarray, shape (n_variants, n_samples), 0/1/2 codes for allel
     """
     path = ZARR_SMALL if small else ZARR_FULL
     if not path.exists():
@@ -119,50 +87,33 @@ def _load_data(small: bool) -> tuple:
         pos = pos.get()
     pos = np.asarray(pos, dtype=np.int64)
     ac = compute_allele_counts(hm)
-    gn = compute_genotype_codes(hm)
-    return hm, pos, ac, gn
+    return hm, pos, ac
 
 
 # -- compute paths -----------------------------------------------------------
 
-def _compute_allel(pos: np.ndarray, ac: np.ndarray, gn: np.ndarray,
+def _compute_allel(pos: np.ndarray, ac: np.ndarray,
                    windows: np.ndarray) -> tuple:
-    """Run scikit-allel's four windowed scans. Returns (pi, theta_w,
-    tajimas_d, ld_median_r2).
-
-    Note: allel.windowed_r_squared crashes in NumPy >= 1.25 when a window
-    contains exactly one variant (rogers_huff_r returns an empty r array
-    and np.percentile raises IndexError on it). We use windowed_statistic
-    directly with a guarded closure to match the intended behaviour.
-    """
+    """Run scikit-allel's three windowed diversity scans. Returns
+    (pi, theta_w, tajimas_d)."""
     pi, _, _, _ = allel.windowed_diversity(pos, ac, windows=windows)
     theta_w, _, _, _ = allel.windowed_watterson_theta(
         pos, ac, windows=windows)
     tajd, _, _ = allel.windowed_tajima_d(pos, ac, windows=windows)
-
-    def _median_r2(gnw):
-        r_sq = allel.rogers_huff_r(gnw) ** 2
-        if len(r_sq) == 0:
-            return np.nan
-        return np.percentile(r_sq, 50)
-
-    ld, _, _ = allel.windowed_statistic(
-        pos, gn, _median_r2, windows=windows, fill=np.nan)
-    return pi, theta_w, tajd, ld
+    return pi, theta_w, tajd
 
 
 def _compute_pg_gpu(hm: HaplotypeMatrix, window_size: int) -> tuple:
     """Run pg_gpu's single fused windowed_analysis call. Returns
-    (pi, theta_w, tajimas_d, zns) plus the result DataFrame so the
-    caller can inspect window edges."""
+    (pi, theta_w, tajimas_d) plus the result DataFrame so the caller
+    can inspect window edges."""
     df = windowed_analysis(
         hm, window_size=window_size, step_size=window_size,
-        statistics=["pi", "theta_w", "tajimas_d", "zns"])
+        statistics=["pi", "theta_w", "tajimas_d"])
     cp.cuda.Device().synchronize()
     return (df["pi"].to_numpy(),
             df["theta_w"].to_numpy(),
-            df["tajimas_d"].to_numpy(),
-            df["zns"].to_numpy()), df
+            df["tajimas_d"].to_numpy()), df
 
 
 def _assert_windows_aligned(allel_windows: np.ndarray,
@@ -192,12 +143,44 @@ def _assert_windows_aligned(allel_windows: np.ndarray,
             f"allel={starts_a[bad]}, pg_gpu={starts_g[bad]}")
 
 
+# -- verify + time -----------------------------------------------------------
+
+def _verify_strict(name: str, allel_arr: np.ndarray,
+                   pg_arr: np.ndarray,
+                   rtol: float = 1e-5, atol: float = 1e-8) -> float:
+    """Assert per-window agreement on a NaN-aligned mask.
+
+    Returns the max absolute difference on the comparison mask so the
+    caller can print a one-line summary.
+    """
+    finite = np.isfinite(allel_arr) & np.isfinite(pg_arr)
+    if not finite.any():
+        raise AssertionError(
+            f"[{name}] no finite windows in either array; cannot verify")
+    diff = np.abs(allel_arr[finite] - pg_arr[finite])
+    max_diff = float(diff.max())
+    try:
+        np.testing.assert_allclose(
+            allel_arr[finite], pg_arr[finite],
+            rtol=rtol, atol=atol,
+            err_msg=f"[{name}] disagreement above tolerance")
+    except AssertionError as e:
+        # Surface the worst-offender windows in the failure
+        order = np.argsort(diff)[::-1][:5]
+        finite_idx = np.where(finite)[0]
+        worst = finite_idx[order]
+        raise AssertionError(
+            f"[{name}] disagreement; worst window indices {worst.tolist()} "
+            f"(max diff = {max_diff:.3e}). Original error:\n{e}") from None
+    return max_diff
+
+
 def main() -> None:
     args = _parse_args()
     if args.self_test:
         _run_self_test()
         return
-    hm, pos, ac, gn = _load_data(args.small)
+    hm, pos, ac = _load_data(args.small)
 
     print("Computing windows ...", flush=True)
     windows = allel.position_windows(
@@ -206,11 +189,37 @@ def main() -> None:
     print(f"  {len(windows)} windows of {args.window_size:,} bp")
 
     print("Running scikit-allel ...", flush=True)
-    pi_a, tw_a, td_a, ld_a = _compute_allel(pos, ac, gn, windows)
+    pi_a, tw_a, td_a = _compute_allel(pos, ac, windows)
     print("Running pg_gpu ...", flush=True)
-    (pi_g, tw_g, td_g, ld_g), df = _compute_pg_gpu(hm, args.window_size)
+    (pi_g, tw_g, td_g), df = _compute_pg_gpu(hm, args.window_size)
     _assert_windows_aligned(windows, df)
     print(f"  {len(pi_a)} aligned windows confirmed")
+
+    # The trailing window can be partial when chrom_end is not a multiple
+    # of window_size. The two libraries normalize partial windows
+    # differently (allel divides per-site sums by actual span; pg_gpu
+    # divides by the fixed window_size parameter), which produces a real
+    # but uninteresting numerical mismatch on that one window. Mask it
+    # out so verification only compares full-width windows.
+    window_widths = windows[:, 1] - windows[:, 0] + 1
+    partial = window_widths != args.window_size
+    n_partial = int(partial.sum())
+    # Work on writable copies so we can set partial windows to NaN.
+    pi_a, tw_a, td_a = (np.array(a) for a in (pi_a, tw_a, td_a))
+    pi_g, tw_g, td_g = (np.array(a) for a in (pi_g, tw_g, td_g))
+    if n_partial:
+        for arr in (pi_a, tw_a, td_a, pi_g, tw_g, td_g):
+            arr[partial] = np.nan
+        print(f"  ({n_partial} partial trailing window(s) masked from "
+              f"comparison)")
+
+    print("Verifying ...", flush=True)
+    md_pi = _verify_strict("pi", pi_a, pi_g)
+    md_tw = _verify_strict("theta_w", tw_a, tw_g)
+    md_td = _verify_strict("tajimas_d", td_a, td_g)
+    print(f"  pi:        max abs diff = {md_pi:.3e}")
+    print(f"  theta_w:   max abs diff = {md_tw:.3e}")
+    print(f"  tajimas_d: max abs diff = {md_td:.3e}")
     return
 
 
@@ -234,7 +243,7 @@ def _parse_args() -> argparse.Namespace:
 
 
 def _run_self_test() -> None:
-    """Quick host-side sanity check on the two helpers."""
+    """Quick host-side sanity check on compute_allele_counts."""
     # 4 haplotypes, 3 variants, no missing
     hap = np.array([
         [0, 1, 0],
@@ -247,10 +256,6 @@ def _run_self_test() -> None:
     ac = compute_allele_counts(hm)
     np.testing.assert_array_equal(ac[:, 0], [3, 1, 3])
     np.testing.assert_array_equal(ac[:, 1], [1, 3, 1])
-    gn = compute_genotype_codes(hm)
-    assert gn.shape == (3, 2), gn.shape
-    np.testing.assert_array_equal(gn[:, 0], [1, 2, 0])
-    np.testing.assert_array_equal(gn[:, 1], [0, 1, 1])
     print("self-test OK")
 
 

--- a/examples/scikit_allel_comparison.py
+++ b/examples/scikit_allel_comparison.py
@@ -148,7 +148,7 @@ def _compute_pg_gpu(hm: HaplotypeMatrix, window_size: int) -> tuple:
 # scikit-allel via allel.rogers_huff_r + manual binning. The two should
 # match numerically up to allel's float32 internal precision.
 
-LD_BP_BINS = np.logspace(2, 6, 25)  # 100 bp .. 1 Mb, 24 log-spaced bins
+LD_BP_BINS = np.logspace(2, 3, 25)  # 100 bp .. 1 kb, 24 log-spaced bins
 
 
 def _subsample_for_ld(hm: HaplotypeMatrix,
@@ -396,23 +396,20 @@ def main() -> None:
     _assert_windows_aligned(windows, df)
     print(f"  {len(pi_a)} aligned windows confirmed")
 
-    # The trailing window can be partial when chrom_end is not a multiple
-    # of window_size. The two libraries normalize partial windows
-    # differently (allel divides per-site sums by actual span; pg_gpu
-    # divides by the fixed window_size parameter), which produces a real
-    # but uninteresting numerical mismatch on that one window. Mask it
-    # out so verification only compares full-width windows.
+    # Trailing partial window: when chrom_end isn't an exact multiple
+    # of window_size, the last window has fewer than window_size bp.
+    # The two libraries disagree about how to normalize that single
+    # window (allel uses the actual span; pg_gpu's per-window span is
+    # computed slightly differently for the last window) -- a
+    # one-window 0.01% effect that has nothing to do with the
+    # comparison. Drop the last window from the strict checks.
     window_widths = windows[:, 1] - windows[:, 0] + 1
     partial = window_widths != args.window_size
-    n_partial = int(partial.sum())
-    # Work on writable copies so we can set partial windows to NaN.
     pi_a, tw_a, td_a = (np.array(a) for a in (pi_a, tw_a, td_a))
     pi_g, tw_g, td_g = (np.array(a) for a in (pi_g, tw_g, td_g))
-    if n_partial:
+    if partial.any():
         for arr in (pi_a, tw_a, td_a, pi_g, tw_g, td_g):
             arr[partial] = np.nan
-        print(f"  ({n_partial} partial trailing window(s) masked from "
-              f"comparison)")
 
     print("Verifying ...", flush=True)
     md_pi = _verify_strict("pi", pi_a, pi_g)

--- a/examples/scikit_allel_comparison.py
+++ b/examples/scikit_allel_comparison.py
@@ -38,6 +38,31 @@ ZARR_SMALL = DATA_DIR / "gamb.X.8-12Mb.n100.derived.zarr"
 
 # -- helpers -----------------------------------------------------------------
 
+def compute_genotype_codes(hm: HaplotypeMatrix) -> np.ndarray:
+    """Build a scikit-allel-style (n_variants, n_samples) int8 genotype
+    array (0 = hom ref, 1 = het, 2 = hom alt).
+
+    Pairs adjacent haplotypes (haplotypes 0,1 = sample 0; 2,3 = sample
+    1; etc.). The gamb X dataset has no missing data; this helper
+    raises if it sees any -1 sentinels.
+    """
+    hap = hm.haplotypes
+    if hasattr(hap, "get"):
+        hap = hap.get()
+    hap = np.asarray(hap, dtype=np.int8)
+    if (hap < 0).any():
+        raise ValueError(
+            "compute_genotype_codes: input haplotypes contain missing "
+            "values (-1).")
+    n_hap, _ = hap.shape
+    if n_hap % 2 != 0:
+        raise ValueError(
+            f"compute_genotype_codes: odd number of haplotypes ({n_hap}); "
+            f"cannot pair into diploids.")
+    paired = hap[0::2, :] + hap[1::2, :]
+    return paired.T.astype(np.int8)
+
+
 def compute_allele_counts(hm: HaplotypeMatrix) -> np.ndarray:
     """Build a scikit-allel-style (n_variants, 2) allele-count array.
 
@@ -87,7 +112,8 @@ def _load_data(small: bool) -> tuple:
         pos = pos.get()
     pos = np.asarray(pos, dtype=np.int64)
     ac = compute_allele_counts(hm)
-    return hm, pos, ac
+    gn = compute_genotype_codes(hm)
+    return hm, pos, ac, gn
 
 
 # -- compute paths -----------------------------------------------------------
@@ -114,6 +140,81 @@ def _compute_pg_gpu(hm: HaplotypeMatrix, window_size: int) -> tuple:
     return (df["pi"].to_numpy(),
             df["theta_w"].to_numpy(),
             df["tajimas_d"].to_numpy()), df
+
+
+# -- LD-decay compute paths --------------------------------------------------
+# Both libraries compute Rogers-Huff (2008) r on diploid 0/1/2 dosages.
+# pg_gpu exposes it via HaplotypeMatrix.windowed_r_squared(..., estimator='rogers_huff');
+# scikit-allel via allel.rogers_huff_r + manual binning. The two should
+# match numerically up to allel's float32 internal precision.
+
+LD_BP_BINS = np.logspace(2, 6, 25)  # 100 bp .. 1 Mb, 24 log-spaced bins
+
+
+def _subsample_for_ld(hm: HaplotypeMatrix,
+                      pos: np.ndarray,
+                      gn: np.ndarray,
+                      n_snps: int,
+                      seed: int) -> tuple:
+    """Pick `n_snps` random SNPs (sorted by position) and build the
+    inputs both libraries need.
+
+    Returns (hm_sub, pos_sub, gn_sub).
+    """
+    n_var = len(pos)
+    if n_snps > n_var:
+        raise ValueError(
+            f"--ld-snps={n_snps} exceeds the dataset size ({n_var})")
+    rng = np.random.RandomState(seed)
+    idx = rng.choice(n_var, size=n_snps, replace=False)
+    idx.sort()
+    pos_sub = pos[idx]
+    gn_sub = gn[idx]
+    hap_full = hm.haplotypes
+    if hasattr(hap_full, "get"):
+        hap_full = hap_full.get()
+    hap_full = np.asarray(hap_full, dtype=np.int8)
+    hap_sub = hap_full[:, idx]
+    hm_sub = HaplotypeMatrix(
+        hap_sub, pos_sub, hm.chrom_start, hm.chrom_end)
+    return hm_sub, pos_sub, gn_sub
+
+
+def _compute_allel_ld_decay(pos_sub: np.ndarray,
+                            gn_sub: np.ndarray,
+                            bp_bins: np.ndarray) -> np.ndarray:
+    """LD-decay curve via scikit-allel's Rogers-Huff path.
+
+    Computes pairwise r with `allel.rogers_huff_r`, squares it,
+    computes pairwise physical distances, bins by distance, and
+    returns the per-bin median r² (NaN for empty bins).
+    """
+    n = len(pos_sub)
+    r = allel.rogers_huff_r(gn_sub)
+    r_sq = r ** 2
+    iu = np.triu_indices(n, k=1)
+    distances = (pos_sub[iu[1]] - pos_sub[iu[0]]).astype(np.int64)
+    finite = np.isfinite(r_sq)
+    bin_idx = np.digitize(distances[finite], bp_bins) - 1
+    n_bins = len(bp_bins) - 1
+    out = np.full(n_bins, np.nan)
+    rsq_finite = r_sq[finite]
+    for b in range(n_bins):
+        mask = bin_idx == b
+        if mask.any():
+            out[b] = float(np.median(rsq_finite[mask]))
+    return out
+
+
+def _compute_pg_gpu_ld_decay(hm_sub: HaplotypeMatrix,
+                             bp_bins: np.ndarray) -> np.ndarray:
+    """LD-decay curve via pg_gpu's windowed_r_squared with the
+    Rogers-Huff estimator (matches allel exactly up to float32
+    precision)."""
+    result, _ = hm_sub.windowed_r_squared(
+        bp_bins, percentile=50, estimator='rogers_huff')
+    cp.cuda.Device().synchronize()
+    return np.asarray(result)
 
 
 def _assert_windows_aligned(allel_windows: np.ndarray,
@@ -155,13 +256,16 @@ def _plot_comparison(
     pi_a: np.ndarray, pi_g: np.ndarray,
     tw_a: np.ndarray, tw_g: np.ndarray,
     td_a: np.ndarray, td_g: np.ndarray,
+    bp_bins: np.ndarray,
+    ld_a: np.ndarray, ld_g: np.ndarray,
     t_allel: float, t_pg: float,
+    t_allel_ld: float, t_pg_ld: float,
     outpath: Path,
 ) -> None:
     sns.set_theme(style="whitegrid", context="paper", font_scale=0.95)
     fig, axes = plt.subplots(
-        4, 1, figsize=(11, 9),
-        gridspec_kw={"height_ratios": [1, 1, 1, 0.5]},
+        5, 1, figsize=(11, 12),
+        gridspec_kw={"height_ratios": [1, 1, 1, 1.1, 0.7]},
         sharex=False)
 
     # Panels 1-3: identical-shape overlays for pi / theta_w / Tajima's D.
@@ -173,25 +277,45 @@ def _plot_comparison(
         ax.plot(centers_mb, a, color=COL_ALLEL, linewidth=1.6, alpha=0.9)
         ax.plot(centers_mb, g, color=COL_PG, linewidth=0.8, alpha=0.95)
         ax.set_ylabel(ylabel)
-
     # Top-panel legend only.
     axes[0].plot([], [], color=COL_ALLEL, linewidth=1.6, label="scikit-allel")
     axes[0].plot([], [], color=COL_PG, linewidth=0.8, label="pg_gpu")
     axes[0].legend(fontsize=8, loc="upper right", frameon=False)
-
     axes[2].set_xlabel("Genomic position (Mb)")
 
-    # Panel 4: timing bars.
-    ax_t = axes[3]
-    ax_t.barh([1, 0], [t_allel, t_pg], color=[COL_ALLEL, COL_PG],
-              height=0.6)
-    ax_t.set_yticks([0, 1])
-    ax_t.set_yticklabels(["pg_gpu", "scikit-allel"])
+    # Panel 4: LD-decay curves (log-x, both libraries overlaid).
+    ax_ld = axes[3]
+    bin_centers = np.sqrt(bp_bins[:-1] * bp_bins[1:])  # log-bin midpoints
+    ax_ld.plot(bin_centers, ld_a, color=COL_ALLEL, linewidth=1.6,
+               alpha=0.9, marker="o", markersize=3)
+    ax_ld.plot(bin_centers, ld_g, color=COL_PG, linewidth=0.8,
+               alpha=0.95, marker="o", markersize=2)
+    ax_ld.set_xscale("log")
+    ax_ld.set_ylabel(r"median $r^2$")
+    ax_ld.set_xlabel("Pair distance (bp)")
+
+    # Panel 5: timing bars - 4 bars (2 libraries x 2 computations).
+    # Top-to-bottom: scikit-allel windowed, pg_gpu windowed,
+    # scikit-allel LD-decay, pg_gpu LD-decay.
+    ax_t = axes[4]
+    labels = ["pg_gpu LD-decay", "scikit-allel LD-decay",
+              "pg_gpu windowed", "scikit-allel windowed"]
+    values = [t_pg_ld, t_allel_ld, t_pg, t_allel]
+    colors = [COL_PG, COL_ALLEL, COL_PG, COL_ALLEL]
+    speeds = [
+        f"  {t_pg_ld:.2f}s ({t_allel_ld / t_pg_ld:.1f}x)",
+        f"  {t_allel_ld:.2f}s",
+        f"  {t_pg:.2f}s ({t_allel / t_pg:.1f}x)",
+        f"  {t_allel:.2f}s",
+    ]
+    y = np.arange(len(labels))
+    ax_t.barh(y, values, color=colors, height=0.6)
+    ax_t.set_yticks(y)
+    ax_t.set_yticklabels(labels)
     ax_t.set_xlabel("seconds")
-    ax_t.text(t_allel, 1, f"  {t_allel:.2f}s",
-              va="center", ha="left", fontsize=9, color="0.2")
-    ax_t.text(t_pg, 0, f"  {t_pg:.2f}s ({t_allel / t_pg:.1f}x)",
-              va="center", ha="left", fontsize=9, color="0.2")
+    for i, (v, txt) in enumerate(zip(values, speeds)):
+        ax_t.text(v, i, txt, va="center", ha="left",
+                  fontsize=9, color="0.2")
     ax_t.grid(axis="y", visible=False)
 
     fig.tight_layout()
@@ -250,7 +374,7 @@ def main() -> None:
     if args.self_test:
         _run_self_test()
         return
-    hm, pos, ac = _load_data(args.small)
+    hm, pos, ac, gn = _load_data(args.small)
 
     print("Computing windows ...", flush=True)
     windows = allel.position_windows(
@@ -298,12 +422,34 @@ def main() -> None:
     print(f"  theta_w:   max abs diff = {md_tw:.3e}")
     print(f"  tajimas_d: max abs diff = {md_td:.3e}")
 
+    print(f"Subsampling {args.ld_snps:,} SNPs for LD-decay (seed={args.seed}) ...",
+          flush=True)
+    hm_sub, pos_sub, gn_sub = _subsample_for_ld(
+        hm, pos, gn, args.ld_snps, args.seed)
+    bp_bins = LD_BP_BINS
+
+    print(f"Timing LD-decay (n_warmup={args.n_warmup}) ...", flush=True)
+    ld_a, t_allel_ld = _time(
+        lambda: _compute_allel_ld_decay(pos_sub, gn_sub, bp_bins),
+        n_warmup=args.n_warmup)
+    ld_g, t_pg_ld = _time(
+        lambda: _compute_pg_gpu_ld_decay(hm_sub, bp_bins),
+        n_warmup=args.n_warmup)
+    speedup_ld = t_allel_ld / t_pg_ld
+    print(f"  scikit-allel: {t_allel_ld:6.2f}s")
+    print(f"  pg_gpu:       {t_pg_ld:6.2f}s  ({speedup_ld:.1f}x speedup)")
+
+    md_ld = _verify_strict("ld_decay", ld_a, ld_g, rtol=1e-4, atol=1e-6)
+    print(f"  median r²: max abs diff = {md_ld:.3e}")
+
     if not args.no_plot:
         centers_mb = (df["start"].to_numpy() + df["end"].to_numpy()) / 2 / 1e6
         _plot_comparison(
             centers_mb,
             pi_a, pi_g, tw_a, tw_g, td_a, td_g,
+            bp_bins=bp_bins, ld_a=ld_a, ld_g=ld_g,
             t_allel=t_allel, t_pg=t_pg,
+            t_allel_ld=t_allel_ld, t_pg_ld=t_pg_ld,
             outpath=args.output)
     return
 
@@ -317,6 +463,11 @@ def _parse_args() -> argparse.Namespace:
                    help="Window size in bp (default: 10 kb)")
     p.add_argument("--n-warmup", type=int, default=1,
                    help="Discarded runs before timing (default: 1)")
+    p.add_argument("--ld-snps", type=int, default=10_000,
+                   help="SNPs subsampled for the LD-decay scan "
+                        "(default: 10_000)")
+    p.add_argument("--seed", type=int, default=0,
+                   help="RNG seed for SNP subsampling (default: 0)")
     p.add_argument("--no-plot", action="store_true",
                    help="Skip the matplotlib figure")
     p.add_argument("-o", "--output", type=Path,
@@ -328,7 +479,7 @@ def _parse_args() -> argparse.Namespace:
 
 
 def _run_self_test() -> None:
-    """Quick host-side sanity check on compute_allele_counts."""
+    """Quick host-side sanity check on the helpers."""
     # 4 haplotypes, 3 variants, no missing
     hap = np.array([
         [0, 1, 0],
@@ -341,6 +492,10 @@ def _run_self_test() -> None:
     ac = compute_allele_counts(hm)
     np.testing.assert_array_equal(ac[:, 0], [3, 1, 3])
     np.testing.assert_array_equal(ac[:, 1], [1, 3, 1])
+    gn = compute_genotype_codes(hm)
+    assert gn.shape == (3, 2), gn.shape
+    np.testing.assert_array_equal(gn[:, 0], [1, 2, 0])
+    np.testing.assert_array_equal(gn[:, 1], [0, 1, 1])
     print("self-test OK")
 
 

--- a/examples/scikit_allel_comparison.py
+++ b/examples/scikit_allel_comparison.py
@@ -89,12 +89,48 @@ def compute_genotype_codes(hm: HaplotypeMatrix) -> np.ndarray:
     return paired.T.astype(np.int8)        # (n_var, n_samples)
 
 
+def _load_data(small: bool) -> tuple:
+    """Load the gamb dataset and build all four views.
+
+    Returns
+    -------
+    hm : HaplotypeMatrix
+    pos : np.ndarray, shape (n_variants,), 1-based positions
+    ac : np.ndarray, shape (n_variants, 2), allele counts for allel
+    gn : np.ndarray, shape (n_variants, n_samples), 0/1/2 codes for allel
+    """
+    path = ZARR_SMALL if small else ZARR_FULL
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Required dataset not found: {path}\n"
+            f"The data fixtures live under examples/data/ and are tracked "
+            f"in the repo. If you cloned without LFS or otherwise lack the "
+            f"file, try `git lfs pull` or refetch from the project root.")
+    print(f"Loading {path.name} ...", flush=True)
+    t0 = time.perf_counter()
+    hm = HaplotypeMatrix.from_zarr(str(path))
+    print(f"  loaded in {time.perf_counter() - t0:.2f}s; "
+          f"{hm.haplotypes.shape[0]} haplotypes, "
+          f"{hm.haplotypes.shape[1]:,} variants, "
+          f"chrom range {hm.chrom_start:,}-{hm.chrom_end:,}",
+          flush=True)
+    pos = hm.positions
+    if hasattr(pos, "get"):
+        pos = pos.get()
+    pos = np.asarray(pos, dtype=np.int64)
+    ac = compute_allele_counts(hm)
+    gn = compute_genotype_codes(hm)
+    return hm, pos, ac, gn
+
+
 def main() -> None:
     args = _parse_args()
     if args.self_test:
         _run_self_test()
         return
-    raise NotImplementedError("main not yet wired up")
+    hm, pos, ac, gn = _load_data(args.small)
+    print(f"shapes: ac={ac.shape}, gn={gn.shape}, pos[0..2]={pos[:3]}")
+    return
 
 
 def _parse_args() -> argparse.Namespace:

--- a/examples/scikit_allel_comparison.py
+++ b/examples/scikit_allel_comparison.py
@@ -33,7 +33,8 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
-from pg_gpu import HaplotypeMatrix
+from pg_gpu import GenotypeMatrix, HaplotypeMatrix
+from pg_gpu.ld_statistics_genotype import sigma_d2_geno
 from pg_gpu.windowed_analysis import windowed_analysis
 
 
@@ -44,9 +45,11 @@ DATA_DIR = Path(__file__).resolve().parent / "data"
 ZARR_FULL = DATA_DIR / "gamb.X.phased.n100.zarr"
 ZARR_SMALL = DATA_DIR / "gamb.X.8-12Mb.n100.derived.zarr"
 
-# Plot palette: scikit-allel is warm grey, pg_gpu is blue.
+# Plot palette: scikit-allel is warm grey, pg_gpu Rogers-Huff is blue,
+# pg_gpu unbiased sigma_D^2 (Ragsdale-Gravel) is orange.
 COL_ALLEL = "#9aa1ac"
 COL_PG = "#2980b9"
+COL_PG_SIGMA = "#e67e22"
 
 # Distance bins for the LD-decay curve: 24 log-spaced bins from 100 bp
 # to 10 kb. Anopheles LD decays within a few kb, so this is the range
@@ -224,6 +227,41 @@ def _compute_pg_gpu_ld_decay(hm_sub, bp_bins):
     return np.asarray(result)
 
 
+def _compute_pg_gpu_sigma_d2_decay(hm_sub, pos_sub, bp_bins):
+    """LD-decay curve via pg_gpu's per-pair Ragsdale-Gravel sigma_D^2.
+
+    Unlike Rogers-Huff (a per-pair r-correlation estimator on dosages),
+    sigma_D^2 = D^2 / pi^2 is the unbiased moments-LD estimator that
+    underlies moments.LD inference. Computed here directly on diploid
+    9-way genotype counts via ``sigma_d2_geno``, then binned by physical
+    distance and median-aggregated to match the other two curves'
+    presentation.
+
+    There is no scikit-allel counterpart for this estimator -- it's
+    shown to demonstrate that on the *same* SNP block one can swap the
+    LD definition itself, not just the implementation.
+    """
+    gm = GenotypeMatrix.from_haplotype_matrix(hm_sub)
+    if gm.device != 'GPU':
+        gm.transfer_to_gpu()
+    n = gm.num_variants
+    sd2 = sigma_d2_geno(gm).get()  # all upper-triangle pairs
+
+    i, j = np.triu_indices(n, k=1)
+    distances = (pos_sub[j] - pos_sub[i]).astype(np.int64)
+    finite = np.isfinite(sd2)
+    distances = distances[finite]
+    sd2 = sd2[finite]
+    bin_idx = np.digitize(distances, bp_bins) - 1
+
+    out = np.full(len(bp_bins) - 1, np.nan)
+    for b in range(len(out)):
+        in_bin = bin_idx == b
+        if in_bin.any():
+            out[b] = float(np.median(sd2[in_bin]))
+    return out
+
+
 # --- 4. Verification + timing helpers ---------------------------------------
 
 def _time(callable_, n_warmup):
@@ -255,7 +293,7 @@ def _verify(name, allel_arr, pg_arr, rtol=1e-5, atol=1e-8):
 
 def _plot_comparison(centers_mb,
                      pi_a, pi_g, tw_a, tw_g, td_a, td_g,
-                     bp_bins, ld_a, ld_g,
+                     bp_bins, ld_a, ld_g, ld_sd2,
                      t_allel, t_pg, t_allel_ld, t_pg_ld,
                      outpath):
     """5-panel figure: pi / theta_W / Tajima's D / LD-decay / timings."""
@@ -283,16 +321,27 @@ def _plot_comparison(centers_mb,
     axes[0].legend(fontsize=8, loc="upper right", frameon=False)
     axes[2].set_xlabel("Genomic position (Mb)")
 
-    # LD-decay panel (log-scale x).
+    # LD-decay panel (log-scale x). Three curves on the same axis:
+    #   scikit-allel Rogers-Huff (grey)        -- median r^2 per bin
+    #   pg_gpu Rogers-Huff (blue, on top)      -- median r^2 per bin
+    #     [the two should overlap exactly: parity story]
+    #   pg_gpu unbiased sigma_D^2 (orange)     -- median sigma_D^2 per bin
+    #     [a different LD estimator on the same SNPs]
     ax_ld = axes[3]
     bin_centers = np.sqrt(bp_bins[:-1] * bp_bins[1:])  # log-bin midpoints
     ax_ld.plot(bin_centers, ld_a, color=COL_ALLEL, linewidth=1.6,
-               alpha=0.9, marker="o", markersize=3)
+               alpha=0.9, marker="o", markersize=3,
+               label=r"scikit-allel Rogers-Huff $r^2$")
     ax_ld.plot(bin_centers, ld_g, color=COL_PG, linewidth=0.8,
-               alpha=0.95, marker="o", markersize=2)
+               alpha=0.95, marker="o", markersize=2,
+               label=r"pg_gpu Rogers-Huff $r^2$")
+    ax_ld.plot(bin_centers, ld_sd2, color=COL_PG_SIGMA, linewidth=1.2,
+               alpha=0.95, marker="s", markersize=3, linestyle="--",
+               label=r"pg_gpu unbiased $\sigma_D^2$ (R-G)")
     ax_ld.set_xscale("log")
-    ax_ld.set_ylabel(r"median $r^2$")
+    ax_ld.set_ylabel("median LD")
     ax_ld.set_xlabel("Pair distance (bp)")
+    ax_ld.legend(fontsize=8, loc="upper right", frameon=False)
 
     # Timing bars: 4 bars (2 libraries x 2 computations).
     ax_t = axes[4]
@@ -384,9 +433,13 @@ def main():
     ld_g, t_pg_ld = _time(
         lambda: _compute_pg_gpu_ld_decay(hm_sub, LD_BP_BINS),
         n_warmup=args.n_warmup)
-    print(f"  scikit-allel: {t_allel_ld:6.2f}s")
-    print(f"  pg_gpu:       {t_pg_ld:6.2f}s  "
+    ld_sd2, t_pg_sd2 = _time(
+        lambda: _compute_pg_gpu_sigma_d2_decay(hm_sub, pos_sub, LD_BP_BINS),
+        n_warmup=args.n_warmup)
+    print(f"  scikit-allel Rogers-Huff: {t_allel_ld:6.2f}s")
+    print(f"  pg_gpu Rogers-Huff:       {t_pg_ld:6.2f}s  "
           f"({t_allel_ld / t_pg_ld:.1f}x speedup)")
+    print(f"  pg_gpu sigma_D^2 (R-G):   {t_pg_sd2:6.2f}s")
     print(f"  median r^2: max abs diff = "
           f"{_verify('ld_decay', ld_a, ld_g, rtol=1e-4, atol=1e-6):.3e}")
 
@@ -395,7 +448,7 @@ def main():
         _plot_comparison(
             centers_mb,
             pi_a, pi_g, tw_a, tw_g, td_a, td_g,
-            bp_bins=LD_BP_BINS, ld_a=ld_a, ld_g=ld_g,
+            bp_bins=LD_BP_BINS, ld_a=ld_a, ld_g=ld_g, ld_sd2=ld_sd2,
             t_allel=t_allel, t_pg=t_pg,
             t_allel_ld=t_allel_ld, t_pg_ld=t_pg_ld,
             outpath=args.output)

--- a/examples/scikit_allel_comparison.py
+++ b/examples/scikit_allel_comparison.py
@@ -1,11 +1,19 @@
 #!/usr/bin/env python
 """
-Side-by-side: scikit-allel vs pg_gpu on a windowed diversity scan.
+Side-by-side: scikit-allel vs pg_gpu on real Anopheles X-chromosome data.
 
-Loads a real Anopheles gambiae X-chromosome dataset and computes
-windowed pi, theta_w, and Tajima's D using both libraries.
-scikit-allel takes three separate calls; pg_gpu takes one. The script
-verifies numerical agreement and reports the wall-clock speedup.
+This script does the same population-genetics work two ways:
+
+  1. Windowed diversity (pi, theta_W, Tajima's D) along the chromosome.
+     scikit-allel needs three separate function calls, one per statistic.
+     pg_gpu fuses all three into a single GPU kernel pass.
+  2. LD-decay: how does linkage disequilibrium (r^2 between pairs of SNPs)
+     drop off with physical distance? scikit-allel computes pairwise r,
+     squares, builds a distance vector, and bins manually. pg_gpu does
+     the whole thing in one call.
+
+For each task we (a) check that the two libraries agree numerically and
+(b) report the wall-clock speedup of pg_gpu over scikit-allel.
 
 Usage
 -----
@@ -29,21 +37,42 @@ from pg_gpu import HaplotypeMatrix
 from pg_gpu.windowed_analysis import windowed_analysis
 
 
-# Datasets: full X-chromosome by default; --small uses a 4 Mb subset.
+# Two datasets ship in examples/data/. The full X-chromosome (~25 Mb,
+# 5.3M variants) is the default; --small picks a 4 Mb subset for fast
+# iteration during development.
 DATA_DIR = Path(__file__).resolve().parent / "data"
 ZARR_FULL = DATA_DIR / "gamb.X.phased.n100.zarr"
 ZARR_SMALL = DATA_DIR / "gamb.X.8-12Mb.n100.derived.zarr"
 
+# Plot palette: scikit-allel is warm grey, pg_gpu is blue.
+COL_ALLEL = "#9aa1ac"
+COL_PG = "#2980b9"
 
-def _load_data(small: bool) -> tuple:
-    """Load the gamb dataset and build the three views needed for comparison.
+# Distance bins for the LD-decay curve: 24 log-spaced bins from 100 bp
+# to 10 kb. Anopheles LD decays within a few kb, so this is the range
+# where the signal lives.
+LD_BP_BINS = np.logspace(2, 4, 25)
 
-    Returns
-    -------
-    hm : HaplotypeMatrix
-    pos : np.ndarray, shape (n_variants,), 1-based positions
-    ac : np.ndarray, shape (n_variants, 2), allele counts (allel)
-    gn : np.ndarray, shape (n_variants, n_samples), 0/1/2 dosages (allel)
+
+def _to_numpy(x):
+    """Bring a possibly-GPU array back to host (CPU) memory.
+
+    pg_gpu stores arrays on the GPU as CuPy arrays; .get() copies them
+    over to NumPy. If x is already NumPy, just hand it back.
+    """
+    return x.get() if hasattr(x, "get") else np.asarray(x)
+
+
+# --- 1. Loading -------------------------------------------------------------
+
+def _load_data(small):
+    """Load the gamb dataset and build the views each library wants.
+
+    Returns (hm, pos, ac, gn):
+      hm  - HaplotypeMatrix (the pg_gpu view)
+      pos - 1-based positions, shape (n_variants,)
+      ac  - allele counts, shape (n_variants, 2), as scikit-allel wants
+      gn  - 0/1/2 dosages, shape (n_variants, n_diploids), also for allel
     """
     path = ZARR_SMALL if small else ZARR_FULL
     if not path.exists():
@@ -58,88 +87,76 @@ def _load_data(small: bool) -> tuple:
     print(f"  loaded in {time.perf_counter() - t0:.2f}s; "
           f"{hm.haplotypes.shape[0]} haplotypes, "
           f"{hm.haplotypes.shape[1]:,} variants, "
-          f"chrom range {hm.chrom_start:,}-{hm.chrom_end:,}",
-          flush=True)
-    pos = hm.positions
-    if hasattr(pos, "get"):
-        pos = pos.get()
-    pos = np.asarray(pos, dtype=np.int64)
-    # Build the two scikit-allel-shaped views from a single HaplotypeArray.
-    # pg_gpu stores haplotypes as (n_haplotypes, n_variants); allel wants
-    # (n_variants, n_haplotypes). Transposing once and going through allel's
-    # converters keeps us out of the hand-rolled-pairing business.
-    hap = hm.haplotypes
-    if hasattr(hap, "get"):
-        hap = hap.get()
-    ha = allel.HaplotypeArray(np.ascontiguousarray(hap.T))
+          f"chrom range {hm.chrom_start:,}-{hm.chrom_end:,}", flush=True)
+    # pg_gpu stores haplotypes as (n_haplotypes, n_variants); scikit-allel
+    # wants (n_variants, n_haplotypes). Transpose once and let allel build
+    # its own allele-count and 0/1/2-dosage views from there.
+    pos = _to_numpy(hm.positions).astype(np.int64)
+    hap_T = np.ascontiguousarray(_to_numpy(hm.haplotypes).T)
+    ha = allel.HaplotypeArray(hap_T)
     ac = np.asarray(ha.count_alleles())
     gn = np.asarray(ha.to_genotypes(ploidy=2).to_n_alt())
     return hm, pos, ac, gn
 
 
-# -- compute paths -----------------------------------------------------------
+# --- 2. Windowed diversity, two ways ----------------------------------------
 
-def _compute_allel(pos: np.ndarray, ac: np.ndarray,
-                   windows: np.ndarray) -> tuple:
-    """Run scikit-allel's three windowed diversity scans. Returns
-    (pi, theta_w, tajimas_d)."""
+def _compute_allel(pos, ac, windows):
+    """scikit-allel: three separate windowed calls, one per statistic."""
     pi, _, _, _ = allel.windowed_diversity(pos, ac, windows=windows)
-    theta_w, _, _, _ = allel.windowed_watterson_theta(
-        pos, ac, windows=windows)
+    theta_w, _, _, _ = allel.windowed_watterson_theta(pos, ac, windows=windows)
     tajd, _, _ = allel.windowed_tajima_d(pos, ac, windows=windows)
     return pi, theta_w, tajd
 
 
-def _compute_pg_gpu(hm: HaplotypeMatrix, window_size: int) -> tuple:
-    """Run pg_gpu's single fused windowed_analysis call. Returns
-    (pi, theta_w, tajimas_d) plus the result DataFrame so the caller
-    can inspect window edges."""
+def _compute_pg_gpu(hm, window_size):
+    """pg_gpu: one fused call computes all three stats together.
+
+    Returns the result DataFrame so the caller can read out the columns
+    and inspect window edges.
+    """
     df = windowed_analysis(
         hm, window_size=window_size, step_size=window_size,
         statistics=["pi", "theta_w", "tajimas_d"])
-    cp.cuda.Device().synchronize()
-    return (df["pi"].to_numpy(),
-            df["theta_w"].to_numpy(),
-            df["tajimas_d"].to_numpy()), df
+    cp.cuda.Device().synchronize()  # Wait for the GPU before timing stops.
+    return df
 
 
-# -- LD-decay compute paths --------------------------------------------------
+# --- 3. LD-decay, two ways --------------------------------------------------
 # Both libraries compute Rogers-Huff (2008) r on diploid 0/1/2 dosages.
-# pg_gpu exposes it via HaplotypeMatrix.windowed_r_squared(..., estimator='rogers_huff');
+# pg_gpu exposes it via HaplotypeMatrix.windowed_r_squared(estimator='rogers_huff');
 # scikit-allel via allel.rogers_huff_r + manual binning. The two should
 # match numerically up to allel's float32 internal precision.
 
-LD_BP_BINS = np.logspace(2, 4, 25)  # 100 bp .. 10 kb, 24 log-spaced bins
-
-
-def _subsample_for_ld(hm: HaplotypeMatrix,
-                      pos: np.ndarray,
-                      gn: np.ndarray,
-                      n_snps: int,
-                      mac_min: int) -> tuple:
+def _subsample_for_ld(hm, pos, gn, n_snps, mac_min):
     """Pick `n_snps` contiguous SNPs centered on the chromosome midpoint,
-    then drop low-frequency variants below the MAC threshold.
+    then drop near-singleton variants below the MAC threshold.
 
-    A contiguous block (vs. a random subsample) gives dense coverage of
-    short pair distances -- which is where the LD-decay signal lives.
-    Anchoring on the midpoint keeps us away from telomere/centromere
-    edge effects. The MAC filter then drops near-singleton variants whose
-    pairwise r^2 is dominated by tied small values (e.g., two singletons
-    that never overlap give r^2 = 1/(n_dip-1)^2 regardless of distance);
-    those tied values pin the per-bin median to a constant and erase any
-    real decay signal. A standard MAF 0.05 floor (MAC >= 10 in n=100
-    diploids) is plenty to recover decay structure.
+    Why a contiguous block (vs. a random subsample)?
+      A random 10k-SNP draw over a 25 Mb chromosome leaves only a handful
+      of pairs at short distances, which is where the LD signal lives;
+      the resulting decay curve washes out into noise. A contiguous
+      block packs many short-distance pairs into the same physical
+      stretch.
 
-    Returns (hm_sub, pos_sub, gn_sub).
+    Why a MAC filter?
+      Two near-singleton variants take a tiny set of tied r^2 values
+      regardless of how close or far apart they are on the chromosome
+      (e.g., two non-overlapping singletons give exactly r^2 = 1/(n-1)^2).
+      Those tied values pin the per-bin median to a constant and erase
+      any real decay signal. Standard MAF 0.05 (= MAC >= 20 in
+      n=100 diploids = 200 haplotypes) is plenty.
     """
     n_var = len(pos)
     if n_snps > n_var:
         raise ValueError(
             f"--ld-snps={n_snps} exceeds the dataset size ({n_var})")
+
+    # Find the SNP closest to the chromosome midpoint and grab a
+    # contiguous range of n_snps SNPs around it (clamped to bounds).
     midpoint = (hm.chrom_start + hm.chrom_end) // 2
     center_idx = int(np.searchsorted(pos, midpoint))
-    half = n_snps // 2
-    start = max(0, center_idx - half)
+    start = max(0, center_idx - n_snps // 2)
     end = start + n_snps
     if end > n_var:
         end = n_var
@@ -147,129 +164,119 @@ def _subsample_for_ld(hm: HaplotypeMatrix,
     idx = np.arange(start, end)
     pos_blk = pos[idx]
     gn_blk = gn[idx]
+
+    # Drop near-singleton variants. See the docstring for why.
     if mac_min > 0:
-        # MAC = minor allele count under a 0/1/2 dosage encoding.
-        n_alt = np.sum(gn_blk, axis=1).astype(np.int64)
-        n_total = 2 * gn_blk.shape[1]
-        mac = np.minimum(n_alt, n_total - n_alt)
+        n_alt = gn_blk.sum(axis=1)
+        mac = np.minimum(n_alt, 2 * gn_blk.shape[1] - n_alt)
         keep = mac >= mac_min
-        idx = idx[keep]
-        pos_blk = pos_blk[keep]
-        gn_blk = gn_blk[keep]
-    hap_full = hm.haplotypes
-    if hasattr(hap_full, "get"):
-        hap_full = hap_full.get()
-    hap_full = np.asarray(hap_full, dtype=np.int8)
-    hap_sub = hap_full[:, idx]
+        idx, pos_blk, gn_blk = idx[keep], pos_blk[keep], gn_blk[keep]
+
+    # Build the matching pg_gpu view (haplotypes subset the same way).
+    hap_full = _to_numpy(hm.haplotypes).astype(np.int8, copy=False)
     hm_sub = HaplotypeMatrix(
-        hap_sub, pos_blk, hm.chrom_start, hm.chrom_end)
+        hap_full[:, idx], pos_blk, hm.chrom_start, hm.chrom_end)
     return hm_sub, pos_blk, gn_blk
 
 
-def _compute_allel_ld_decay(pos_sub: np.ndarray,
-                            gn_sub: np.ndarray,
-                            bp_bins: np.ndarray) -> np.ndarray:
-    """LD-decay curve via scikit-allel's Rogers-Huff path.
-
-    Computes pairwise r with `allel.rogers_huff_r`, squares it,
-    computes pairwise physical distances, bins by distance, and
-    returns the per-bin median r² (NaN for empty bins).
+def _compute_allel_ld_decay(pos_sub, gn_sub, bp_bins):
+    """LD-decay curve via scikit-allel: build pairwise r, square, bin,
+    take median r^2 per bin.
     """
+    # rogers_huff_r returns the upper triangle of the pairwise r matrix
+    # in row-major order, i.e. one entry per (i, j) with i < j.
+    r_sq = allel.rogers_huff_r(gn_sub) ** 2
     n = len(pos_sub)
-    r = allel.rogers_huff_r(gn_sub)
-    r_sq = r ** 2
-    iu = np.triu_indices(n, k=1)
-    distances = (pos_sub[iu[1]] - pos_sub[iu[0]]).astype(np.int64)
+    i, j = np.triu_indices(n, k=1)
+    distances = (pos_sub[j] - pos_sub[i]).astype(np.int64)
+
+    # Drop pairs with NaN r (e.g., monomorphic), then assign each
+    # pair to a distance bin and median-aggregate.
     finite = np.isfinite(r_sq)
-    bin_idx = np.digitize(distances[finite], bp_bins) - 1
-    n_bins = len(bp_bins) - 1
-    out = np.full(n_bins, np.nan)
-    rsq_finite = r_sq[finite]
-    for b in range(n_bins):
-        mask = bin_idx == b
-        if mask.any():
-            out[b] = float(np.median(rsq_finite[mask]))
+    distances = distances[finite]
+    r_sq = r_sq[finite]
+    bin_idx = np.digitize(distances, bp_bins) - 1  # 0..len(bp_bins)-2
+
+    out = np.full(len(bp_bins) - 1, np.nan)
+    for b in range(len(out)):
+        in_bin = bin_idx == b
+        if in_bin.any():
+            out[b] = float(np.median(r_sq[in_bin]))
     return out
 
 
-def _compute_pg_gpu_ld_decay(hm_sub: HaplotypeMatrix,
-                             bp_bins: np.ndarray) -> np.ndarray:
-    """LD-decay curve via pg_gpu's windowed_r_squared with the
-    Rogers-Huff estimator (matches allel exactly up to float32
-    precision)."""
+def _compute_pg_gpu_ld_decay(hm_sub, bp_bins):
+    """LD-decay curve via pg_gpu: one call does pairs + binning + median.
+
+    estimator='rogers_huff' makes this match scikit-allel's path
+    (vs. the pg_gpu default sigma_d^2 estimator).
+    """
     result, _ = hm_sub.windowed_r_squared(
         bp_bins, percentile=50, estimator='rogers_huff')
     cp.cuda.Device().synchronize()
     return np.asarray(result)
 
 
-def _assert_windows_aligned(allel_windows: np.ndarray,
-                            pg_gpu_df) -> None:
-    """Confirm both libraries laid out the same windows.
+# --- 4. Verification + timing helpers ---------------------------------------
 
-    scikit-allel returns `windows` as (n_windows, 2) of (start, stop)
-    in 1-based inclusive coordinates. pg_gpu's windowed_analysis
-    returns `start` and `end` columns. We check that they match
-    exactly.
+def _time(callable_, n_warmup):
+    """Run n_warmup discarded calls (to absorb JIT / GPU init), then one
+    timed call. Returns (result, elapsed_seconds).
     """
-    n_allel = allel_windows.shape[0]
-    n_pg = len(pg_gpu_df)
-    if n_allel != n_pg:
-        raise AssertionError(
-            f"window count mismatch: allel={n_allel}, pg_gpu={n_pg}. "
-            f"This means the two libraries laid out different windows "
-            f"for the same input range; the rest of the comparison "
-            f"would be apples-to-oranges. Check that window_size, "
-            f"step_size, and the chromosome range agree.")
-    starts_a = allel_windows[:, 0]
-    starts_g = pg_gpu_df["start"].to_numpy()
-    if not np.array_equal(starts_a, starts_g):
-        bad = np.where(starts_a != starts_g)[0][:5]
-        raise AssertionError(
-            f"window-start mismatch at indices {bad}: "
-            f"allel={starts_a[bad]}, pg_gpu={starts_g[bad]}")
+    for _ in range(n_warmup):
+        callable_()
+    t0 = time.perf_counter()
+    result = callable_()
+    return result, time.perf_counter() - t0
 
 
-# -- plotting ----------------------------------------------------------------
+def _verify(name, allel_arr, pg_arr, rtol=1e-5, atol=1e-8):
+    """Assert the two libraries agree to the given tolerance on the
+    finite (non-NaN) entries. Returns max abs diff for printing.
+    """
+    finite = np.isfinite(allel_arr) & np.isfinite(pg_arr)
+    if not finite.any():
+        raise AssertionError(f"[{name}] no finite entries to compare")
+    np.testing.assert_allclose(
+        allel_arr[finite], pg_arr[finite],
+        rtol=rtol, atol=atol,
+        err_msg=f"[{name}] disagreement above tolerance")
+    return float(np.abs(allel_arr[finite] - pg_arr[finite]).max())
 
-# Two-color palette: scikit-allel = warm grey, pg_gpu = blue.
-COL_ALLEL = "#9aa1ac"   # light grey-blue
-COL_PG = "#2980b9"      # pg_gpu blue (matches accessibility_mask.py)
 
+# --- 5. Plotting ------------------------------------------------------------
 
-def _plot_comparison(
-    centers_mb: np.ndarray,
-    pi_a: np.ndarray, pi_g: np.ndarray,
-    tw_a: np.ndarray, tw_g: np.ndarray,
-    td_a: np.ndarray, td_g: np.ndarray,
-    bp_bins: np.ndarray,
-    ld_a: np.ndarray, ld_g: np.ndarray,
-    t_allel: float, t_pg: float,
-    t_allel_ld: float, t_pg_ld: float,
-    outpath: Path,
-) -> None:
+def _plot_comparison(centers_mb,
+                     pi_a, pi_g, tw_a, tw_g, td_a, td_g,
+                     bp_bins, ld_a, ld_g,
+                     t_allel, t_pg, t_allel_ld, t_pg_ld,
+                     outpath):
+    """5-panel figure: pi / theta_W / Tajima's D / LD-decay / timings."""
     sns.set_theme(style="whitegrid", context="paper", font_scale=0.95)
     fig, axes = plt.subplots(
         5, 1, figsize=(11, 12),
         gridspec_kw={"height_ratios": [1, 1, 1, 1.1, 0.7]},
         sharex=False)
 
-    # Panels 1-3: identical-shape overlays for pi / theta_w / Tajima's D.
-    for ax, (a, g, ylabel) in zip(
-        axes[:3],
-        [(pi_a, pi_g, r"$\pi$"),
-         (tw_a, tw_g, r"$\theta_W$"),
-         (td_a, td_g, r"Tajima's $D$")]):
+    # Top three panels: scikit-allel and pg_gpu lines overlaid. Perfect
+    # agreement looks like a single line (the pg_gpu trace sits exactly
+    # on top of the allel trace).
+    diversity_panels = [
+        (pi_a, pi_g, r"$\pi$"),
+        (tw_a, tw_g, r"$\theta_W$"),
+        (td_a, td_g, r"Tajima's $D$"),
+    ]
+    for ax, (a, g, ylabel) in zip(axes[:3], diversity_panels):
         ax.plot(centers_mb, a, color=COL_ALLEL, linewidth=1.6, alpha=0.9)
         ax.plot(centers_mb, g, color=COL_PG, linewidth=0.8, alpha=0.95)
         ax.set_ylabel(ylabel)
-    # Top-panel legend only.
+    # One legend only, on the top panel.
     axes[0].plot([], [], color=COL_ALLEL, linewidth=1.6, label="scikit-allel")
     axes[0].plot([], [], color=COL_PG, linewidth=0.8, label="pg_gpu")
     axes[0].legend(fontsize=8, loc="upper right", frameon=False)
     axes[2].set_xlabel("Genomic position (Mb)")
 
-    # Panel 4: LD-decay curves (log-x, both libraries overlaid).
+    # LD-decay panel (log-scale x).
     ax_ld = axes[3]
     bin_centers = np.sqrt(bp_bins[:-1] * bp_bins[1:])  # log-bin midpoints
     ax_ld.plot(bin_centers, ld_a, color=COL_ALLEL, linewidth=1.6,
@@ -280,28 +287,22 @@ def _plot_comparison(
     ax_ld.set_ylabel(r"median $r^2$")
     ax_ld.set_xlabel("Pair distance (bp)")
 
-    # Panel 5: timing bars - 4 bars (2 libraries x 2 computations).
-    # Top-to-bottom: scikit-allel windowed, pg_gpu windowed,
-    # scikit-allel LD-decay, pg_gpu LD-decay.
+    # Timing bars: 4 bars (2 libraries x 2 computations).
     ax_t = axes[4]
-    labels = ["pg_gpu LD-decay", "scikit-allel LD-decay",
-              "pg_gpu windowed", "scikit-allel windowed"]
-    values = [t_pg_ld, t_allel_ld, t_pg, t_allel]
-    colors = [COL_PG, COL_ALLEL, COL_PG, COL_ALLEL]
-    speeds = [
-        f"  {t_pg_ld:.2f}s ({t_allel_ld / t_pg_ld:.1f}x)",
-        f"  {t_allel_ld:.2f}s",
-        f"  {t_pg:.2f}s ({t_allel / t_pg:.1f}x)",
-        f"  {t_allel:.2f}s",
+    bars = [
+        ("pg_gpu LD-decay",       t_pg_ld,    COL_PG,    f"  {t_pg_ld:.2f}s ({t_allel_ld / t_pg_ld:.1f}x)"),
+        ("scikit-allel LD-decay", t_allel_ld, COL_ALLEL, f"  {t_allel_ld:.2f}s"),
+        ("pg_gpu windowed",       t_pg,       COL_PG,    f"  {t_pg:.2f}s ({t_allel / t_pg:.1f}x)"),
+        ("scikit-allel windowed", t_allel,    COL_ALLEL, f"  {t_allel:.2f}s"),
     ]
-    y = np.arange(len(labels))
+    labels, values, colors, annots = zip(*bars)
+    y = np.arange(len(bars))
     ax_t.barh(y, values, color=colors, height=0.6)
     ax_t.set_yticks(y)
     ax_t.set_yticklabels(labels)
     ax_t.set_xlabel("seconds")
-    for i, (v, txt) in enumerate(zip(values, speeds)):
-        ax_t.text(v, i, txt, va="center", ha="left",
-                  fontsize=9, color="0.2")
+    for i, (v, txt) in enumerate(zip(values, annots)):
+        ax_t.text(v, i, txt, va="center", ha="left", fontsize=9, color="0.2")
     ax_t.grid(axis="y", visible=False)
 
     fig.tight_layout()
@@ -310,135 +311,92 @@ def _plot_comparison(
     print(f"\nFigure saved to {outpath}")
 
 
-# -- verify + time -----------------------------------------------------------
+# --- 6. Main ----------------------------------------------------------------
 
-def _time(callable_, n_warmup: int) -> tuple:
-    """Run `n_warmup` discarded calls, then one timed call.
-
-    Returns (result, elapsed_seconds).
-    """
-    for _ in range(n_warmup):
-        callable_()
-    t0 = time.perf_counter()
-    result = callable_()
-    elapsed = time.perf_counter() - t0
-    return result, elapsed
-
-
-def _verify_strict(name: str, allel_arr: np.ndarray,
-                   pg_arr: np.ndarray,
-                   rtol: float = 1e-5, atol: float = 1e-8) -> float:
-    """Assert per-window agreement on a NaN-aligned mask.
-
-    Returns the max absolute difference on the comparison mask so the
-    caller can print a one-line summary.
-    """
-    finite = np.isfinite(allel_arr) & np.isfinite(pg_arr)
-    if not finite.any():
-        raise AssertionError(
-            f"[{name}] no finite windows in either array; cannot verify")
-    diff = np.abs(allel_arr[finite] - pg_arr[finite])
-    max_diff = float(diff.max())
-    try:
-        np.testing.assert_allclose(
-            allel_arr[finite], pg_arr[finite],
-            rtol=rtol, atol=atol,
-            err_msg=f"[{name}] disagreement above tolerance")
-    except AssertionError as e:
-        # Surface the worst-offender windows in the failure
-        order = np.argsort(diff)[::-1][:5]
-        finite_idx = np.where(finite)[0]
-        worst = finite_idx[order]
-        raise AssertionError(
-            f"[{name}] disagreement; worst window indices {worst.tolist()} "
-            f"(max diff = {max_diff:.3e}). Original error:\n{e}") from None
-    return max_diff
-
-
-def main() -> None:
+def main():
     args = _parse_args()
     hm, pos, ac, gn = _load_data(args.small)
 
+    # Decide where windows fall ONCE, then pass the same windows to both
+    # libraries. This is what makes the comparison apples-to-apples.
     print("Computing windows ...", flush=True)
     windows = allel.position_windows(
         pos, size=args.window_size, step=args.window_size,
         start=int(pos[0]), stop=int(pos[-1]))
     print(f"  {len(windows)} windows of {args.window_size:,} bp")
 
-    print(f"Timing (n_warmup={args.n_warmup}) ...", flush=True)
+    # Time each library on the windowed-diversity scan.
+    print(f"Timing windowed scan (n_warmup={args.n_warmup}) ...", flush=True)
     (pi_a, tw_a, td_a), t_allel = _time(
-        lambda: _compute_allel(pos, ac, windows),
-        n_warmup=args.n_warmup)
-    ((pi_g, tw_g, td_g), df), t_pg = _time(
-        lambda: _compute_pg_gpu(hm, args.window_size),
-        n_warmup=args.n_warmup)
-    speedup = t_allel / t_pg
+        lambda: _compute_allel(pos, ac, windows), n_warmup=args.n_warmup)
+    df, t_pg = _time(
+        lambda: _compute_pg_gpu(hm, args.window_size), n_warmup=args.n_warmup)
+    pi_g = df["pi"].to_numpy()
+    tw_g = df["theta_w"].to_numpy()
+    td_g = df["tajimas_d"].to_numpy()
     print(f"  scikit-allel: {t_allel:6.2f}s")
-    print(f"  pg_gpu:       {t_pg:6.2f}s  ({speedup:.1f}x speedup)")
+    print(f"  pg_gpu:       {t_pg:6.2f}s  ({t_allel / t_pg:.1f}x speedup)")
 
-    _assert_windows_aligned(windows, df)
+    # Sanity check: both libraries must lay out the same windows.
+    assert len(windows) == len(df), (
+        f"window count mismatch: allel={len(windows)}, pg_gpu={len(df)}")
+    assert np.array_equal(windows[:, 0], df["start"].to_numpy()), \
+        "window start positions disagree between the two libraries"
     print(f"  {len(pi_a)} aligned windows confirmed")
 
-    # Trailing partial window: when chrom_end isn't an exact multiple
-    # of window_size, the last window has fewer than window_size bp.
-    # The two libraries disagree about how to normalize that single
-    # window (allel uses the actual span; pg_gpu's per-window span is
-    # computed slightly differently for the last window) -- a
-    # one-window 0.01% effect that has nothing to do with the
-    # comparison. Drop the last window from the strict checks.
-    window_widths = windows[:, 1] - windows[:, 0] + 1
-    partial = window_widths != args.window_size
-    pi_a, tw_a, td_a = (np.array(a) for a in (pi_a, tw_a, td_a))
-    pi_g, tw_g, td_g = (np.array(a) for a in (pi_g, tw_g, td_g))
+    # When chrom_end isn't a clean multiple of window_size, the last
+    # window has fewer than window_size bp. The two libraries normalize
+    # that single partial window slightly differently -- a one-window
+    # cosmetic effect, not a real numerical disagreement. Mask it out
+    # of the comparison so it doesn't flag a false failure.
+    arrays = [np.array(a) for a in (pi_a, tw_a, td_a, pi_g, tw_g, td_g)]
+    partial = (windows[:, 1] - windows[:, 0] + 1) != args.window_size
     if partial.any():
-        for arr in (pi_a, tw_a, td_a, pi_g, tw_g, td_g):
+        for arr in arrays:
             arr[partial] = np.nan
+    pi_a, tw_a, td_a, pi_g, tw_g, td_g = arrays
 
-    print("Verifying ...", flush=True)
-    md_pi = _verify_strict("pi", pi_a, pi_g)
-    md_tw = _verify_strict("theta_w", tw_a, tw_g)
-    md_td = _verify_strict("tajimas_d", td_a, td_g)
-    print(f"  pi:        max abs diff = {md_pi:.3e}")
-    print(f"  theta_w:   max abs diff = {md_tw:.3e}")
-    print(f"  tajimas_d: max abs diff = {md_td:.3e}")
+    # Strict numerical agreement on all three diversity stats.
+    print("Verifying diversity ...", flush=True)
+    print(f"  pi:        max abs diff = {_verify('pi', pi_a, pi_g):.3e}")
+    print(f"  theta_w:   max abs diff = {_verify('theta_w', tw_a, tw_g):.3e}")
+    print(f"  tajimas_d: max abs diff = {_verify('tajimas_d', td_a, td_g):.3e}")
 
+    # LD-decay: pick the SNPs once and time both libraries on the same set.
     print(f"Selecting contiguous block of {args.ld_snps:,} SNPs centered "
           f"on the chromosome midpoint for LD-decay ...", flush=True)
     hm_sub, pos_sub, gn_sub = _subsample_for_ld(
         hm, pos, gn, args.ld_snps, args.ld_mac_min)
-    print(f"  block spans {pos_sub[0]:,}-{pos_sub[-1]:,} "
-          f"({(pos_sub[-1] - pos_sub[0]) / 1e3:.1f} kb), "
+    span_kb = (pos_sub[-1] - pos_sub[0]) / 1e3
+    print(f"  block spans {pos_sub[0]:,}-{pos_sub[-1]:,} ({span_kb:.1f} kb), "
           f"{len(pos_sub):,} variants kept (MAC >= {args.ld_mac_min})",
           flush=True)
-    bp_bins = LD_BP_BINS
 
     print(f"Timing LD-decay (n_warmup={args.n_warmup}) ...", flush=True)
     ld_a, t_allel_ld = _time(
-        lambda: _compute_allel_ld_decay(pos_sub, gn_sub, bp_bins),
+        lambda: _compute_allel_ld_decay(pos_sub, gn_sub, LD_BP_BINS),
         n_warmup=args.n_warmup)
     ld_g, t_pg_ld = _time(
-        lambda: _compute_pg_gpu_ld_decay(hm_sub, bp_bins),
+        lambda: _compute_pg_gpu_ld_decay(hm_sub, LD_BP_BINS),
         n_warmup=args.n_warmup)
-    speedup_ld = t_allel_ld / t_pg_ld
     print(f"  scikit-allel: {t_allel_ld:6.2f}s")
-    print(f"  pg_gpu:       {t_pg_ld:6.2f}s  ({speedup_ld:.1f}x speedup)")
-
-    md_ld = _verify_strict("ld_decay", ld_a, ld_g, rtol=1e-4, atol=1e-6)
-    print(f"  median r²: max abs diff = {md_ld:.3e}")
+    print(f"  pg_gpu:       {t_pg_ld:6.2f}s  "
+          f"({t_allel_ld / t_pg_ld:.1f}x speedup)")
+    print(f"  median r^2: max abs diff = "
+          f"{_verify('ld_decay', ld_a, ld_g, rtol=1e-4, atol=1e-6):.3e}")
 
     if not args.no_plot:
         centers_mb = (df["start"].to_numpy() + df["end"].to_numpy()) / 2 / 1e6
         _plot_comparison(
             centers_mb,
             pi_a, pi_g, tw_a, tw_g, td_a, td_g,
-            bp_bins=bp_bins, ld_a=ld_a, ld_g=ld_g,
+            bp_bins=LD_BP_BINS, ld_a=ld_a, ld_g=ld_g,
             t_allel=t_allel, t_pg=t_pg,
             t_allel_ld=t_allel_ld, t_pg_ld=t_pg_ld,
             outpath=args.output)
-    return
 
 
-def _parse_args() -> argparse.Namespace:
+def _parse_args():
     p = argparse.ArgumentParser(
         description="Side-by-side scikit-allel vs pg_gpu windowed scan")
     p.add_argument("--small", action="store_true",
@@ -447,16 +405,16 @@ def _parse_args() -> argparse.Namespace:
                    help="Window size in bp (default: 10 kb)")
     p.add_argument("--n-warmup", type=int, default=1,
                    help="Discarded runs before timing (default: 1)")
-    p.add_argument("--ld-snps", type=int, default=100_000,
+    p.add_argument("--ld-snps", type=int, default=500_000,
                    help="Size of the contiguous SNP block (centered on "
                         "the chromosome midpoint) used for the LD-decay "
                         "scan, before the MAC filter is applied "
-                        "(default: 100_000)")
-    p.add_argument("--ld-mac-min", type=int, default=10,
+                        "(default: 500_000)")
+    p.add_argument("--ld-mac-min", type=int, default=20,
                    help="Drop variants with minor allele count below this "
                         "threshold from the LD block. Standard MAF 0.05 "
-                        "in n=100 diploids -> 10. Set to 0 to disable. "
-                        "(default: 10)")
+                        "in n=100 diploids -> 20. Set to 0 to disable. "
+                        "(default: 20)")
     p.add_argument("--no-plot", action="store_true",
                    help="Skip the matplotlib figure")
     p.add_argument("-o", "--output", type=Path,

--- a/pg_gpu/genotype_kernels.py
+++ b/pg_gpu/genotype_kernels.py
@@ -1,13 +1,16 @@
 """
 Fused CUDA kernels for genotype-based LD statistics (DD, Dz, pi2).
 
-All multi-population pi2 and Dz cases use RawKernels that compute one
-output per GPU thread with all arithmetic in registers. Genotype counts
-use 9-way layout: (g1..g9) per locus pair per population, following the
-moments convention.
+Every LD primitive on the diploid path is kernel-backed: DD via
+_DD_GENO_SINGLE_KERN and _DD_GENO_BETWEEN_KERN, Dz via _DZ_*_KERN
+(and the upstream _DZ_PRECOMP_KERN), pi2 via _PI2_*_KERN. All
+kernels compute one output per GPU thread with arithmetic in
+registers. Genotype counts use 9-way layout: (g1..g9) per locus
+pair per population, following the moments convention.
 
-DD uses the ld_statistics_genotype polynomial formulas directly (few
-calls, already fast, not worth fused kernels).
+The polynomial formulas in pg_gpu.ld_statistics_genotype are
+retained as a readable reference and as parity targets for the
+kernels here.
 """
 import cupy as cp
 
@@ -20,11 +23,150 @@ def _launch(kernel, args, M):
 # ---------------------------------------------------------------------------
 # DD kernels
 # ---------------------------------------------------------------------------
-# Genotype DD does not have fused CUDA kernels. The number of DD calls is
-# small (at most 10 for 4 populations), so we dispatch directly to the
-# ld_statistics_genotype formula functions (dd_geno_single, dd_geno_between)
-# in the compute_all_dd_geno dispatch function below.
+
+_DD_GENO_SINGLE_KERN = cp.RawKernel(r'''
+extern "C" __global__
+void k(const double* __restrict__ g, double* __restrict__ out, const long long N){
+    const long long idx=(long long)blockDim.x*blockIdx.x+threadIdx.x;
+    if(idx>=N)return;
+    const double*row=g+9*idx;
+    double n1=row[0],n2=row[1],n3=row[2],n4=row[3],n5=row[4],
+           n6=row[5],n7=row[6],n8=row[7],n9=row[8];
+    double ns=n1+n2+n3+n4+n5+n6+n7+n8+n9;
+    if(ns<4.0){out[idx]=0.0;return;}
+    // D from genotype frequencies (matches _PopDataGeno.D_geno).
+    double Dg=-(0.5*n2+n3+0.25*n5+0.5*n6)*(0.5*n4+0.25*n5+n7+0.5*n8)
+              +(n1+0.5*n2+0.5*n4+0.25*n5)*(0.25*n5+0.5*n6+0.5*n8+n9);
+    // Polynomial numerator (transcribed from dd_geno_single in
+    // ld_statistics_genotype.py:43-135). Grouped here in monomial blocks
+    // matching the source's line layout for ease of audit.
+    double poly=
+        (n2*n4-n2*n2*n4+4.0*n3*n4-4.0*n2*n3*n4-4.0*n3*n3*n4)
+        +(-n2*n4*n4-4.0*n3*n4*n4)
+        +(n1*n5-n1*n1*n5+n3*n5+2.0*n1*n3*n5-n3*n3*n5
+          -4.0*n3*n4*n5-n1*n5*n5-n3*n5*n5)
+        +(4.0*n1*n6-4.0*n1*n1*n6+n2*n6-4.0*n1*n2*n6-n2*n2*n6
+          +2.0*n2*n4*n6-4.0*n1*n5*n6-4.0*n1*n6*n6-n2*n6*n6)
+        +(4.0*n2*n7-4.0*n2*n2*n7
+          +16.0*n3*n7-16.0*n2*n3*n7-16.0*n3*n3*n7
+          -4.0*n2*n4*n7-16.0*n3*n4*n7
+          +n5*n7+2.0*n1*n5*n7-4.0*n2*n5*n7-18.0*n3*n5*n7-n5*n5*n7
+          +4.0*n6*n7+8.0*n1*n6*n7-16.0*n3*n6*n7-4.0*n5*n6*n7-4.0*n6*n6*n7
+          -4.0*n2*n7*n7-16.0*n3*n7*n7-n5*n7*n7-4.0*n6*n7*n7)
+        +(4.0*n1*n8-4.0*n1*n1*n8+4.0*n3*n8+8.0*n1*n3*n8-4.0*n3*n3*n8
+          +n4*n8-4.0*n1*n4*n8+2.0*n2*n4*n8-n4*n4*n8
+          -4.0*n1*n5*n8-4.0*n3*n5*n8
+          +n6*n8+2.0*n2*n6*n8-4.0*n3*n6*n8+2.0*n4*n6*n8-n6*n6*n8
+          -16.0*n3*n7*n8-4.0*n6*n7*n8
+          -4.0*n1*n8*n8-4.0*n3*n8*n8-n4*n8*n8-n6*n8*n8)
+        +(16.0*n1*n9-16.0*n1*n1*n9+4.0*n2*n9-16.0*n1*n2*n9-4.0*n2*n2*n9
+          +4.0*n4*n9-16.0*n1*n4*n9+8.0*n3*n4*n9-4.0*n4*n4*n9
+          +n5*n9-18.0*n1*n5*n9-4.0*n2*n5*n9+2.0*n3*n5*n9-4.0*n4*n5*n9-n5*n5*n9
+          -16.0*n1*n6*n9-4.0*n2*n6*n9
+          +8.0*n2*n7*n9+2.0*n5*n7*n9
+          -16.0*n1*n8*n9-4.0*n4*n8*n9
+          -16.0*n1*n9*n9-4.0*n2*n9*n9-4.0*n4*n9*n9-n5*n9*n9);
+    double numer=poly*(1.0/16.0)+Dg*Dg;
+    out[idx]=4.0*numer/(ns*(ns-1.0)*(ns-2.0)*(ns-3.0));
+}''', "k", options=("-std=c++11",))
+
+_DD_GENO_BETWEEN_KERN = cp.RawKernel(r'''
+extern "C" __global__
+void k(const double*D, const double*nn,
+       const int*I, const int*J, double*out, const int M){
+    int t=blockDim.x*blockIdx.x+threadIdx.x; if(t>=M)return;
+    int i=I[t], j=J[t];
+    double den=nn[i]*(nn[i]-1.0)*nn[j]*(nn[j]-1.0);
+    out[t]=(den>0.0)?4.0*D[i]*D[j]/den:0.0;
+}''', "k", options=("-std=c++11",))
+
 # ---------------------------------------------------------------------------
+# sigma_D^2 (per-pair single-pop) -- fused DD/pi^2 ratio
+# ---------------------------------------------------------------------------
+# Inlines the DD-single and pi2-IIII polynomials and emits their ratio
+# directly. Both share the same denominator n*(n-1)*(n-2)*(n-3), which
+# cancels in the ratio, so the kernel computes only the polynomial
+# numerators and divides them. NaN is returned where ns<4 or pi2<=0.
+
+_SIGMA_D2_GENO_KERN = cp.RawKernel(r'''
+extern "C" __global__
+void k(const double* __restrict__ g, double* __restrict__ out, const long long N){
+    const long long idx=(long long)blockDim.x*blockIdx.x+threadIdx.x;
+    if(idx>=N)return;
+    const double*row=g+9*idx;
+    double n1=row[0],n2=row[1],n3=row[2],n4=row[3],n5=row[4],
+           n6=row[5],n7=row[6],n8=row[7],n9=row[8];
+    double ns=n1+n2+n3+n4+n5+n6+n7+n8+n9;
+    if(ns<4.0){out[idx]=nan("");return;}
+
+    // --- DD numerator ---
+    double Dg=-(0.5*n2+n3+0.25*n5+0.5*n6)*(0.5*n4+0.25*n5+n7+0.5*n8)
+              +(n1+0.5*n2+0.5*n4+0.25*n5)*(0.25*n5+0.5*n6+0.5*n8+n9);
+    double poly_DD=
+        (n2*n4-n2*n2*n4+4.0*n3*n4-4.0*n2*n3*n4-4.0*n3*n3*n4)
+        +(-n2*n4*n4-4.0*n3*n4*n4)
+        +(n1*n5-n1*n1*n5+n3*n5+2.0*n1*n3*n5-n3*n3*n5
+          -4.0*n3*n4*n5-n1*n5*n5-n3*n5*n5)
+        +(4.0*n1*n6-4.0*n1*n1*n6+n2*n6-4.0*n1*n2*n6-n2*n2*n6
+          +2.0*n2*n4*n6-4.0*n1*n5*n6-4.0*n1*n6*n6-n2*n6*n6)
+        +(4.0*n2*n7-4.0*n2*n2*n7
+          +16.0*n3*n7-16.0*n2*n3*n7-16.0*n3*n3*n7
+          -4.0*n2*n4*n7-16.0*n3*n4*n7
+          +n5*n7+2.0*n1*n5*n7-4.0*n2*n5*n7-18.0*n3*n5*n7-n5*n5*n7
+          +4.0*n6*n7+8.0*n1*n6*n7-16.0*n3*n6*n7-4.0*n5*n6*n7-4.0*n6*n6*n7
+          -4.0*n2*n7*n7-16.0*n3*n7*n7-n5*n7*n7-4.0*n6*n7*n7)
+        +(4.0*n1*n8-4.0*n1*n1*n8+4.0*n3*n8+8.0*n1*n3*n8-4.0*n3*n3*n8
+          +n4*n8-4.0*n1*n4*n8+2.0*n2*n4*n8-n4*n4*n8
+          -4.0*n1*n5*n8-4.0*n3*n5*n8
+          +n6*n8+2.0*n2*n6*n8-4.0*n3*n6*n8+2.0*n4*n6*n8-n6*n6*n8
+          -16.0*n3*n7*n8-4.0*n6*n7*n8
+          -4.0*n1*n8*n8-4.0*n3*n8*n8-n4*n8*n8-n6*n8*n8)
+        +(16.0*n1*n9-16.0*n1*n1*n9+4.0*n2*n9-16.0*n1*n2*n9-4.0*n2*n2*n9
+          +4.0*n4*n9-16.0*n1*n4*n9+8.0*n3*n4*n9-4.0*n4*n4*n9
+          +n5*n9-18.0*n1*n5*n9-4.0*n2*n5*n9+2.0*n3*n5*n9-4.0*n4*n5*n9-n5*n5*n9
+          -16.0*n1*n6*n9-4.0*n2*n6*n9
+          +8.0*n2*n7*n9+2.0*n5*n7*n9
+          -16.0*n1*n8*n9-4.0*n4*n8*n9
+          -16.0*n1*n9*n9-4.0*n2*n9*n9-4.0*n4*n9*n9-n5*n9*n9);
+    double DD_num=(poly_DD*(1.0/16.0)+Dg*Dg)*4.0;
+
+    // --- pi^2 numerator (factored term + 1/16 * correction) ---
+    double a1=n1+n2+n3+0.5*n4+0.5*n5+0.5*n6;
+    double a2=n1+0.5*n2+n4+0.5*n5+n7+0.5*n8;
+    double a3=0.5*n2+n3+0.5*n5+n6+0.5*n8+n9;
+    double a4=0.5*n4+0.5*n5+0.5*n6+n7+n8+n9;
+    double corr=(
+        (13.0*n2*n4-16.0*n1*n2*n4-11.0*n2*n2*n4+16.0*n3*n4-28.0*n1*n3*n4-24.0*n2*n3*n4)+
+        (-8.0*n3*n3*n4-11.0*n2*n4*n4-20.0*n3*n4*n4-6.0*n5+12.0*n1*n5-4.0*n1*n1*n5+17.0*n2*n5)+
+        (-20.0*n1*n2*n5-11.0*n2*n2*n5+12.0*n3*n5-28.0*n1*n3*n5-20.0*n2*n3*n5-4.0*n3*n3*n5)+
+        (17.0*n4*n5-20.0*n1*n4*n5-32.0*n2*n4*n5-40.0*n3*n4*n5-11.0*n4*n4*n5+11.0*n5*n5)+
+        (-16.0*n1*n5*n5-17.0*n2*n5*n5-16.0*n3*n5*n5-17.0*n4*n5*n5-6.0*n5*n5*n5+16.0*n1*n6-8.0*n1*n1*n6)+
+        (13.0*n2*n6-24.0*n1*n2*n6-11.0*n2*n2*n6-28.0*n1*n3*n6-16.0*n2*n3*n6+24.0*n4*n6)+
+        (-36.0*n1*n4*n6-38.0*n2*n4*n6-36.0*n3*n4*n6-20.0*n4*n4*n6+17.0*n5*n6-40.0*n1*n5*n6)+
+        (-32.0*n2*n5*n6-20.0*n3*n5*n6-42.0*n4*n5*n6-17.0*n5*n5*n6-20.0*n1*n6*n6-11.0*n2*n6*n6)+
+        (-20.0*n4*n6*n6-11.0*n5*n6*n6+16.0*n2*n7-28.0*n1*n2*n7-20.0*n2*n2*n7+16.0*n3*n7)+
+        (-48.0*n1*n3*n7-44.0*n2*n3*n7-16.0*n3*n3*n7-24.0*n2*n4*n7-44.0*n3*n4*n7)+
+        (12.0*n5*n7-28.0*n1*n5*n7-40.0*n2*n5*n7-48.0*n3*n5*n7-20.0*n4*n5*n7-16.0*n5*n5*n7)+
+        (16.0*n6*n7-48.0*n1*n6*n7-48.0*n2*n6*n7-44.0*n3*n6*n7-36.0*n4*n6*n7-40.0*n5*n6*n7)+
+        (-20.0*n6*n6*n7-8.0*n2*n7*n7-16.0*n3*n7*n7-4.0*n5*n7*n7-8.0*n6*n7*n7+16.0*n1*n8-8.0*n1*n1*n8)+
+        (24.0*n2*n8-36.0*n1*n2*n8-20.0*n2*n2*n8+16.0*n3*n8-48.0*n1*n3*n8-36.0*n2*n3*n8-8.0*n3*n3*n8)+
+        (13.0*n4*n8-24.0*n1*n4*n8-38.0*n2*n4*n8-48.0*n3*n4*n8-11.0*n4*n4*n8+17.0*n5*n8-40.0*n1*n5*n8)+
+        (-42.0*n2*n5*n8-40.0*n3*n5*n8-32.0*n4*n5*n8-17.0*n5*n5*n8+13.0*n6*n8-48.0*n1*n6*n8)+
+        (-38.0*n2*n6*n8-24.0*n3*n6*n8-38.0*n4*n6*n8-32.0*n5*n6*n8-11.0*n6*n6*n8-28.0*n1*n7*n8)+
+        (-36.0*n2*n7*n8-44.0*n3*n7*n8-16.0*n4*n7*n8-20.0*n5*n7*n8-24.0*n6*n7*n8-20.0*n1*n8*n8)+
+        (-20.0*n2*n8*n8-20.0*n3*n8*n8-11.0*n4*n8*n8-11.0*n5*n8*n8-11.0*n6*n8*n8+16.0*n1*n9-16.0*n1*n1*n9)+
+        (16.0*n2*n9-44.0*n1*n2*n9-20.0*n2*n2*n9-48.0*n1*n3*n9-28.0*n2*n3*n9+16.0*n4*n9)+
+        (-44.0*n1*n4*n9-48.0*n2*n4*n9-48.0*n3*n4*n9-20.0*n4*n4*n9+12.0*n5*n9-48.0*n1*n5*n9)+
+        (-40.0*n2*n5*n9-28.0*n3*n5*n9-40.0*n4*n5*n9-16.0*n5*n5*n9-44.0*n1*n6*n9-24.0*n2*n6*n9)+
+        (-36.0*n4*n6*n9-20.0*n5*n6*n9-48.0*n1*n7*n9-48.0*n2*n7*n9-48.0*n3*n7*n9-28.0*n4*n7*n9)+
+        (-28.0*n5*n7*n9-28.0*n6*n7*n9-44.0*n1*n8*n9-36.0*n2*n8*n9-28.0*n3*n8*n9-24.0*n4*n8*n9)+
+        (-20.0*n5*n8*n9-16.0*n6*n8*n9-16.0*n1*n9*n9-8.0*n2*n9*n9-8.0*n4*n9*n9-4.0*n5*n9*n9)
+    );
+    double pi2_num=a1*a2*a3*a4+corr*(1.0/16.0);
+
+    // --- ratio (denominators cancel) ---
+    out[idx]=(pi2_num>0.0)?DD_num/pi2_num:nan("");
+}''', "k", options=("-std=c++11",))
 
 
 # ---------------------------------------------------------------------------
@@ -417,20 +559,58 @@ class _GenoPopFlat:
 # ---------------------------------------------------------------------------
 
 def compute_all_dd_geno(pops, dd_calls):
-    """Compute all DD values for genotype data.
+    """Fused DD computation for all calls using genotype kernels.
 
-    DD has only ~10 calls even for 4 populations, so we dispatch directly
-    to the ld_statistics_genotype polynomial formulas rather than using
-    fused CUDA kernels.
+    Single-pop calls go through _DD_GENO_SINGLE_KERN, between-pop calls
+    through _DD_GENO_BETWEEN_KERN. Calls of each type are batched into a
+    single kernel launch so the per-launch overhead is amortized across
+    the (P*N)-element pair stream.
     """
-    from . import ld_statistics_genotype as ldg
+    P = len(pops)
+    N = pops[0].n.shape[0]
 
-    results = []
-    for i, j in dd_calls:
-        if i == j:
-            results.append(ldg.dd_geno_single(pops[i]))
-        else:
-            results.append(ldg.dd_geno_between(pops[i], pops[j]))
+    # Flatten per-pop arrays into (P*N,) once; reuse for both kernels.
+    g_moments = cp.ascontiguousarray(cp.stack([
+        cp.stack([p.g1, p.g2, p.g3, p.g4, p.g5, p.g6, p.g7, p.g8, p.g9],
+                 axis=-1)
+        for p in pops
+    ]).reshape(P * N, 9))
+    D_f = cp.ascontiguousarray(cp.concatenate([p.D_geno for p in pops]))
+    nn_f = cp.ascontiguousarray(cp.concatenate([p.n for p in pops]))
+
+    # Group calls by case type so we can launch each case once.
+    single_calls = []   # indices into dd_calls
+    between_calls = []
+    for idx, (i, j) in enumerate(dd_calls):
+        (single_calls if i == j else between_calls).append(idx)
+
+    results = [None] * len(dd_calls)
+
+    if single_calls:
+        # Concat the single-pop slices of g into one (n_calls * N, 9) block.
+        pop_idx = [dd_calls[c][0] for c in single_calls]
+        g_concat = cp.ascontiguousarray(cp.concatenate(
+            [g_moments[p * N:(p + 1) * N] for p in pop_idx], axis=0))
+        M = len(single_calls) * N
+        out = cp.empty(M, dtype=cp.float64)
+        _launch(_DD_GENO_SINGLE_KERN, (g_concat, out, M), M)
+        for k, c in enumerate(single_calls):
+            results[c] = out[k * N:(k + 1) * N]
+
+    if between_calls:
+        # Build flat I/J indices into the concatenated D_f / nn_f arrays.
+        I_arr = cp.array(
+            [dd_calls[c][0] * N + n for c in between_calls for n in range(N)],
+            dtype=cp.int32)
+        J_arr = cp.array(
+            [dd_calls[c][1] * N + n for c in between_calls for n in range(N)],
+            dtype=cp.int32)
+        M = len(between_calls) * N
+        out = cp.empty(M, dtype=cp.float64)
+        _launch(_DD_GENO_BETWEEN_KERN, (D_f, nn_f, I_arr, J_arr, out, M), M)
+        for k, c in enumerate(between_calls):
+            results[c] = out[k * N:(k + 1) * N]
+
     return results
 
 

--- a/pg_gpu/haplotype_kernels.py
+++ b/pg_gpu/haplotype_kernels.py
@@ -14,6 +14,55 @@ def _launch(kernel, args, M):
 
 
 # ---------------------------------------------------------------------------
+# Pearson r, r^2, and Lewontin's D' kernels (count-based)
+# ---------------------------------------------------------------------------
+
+_R_KERN = cp.RawKernel(r'''
+extern "C" __global__
+void k(const double*c11, const double*c10, const double*c01, const double*c00,
+       const double*nn, double*out, const int N){
+    int t=blockDim.x*blockIdx.x+threadIdx.x; if(t>=N)return;
+    double a=c11[t], b=c10[t], c=c01[t], d=c00[t], n=nn[t];
+    double pA=(a+b)/n, pB=(a+c)/n;
+    double D=(a*d-b*c)/(n*n);
+    double denom=pA*(1.0-pA)*pB*(1.0-pB);
+    out[t]=(denom>0.0)?D/sqrt(denom):nan("");
+}''', "k", options=("-std=c++11",))
+
+_R_SQUARED_KERN = cp.RawKernel(r'''
+extern "C" __global__
+void k(const double*c11, const double*c10, const double*c01, const double*c00,
+       const double*nn, double*out, const int N){
+    int t=blockDim.x*blockIdx.x+threadIdx.x; if(t>=N)return;
+    double a=c11[t], b=c10[t], c=c01[t], d=c00[t], n=nn[t];
+    double pA=(a+b)/n, pB=(a+c)/n;
+    double D=(a*d-b*c)/(n*n);
+    double denom=pA*(1.0-pA)*pB*(1.0-pB);
+    out[t]=(denom>0.0)?D*D/denom:nan("");
+}''', "k", options=("-std=c++11",))
+
+_D_PRIME_KERN = cp.RawKernel(r'''
+extern "C" __global__
+void k(const double*c11, const double*c10, const double*c01, const double*c00,
+       const double*nn, double*out, const int N){
+    int t=blockDim.x*blockIdx.x+threadIdx.x; if(t>=N)return;
+    double a=c11[t], b=c10[t], c=c01[t], d=c00[t], n=nn[t];
+    double pA=(a+b)/n, qA=1.0-pA;
+    double pB=(a+c)/n, qB=1.0-pB;
+    double D=(a*d-b*c)/(n*n);
+    double Dmax;
+    if(D>=0.0){
+        double v1=pA*qB, v2=qA*pB;
+        Dmax=(v1<v2)?v1:v2;
+    }else{
+        double v1=pA*pB, v2=qA*qB;
+        Dmax=(v1<v2)?v1:v2;
+    }
+    out[t]=(Dmax>0.0)?D/Dmax:nan("");
+}''', "k", options=("-std=c++11",))
+
+
+# ---------------------------------------------------------------------------
 # DD kernels
 # ---------------------------------------------------------------------------
 

--- a/pg_gpu/ld_statistics.py
+++ b/pg_gpu/ld_statistics.py
@@ -150,6 +150,20 @@ def dd_between(counts: cp.ndarray,
     return _dd_between(counts, pop1_idx, pop2_idx, n_valid)
 
 
+def _hap_count_inputs(counts, n_valid):
+    """Unpack a (N,4) counts array into the 5 contiguous float64 arrays
+    the haplotype r/r_squared/d_prime kernels expect."""
+    c11 = cp.ascontiguousarray(counts[:, 0].astype(cp.float64))
+    c10 = cp.ascontiguousarray(counts[:, 1].astype(cp.float64))
+    c01 = cp.ascontiguousarray(counts[:, 2].astype(cp.float64))
+    c00 = cp.ascontiguousarray(counts[:, 3].astype(cp.float64))
+    if n_valid is None:
+        n = c11 + c10 + c01 + c00
+    else:
+        n = cp.ascontiguousarray(n_valid.astype(cp.float64))
+    return c11, c10, c01, c00, n
+
+
 def r(counts: cp.ndarray,
       n_valid: Optional[cp.ndarray] = None) -> cp.ndarray:
     """
@@ -169,19 +183,12 @@ def r(counts: cp.ndarray,
         Pearson r values. NaN where computation is undefined
         (monomorphic at either locus).
     """
-    c11, c10, c01, c00 = counts[:, 0], counts[:, 1], counts[:, 2], counts[:, 3]
-    n = n_valid.astype(cp.float64) if n_valid is not None else cp.sum(counts, axis=1).astype(cp.float64)
-
-    p_A = (c11 + c10) / n
-    p_B = (c11 + c01) / n
-    D = (c11 * c00 - c10 * c01).astype(cp.float64) / (n * n)
-    denom = p_A * (1 - p_A) * p_B * (1 - p_B)
-
-    valid_mask = denom > 0
-    result = cp.full(n.shape[0], cp.nan, dtype=cp.float64)
-    result[valid_mask] = D[valid_mask] / cp.sqrt(denom[valid_mask])
-
-    return result
+    from .haplotype_kernels import _R_KERN, _launch
+    c11, c10, c01, c00, n = _hap_count_inputs(counts, n_valid)
+    N = c11.shape[0]
+    out = cp.empty(N, dtype=cp.float64)
+    _launch(_R_KERN, (c11, c10, c01, c00, n, out, N), N)
+    return out
 
 
 def r_squared(counts: cp.ndarray,
@@ -202,7 +209,12 @@ def r_squared(counts: cp.ndarray,
     cp.ndarray, float64, shape (N,)
         r-squared values. NaN where computation is undefined.
     """
-    return r(counts, n_valid) ** 2
+    from .haplotype_kernels import _R_SQUARED_KERN, _launch
+    c11, c10, c01, c00, n = _hap_count_inputs(counts, n_valid)
+    N = c11.shape[0]
+    out = cp.empty(N, dtype=cp.float64)
+    _launch(_R_SQUARED_KERN, (c11, c10, c01, c00, n, out, N), N)
+    return out
 
 
 def d_prime(counts: cp.ndarray,
@@ -226,24 +238,12 @@ def d_prime(counts: cp.ndarray,
         D' values in [-1, 1]. NaN where computation is undefined
         (monomorphic at either locus or D_max is zero).
     """
-    c11, c10, c01, c00 = counts[:, 0], counts[:, 1], counts[:, 2], counts[:, 3]
-    n = n_valid.astype(cp.float64) if n_valid is not None else cp.sum(counts, axis=1).astype(cp.float64)
-
-    p_A = (c11 + c10) / n
-    q_A = 1.0 - p_A
-    p_B = (c11 + c01) / n
-    q_B = 1.0 - p_B
-    D = (c11 * c00 - c10 * c01).astype(cp.float64) / (n * n)
-
-    D_max_pos = cp.minimum(p_A * q_B, q_A * p_B)
-    D_max_neg = cp.minimum(p_A * p_B, q_A * q_B)
-    D_max = cp.where(D >= 0, D_max_pos, D_max_neg)
-
-    valid_mask = D_max > 0
-    result = cp.full(n.shape[0], cp.nan, dtype=cp.float64)
-    result[valid_mask] = D[valid_mask] / D_max[valid_mask]
-
-    return result
+    from .haplotype_kernels import _D_PRIME_KERN, _launch
+    c11, c10, c01, c00, n = _hap_count_inputs(counts, n_valid)
+    N = c11.shape[0]
+    out = cp.empty(N, dtype=cp.float64)
+    _launch(_D_PRIME_KERN, (c11, c10, c01, c00, n, out, N), N)
+    return out
 
 
 def _prepare_segregating(mat, missing_data='include'):

--- a/pg_gpu/ld_statistics_genotype.py
+++ b/pg_gpu/ld_statistics_genotype.py
@@ -8,18 +8,17 @@ genotype configuration counts.
 
 Module status
 -------------
-DD functions (dd_geno_single, dd_geno_between) are LIVE -- called
-by genotype_kernels.compute_all_dd_geno() for the small number of
-DD evaluations per chunk.
-
-Dz and pi2 functions are RETAINED AS REFERENCE but no longer called
-in the production path. They have been superseded by fused CUDA
-RawKernels in genotype_kernels.py that compute each statistic in
-a single kernel launch with all arithmetic in GPU registers. The
-CuPy-based formulas here serve as:
+All polynomial functions in this module are RETAINED AS REFERENCE
+but no longer called in the production path. They have been
+superseded by fused CUDA RawKernels in genotype_kernels.py that
+compute each statistic in a single kernel launch with all
+arithmetic in GPU registers. The CuPy-based formulas here serve
+as:
   - A readable reference for the exact polynomial expressions
   - A potential CPU-fallback path (CuPy ops work without CUDA)
-  - A validation target for the fused kernels
+  - A validation target for the fused kernels (parity tests in
+    tests/test_genotype_kernels_dd.py and friends assert the
+    kernels match these polynomials to ~1e-12)
 """
 import cupy as cp
 
@@ -30,7 +29,8 @@ def _safe_div(numer, denom, valid):
 
 
 # ===========================================================================
-# DD  (D^2 and D1*D2)  --  LIVE: called by genotype_kernels
+# DD  (D^2 and D1*D2)  --  REFERENCE ONLY: superseded by fused CUDA kernels
+#         genotype_kernels._DD_GENO_SINGLE_KERN, _DD_GENO_BETWEEN_KERN
 # ===========================================================================
 
 
@@ -616,7 +616,7 @@ def pi2_geno_single(p):
         - 20 * g5 * g7 * g8
         - 24 * g6 * g7 * g8
         - 20 * g1 * g8 ** 2
-        + 20 * g2 * g8 ** 2
+        - 20 * g2 * g8 ** 2
         - 20 * g3 * g8 ** 2
         - 11 * g4 * g8 ** 2
         - 11 * g5 * g8 ** 2
@@ -1549,7 +1549,11 @@ def sigma_d2_geno(matrix, idx_i=None, idx_j=None):
         If ``matrix`` contains missing values.
     """
     from .ld_pipeline import compute_genotype_counts_for_pairs
-    from .genotype_kernels import _PopDataGeno
+    from .genotype_kernels import (
+        _PopDataGeno,
+        _SIGMA_D2_GENO_KERN,
+        _launch,
+    )
     from .genotype_matrix import GenotypeMatrix
     from .haplotype_matrix import HaplotypeMatrix
 
@@ -1585,6 +1589,13 @@ def sigma_d2_geno(matrix, idx_i=None, idx_j=None):
 
     counts, n_valid = compute_genotype_counts_for_pairs(g, idx_i, idx_j)
     p = _PopDataGeno(counts, n_valid)
-    DD = dd_geno_single(p)        # per-pair D^2 (numerator)
-    PI2 = pi2_geno_single(p)      # per-pair pi^2 (denominator)
-    return cp.where(PI2 > 0, DD / PI2, cp.nan)
+    # Fused kernel: emits D^2 / pi^2 in one launch. Numerator and
+    # denominator share the same n*(n-1)*(n-2)*(n-3) factor, which
+    # cancels; the kernel only computes the polynomial parts.
+    g_arr = cp.ascontiguousarray(cp.stack(
+        [p.g1, p.g2, p.g3, p.g4, p.g5, p.g6, p.g7, p.g8, p.g9],
+        axis=-1))
+    N = g_arr.shape[0]
+    out = cp.empty(N, dtype=cp.float64)
+    _launch(_SIGMA_D2_GENO_KERN, (g_arr, out, N), N)
+    return out

--- a/tests/test_examples_run.py
+++ b/tests/test_examples_run.py
@@ -1,0 +1,26 @@
+"""Smoke tests that run example scripts end-to-end on small fixtures."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_scikit_allel_comparison_runs_small():
+    """examples/scikit_allel_comparison.py --small --no-plot must exit 0
+    and verify all three diversity statistics on the 4 Mb gamb subset."""
+    script = REPO_ROOT / "examples" / "scikit_allel_comparison.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--small", "--no-plot"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, (
+        f"script failed (exit {result.returncode})\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}\n")
+    # Sanity: the script must have actually run the verification.
+    assert "max abs diff" in result.stdout, result.stdout

--- a/tests/test_examples_run.py
+++ b/tests/test_examples_run.py
@@ -14,11 +14,13 @@ def test_scikit_allel_comparison_runs_small():
 
     Uses a smaller --ld-snps to keep the smoke test under a minute on
     CI-class hardware (the default 10_000 takes ~20s on the
-    scikit-allel side, mostly in rogers_huff_r)."""
+    scikit-allel side, mostly in rogers_huff_r). Disables the MAC
+    filter so the small block keeps enough variants for parity to be
+    meaningful."""
     script = REPO_ROOT / "examples" / "scikit_allel_comparison.py"
     result = subprocess.run(
         [sys.executable, str(script), "--small", "--no-plot",
-         "--ld-snps", "2000"],
+         "--ld-snps", "2000", "--ld-mac-min", "0"],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,

--- a/tests/test_examples_run.py
+++ b/tests/test_examples_run.py
@@ -9,18 +9,25 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 def test_scikit_allel_comparison_runs_small():
     """examples/scikit_allel_comparison.py --small --no-plot must exit 0
-    and verify all three diversity statistics on the 4 Mb gamb subset."""
+    and verify the three diversity statistics + the LD-decay curve on
+    the 4 Mb gamb subset.
+
+    Uses a smaller --ld-snps to keep the smoke test under a minute on
+    CI-class hardware (the default 10_000 takes ~20s on the
+    scikit-allel side, mostly in rogers_huff_r)."""
     script = REPO_ROOT / "examples" / "scikit_allel_comparison.py"
     result = subprocess.run(
-        [sys.executable, str(script), "--small", "--no-plot"],
+        [sys.executable, str(script), "--small", "--no-plot",
+         "--ld-snps", "2000"],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=180,
     )
     assert result.returncode == 0, (
         f"script failed (exit {result.returncode})\n"
         f"--- stdout ---\n{result.stdout}\n"
         f"--- stderr ---\n{result.stderr}\n")
-    # Sanity: the script must have actually run the verification.
-    assert "max abs diff" in result.stdout, result.stdout
+    # Sanity: both verification blocks must have printed.
+    assert "tajimas_d: max abs diff" in result.stdout, result.stdout
+    assert "median r" in result.stdout, result.stdout

--- a/tests/test_genotype_kernels_dd.py
+++ b/tests/test_genotype_kernels_dd.py
@@ -1,0 +1,172 @@
+"""Parity tests for the diploid DD fused CUDA kernels.
+
+Verify that ``_DD_GENO_SINGLE_KERN`` and ``_DD_GENO_BETWEEN_KERN``
+in ``pg_gpu.genotype_kernels`` produce the same per-pair output
+as the reference polynomial implementations
+``ld_statistics_genotype.dd_geno_single`` and ``dd_geno_between``,
+to floating-point precision (rtol=1e-12).
+"""
+
+import cupy as cp
+import numpy as np
+import pytest
+
+from pg_gpu.genotype_kernels import (
+    _DD_GENO_SINGLE_KERN,
+    _DD_GENO_BETWEEN_KERN,
+    _PopDataGeno,
+    _launch,
+    compute_all_dd_geno,
+)
+from pg_gpu.ld_pipeline import compute_genotype_counts_for_pairs
+from pg_gpu import GenotypeMatrix
+from pg_gpu import ld_statistics_genotype as ldg
+
+
+def _random_gm(n_indiv, n_var, seed=0):
+    rng = np.random.default_rng(seed)
+    af = rng.uniform(0.05, 0.95, size=n_var)
+    a1 = rng.binomial(1, af[None, :], size=(n_indiv, n_var))
+    a2 = rng.binomial(1, af[None, :], size=(n_indiv, n_var))
+    geno = (a1 + a2).astype(np.int8)
+    pos = np.arange(n_var, dtype=np.int64) * 1000
+    return GenotypeMatrix(geno, pos, 0, n_var * 1000)
+
+
+def _build_pop_data(gm, idx_i=None, idx_j=None):
+    """Build a single _PopDataGeno from all-pairs upper-triangle counts."""
+    if gm.device != 'GPU':
+        gm.transfer_to_gpu()
+    g = gm.genotypes
+    n_var = g.shape[1]
+    if idx_i is None or idx_j is None:
+        i, j = cp.triu_indices(n_var, k=1)
+        idx_i = i.astype(cp.int32)
+        idx_j = j.astype(cp.int32)
+    counts, n_valid = compute_genotype_counts_for_pairs(g, idx_i, idx_j)
+    return _PopDataGeno(counts, n_valid)
+
+
+def _kernel_dd_single(p):
+    """Run _DD_GENO_SINGLE_KERN over a single _PopDataGeno."""
+    g = cp.ascontiguousarray(cp.stack(
+        [p.g1, p.g2, p.g3, p.g4, p.g5, p.g6, p.g7, p.g8, p.g9], axis=-1))
+    N = g.shape[0]
+    out = cp.empty(N, dtype=cp.float64)
+    _launch(_DD_GENO_SINGLE_KERN, (g, out, N), N)
+    return out
+
+
+def _kernel_dd_between(pi, pj):
+    """Run _DD_GENO_BETWEEN_KERN over two _PopDataGeno objects."""
+    D = cp.ascontiguousarray(cp.concatenate([pi.D_geno, pj.D_geno]))
+    nn = cp.ascontiguousarray(cp.concatenate([pi.n, pj.n]))
+    N = pi.D_geno.shape[0]
+    I = cp.arange(N, dtype=cp.int32)
+    J = cp.arange(N, 2 * N, dtype=cp.int32)
+    out = cp.empty(N, dtype=cp.float64)
+    _launch(_DD_GENO_BETWEEN_KERN, (D, nn, I, J, out, N), N)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Single-pop parity
+# ---------------------------------------------------------------------------
+
+
+class TestSinglePopParity:
+
+    @pytest.mark.parametrize("seed", [0, 1, 7, 42])
+    def test_random_panels(self, seed):
+        gm = _random_gm(40, 30, seed=seed)
+        p = _build_pop_data(gm)
+        kern = _kernel_dd_single(p).get()
+        poly = ldg.dd_geno_single(p).get()
+        np.testing.assert_allclose(kern, poly, rtol=1e-12, atol=1e-12)
+
+    def test_small_sample_size(self):
+        # n=4 is the smallest valid case; verify both paths agree there.
+        gm = _random_gm(4, 15, seed=99)
+        p = _build_pop_data(gm)
+        kern = _kernel_dd_single(p).get()
+        poly = ldg.dd_geno_single(p).get()
+        np.testing.assert_allclose(kern, poly, rtol=1e-12, atol=1e-12)
+
+    def test_larger_panel(self):
+        gm = _random_gm(100, 60, seed=2026)
+        p = _build_pop_data(gm)
+        kern = _kernel_dd_single(p).get()
+        poly = ldg.dd_geno_single(p).get()
+        np.testing.assert_allclose(kern, poly, rtol=1e-12, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Between-pop parity
+# ---------------------------------------------------------------------------
+
+
+class TestBetweenPopParity:
+
+    @pytest.mark.parametrize("seed", [3, 11, 100])
+    def test_random_panels(self, seed):
+        gm1 = _random_gm(30, 25, seed=seed)
+        gm2 = _random_gm(30, 25, seed=seed + 1000)
+        p1 = _build_pop_data(gm1)
+        p2 = _build_pop_data(gm2)
+        kern = _kernel_dd_between(p1, p2).get()
+        poly = ldg.dd_geno_between(p1, p2).get()
+        np.testing.assert_allclose(kern, poly, rtol=1e-12, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: compute_all_dd_geno dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestComputeAllDispatch:
+
+    def test_mixed_calls_match_polynomial(self):
+        """compute_all_dd_geno (now kernel-backed) must agree with
+        the prior polynomial dispatch on the same inputs."""
+        gm1 = _random_gm(30, 20, seed=4)
+        gm2 = _random_gm(30, 20, seed=5)
+        gm3 = _random_gm(30, 20, seed=6)
+        # Each pop needs its own pair-counts so all three _PopDataGeno
+        # objects share the same N (number of pairs).
+        ps = [_build_pop_data(gm) for gm in (gm1, gm2, gm3)]
+
+        dd_calls = [(0, 0), (1, 1), (0, 1), (0, 2), (1, 2), (2, 2)]
+        kernel_results = compute_all_dd_geno(ps, dd_calls)
+
+        for k, (i, j) in enumerate(dd_calls):
+            if i == j:
+                expected = ldg.dd_geno_single(ps[i]).get()
+            else:
+                expected = ldg.dd_geno_between(ps[i], ps[j]).get()
+            np.testing.assert_allclose(
+                kernel_results[k].get(), expected,
+                rtol=1e-12, atol=1e-12,
+                err_msg=f"call {k} (i={i}, j={j}) disagrees")
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+
+    def test_n_below_4_returns_zero(self):
+        """Both kernel and polynomial return 0 when n<4 (denominator
+        guard). Build a small fixture where the per-pair valid sample
+        count is below 4 to exercise the early-return branch."""
+        n_indiv, n_var = 3, 4
+        rng = np.random.default_rng(0)
+        geno = rng.integers(0, 3, (n_indiv, n_var)).astype(np.int8)
+        pos = np.arange(n_var) * 100
+        gm = GenotypeMatrix(geno, pos, 0, n_var * 100)
+        p = _build_pop_data(gm)
+        kern = _kernel_dd_single(p).get()
+        poly = ldg.dd_geno_single(p).get()
+        assert np.all(kern == 0.0)
+        assert np.all(poly == 0.0)

--- a/tests/test_haplotype_kernels_rsq.py
+++ b/tests/test_haplotype_kernels_rsq.py
@@ -1,0 +1,126 @@
+"""Parity tests for haplotype count-based r, r^2, D' fused CUDA kernels.
+
+The polynomial elementwise expressions previously living inline in
+``pg_gpu.ld_statistics.r``, ``r_squared``, and ``d_prime`` were replaced
+by single-launch RawKernels (``_R_KERN``, ``_R_SQUARED_KERN``,
+``_D_PRIME_KERN``) in ``pg_gpu.haplotype_kernels``. These tests verify
+that the new kernel-backed entry points produce the same output as the
+old polynomial expressions on the same inputs.
+"""
+
+import cupy as cp
+import numpy as np
+import pytest
+
+from pg_gpu import ld_statistics
+
+
+def _polynomial_r(counts, n_valid=None):
+    """Old elementwise-polynomial path, kept here as the parity reference."""
+    c11, c10, c01, c00 = counts[:, 0], counts[:, 1], counts[:, 2], counts[:, 3]
+    n = (n_valid.astype(cp.float64) if n_valid is not None
+         else cp.sum(counts, axis=1).astype(cp.float64))
+    p_A = (c11 + c10) / n
+    p_B = (c11 + c01) / n
+    D = (c11 * c00 - c10 * c01).astype(cp.float64) / (n * n)
+    denom = p_A * (1 - p_A) * p_B * (1 - p_B)
+    out = cp.full(n.shape[0], cp.nan, dtype=cp.float64)
+    valid = denom > 0
+    out[valid] = D[valid] / cp.sqrt(denom[valid])
+    return out
+
+
+def _polynomial_r_squared(counts, n_valid=None):
+    return _polynomial_r(counts, n_valid) ** 2
+
+
+def _polynomial_d_prime(counts, n_valid=None):
+    c11, c10, c01, c00 = counts[:, 0], counts[:, 1], counts[:, 2], counts[:, 3]
+    n = (n_valid.astype(cp.float64) if n_valid is not None
+         else cp.sum(counts, axis=1).astype(cp.float64))
+    p_A = (c11 + c10) / n
+    q_A = 1.0 - p_A
+    p_B = (c11 + c01) / n
+    q_B = 1.0 - p_B
+    D = (c11 * c00 - c10 * c01).astype(cp.float64) / (n * n)
+    Dmax = cp.where(D >= 0,
+                    cp.minimum(p_A * q_B, q_A * p_B),
+                    cp.minimum(p_A * p_B, q_A * q_B))
+    out = cp.full(n.shape[0], cp.nan, dtype=cp.float64)
+    valid = Dmax > 0
+    out[valid] = D[valid] / Dmax[valid]
+    return out
+
+
+def _random_counts(n_pairs, n_total=200, seed=0):
+    """Random multinomial-ish 4-way haplotype counts."""
+    rng = np.random.default_rng(seed)
+    raw = rng.dirichlet([1, 1, 1, 1], size=n_pairs)
+    counts = np.round(raw * n_total).astype(np.int64)
+    return cp.asarray(counts.astype(np.float64))
+
+
+def _check_finite_match(kernel_out, ref):
+    kern = kernel_out.get()
+    poly = ref.get()
+    finite = np.isfinite(kern) & np.isfinite(poly)
+    assert np.array_equal(np.isnan(kern), np.isnan(poly))
+    np.testing.assert_allclose(
+        kern[finite], poly[finite], rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.parametrize("seed", [0, 1, 7, 42])
+class TestRParity:
+
+    def test_r_random_panels(self, seed):
+        counts = _random_counts(200, seed=seed)
+        _check_finite_match(ld_statistics.r(counts), _polynomial_r(counts))
+
+    def test_r_squared_random_panels(self, seed):
+        counts = _random_counts(200, seed=seed)
+        _check_finite_match(
+            ld_statistics.r_squared(counts), _polynomial_r_squared(counts))
+
+    def test_d_prime_random_panels(self, seed):
+        counts = _random_counts(200, seed=seed)
+        _check_finite_match(
+            ld_statistics.d_prime(counts), _polynomial_d_prime(counts))
+
+
+class TestEdgeCases:
+
+    def test_monomorphic_pair_yields_nan(self):
+        # n10 = n11 = 0 -> p_A = 0 -> denom = 0 -> NaN.
+        counts = cp.asarray([[0.0, 0.0, 50.0, 50.0]])
+        assert cp.all(cp.isnan(ld_statistics.r(counts)))
+        assert cp.all(cp.isnan(ld_statistics.r_squared(counts)))
+        assert cp.all(cp.isnan(ld_statistics.d_prime(counts)))
+
+    def test_perfect_positive_correlation(self):
+        # Only (1,1) and (0,0) -> r=1, r^2=1, D'=1.
+        counts = cp.asarray([[50.0, 0.0, 0.0, 50.0]])
+        np.testing.assert_allclose(ld_statistics.r(counts).get(), [1.0],
+                                   atol=1e-12)
+        np.testing.assert_allclose(ld_statistics.r_squared(counts).get(),
+                                   [1.0], atol=1e-12)
+        np.testing.assert_allclose(ld_statistics.d_prime(counts).get(),
+                                   [1.0], atol=1e-12)
+
+    def test_perfect_negative_correlation(self):
+        # Only (1,0) and (0,1) -> r=-1, r^2=1, D'=-1.
+        counts = cp.asarray([[0.0, 50.0, 50.0, 0.0]])
+        np.testing.assert_allclose(ld_statistics.r(counts).get(), [-1.0],
+                                   atol=1e-12)
+        np.testing.assert_allclose(ld_statistics.r_squared(counts).get(),
+                                   [1.0], atol=1e-12)
+        np.testing.assert_allclose(ld_statistics.d_prime(counts).get(),
+                                   [-1.0], atol=1e-12)
+
+    def test_with_n_valid_override(self):
+        counts = _random_counts(50, seed=99)
+        n_valid = cp.sum(counts, axis=1)  # happens to equal the default
+        kern = ld_statistics.r_squared(counts, n_valid).get()
+        ref = _polynomial_r_squared(counts, n_valid).get()
+        finite = np.isfinite(kern) & np.isfinite(ref)
+        np.testing.assert_allclose(
+            kern[finite], ref[finite], rtol=1e-12, atol=1e-12)

--- a/tests/test_sigma_d2_geno.py
+++ b/tests/test_sigma_d2_geno.py
@@ -105,6 +105,41 @@ class TestHaplotypeMatrixPath:
         assert out.shape == (n_var * (n_var - 1) // 2,)
 
 
+class TestKernelParity:
+    """The fused _SIGMA_D2_GENO_KERN must match the polynomial path
+    (DD_polynomial / pi2_polynomial) on the same input to floating-point
+    precision."""
+
+    @pytest.mark.parametrize("seed", [0, 1, 42, 2026])
+    def test_kernel_matches_polynomial(self, seed):
+        from pg_gpu.ld_pipeline import compute_genotype_counts_for_pairs
+        from pg_gpu.genotype_kernels import _PopDataGeno
+        from pg_gpu.ld_statistics_genotype import (
+            dd_geno_single,
+            pi2_geno_single,
+        )
+
+        gm = _random_gm(40, 25, seed=seed)
+        gm.transfer_to_gpu()
+        i, j = cp.triu_indices(25, k=1)
+        idx_i, idx_j = i.astype(cp.int32), j.astype(cp.int32)
+
+        kernel_out = sigma_d2_geno(gm, idx_i, idx_j).get()
+
+        counts, n_valid = compute_genotype_counts_for_pairs(
+            gm.genotypes, idx_i, idx_j)
+        p = _PopDataGeno(counts, n_valid)
+        dd = dd_geno_single(p).get()
+        pi2 = pi2_geno_single(p).get()
+        reference = np.where(pi2 > 0, dd / pi2, np.nan)
+
+        finite = np.isfinite(kernel_out) & np.isfinite(reference)
+        np.testing.assert_allclose(
+            kernel_out[finite], reference[finite],
+            rtol=1e-12, atol=1e-12)
+        assert np.array_equal(np.isnan(kernel_out), np.isnan(reference))
+
+
 class TestMomentsLDConsistency:
     """The per-pair sigma_d^2 estimator must use the SAME polynomial
     components that the moments-LD pipeline aggregates per bin. Sum the


### PR DESCRIPTION
Combines two pieces of work that ended up sequenced on the same branch:

## Part 1: side-by-side scikit-allel vs pg_gpu tutorial

Adds \`examples/scikit_allel_comparison.py\` plus \`docs/source/tutorials/scikit_allel_comparison.rst\` and a smoke test \`tests/test_examples_run.py\`. Loads the gamb X-chromosome dataset, computes windowed pi/theta_W/Tajima's D two ways, computes LD-decay three ways (scikit-allel Rogers-Huff, pg_gpu Rogers-Huff, pg_gpu unbiased σ_D²), verifies parity, reports speedups, plots a 5-panel figure.

This was open as PR #84; this PR supersedes it.

## Part 2: fused RawKernels for all LD primitives

Closes the architectural gap surfaced by the tutorial work: every LD primitive now has a fused CUDA RawKernel implementation, with polynomial paths retained only as reference/validation.

**New kernels:**
- Diploid: \`_DD_GENO_SINGLE_KERN\`, \`_DD_GENO_BETWEEN_KERN\`, \`_SIGMA_D2_GENO_KERN\`
- Haplotype (count-based): \`_R_KERN\`, \`_R_SQUARED_KERN\`, \`_D_PRIME_KERN\`

**Wiring:** \`compute_all_dd_geno\` now dispatches through fused kernels (was polynomial). \`sigma_d2_geno\` launches the fused σ_D² kernel directly. Count-based \`r\`/\`r_squared\`/\`d_prime\` in \`pg_gpu.ld_statistics\` dispatch through their kernels.

**Drive-by polynomial bug fix:** \`pi2_geno_single\` had a sign error (\`+ 20 * g2 * g8 ** 2\` should have been \`- 20\`). The existing \`_PI2_IIII_KERN\` already had the correct sign and matched moments source exactly; the polynomial was the buggy one. The previous \`TestMomentsLDConsistency\` test passed vacuously because both numerator and denominator used the same buggy polynomial.

**Benchmark (\`debug/bench_ld_kernels.py\`, 10M pairs on A100):**
- DD single-pop: 100x speedup
- DD between-pop: 28x
- σ_D²: 114x
- haplotype r²: 58x

## Test plan

- [x] 655 tests pass in default env, 0 failures
- [x] 23 moments-LD tests pass against upstream moments at rtol=1e-6
- [x] 31 new parity tests at rtol=1e-12 (DD: 11, sigma_D²: 4, r/r²/D': 16)
- [x] examples/scikit_allel_comparison.py runs end-to-end on full X
- [x] examples/scikit_allel_comparison.py --small smoke test passes
- [x] ruff check clean