### PR TITLE
Revising the Examples

### DIFF
--- a/docs/source/tutorials/accessibility_mask.rst
+++ b/docs/source/tutorials/accessibility_mask.rst
@@ -42,7 +42,7 @@ known, then verifies that the mask recovers it:
 
 1. Simulate a 1 Mb chromosome under ``msprime`` with a 200 kb central
    block of 100x lower mutation rate -- a stand-in for a low-callability
-   exon. The genealogy is identical inside and outside the block, so
+   region. The genealogy is identical inside and outside the block, so
    the per-site pattern of coalescence is the same; only the *probability of
    observing* a mutation differs. Outside the block, per-bp
    diversity is :math:`4 N_e \mu_{\text{high}}`.
@@ -69,7 +69,7 @@ looks lower even though the genealogy is unchanged. With the mask:
 Why it's useful as a template
 -----------------------------
 
-The lesson generalizes beyond simulated exons. Any region where the
+This example is applicable to any region where the
 *probability of observing variation* differs from the surrounding
 genome (repeat masks, low-coverage regions, hard-to-map duplications,
 centromeres) biases per-bp summary statistics unless the denominator

--- a/docs/source/tutorials/admixture_detection.rst
+++ b/docs/source/tutorials/admixture_detection.rst
@@ -52,7 +52,8 @@ What the script does
 
 The expected (and observed) outcome: the null scenario's CI brackets
 zero, while the admixed scenario's CI excludes zero with a clearly
-positive :math:`\hat D` consistent with :math:`C \to B` gene flow.
+negative :math:`\hat D` consistent with :math:`C \to B` gene flow.
+Also, you can see the per-block :math:`D` distribution is shifted to the left (more negative values) in the admixed scenario, showing the genome-wide signal of admixture.
 
 Why it's useful as a template
 -----------------------------

--- a/docs/source/tutorials/moments_integration.rst
+++ b/docs/source/tutorials/moments_integration.rst
@@ -45,7 +45,7 @@ A100 is under five minutes -- on the same hardware, the CPU
 Recipe
 ------
 
-The core swap looks like:
+The core change between a ``moments.LD`` workflow and a ``pg_gpu``-accelerated workflow is:
 
 .. code-block:: python
 
@@ -54,7 +54,7 @@ The core swap looks like:
 
    r_bins = [0, 1e-6, 2e-6, 5e-6, 1e-5, 2e-5, 5e-5, 1e-4]
 
-   # Step 1: GPU-accelerated LD parsing (the only line that changes
+   # Step 1: GPU-accelerated LD parsing (the only part that changes
    # vs. a pure-moments workflow).
    ld_stats = {}
    for i, vcf in enumerate(vcf_files):

--- a/examples/sweep_tajimas_d_bootstrap.py
+++ b/examples/sweep_tajimas_d_bootstrap.py
@@ -74,8 +74,8 @@ def _simulate(n_diploids: int, s: float, seed: int):
     ts = msprime.sim_mutations(ts, rate=MU, random_seed=seed)
     hap = ts.genotype_matrix().T.astype(np.int8)
     positions = ts.tables.sites.position.astype(np.int64)
-    # Msprime can simulate multiple mutations at the same position, so here we are enforcing unique positions by shifting any non-ascending positions to the right. 
-    # In real data, this would be a multi-allelic site, and the VCF format allows representing it as a single site with multiple alternate alleles. 
+    # Msprime can simulate multiple mutations at the same position, so here we are enforcing unique positions by shifting any non-ascending positions to the right.
+    # In real data, this would be a multi-allelic site, and the VCF format allows representing it as a single site with multiple alternate alleles.
     # Though the HaplotypeMatrix can also represent multi-allelic sites, for simplicity we are treating them as separate biallelic sites here.
     for i in range(1, len(positions)):
         if positions[i] <= positions[i - 1]:

--- a/examples/sweep_tajimas_d_bootstrap.py
+++ b/examples/sweep_tajimas_d_bootstrap.py
@@ -74,6 +74,9 @@ def _simulate(n_diploids: int, s: float, seed: int):
     ts = msprime.sim_mutations(ts, rate=MU, random_seed=seed)
     hap = ts.genotype_matrix().T.astype(np.int8)
     positions = ts.tables.sites.position.astype(np.int64)
+    # Msprime can simulate multiple mutations at the same position, so here we are enforcing unique positions by shifting any non-ascending positions to the right. 
+    # In real data, this would be a multi-allelic site, and the VCF format allows representing it as a single site with multiple alternate alleles. 
+    # Though the HaplotypeMatrix can also represent multi-allelic sites, for simplicity we are treating them as separate biallelic sites here.
     for i in range(1, len(positions)):
         if positions[i] <= positions[i - 1]:
             positions[i] = positions[i - 1] + 1


### PR DESCRIPTION
I carefully reviewed and ran all the Example scripts.

Here are my main changes:
- Fix a factual error in admixture_detection doc: the expected D under gene flow is negative, not positive. Also adds a sentence noting the leftward shift in the per-block D distribution due to genome-wide admix.
- Tighten wording in accessibility_mask: "exon" → "region" (the simulated block is a generic low-callability region, not specifically an exon
- Make explicit that the change is between a moments.LD workflow and a pg_gpu-accelerated one; fix "only line" → "only part" to match the actual multi-line loop.
- Add comments to examples/sweep_tajimas_d_bootstrap.py explaining why duplicate positions are shifted.

One thing that needs to be dealt with still:
- [ ] The full dataset hard-coded in the scikit-allel vs pg-gpu script does not exist (`gamb.X.phased.n100.zarr`)