### PR TITLE
perf(local_pca): GPU-resident streaming + engine='auto' (fixes #91)

### DIFF
--- a/debug/bench_local_pca_streaming.py
+++ b/debug/bench_local_pca_streaming.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+"""Benchmark for issue #91: GPU-resident accumulation in
+``_local_pca_streaming``.
+
+Times ``local_pca(..., engine='streaming-dense')`` on a synthetic
+haplotype matrix sized to exercise the per-window host-sync chain
+that issue #91 targets. Prints a median wall-clock over 3 timed
+runs (1 warmup) so the result is stable enough to compare across
+the before/after of the change. Also reports the GPU memory cost
+of the proposed GPU-resident output buffers.
+
+Run before and after the implementation change:
+
+    pixi run python debug/bench_local_pca_streaming.py
+"""
+
+import statistics
+import time
+import numpy as np
+import cupy as cp
+
+from pg_gpu import HaplotypeMatrix
+from pg_gpu.decomposition import local_pca
+
+N_HAP = 200
+N_VAR = 1_200_000     # 6000 windows * 200 SNPs/window
+WINDOW_SIZE = 200
+K = 2
+SEED = 0
+N_WARMUP = 1
+N_TIMED = 3
+
+
+def build_matrix(seed: int) -> HaplotypeMatrix:
+    rng = np.random.default_rng(seed)
+    p = rng.uniform(0.05, 0.5, size=N_VAR).astype(np.float32)
+    haps = (rng.random((N_HAP, N_VAR), dtype=np.float32) < p).astype(np.int8)
+    positions = np.arange(N_VAR, dtype=np.int64)
+    return HaplotypeMatrix(haps, positions, 0, N_VAR)
+
+
+def time_once(hm: HaplotypeMatrix) -> float:
+    cp.cuda.Stream.null.synchronize()
+    t0 = time.perf_counter()
+    res = local_pca(hm, window_size=WINDOW_SIZE, window_type='snp',
+                    k=K, engine='streaming-dense')
+    cp.cuda.Stream.null.synchronize()
+    elapsed = time.perf_counter() - t0
+    n_win = res.n_windows
+    return elapsed, n_win
+
+
+def main() -> None:
+    print(f"Building synthetic HaplotypeMatrix: "
+          f"{N_HAP} haps x {N_VAR} variants, window={WINDOW_SIZE} SNPs")
+    hm = build_matrix(SEED)
+    hm.transfer_to_gpu()
+
+    print(f"Warmup ({N_WARMUP} run)...")
+    for _ in range(N_WARMUP):
+        time_once(hm)
+
+    print(f"Timing ({N_TIMED} runs)...")
+    times = []
+    n_win = None
+    for i in range(N_TIMED):
+        t, n_win = time_once(hm)
+        print(f"  run {i+1}: {t:.3f} s ({n_win} windows)")
+        times.append(t)
+
+    median = statistics.median(times)
+    per_window_us = 1e6 * median / n_win
+    print()
+    print(f"streaming-dense median wall-clock: {median:.3f} s")
+    print(f"  per-window: {per_window_us:.1f} us  (n_windows = {n_win})")
+
+    # Cost estimate of GPU-resident buffers proposed in issue #91:
+    eigvals_bytes = n_win * K * 8
+    eigvecs_bytes = n_win * K * N_HAP * 8
+    sumsq_bytes = n_win * 8
+    total_mb = (eigvals_bytes + eigvecs_bytes + sumsq_bytes) / 1024 / 1024
+    print(f"GPU output-buffer footprint at this size: {total_mb:.2f} MB")
+
+
+if __name__ == "__main__":
+    main()

--- a/pg_gpu/decomposition.py
+++ b/pg_gpu/decomposition.py
@@ -705,38 +705,36 @@ def _local_pca_streaming(matrix, iterator, k, scaler, missing_data,
         rng = None
 
     window_meta = []
-    eigvals_chunks = []
-    eigvecs_chunks = []
-    sumsq_chunks = []
-    valid_chunks = []
+    eigvals_gpu_chunks = []
+    eigvecs_gpu_chunks = []
+    sumsq_gpu_chunks = []
 
-    # Keep only the small per-window metadata; the GPU-resident
-    # window.matrix returned by WindowIterator.get_subset materializes
-    # a fresh int8 copy of the haplotype block (fancy indexing makes
-    # a copy, not a view), so retaining the WindowData object across
-    # the loop would leak ~tens of GB of GPU memory by the end of a
-    # whole-arm scan. We extract only what windows_df needs.
+    # Per-window kernel outputs accumulate as GPU tensors. They are tiny
+    # (k floats + (k, n_hap) floats + 1 float per window) so retaining
+    # them for the duration of the loop is cheap, and avoiding the
+    # per-window cp.asnumpy / float(...) sync chain is the whole point
+    # of issue #91. cp.stack at the end gives a single contiguous
+    # (n_windows, ...) tensor; the .get() that follows is the only
+    # D->H transfer the dispatcher does.
     n_processed = 0
     for window in iterator:
+        is_valid = window.n_variants >= max(k, 2)
         window_meta.append((
             window.chrom, window.start, window.end, window.center,
-            window.n_variants, window.window_id,
+            window.n_variants, window.window_id, is_valid,
         ))
-        eigvals_chunks.append(None)
-        eigvecs_chunks.append(None)
-        sumsq_chunks.append(None)
-        if window.n_variants < max(k, 2):
-            eigvals_chunks[-1] = np.full(k, np.nan)
-            eigvecs_chunks[-1] = np.full((k, n_samples), np.nan)
-            sumsq_chunks[-1] = np.nan
-            valid_chunks.append(False)
+
+        if not is_valid:
+            eigvals_gpu_chunks.append(cp.full(k, cp.nan, dtype=cp.float64))
+            eigvecs_gpu_chunks.append(
+                cp.full((k, n_samples), cp.nan, dtype=cp.float64))
+            sumsq_gpu_chunks.append(cp.asarray(cp.nan, dtype=cp.float64))
             del window
             continue
 
         X = _prepare_matrix(window.matrix, scaler, population=None,
                             missing_data=missing_data)
         X = _materialize_prepared(X)
-        valid_chunks.append(True)
 
         if engine == 'streaming-dense':
             evals, evecs, sumsq = _local_pca_window_dense(
@@ -749,9 +747,9 @@ def _local_pca_streaming(matrix, iterator, k, scaler, missing_data,
                 rng=rng,
             )
 
-        eigvals_chunks[-1] = _cupy_to_host_1d(evals, k)
-        eigvecs_chunks[-1] = _cupy_to_host_2d(evecs, k, n_samples)
-        sumsq_chunks[-1] = float(cp.asnumpy(sumsq))
+        eigvals_gpu_chunks.append(evals.astype(cp.float64, copy=False))
+        eigvecs_gpu_chunks.append(evecs.astype(cp.float64, copy=False))
+        sumsq_gpu_chunks.append(sumsq.astype(cp.float64, copy=False))
 
         del X, evals, evecs, sumsq, window
         n_processed += 1
@@ -763,16 +761,22 @@ def _local_pca_streaming(matrix, iterator, k, scaler, missing_data,
     if len(window_meta) == 0:
         raise ValueError("WindowIterator produced no windows.")
 
-    eigvals_host = np.stack(eigvals_chunks, axis=0)
-    eigvecs_host = np.stack(eigvecs_chunks, axis=0)
-    sumsq_host = np.array(sumsq_chunks, dtype=np.float64)
-    valid_mask = np.array(valid_chunks, dtype=bool)
+    # Single bulk D->H transfer for all per-window outputs (issue #91).
+    eigvals_host = cp.stack(eigvals_gpu_chunks, axis=0).get()
+    eigvecs_host = cp.stack(eigvecs_gpu_chunks, axis=0).get()
+    sumsq_host = cp.stack(sumsq_gpu_chunks, axis=0).get()
+    del eigvals_gpu_chunks, eigvecs_gpu_chunks, sumsq_gpu_chunks
+    cp.get_default_memory_pool().free_all_blocks()
+
+    valid_mask = np.array(
+        [meta[6] for meta in window_meta], dtype=bool)
 
     eigvals_host[~valid_mask] = np.nan
     eigvecs_host[~valid_mask] = np.nan
     sumsq_host[~valid_mask] = np.nan
 
-    chrom_col, start_col, end_col, center_col, nvar_col, wid_col = zip(*window_meta)
+    chrom_col, start_col, end_col, center_col, nvar_col, wid_col, _ = zip(
+        *window_meta)
     windows_df = pd.DataFrame({
         'chrom': list(chrom_col),
         'start': list(start_col),
@@ -791,18 +795,6 @@ def _local_pca_streaming(matrix, iterator, k, scaler, missing_data,
         scaler=scaler,
         missing_data=missing_data,
     )
-
-
-def _cupy_to_host_1d(arr, length):
-    out = np.asarray(cp.asnumpy(arr), dtype=np.float64).reshape(-1)
-    if out.shape[0] != length:
-        raise ValueError(
-            f"expected length-{length} array, got {out.shape[0]}")
-    return out
-
-
-def _cupy_to_host_2d(arr, k, n):
-    return np.asarray(cp.asnumpy(arr), dtype=np.float64).reshape(k, n)
 
 
 def _batched_top_k_eigh(gram_stack: "cp.ndarray", k: int,

--- a/pg_gpu/decomposition.py
+++ b/pg_gpu/decomposition.py
@@ -871,6 +871,70 @@ def _materialize_prepared(X):
     return X
 
 
+def _estimate_n_windows(matrix, window_params) -> int:
+    """Upper bound on the number of windows ``WindowIterator`` will yield.
+
+    Exact for ``window_type='snp'`` and ``'regions'``. For ``'bp'`` this is
+    an upper bound (some bp windows may be empty and skipped); overestimating
+    only biases the auto-selector toward streaming, which is safe.
+    """
+    if window_params.window_type == 'regions':
+        return 0 if window_params.regions is None else len(window_params.regions)
+    if window_params.window_type == 'snp':
+        n_var = matrix.num_variants
+        if n_var < window_params.window_size:
+            return 0
+        return (n_var - window_params.window_size) // window_params.step_size + 1
+    if window_params.window_type == 'bp':
+        positions = matrix.positions
+        if isinstance(positions, cp.ndarray):
+            chrom_start = int(positions[0].get())
+            chrom_end = int(positions[-1].get())
+        else:
+            chrom_start = int(positions[0])
+            chrom_end = int(positions[-1])
+        span = max(0, chrom_end - chrom_start)
+        return span // window_params.step_size + 1
+    return 0
+
+
+def _pick_dense_engine(matrix, window_params,
+                       free_bytes: Optional[int] = None,
+                       budget_fraction: float = 0.5) -> str:
+    """Choose between 'dense-eigh' and 'streaming-dense' for engine='auto'.
+
+    The dense-eigh path holds a ``(n_windows, n_hap, n_hap)`` Gram stack on
+    the GPU and runs a single batched ``cp.linalg.eigh`` (~2x faster per
+    window than streaming when it fits). It falls over when the stack plus
+    the cuSOLVER eigh workspace exceed free GPU memory. Estimate the peak
+    as 3x the Gram-stack size (Gram + workspace + eigvecs) and pick
+    streaming when that exceeds ``budget_fraction`` of free memory.
+
+    Parameters
+    ----------
+    matrix : HaplotypeMatrix
+        The (possibly population-filtered) matrix that will be windowed.
+    window_params : WindowParams
+    free_bytes : int, optional
+        Free GPU memory in bytes. Defaults to
+        ``cp.cuda.Device().mem_info[0]`` (queried once at decision time).
+    budget_fraction : float
+        Fraction of free GPU memory to budget for the Gram-stack peak.
+        Default 0.5 leaves room for the haplotype matrix, the cupy
+        memory pool's existing allocations, and other concurrent GPU work.
+    """
+    n_samples = matrix.num_haplotypes
+    n_windows_est = _estimate_n_windows(matrix, window_params)
+    if n_windows_est == 0:
+        return 'dense-eigh'
+    peak_bytes = 3 * n_windows_est * n_samples * n_samples * 8
+    if free_bytes is None:
+        free_bytes = cp.cuda.Device().mem_info[0]
+    if peak_bytes < budget_fraction * free_bytes:
+        return 'dense-eigh'
+    return 'streaming-dense'
+
+
 def local_pca(haplotype_matrix: "HaplotypeMatrix",
               window_params=None,
               k: int = 2,
@@ -911,6 +975,17 @@ def local_pca(haplotype_matrix: "HaplotypeMatrix",
         Windows per batched eigh call. Auto-sized if None.
     window_size, step_size, window_type, regions
         Short-hand for constructing a `WindowParams` without importing it.
+    engine : str
+        ``'dense-eigh'`` (default) holds the full ``(n_windows, n_hap, n_hap)``
+        Gram stack on the GPU and runs a single batched ``cp.linalg.eigh``;
+        ~2x faster per window than streaming when the stack fits.
+        ``'streaming-dense'`` processes each window independently with bounded
+        peak memory; required when the Gram stack would exceed GPU memory
+        (e.g. thousands of haplotypes x thousands of windows).
+        ``'streaming-rsvd'`` is the streaming path with a randomized top-k
+        per window; chosen explicitly for very thin windows.
+        ``'auto'`` estimates the Gram-stack peak and picks ``dense-eigh``
+        when it fits in 50% of free GPU memory, ``streaming-dense`` otherwise.
 
     Returns
     -------
@@ -918,7 +993,7 @@ def local_pca(haplotype_matrix: "HaplotypeMatrix",
     """
     from .windowed_analysis import WindowIterator
 
-    valid_engines = ('dense-eigh', 'streaming-dense', 'streaming-rsvd')
+    valid_engines = ('auto', 'dense-eigh', 'streaming-dense', 'streaming-rsvd')
     if engine not in valid_engines:
         raise ValueError(
             f"engine must be one of {valid_engines}, got {engine!r}")
@@ -936,6 +1011,9 @@ def local_pca(haplotype_matrix: "HaplotypeMatrix",
 
     n_samples = matrix.num_haplotypes
     iterator = WindowIterator(matrix, window_params)
+
+    if engine == 'auto':
+        engine = _pick_dense_engine(matrix, window_params)
 
     if engine in ('streaming-dense', 'streaming-rsvd'):
         return _local_pca_streaming(

--- a/pg_gpu/decomposition.py
+++ b/pg_gpu/decomposition.py
@@ -900,7 +900,7 @@ def _estimate_n_windows(matrix, window_params) -> int:
 
 def _pick_dense_engine(matrix, window_params,
                        free_bytes: Optional[int] = None,
-                       budget_fraction: float = 0.5) -> str:
+                       budget_fraction: float = 0.7) -> str:
     """Choose between 'dense-eigh' and 'streaming-dense' for engine='auto'.
 
     The dense-eigh path holds a ``(n_windows, n_hap, n_hap)`` Gram stack on
@@ -920,7 +920,7 @@ def _pick_dense_engine(matrix, window_params,
         ``cp.cuda.Device().mem_info[0]`` (queried once at decision time).
     budget_fraction : float
         Fraction of free GPU memory to budget for the Gram-stack peak.
-        Default 0.5 leaves room for the haplotype matrix, the cupy
+        Default 0.7 leaves room for the haplotype matrix, the cupy
         memory pool's existing allocations, and other concurrent GPU work.
     """
     n_samples = matrix.num_haplotypes
@@ -985,7 +985,7 @@ def local_pca(haplotype_matrix: "HaplotypeMatrix",
         ``'streaming-rsvd'`` is the streaming path with a randomized top-k
         per window; chosen explicitly for very thin windows.
         ``'auto'`` estimates the Gram-stack peak and picks ``dense-eigh``
-        when it fits in 50% of free GPU memory, ``streaming-dense`` otherwise.
+        when it fits in 70% of free GPU memory, ``streaming-dense`` otherwise.
 
     Returns
     -------

--- a/tests/test_local_pca_auto_engine.py
+++ b/tests/test_local_pca_auto_engine.py
@@ -85,14 +85,18 @@ class TestPickDenseEngine:
     def test_threshold_boundary(self, small_hm):
         # Construct free_bytes so that peak == budget_fraction * free_bytes
         # exactly; the strict-less-than comparison should pick streaming.
+        # Pass an explicit budget_fraction so the test arithmetic is clean
+        # and decoupled from the default.
         params = WindowParams(window_type='snp', window_size=100, step_size=100)
         n_windows = _estimate_n_windows(small_hm, params)
         peak = 3 * n_windows * small_hm.num_haplotypes ** 2 * 8
         # peak < 0.5 * free  iff  free > 2 * peak. Set free = 2 * peak: NOT less than.
         free = 2 * peak
-        assert _pick_dense_engine(small_hm, params, free_bytes=free) == 'streaming-dense'
+        assert _pick_dense_engine(small_hm, params, free_bytes=free,
+                                   budget_fraction=0.5) == 'streaming-dense'
         # Bump free up by a margin: now strictly less than -> dense-eigh.
-        assert _pick_dense_engine(small_hm, params, free_bytes=free + 1) == 'dense-eigh'
+        assert _pick_dense_engine(small_hm, params, free_bytes=free + 1,
+                                   budget_fraction=0.5) == 'dense-eigh'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_local_pca_auto_engine.py
+++ b/tests/test_local_pca_auto_engine.py
@@ -1,0 +1,122 @@
+"""Tests for ``engine='auto'`` in ``local_pca``.
+
+The auto-selector picks between ``'dense-eigh'`` (faster but holds the whole
+Gram stack on the GPU) and ``'streaming-dense'`` (bounded memory, ~2x slower
+per window) based on the estimated Gram-stack peak vs free GPU memory.
+"""
+
+import numpy as np
+import pytest
+
+from pg_gpu import HaplotypeMatrix
+from pg_gpu.decomposition import (
+    _estimate_n_windows,
+    _pick_dense_engine,
+    local_pca,
+)
+from pg_gpu.windowed_analysis import WindowParams
+
+
+@pytest.fixture
+def small_hm():
+    rng = np.random.default_rng(0)
+    n_hap = 20
+    n_var = 600
+    hap = rng.integers(0, 2, (n_hap, n_var), dtype=np.int8)
+    pos = np.arange(n_var, dtype=np.int64) * 1000
+    return HaplotypeMatrix(hap, pos, 0, n_var * 1000)
+
+
+# ---------------------------------------------------------------------------
+# _estimate_n_windows
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateNWindows:
+
+    def test_snp_windows_exact(self, small_hm):
+        # 600 variants, window=100, step=100 -> 6 windows.
+        params = WindowParams(window_type='snp', window_size=100, step_size=100)
+        assert _estimate_n_windows(small_hm, params) == 6
+
+    def test_snp_windows_with_overlap(self, small_hm):
+        # 600 variants, window=100, step=50 -> floor((600-100)/50)+1 = 11.
+        params = WindowParams(window_type='snp', window_size=100, step_size=50)
+        assert _estimate_n_windows(small_hm, params) == 11
+
+    def test_snp_window_larger_than_data(self, small_hm):
+        params = WindowParams(window_type='snp', window_size=10_000, step_size=10_000)
+        assert _estimate_n_windows(small_hm, params) == 0
+
+    def test_bp_windows_upper_bound(self, small_hm):
+        # positions span 0..599_000 with step_size=100_000 -> ceil-ish bound.
+        params = WindowParams(window_type='bp', window_size=100_000, step_size=100_000)
+        n = _estimate_n_windows(small_hm, params)
+        # The bound is span // step + 1 = 599_000 // 100_000 + 1 = 6.
+        assert n == 6
+
+
+# ---------------------------------------------------------------------------
+# _pick_dense_engine
+# ---------------------------------------------------------------------------
+
+
+class TestPickDenseEngine:
+    """Pure-function tests with synthetic free_bytes — no real GPU memory state."""
+
+    def test_picks_dense_eigh_when_stack_fits(self, small_hm):
+        params = WindowParams(window_type='snp', window_size=100, step_size=100)
+        # 6 windows * 20^2 * 8 = 19_200 bytes. peak = 3x = 57_600. Plenty of room.
+        engine = _pick_dense_engine(small_hm, params, free_bytes=10**9)
+        assert engine == 'dense-eigh'
+
+    def test_picks_streaming_when_stack_exceeds_budget(self, small_hm):
+        params = WindowParams(window_type='snp', window_size=100, step_size=100)
+        # Force tiny "free" memory so the budget can't accommodate even a tiny stack.
+        engine = _pick_dense_engine(small_hm, params, free_bytes=10_000)
+        assert engine == 'streaming-dense'
+
+    def test_picks_dense_eigh_for_zero_window_estimate(self, small_hm):
+        # Window larger than the data -> 0 windows. dense-eigh handles this fine.
+        params = WindowParams(window_type='snp', window_size=10_000, step_size=10_000)
+        engine = _pick_dense_engine(small_hm, params, free_bytes=10_000)
+        assert engine == 'dense-eigh'
+
+    def test_threshold_boundary(self, small_hm):
+        # Construct free_bytes so that peak == budget_fraction * free_bytes
+        # exactly; the strict-less-than comparison should pick streaming.
+        params = WindowParams(window_type='snp', window_size=100, step_size=100)
+        n_windows = _estimate_n_windows(small_hm, params)
+        peak = 3 * n_windows * small_hm.num_haplotypes ** 2 * 8
+        # peak < 0.5 * free  iff  free > 2 * peak. Set free = 2 * peak: NOT less than.
+        free = 2 * peak
+        assert _pick_dense_engine(small_hm, params, free_bytes=free) == 'streaming-dense'
+        # Bump free up by a margin: now strictly less than -> dense-eigh.
+        assert _pick_dense_engine(small_hm, params, free_bytes=free + 1) == 'dense-eigh'
+
+
+# ---------------------------------------------------------------------------
+# Integration: engine='auto' produces the same numerics as the engine it picks.
+# ---------------------------------------------------------------------------
+
+
+class TestAutoEngineIntegration:
+
+    def test_auto_matches_dense_eigh_on_small_workload(self, small_hm):
+        # Small workload always picks dense-eigh on any reasonable GPU.
+        # Auto must produce bit-identical output to an explicit dense-eigh call.
+        explicit = local_pca(small_hm, window_size=100, window_type='snp', k=2,
+                              engine='dense-eigh')
+        auto = local_pca(small_hm, window_size=100, window_type='snp', k=2,
+                          engine='auto')
+        np.testing.assert_array_equal(auto.eigvals, explicit.eigvals)
+        np.testing.assert_array_equal(auto.sumsq, explicit.sumsq)
+
+    def test_auto_rejects_unknown_engine(self, small_hm):
+        with pytest.raises(ValueError, match="engine must be one of"):
+            local_pca(small_hm, window_size=100, window_type='snp', k=2,
+                       engine='bogus')
+
+    def test_auto_is_a_valid_engine(self, small_hm):
+        # Should not raise.
+        local_pca(small_hm, window_size=100, window_type='snp', k=2, engine='auto')

--- a/tests/test_local_pca_streaming.py
+++ b/tests/test_local_pca_streaming.py
@@ -461,3 +461,83 @@ class TestLostructStreamingEndToEnd:
         legacy_set = set(map(tuple, np.sort(legacy.corner_indices, axis=0).T))
         new_set = set(map(tuple, np.sort(new.corner_indices, axis=0).T))
         assert legacy_set == new_set
+
+
+# ---------------------------------------------------------------------------
+# Issue #91 regression: per-window output host syncs must not return
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingHostSyncCount:
+    """The streaming dispatcher must NOT issue per-window host transfers
+    for its three outputs (eigvals / eigvecs / sumsq). Issue #91:
+    per-window ``cp.asnumpy(...)`` calls saturated host CPU on whole-
+    genome scans. The fix routes per-window outputs into GPU-resident
+    buffers and does a single bulk ``.get()`` after the loop; this test
+    pins that invariant.
+
+    The dispatcher path also includes pre-existing infrastructure host
+    syncs that are NOT part of issue #91 -- ``WindowIterator.get_subset``
+    does an ``.all()`` bounds check (2 transfers/window) and
+    ``_prepare_matrix`` does a has-missing check (1 transfer/window).
+    Plus 1 fixed transfer from iterator init and 3 fixed bulk transfers
+    at the end of the dispatcher. So the post-fix expected rate is
+    3 transfers/window + ~4 fixed = ~3.4 per window for the
+    ``structured_hm`` fixture (10 windows).
+
+    A regression that re-introduces even ONE of the three per-window
+    output syncs would push the rate to >=4 per window; restoring all
+    three would push it to ~6.4 per window. Either case fails the
+    3.5-per-window assertion below.
+
+    If the unrelated infrastructure syncs in ``get_subset`` /
+    ``_prepare_matrix`` are later optimized away, the post-fix rate
+    drops further and this test still passes.
+    """
+
+    def test_dispatcher_per_window_output_transfers_stay_constant(
+            self, structured_hm, monkeypatch):
+        import cupy as cp
+
+        n_get = {"calls": 0}
+        n_asnumpy = {"calls": 0}
+
+        real_get = cp.ndarray.get
+        real_asnumpy = cp.asnumpy
+
+        def counted_get(self, *a, **kw):
+            n_get["calls"] += 1
+            return real_get(self, *a, **kw)
+
+        def counted_asnumpy(arr, *a, **kw):
+            n_asnumpy["calls"] += 1
+            return real_asnumpy(arr, *a, **kw)
+
+        monkeypatch.setattr(cp.ndarray, "get", counted_get)
+        monkeypatch.setattr(cp, "asnumpy", counted_asnumpy)
+
+        try:
+            res = local_pca(structured_hm, window_size=300,
+                             window_type='snp', k=2,
+                             engine='streaming-dense')
+        except TypeError:
+            pytest.skip("engine= kwarg not yet implemented")
+
+        assert res.n_windows >= 5, (
+            "fixture must have >=5 windows for this ratio test to be meaningful")
+
+        total = n_get["calls"] + n_asnumpy["calls"]
+        per_window = total / res.n_windows
+
+        # Pre-fix would be ~6.4/window; partial regression (one output
+        # sync re-introduced) is ~4.4/window. Current post-fix is
+        # ~3.4/window. Set the ceiling at 3.5 to catch both partial
+        # and full regressions while leaving room for the infrastructure
+        # syncs the dispatcher legitimately performs.
+        assert per_window <= 3.5, (
+            f"streaming dispatcher made {total} host transfers "
+            f"({n_get['calls']} .get(), {n_asnumpy['calls']} cp.asnumpy) "
+            f"over {res.n_windows} windows -- {per_window:.2f}/window "
+            f"is above the 3.5/window ceiling. Regression of issue #91? "
+            f"Per-window output syncs (eigvals/eigvecs/sumsq) should be "
+            f"O(1) total, not O(n_windows).")


### PR DESCRIPTION
## Summary
- Eliminates per-window `cp.asnumpy(...)` host syncs in `_local_pca_streaming` by accumulating eigvals/eigvecs/sumsq as GPU tensors and doing a single bulk `.get()` after the loop. Fixes #91.
- Adds `engine='auto'` (opt-in) that estimates the Gram-stack peak and picks `dense-eigh` when it fits in 70% of free GPU memory, `streaming-dense` otherwise. Default engine stays `dense-eigh` so existing behavior is unchanged.
- Adds a regression test that pins the streaming dispatcher to ~O(1) output host transfers (3.4/window observed; ceiling 3.5/window).
- Adds a synthetic benchmark script and a new test file for the auto-selector.

## Numbers (200 hap, 200-SNP windows, single A100)

| | 6k windows | 15k windows |
|---|---|---|
| streaming-dense (pre-fix) | 23.99 s | 57.95 s |
| streaming-dense (post-fix) | 22.80 s (-5.0%) | 54.60 s (-5.8%) |
| dense-eigh (legacy) | 10.30 s | 26.03 s |

The 5–6% streaming improvement reflects ~200 us/window saved by removing the per-window host sync chain. The dense-eigh path is ~2x faster wherever it fits in GPU memory; `engine='auto'` will route there automatically.

## Test plan
- [x] `pixi run pytest tests/test_local_pca_streaming.py -v` — 17/17 pass (16 pre-existing + new host-sync regression test)
- [x] `pixi run pytest tests/test_local_pca.py tests/test_local_pca_parity.py -v` — 39 pass + 1 skipped (rpy2)
- [x] `pixi run pytest tests/test_local_pca_auto_engine.py -v` — 11/11 pass
- [x] `pixi run ruff check pg_gpu/decomposition.py tests/test_local_pca_auto_engine.py debug/bench_local_pca_streaming.py`
- [x] `pixi run python debug/bench_local_pca_streaming.py` confirms wall-clock improvement