### PR TITLE
fix(lint): noqa E402 for importorskip-then-import pattern

### DIFF
--- a/tests/test_local_pca_streaming.py
+++ b/tests/test_local_pca_streaming.py
@@ -43,8 +43,8 @@ import pytest
 
 cupy = pytest.importorskip("cupy")
 
-from pg_gpu import HaplotypeMatrix
-from pg_gpu.decomposition import (
+from pg_gpu import HaplotypeMatrix  # noqa: E402
+from pg_gpu.decomposition import (  # noqa: E402
     LocalPCAResult,
     local_pca,
     lostruct,


### PR DESCRIPTION
## Summary
- Adds `# noqa: E402` to the two module-level imports at `tests/test_local_pca_streaming.py:46-47` that legitimately follow `pytest.importorskip("cupy")`. This pattern requires the importorskip to come first so the whole test file is skipped on CPU-only runners; without the noqa, ruff E402 trips CI Lint.

These errors were pre-existing on main (visible in CI failures back to PR #89) but went unfixed; they were the lint failure called out after #92.

## Test plan
- [x] `pixi run ruff check pg_gpu/ tests/ examples/` is now clean
- [x] `pixi run pytest tests/test_local_pca_streaming.py -v` — 17/17 still pass