### PR TITLE
Transparent biobank-scale zarr streaming for HaplotypeMatrix and GenotypeMatrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,19 @@ Interactive walkthrough: [examples/pg_gpu_tour.ipynb](examples/pg_gpu_tour.ipynb
 
 | Category | Functions |
 |----------|-----------|
-| Diversity | `pi`, `theta_w`, `theta_h`, `theta_l`, `tajimas_d`, `fay_wus_h`, `zeng_e`, `segregating_sites`, `singleton_count` |
-| Divergence | `fst_hudson`, `fst_weir_cockerham`, `fst_nei`, `dxy`, `da`, `pbs`, `snn`, `gmin`, `dd`, `dd_rank`, `zx` |
-| SFS | `sfs`, `sfs_folded`, `joint_sfs`, `joint_sfs_folded` |
-| Selection | `ihs`, `nsl`, `xpehh`, `xpnsl`, `garud_h`, `ehh_decay` |
-| LD | `dd`, `dz`, `pi2`, `r_squared`, `zns`, `omega` |
-| Admixture | `patterson_f2`, `patterson_f3`, `patterson_d` |
-| Decomposition | `pca`, `randomized_pca`, `pairwise_distance` |
+| Diversity | `pi`, `theta_w`, `theta_h`, `theta_l`, `tajimas_d`, `fay_wus_h`, `normalized_fay_wus_h`, `zeng_e`, `zeng_dh`, `segregating_sites`, `singleton_count`, `haplotype_diversity`, `haplotype_count`, `heterozygosity_expected`, `heterozygosity_observed`, `inbreeding_coefficient`, `allele_frequency_spectrum`, `max_daf`, `daf_histogram`, `diplotype_frequency_spectrum`, `diversity_stats` |
+| Divergence | `fst_hudson`, `fst_weir_cockerham`, `fst_nei`, `dxy`, `da`, `pbs`, `pairwise_fst` |
+| Distance-based two-pop | `snn`, `dxy_min`, `gmin`, `dd`, `dd_rank`, `zx` |
+| Distance moments | `pairwise_diffs`, `dist_var`, `dist_skew`, `dist_kurt`, `dist_moments` |
+| Selection scans | `ihs`, `nsl`, `xpehh`, `xpnsl`, `garud_h`, `moving_garud_h`, `ehh_decay` |
+| LD | `r`, `r_squared`, `dd` (LD), `dz`, `pi2`, `zns`, `omega`, `mu_ld` |
+| SFS | `sfs`, `sfs_folded`, `sfs_scaled`, `sfs_folded_scaled`, `joint_sfs`, `joint_sfs_folded`, `joint_sfs_scaled`, `joint_sfs_folded_scaled`, `project_joint_sfs`, `fold_sfs`, `fold_joint_sfs` |
+| Admixture / F-stats | `patterson_f2`, `patterson_f3`, `patterson_d`, `moving_patterson_f3`, `moving_patterson_d`, `average_patterson_f3`, `average_patterson_d` |
+| Resampling | `block_jackknife`, `block_bootstrap` |
+| Decomposition | `pca`, `randomized_pca`, `pairwise_distance`, `pcoa`, `local_pca`, `local_pca_jackknife`, `pc_dist`, `corners` |
 | Relatedness | `grm`, `ibs` |
+| Windowed pipeline | `windowed_analysis` — fused GPU windowing for any of the above |
+| Biobank-scale streaming | `HaplotypeMatrix.from_zarr(streaming='always')` walks VCZ stores chunk by chunk; every per-window / SFS / LD / pairwise relatedness statistic dispatches transparently. See [tutorials/biobank_streaming](https://pg-gpu.readthedocs.io/en/latest/tutorials/biobank_streaming.html). |
 
 ## Development
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -17,6 +17,47 @@ GenotypeMatrix
    :undoc-members:
    :show-inheritance:
 
+Biobank-Scale Streaming
+-----------------------
+
+For VCZ stores that do not fit on the GPU eagerly,
+``HaplotypeMatrix.from_zarr`` / ``GenotypeMatrix.from_zarr`` can
+return a streaming view (``streaming='always'``, or
+``streaming='auto'`` with a too-large eager footprint). The streaming
+object iterates the chromosome chunk by chunk through every kernel
+that accepts an eager matrix; see :doc:`tutorials/biobank_streaming`
+for the end-to-end pattern.
+
+.. autoclass:: pg_gpu.streaming_matrix.StreamingHaplotypeMatrix
+   :members: iter_gpu_chunks, materialize, num_haplotypes, num_variants,
+             chrom, chrom_start, chrom_end, sample_sets, align_bp,
+             compute_ld_statistics_gpu_single_pop,
+             compute_ld_statistics_gpu_two_pops
+   :show-inheritance:
+
+.. autoclass:: pg_gpu.streaming_matrix.StreamingGenotypeMatrix
+   :members: iter_gpu_chunks, materialize, num_individuals, num_variants,
+             chrom, chrom_start, chrom_end, sample_sets, align_bp
+   :show-inheritance:
+
+.. autoclass:: pg_gpu.zarr_source.ZarrGenotypeSource
+   :members: slice_region, slice_region_gpu, slice_subsample,
+             slice_subsample_gpu, iter_chunks
+   :show-inheritance:
+
+.. autoclass:: pg_gpu.streaming_matrix.KvikioChunkFetcher
+   :members: iter_chunks, close
+   :show-inheritance:
+
+.. autoclass:: pg_gpu.streaming_matrix.HostChunkFetcher
+   :members: iter_chunks
+   :show-inheritance:
+
+.. autoclass:: pg_gpu.BiobankScaleWarning
+   :show-inheritance:
+
+.. autofunction:: pg_gpu.zarr_io.allel_zarr_to_vcz
+
 LD Statistics
 -------------
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -20,13 +20,16 @@ GenotypeMatrix
 Biobank-Scale Streaming
 -----------------------
 
-For VCZ stores that do not fit on the GPU eagerly,
-``HaplotypeMatrix.from_zarr`` / ``GenotypeMatrix.from_zarr`` can
-return a streaming view (``streaming='always'``, or
-``streaming='auto'`` with a too-large eager footprint). The streaming
-object iterates the chromosome chunk by chunk through every kernel
-that accepts an eager matrix; see :doc:`tutorials/biobank_streaming`
-for the end-to-end pattern.
+A *VCZ store* is bio2zarr's Zarr-on-disk encoding of a VCF: the
+genotype matrix is split into compressed chunks, each chunk a small
+array of samples by variants. For VCZ stores that do not fit
+entirely in GPU memory, ``HaplotypeMatrix.from_zarr`` /
+``GenotypeMatrix.from_zarr`` can return a streaming view
+(``streaming='always'``, or ``streaming='auto'`` with a too-large
+projected footprint). The streaming object iterates the chromosome
+chunk by chunk through every kernel that accepts a fully loaded
+matrix; see :doc:`tutorials/biobank_streaming` for the end-to-end
+pattern and the VCF-to-VCZ conversion step.
 
 .. autoclass:: pg_gpu.streaming_matrix.StreamingHaplotypeMatrix
    :members: iter_gpu_chunks, materialize, num_haplotypes, num_variants,
@@ -53,7 +56,7 @@ for the end-to-end pattern.
    :members: iter_chunks
    :show-inheritance:
 
-.. autoclass:: pg_gpu.BiobankScaleWarning
+.. autoclass:: pg_gpu.MemoryLimitedWarning
    :show-inheritance:
 
 .. autofunction:: pg_gpu.zarr_io.allel_zarr_to_vcz

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -206,6 +206,7 @@ Joint (Two-Population)
 .. autofunction:: pg_gpu.sfs.joint_sfs_folded
 .. autofunction:: pg_gpu.sfs.joint_sfs_scaled
 .. autofunction:: pg_gpu.sfs.joint_sfs_folded_scaled
+.. autofunction:: pg_gpu.sfs.project_joint_sfs
 
 Scaling and Folding Utilities
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -29,7 +29,8 @@ entirely in GPU memory, ``HaplotypeMatrix.from_zarr`` /
 projected footprint). The streaming object iterates the chromosome
 chunk by chunk through every kernel that accepts a fully loaded
 matrix; see :doc:`tutorials/biobank_streaming` for the end-to-end
-pattern and the VCF-to-VCZ conversion step.
+pattern and the VCF-to-VCZ conversion step. The reader requires
+diploid genotypes; haploid and polyploid stores are rejected.
 
 .. autoclass:: pg_gpu.streaming_matrix.StreamingHaplotypeMatrix
    :members: iter_gpu_chunks, materialize, num_haplotypes, num_variants,

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -411,6 +411,35 @@ Distance Distribution Statistics
      - Variance, skewness, and kurtosis in one call
      - Schrider et al. (2018)
 
+Biobank-Scale Streaming
+-----------------------
+
+VCZ stores too large for the GPU eagerly (tens to hundreds of
+thousands of haplotypes) open via ``HaplotypeMatrix.from_zarr`` /
+``GenotypeMatrix.from_zarr`` as a streaming view that walks the
+chromosome chunk by chunk. Every per-chunk-reducible kernel below
+dispatches transparently on the streaming object -- the calling code
+is identical to the eager path. See :doc:`tutorials/biobank_streaming`.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Entry point
+     - Streaming behavior
+   * - ``windowed_analysis``
+     - Per-chunk dispatch + row-concat; window grids are aligned to the chunk grid.
+   * - ``sfs.sfs``, ``sfs.joint_sfs``, ``sfs.sfs_folded``, ``sfs.joint_sfs_folded``
+     - Per-chunk SFS bincount, summed across chunks.
+   * - ``HaplotypeMatrix.compute_ld_statistics_gpu_single_pop`` / ``_two_pops``
+     - Per-chunk pair-bin sums with a tail-buffer that captures pairs straddling chunk boundaries exactly once. Returns moments-LD DD, Dz, pi² (3 stats single-pop, 15 stats two-pop).
+   * - ``relatedness.ibs``, ``relatedness.grm``
+     - Variant-axis streamed; individual axis tiled into row blocks. ``(n_ind, n_ind)`` accumulators live on host so the output can exceed GPU memory. ``grm`` is two-pass (chromosome-wide allele frequencies, then per-chunk standardized outer product).
+   * - ``StreamingHaplotypeMatrix.materialize(region, sample_subset)``
+     - Sub-region eager build for kernels that need every variant simultaneously (``pairwise_r2``, Garud H, custom recipes). At biobank scale the sample-subset read decompresses directly to the GPU via kvikio + nvCOMP.
+   * - ``zarr_io.allel_zarr_to_vcz``
+     - Streaming converter from scikit-allel layout to VCZ for stores that pre-date bio2zarr.
+
 Fused Windowed Statistics
 -------------------------
 

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -414,29 +414,44 @@ Distance Distribution Statistics
 Biobank-Scale Streaming
 -----------------------
 
-VCZ stores too large for the GPU eagerly (tens to hundreds of
-thousands of haplotypes) open via ``HaplotypeMatrix.from_zarr`` /
+A *VCZ store* is a Zarr-on-disk encoding of a VCF: the genotype
+matrix is split into compressed chunks, each chunk a small array of
+samples by variants. ``pg_gpu`` reads VCZ stores; if your data
+is in VCF you can convert it with the bio2zarr tools
+(``vcf2zarr explode`` then ``vcf2zarr encode``). The streaming
+codepath needs that VCZ layout because it relies on per-chunk
+decode -- a VCF row-text dump can't be sliced or decompressed
+chunk-wise the way zarr can. See
+:doc:`tutorials/biobank_streaming` for the VCF→VCZ conversion
+and a worked end-to-end example.
+
+A VCZ store too large for the GPU (tens to hundreds of thousands
+of haplotypes) opens via ``HaplotypeMatrix.from_zarr`` /
 ``GenotypeMatrix.from_zarr`` as a streaming view that walks the
-chromosome chunk by chunk. Every per-chunk-reducible kernel below
-dispatches transparently on the streaming object -- the calling code
-is identical to the eager path. See :doc:`tutorials/biobank_streaming`.
+chromosome chunk by chunk; every kernel listed below dispatches
+on the streaming object the same way it would on a fully loaded
+matrix -- the calling code is identical to the in-memory path.
+
+What runs on a streaming matrix:
 
 .. list-table::
    :header-rows: 1
    :widths: 35 65
 
    * - Entry point
-     - Streaming behavior
+     - How it streams
    * - ``windowed_analysis``
-     - Per-chunk dispatch + row-concat; window grids are aligned to the chunk grid.
+     - Each chunk's windows are computed on the GPU as the chunk arrives, then rows are concatenated; window grids are aligned to the chunk grid so no window straddles a chunk boundary.
    * - ``sfs.sfs``, ``sfs.joint_sfs``, ``sfs.sfs_folded``, ``sfs.joint_sfs_folded``
-     - Per-chunk SFS bincount, summed across chunks.
+     - Each chunk contributes its own per-site frequency-spectrum counts; the chromosome-wide answer is the sum across chunks.
+   * - ``sfs.project_joint_sfs``
+     - Same per-chunk accumulation, but the joint SFS is projected (via hypergeometric sampling) to a small target grid as it is built, so the full ``(n1+1, n2+1)`` histogram is never materialized.
    * - ``HaplotypeMatrix.compute_ld_statistics_gpu_single_pop`` / ``_two_pops``
-     - Per-chunk pair-bin sums with a tail-buffer that captures pairs straddling chunk boundaries exactly once. Returns moments-LD DD, Dz, pi² (3 stats single-pop, 15 stats two-pop).
+     - Variant-pair statistics within ``max_bp_dist`` are summed per chunk into the bp bins. Pairs that fall on opposite sides of a chunk boundary would be missed by naive per-chunk sums, so the last ``max_bp_dist`` of one chunk is carried forward and paired with the start of the next, counted exactly once. Returns moments-LD ``DD``, ``Dz``, ``pi²`` (3 stats single-pop, 15 stats two-pop).
    * - ``relatedness.ibs``, ``relatedness.grm``
-     - Variant-axis streamed; individual axis tiled into row blocks. ``(n_ind, n_ind)`` accumulators live on host so the output can exceed GPU memory. ``grm`` is two-pass (chromosome-wide allele frequencies, then per-chunk standardized outer product).
+     - Streamed along the variant axis; the individual axis is tiled into row blocks. ``(n_ind, n_ind)`` accumulators live on host so the output can exceed GPU memory. ``grm`` is a two-pass operation (first to calculate chromosome-wide allele frequencies, second to accumulate a per-chunk outer product).
    * - ``StreamingHaplotypeMatrix.materialize(region, sample_subset)``
-     - Sub-region eager build for kernels that need every variant simultaneously (``pairwise_r2``, Garud H, custom recipes). At biobank scale the sample-subset read decompresses directly to the GPU via kvikio + nvCOMP.
+     - Pulls one sub-region (and optionally a subset of haplotypes) of the chromosome into a fully-loaded matrix on the GPU for kernels that need every variant simultaneously -- ``pairwise_r2``, Garud's H, or any custom recipe. At hundreds of thousands of haplotypes the kvikio + nvCOMP path lets the subset read decompress directly into GPU memory rather than round-tripping the full sample axis through the host.
    * - ``zarr_io.allel_zarr_to_vcz``
      - Streaming converter from scikit-allel layout to VCZ for stores that pre-date bio2zarr.
 

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -414,14 +414,13 @@ Distance Distribution Statistics
 Biobank-Scale Streaming
 -----------------------
 
-A *VCZ store* is a Zarr-on-disk encoding of a VCF: the genotype
+A *VCZ store* is a Zarr encoding of a VCF stored on disk: the genotype
 matrix is split into compressed chunks, each chunk a small array of
 samples by variants. ``pg_gpu`` reads VCZ stores; if your data
 is in VCF you can convert it with the bio2zarr tools
 (``vcf2zarr explode`` then ``vcf2zarr encode``). The streaming
-codepath needs that VCZ layout because it relies on per-chunk
-decode -- a VCF row-text dump can't be sliced or decompressed
-chunk-wise the way zarr can. See
+codepath needs that VCZ layout because it relies ona fast per-chunk
+decode, an opperation that can't be done on a VCF. See
 :doc:`tutorials/biobank_streaming` for the VCF→VCZ conversion
 and a worked end-to-end example.
 
@@ -451,7 +450,7 @@ What runs on a streaming matrix:
    * - ``relatedness.ibs``, ``relatedness.grm``
      - Streamed along the variant axis; the individual axis is tiled into row blocks. ``(n_ind, n_ind)`` accumulators live on host so the output can exceed GPU memory. ``grm`` is a two-pass operation (first to calculate chromosome-wide allele frequencies, second to accumulate a per-chunk outer product).
    * - ``StreamingHaplotypeMatrix.materialize(region, sample_subset)``
-     - Pulls one sub-region (and optionally a subset of haplotypes) of the chromosome into a fully-loaded matrix on the GPU for kernels that need every variant simultaneously -- ``pairwise_r2``, Garud's H, or any custom recipe. At hundreds of thousands of haplotypes the kvikio + nvCOMP path lets the subset read decompress directly into GPU memory rather than round-tripping the full sample axis through the host.
+     - Pulls one sub-region (and optionally a subset of haplotypes) of the chromosome into GPU memory for kernels that need every variant simultaneously -- ``pairwise_r2``, Garud's H, or any custom recipe. 
    * - ``zarr_io.allel_zarr_to_vcz``
      - Streaming converter from scikit-allel layout to VCZ for stores that pre-date bio2zarr.
 

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -419,8 +419,8 @@ matrix is split into compressed chunks, each chunk a small array of
 samples by variants. ``pg_gpu`` reads VCZ stores; if your data
 is in VCF you can convert it with the bio2zarr tools
 (``vcf2zarr explode`` then ``vcf2zarr encode``). The streaming
-codepath needs that VCZ layout because it relies ona fast per-chunk
-decode, an opperation that can't be done on a VCF. See
+codepath needs that VCZ layout because it relies on a fast
+per-chunk decode, an operation that can't be done on a VCF. See
 :doc:`tutorials/biobank_streaming` for the VCF→VCZ conversion
 and a worked end-to-end example.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,6 +36,7 @@ Key Features
 * **Multi-population analyses** with flexible population specification
 * **8 theta estimators and 4 neutrality tests** (pi, theta_w, theta_h, theta_l, eta1, eta1_star, minus_eta1, minus_eta1_star, Tajima's D, Fay-Wu's H, Zeng's E, DH)
 * **Validated against scikit-allel** -- 29 statistics verified at machine precision using real Ag1000G data
+* **Biobank-scale streaming** -- VCZ stores too large to fit on the GPU eagerly open as a streaming view that walks the chromosome chunk by chunk; every per-window / SFS / moments-LD / pairwise relatedness kernel dispatches transparently. See :doc:`tutorials/biobank_streaming`.
 
 Installation
 ------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,7 +36,7 @@ Key Features
 * **Multi-population analyses** with flexible population specification
 * **8 theta estimators and 4 neutrality tests** (pi, theta_w, theta_h, theta_l, eta1, eta1_star, minus_eta1, minus_eta1_star, Tajima's D, Fay-Wu's H, Zeng's E, DH)
 * **Validated against scikit-allel** -- 29 statistics verified at machine precision using real Ag1000G data
-* **Biobank-scale streaming** -- VCZ stores too large to fit on the GPU eagerly open as a streaming view that walks the chromosome chunk by chunk; every per-window / SFS / moments-LD / pairwise relatedness kernel dispatches transparently. See :doc:`tutorials/biobank_streaming`.
+* **Biobank-scale streaming** -- VCZ stores too large to fit on the GPU open as a streaming view that walks the chromosome chunk by chunk; every per-window / SFS / moments-LD / pairwise relatedness kernel dispatches transparently. See :doc:`tutorials/biobank_streaming`.
 
 Installation
 ------------

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -21,6 +21,7 @@ time, see :doc:`examples` instead.
    tutorials/ld_blocks
    tutorials/scikit_allel_comparison
    tutorials/moments_integration
+   tutorials/biobank_streaming
 
 Each tutorial follows the same structure:
 

--- a/docs/source/tutorials/biobank_streaming.rst
+++ b/docs/source/tutorials/biobank_streaming.rst
@@ -93,11 +93,11 @@ functions:
    # Marginal SFS uses the full panel (1D output, fits anywhere).
    sfs_afr = sfs.sfs(stream, population="AFR")
 
-   # Joint SFS at biobank scale: the full (n1+1, n2+1) histogram is
-   # 80 GB at 100k haps per population, so use project_joint_sfs
-   # instead. It applies a hypergeometric projection per variant and
-   # accumulates straight into the small target grid -- every variant
-   # from every haplotype contributes, no subsampling.
+   # Joint SFS: the full (n1+1, n2+1) histogram is 80 GB at 100k haps
+   # per population, so use project_joint_sfs instead. It applies a
+   # hypergeometric projection per variant and accumulates straight
+   # into the small target grid -- every variant from every haplotype
+   # contributes, no subsampling.
    joint_projected = sfs.project_joint_sfs(
        stream, pop1="AFR", pop2="EUR",
        target_n1=200, target_n2=200,

--- a/docs/source/tutorials/biobank_streaming.rst
+++ b/docs/source/tutorials/biobank_streaming.rst
@@ -1,0 +1,182 @@
+Biobank-Scale Streaming from VCZ
+================================
+
+For stores too large to fit on the GPU eagerly -- biobank-scale VCZ
+(bio2zarr) datasets with tens to hundreds of thousands of haplotypes
+-- ``HaplotypeMatrix.from_zarr`` (and ``GenotypeMatrix.from_zarr``)
+returns a *streaming matrix* that walks the chromosome chunk by
+chunk. The streaming object plugs into every scalar / windowed /
+pair-bin / pairwise kernel that already accepts an eager matrix; GPU
+peak memory scales with one chunk, not the chromosome length.
+
+Background
+----------
+
+The eager path materializes the full ``(n_haplotypes, n_variants)``
+haplotype matrix on the GPU before any statistic runs. At biobank
+sample counts the matrix alone is dozens of gigabytes per chromosome
+-- before any working memory for the kernel itself -- and on a 100k-
+diploid store an A100 80 GB will OOM at the load step. Streaming
+solves this by:
+
+* Opening the zarr store as a ``ZarrGenotypeSource`` and probing the
+  on-disk chunking + codec.
+* Returning a ``StreamingHaplotypeMatrix`` (or
+  ``StreamingGenotypeMatrix``) instead of an eager
+  ``HaplotypeMatrix``.
+* Iterating that object yields per-chunk *eager* matrices on the
+  GPU; the next chunk's host read overlaps the current chunk's
+  compute through a producer thread.
+* Per-chunk reducible statistics (windowed diversity / divergence /
+  Garud H, SFS, joint SFS, moments-LD pair bins) are *dispatched
+  through the existing function names* -- you do not write a chunk
+  loop yourself.
+* Cross-window or pairwise kernels (``pairwise_r2``,
+  per-individual-pair distance, custom recipes that need every
+  variant simultaneously) get a sub-region eager matrix via
+  ``streaming_matrix.materialize(region=..., sample_subset=...)``
+  and run on that.
+
+The store layout that gets the on-GPU codec decode path is
+*bio2zarr-style sample chunking* (small enough chunks on the sample
+axis that each chunk fits in a kvikio + nvCOMP decompression buffer).
+A store whose sample axis is one chunk falls back to the host fetcher
+with a one-time ``BadlyChunkedWarning``; everything else still works.
+
+When ``HaplotypeMatrix.from_zarr`` returns a streaming object
+--------------------------------------------------------------
+
+``streaming='auto'`` (the default) picks based on whether the eager
+matrix fits in roughly half the free GPU memory. ``streaming='always'``
+forces it; ``streaming='never'`` forces eager. The streaming object
+is a drop-in for the eager class for every kernel below -- the
+calling code is the same.
+
+.. code-block:: python
+
+   from pg_gpu import HaplotypeMatrix, windowed_analysis, sfs
+   from pg_gpu.relatedness import ibs, grm
+
+   stream = HaplotypeMatrix.from_zarr(
+       "biobank/chr15.vcz",
+       streaming="always",
+       chunk_bp=500_000,         # genomic chunk size (default auto)
+       prefetch=1,               # read-ahead depth (0 disables)
+       pop_file="biobank/chr15.pops.tsv",   # optional sample -> pop TSV
+   )
+
+   # Per-window diversity + divergence: one streaming pass per call.
+   df = windowed_analysis(stream, window_size=100_000, step_size=100_000,
+                          statistics=["pi", "theta_w", "tajimas_d",
+                                       "fst", "dxy"],
+                          populations=["AFR", "EUR"])
+
+   # Marginal + joint SFS: per-chunk reduction.
+   sfs_afr = sfs.sfs(stream, population="AFR")
+   joint   = sfs.joint_sfs(stream, pop1=list(stream.sample_sets["AFR"][:200]),
+                                   pop2=list(stream.sample_sets["EUR"][:200]))
+
+   # moments-LD bin sums with tail-buffer cross-chunk pair handling.
+   ld = stream.compute_ld_statistics_gpu_two_pops(
+       bp_bins=[0, 1_000, 10_000, 100_000], pop1="AFR", pop2="EUR",
+   )
+
+   # Pairwise relatedness: variant axis streamed, (n_ind, n_ind)
+   # accumulators on host so the output can exceed GPU memory.
+   ibs_mat = ibs(stream)
+   grm_mat = grm(stream)
+
+The same code on an eager ``HaplotypeMatrix`` (small store) runs
+unchanged -- the only difference is which class ``from_zarr`` returns.
+
+Sub-region eager builds for pairwise kernels
+--------------------------------------------
+
+A pairwise-r² heatmap, a Garud's H hash table, or a per-individual-pair
+distance over an entire chromosome would not fit eagerly at biobank
+scale, but a single 1 Mb sub-region with a haplotype subsample does:
+
+.. code-block:: python
+
+   # Pull a 1 Mb region restricted to 5,000 haplotypes from one pop.
+   region = (50_000_000, 51_000_000)
+   subsample = list(stream.sample_sets["AFR"][:5_000])
+   eager = stream.materialize(region=region, sample_subset=subsample)
+
+   # Run any pairwise kernel on the eager view.
+   r2 = eager.pairwise_r2()
+
+``materialize(sample_subset=...)`` routes the read through
+``slice_subsample_gpu`` when the streaming source uses the kvikio
+backend -- the (variants × subsample × 2) call_genotype block is
+decompressed directly on the GPU rather than going through zarr's
+sync host-side ``oindex``. At biobank scale this drops a 5 Mb / 10 k-
+haplotype probe from ~170 s to ~3 s.
+
+Converting a scikit-allel store
+-------------------------------
+
+Empirical biobank data often arrives in scikit-allel zarr layout
+(``calldata/GT``, ``variants/POS``, ``samples``) -- e.g. the
+Ag1000G ``AgamP3.phased.zarr`` release. ``pg_gpu.zarr_io.allel_zarr_to_vcz``
+streams the source in variant blocks (so the conversion does not
+materialize the full matrix) and writes a VCZ store with
+bio2zarr-style sample chunking the streaming reader can consume:
+
+.. code-block:: python
+
+   from pg_gpu.zarr_io import allel_zarr_to_vcz
+
+   allel_zarr_to_vcz(
+       "AgamP3.phased.zarr",          # scikit-allel layout
+       "AgamP3.phased.3R.vcz",        # output VCZ
+       contig="3R",                    # required for grouped allel stores
+       region="3R:1_000_000-2_000_000",  # optional sub-range
+       variant_chunk=10_000, sample_chunk=1_000,
+   )
+
+The resulting store is what ``HaplotypeMatrix.from_zarr`` opens for
+streaming.
+
+Storage and host RAM footprints
+-------------------------------
+
+* A 100 k-diploid / 11.6 M-variant chr15 store at zstd-compressed
+  bio2zarr chunking lives on disk at ~8 GB; the same chromosome
+  uncompressed is ~2.3 TB. Streaming reads the compressed bytes from
+  disk and decompresses one chunk at a time into ~12 GB GPU memory.
+* The producer thread holds one extra decompressed chunk in host RAM
+  (~12 GB for the parameters above), so peak host = ``(prefetch + 1)
+  * chunk_bytes``. ``prefetch=0`` disables the read-ahead and reads
+  serially.
+* The ``(n_ind, n_ind)`` outputs of ``ibs`` and ``grm`` live on host
+  as numpy arrays. At 50 k diploids that is ~20 GB of host RAM for
+  ``grm``; ``ibs`` carries three such accumulators (~60 GB). The
+  ``block_size=`` kwarg controls how many rows of the output are
+  resident on the GPU at a time.
+
+End-to-end paper example
+------------------------
+
+A complete biobank-scale scan -- per-window diversity + divergence
+at three scales, marginal + joint SFS, Garud's H per pop, moments-LD
+decay across probe regions, and a pairwise-r² heatmap of a 1 Mb
+sub-region -- ships as
+``06_simulated_genome_scan/scripts/genome_scan_ooa.py`` in the
+companion paper-analysis repository. On chr15 from ``stdpopsim``
+``OutOfAfrica_2T12`` simulated at 50 k diploids per population (200 k
+haplotypes, 11.6 M variants, 7.9 GB on disk) the script completes
+in ~16 minutes on a single A100 80 GB.
+
+When streaming is not what you want
+-----------------------------------
+
+* The data already fits on the GPU eagerly. ``streaming='auto'``
+  picks eager automatically; the eager path is faster per call
+  because there is no per-chunk dispatch overhead.
+* The kernel needs every variant simultaneously and the chromosome
+  cannot be partitioned (e.g. a chromosome-wide pairwise r² heatmap
+  on the full sample axis). Use ``materialize(region=...)`` to scope
+  it to a tractable sub-region.
+* The store is in scikit-allel layout, not VCZ. Convert it first
+  with ``allel_zarr_to_vcz``; the streaming reader is VCZ-only.

--- a/docs/source/tutorials/biobank_streaming.rst
+++ b/docs/source/tutorials/biobank_streaming.rst
@@ -1,74 +1,113 @@
 Biobank-Scale Streaming from VCZ
 ================================
 
-When a VCZ (bio2zarr) dataset has too many haplotypes to fit on the
-GPU all at once -- tens to hundreds of thousands --
-``HaplotypeMatrix.from_zarr`` (and ``GenotypeMatrix.from_zarr``)
-gives you a *streaming matrix* that reads the chromosome one chunk
-at a time. The streaming object works with every per-window, SFS,
-LD, and pairwise relatedness function in pg_gpu with no change to
-your code; GPU memory use scales with one chunk, not the whole
-chromosome.
+TL;DR
+-----
 
-Background
-----------
+If your genotype matrix is too big to fit on the GPU (tens of
+thousands of haplotypes upward), keep using ``pg_gpu`` the way you
+always have -- just pass ``streaming='always'`` (or let the default
+``streaming='auto'`` pick) to ``HaplotypeMatrix.from_zarr``. Every
+per-window, per-site, LD, and pairwise relatedness function in the
+library dispatches transparently on the streaming object, walking
+the chromosome chunk by chunk on the GPU. GPU memory use is bounded
+by one chunk's size (e.g. roughly 12 GB for chr15 at 100k diploids
+and 500 kb chunks) regardless of how long the chromosome is.
 
-Normally pg_gpu loads the entire ``(n_haplotypes, n_variants)``
-genotype matrix onto the GPU before any statistic runs. At biobank
-sample sizes that matrix is dozens of gigabytes per chromosome --
-and that is before pg_gpu allocates any working memory for the
-statistic itself. On a store with 100,000 diploids an A100 80 GB
-will run out of memory just trying to load the data.
+The only constraint is that your data must be a VCZ store. If
+you currently have a VCF or an older scikit-allel zarr, see
+*Data format: VCZ vs VCF* and *Converting a scikit-allel store*
+below for the one-time conversion.
 
-Streaming avoids that by reading the chromosome in genomic chunks
-(e.g. 500 kb at a time). Each chunk is decompressed onto the GPU,
-the statistic is computed for that chunk, the result is added to a
-running total, and the chunk is freed before the next one is read.
-The next chunk is read on a background thread while the current
-chunk is being processed, so disk I/O and GPU compute overlap.
+Data format: VCZ vs VCF
+-----------------------
 
-Statistics that combine naturally across chunks --
+The streaming path reads VCZ stores, not VCFs. A VCZ store is
+bio2zarr's Zarr-on-disk encoding of a VCF: the genotype matrix
+``call_genotype`` is laid out as small chunks of samples by
+variants, each chunk compressed independently on disk. That layout
+is what lets the reader pull a single chunk into GPU memory
+without paying for the rest of the chromosome.
 
-* per-window diversity and divergence,
-* the site frequency spectrum,
-* the joint SFS,
-* Garud's H,
+VCF text doesn't work for streaming -- the format isn't sliceable
+chunk-wise and VCF parsing in htslib is single-threaded, so
+loading a very large VCF takes hours and the parsed matrix still
+has to fit in host memory.
+
+Convert a VCF to VCZ once via the ``bio2zarr`` CLI (``vcf2zarr``):
+
+.. code-block:: bash
+
+   # One-time intermediate followed by the final VCZ encode.
+   vcf2zarr explode biobank.vcf.gz biobank.icf
+   vcf2zarr encode  biobank.icf     biobank.vcz
+
+Both steps are parallelized; the encode step is what produces the
+sample-by-variant chunking the streaming reader needs (see
+*Required Zarr format* below).
+
+How chunk-by-chunk accumulation works
+-------------------------------------
+
+For a streaming-friendly statistic -- per-window diversity, the
+SFS, moments-LD bins, IBS, GRM -- ``pg_gpu``:
+
+1. Reads one genomic chunk (default 500 kb) into GPU memory.
+2. Runs the statistic on that chunk.
+3. Adds the chunk's contribution to a running total kept either
+   on the host or in a small on-GPU accumulator.
+4. Frees the chunk and reads the next.
+5. While the GPU is computing on chunk N, the next chunk is being
+   read on a background thread (overlapped I/O).
+
+The chromosome-wide answer is the running total at the end of the
+walk. A concrete one-statistic example -- nucleotide diversity per
+100 kb window on a chr15 store with 100,000 diploids:
+
+.. code-block:: python
+
+   from pg_gpu import HaplotypeMatrix, windowed_analysis
+
+   stream = HaplotypeMatrix.from_zarr("biobank/chr15.vcz",
+                                       streaming="always")
+   pi = windowed_analysis(stream, window_size=100_000,
+                          step_size=100_000, statistics=["pi"])
+   # pi is a pandas.DataFrame, one row per 100 kb window across
+   # chr15 (~1,000 rows). Peak GPU memory while this runs: ~12 GB
+   # for the chunk that's currently on the device -- a single-shot
+   # load of the same chromosome would have wanted ~2.3 TB.
+
+Statistics that combine across chunks naturally:
+
+* per-window diversity and divergence (``windowed_analysis``),
+* the site frequency spectrum -- ``sfs.sfs``, ``sfs.joint_sfs``,
+  ``sfs.sfs_folded``, ``sfs.joint_sfs_folded``,
+* the projected joint SFS at sample sizes where the full histogram
+  does not fit (``sfs.project_joint_sfs``),
 * moments-LD pair bins (``DD``, ``Dz``, ``pi2``, derived
   :math:`\sigma_D^2`),
-* identity by state (``ibs``) and the genetic relationship matrix
-  (``grm``)
+* identity by state (``relatedness.ibs``) and the genetic
+  relationship matrix (``relatedness.grm``).
 
--- are handled automatically: you call the same function as on a
-small in-memory matrix and pg_gpu takes care of the chunk-by-chunk
-accumulation.
+Statistics that need every variant present at the same time --
+pairwise :math:`r^2` heatmaps, Garud's H hash tables -- cannot be
+streamed end to end. The *Pulling a sub-region into memory*
+section below shows how to pull a smaller piece into a regular
+fully loaded matrix and run those.
 
-For statistics that need every variant in scope at the same time
-(a pairwise-:math:`r^2` heatmap, a Garud's H hash table, a per-
-individual-pair distance matrix), call
-``streaming_matrix.materialize(region=..., sample_subset=...)`` to
-read a smaller piece -- a sub-region of the chromosome, restricted
-to a subset of haplotypes -- into a regular in-memory
-``HaplotypeMatrix`` and run the statistic on that.
+streaming='auto' vs 'always' vs 'never'
+---------------------------------------
 
-The streaming reader needs a VCZ store with bio2zarr-style chunking
-on the sample axis (the standard layout produced by
-``bio2zarr explode``). A store that puts the entire sample axis in
-a single chunk still works, but falls back to a slower read path
-with a one-time ``BadlyChunkedWarning``.
+``HaplotypeMatrix.from_zarr`` chooses between a single-shot load
+and a streaming view based on the ``streaming`` argument:
 
-When you get a streaming object back
-------------------------------------
-
-``HaplotypeMatrix.from_zarr`` chooses between in-memory and
-streaming based on the ``streaming`` argument:
-
-* ``streaming='auto'`` (default): in-memory if the data fits in
-  roughly half of the free GPU memory; streaming otherwise.
+* ``streaming='auto'`` (default): a single-shot load if the data
+  fits in roughly half of free GPU memory; streaming otherwise.
 * ``streaming='always'``: always streaming.
-* ``streaming='never'``: always in-memory (raises if the data does
-  not fit).
+* ``streaming='never'``: always single-shot. Raises ``MemoryError``
+  if the data does not fit.
 
-Either way, the object you get back accepts the same pg_gpu
+Either way, the object you get back accepts the same ``pg_gpu``
 functions:
 
 .. code-block:: python
@@ -79,12 +118,11 @@ functions:
    stream = HaplotypeMatrix.from_zarr(
        "biobank/chr15.vcz",
        streaming="always",
-       chunk_bp=500_000,         # genomic chunk size (default auto)
-       prefetch=1,               # read-ahead depth (0 disables)
-       pop_file="biobank/chr15.pops.tsv",   # optional sample -> pop TSV
+       chunk_bp=500_000,                   # genomic chunk size
+       pop_file="biobank/chr15.pops.tsv",  # optional sample -> pop
    )
 
-   # Per-window diversity + divergence, one streaming pass per call.
+   # Per-window diversity + divergence in a single streaming pass.
    df = windowed_analysis(stream, window_size=100_000, step_size=100_000,
                           statistics=["pi", "theta_w", "tajimas_d",
                                        "fst", "dxy"],
@@ -93,19 +131,20 @@ functions:
    # Marginal SFS uses the full panel (1D output, fits anywhere).
    sfs_afr = sfs.sfs(stream, population="AFR")
 
-   # Joint SFS: the full (n1+1, n2+1) histogram is 80 GB at 100k haps
-   # per population, so use project_joint_sfs instead. It applies a
-   # hypergeometric projection per variant and accumulates straight
-   # into the small target grid -- every variant from every haplotype
-   # contributes, no subsampling.
+   # Joint SFS: the full (n1+1, n2+1) histogram is 80 GB at 100k
+   # haps per population, so use project_joint_sfs instead. It
+   # applies a hypergeometric projection per variant and
+   # accumulates straight into the small target grid -- every
+   # variant from every haplotype contributes, no subsampling.
    joint_projected = sfs.project_joint_sfs(
        stream, pop1="AFR", pop2="EUR",
        target_n1=200, target_n2=200,
    )
 
-   # moments-LD pair-bin statistics. Pairs that fall on opposite
-   # sides of a chunk boundary are handled correctly via a tail
-   # buffer that carries the last max(bp_bins) of variants forward.
+   # moments-LD pair-bin statistics. Pairs that straddle a chunk
+   # boundary are kept correct by a tail buffer that carries the
+   # last max(bp_bins) of variants of one chunk forward and pairs
+   # them with the start of the next.
    ld = stream.compute_ld_statistics_gpu_two_pops(
        bp_bins=[0, 1_000, 10_000, 100_000], pop1="AFR", pop2="EUR",
    )
@@ -116,18 +155,22 @@ functions:
    ibs_mat = ibs(stream)
    grm_mat = grm(stream)
 
-The same code on a small in-memory ``HaplotypeMatrix`` runs
+The same code run on a fully loaded ``HaplotypeMatrix`` is
 unchanged -- the only difference is which kind of object
 ``from_zarr`` returns.
 
-Pulling a sub-region into memory for pairwise statistics
---------------------------------------------------------
+The ``pop_file`` kwarg accepts a path to a TSV, a dict mapping
+sample to population, a numpy array of labels (one per sample), or
+the name of a zarr key in the store that holds a 1-D population
+array. See ``HaplotypeMatrix.from_zarr`` for the full list.
 
-Some statistics -- a pairwise-:math:`r^2` heatmap, Garud's H, per-
-individual distance matrices -- need every variant present at the
-same time. The full chromosome at biobank scale will not fit in
-GPU memory for those, but a single 1 Mb sub-region with a
-haplotype subsample easily will:
+Pulling a sub-region into memory for kernels that need every variant at once
+----------------------------------------------------------------------------
+
+A pairwise-:math:`r^2` heatmap or a Garud's H hash table needs
+every variant present at the same time. The full chromosome at
+biobank scale will not fit in GPU memory for those, but a single
+1 Mb sub-region with a haplotype subsample easily will:
 
 .. code-block:: python
 
@@ -136,21 +179,44 @@ haplotype subsample easily will:
    subsample = list(stream.sample_sets["AFR"][:5_000])
    region_hm = stream.materialize(region=region, sample_subset=subsample)
 
-   # Run any pairwise statistic on the regular in-memory matrix.
+   # Run any pairwise statistic on the fully loaded matrix.
    r2 = region_hm.pairwise_r2()
 
 ``materialize(sample_subset=...)`` reads the (variants × subsample)
 genotype block directly onto the GPU when the store is set up for
 it (zstd / blosc / lz4 / deflate compressed bio2zarr chunks decoded
-through kvikio + nvCOMP). At biobank scale this is roughly 60×
-faster than the equivalent CPU-side path: a 5 Mb / 10,000-haplotype
+through kvikio + nvCOMP). At biobank-scale sample sizes this is
+roughly 60× faster than the CPU-side path: a 5 Mb / 10,000-haplotype
 block drops from ~170 seconds to ~3 seconds.
+
+Required Zarr format
+--------------------
+
+The streaming reader needs a VCZ store -- a bio2zarr-encoded zarr
+group with ``call_genotype``, ``variant_position``, and
+``sample_id``. The on-GPU codec decode (kvikio + nvCOMP) is enabled
+when:
+
+* The ``call_genotype`` codec is one of zstd, blosc, lz4, deflate.
+  bio2zarr defaults to zstd, so this is usually free; other codecs
+  surface as a ``ValueError`` at construction time so the caller
+  can re-encode.
+* The ``call_genotype`` chunks are not whole-sample-axis. A store
+  written with ``sample_chunk`` equal to the full sample axis still
+  works but warns once (``BadlyChunkedWarning``) and falls back to
+  the host-buffer fetcher because the kvikio path gives no speedup
+  at that chunking.
+
+bio2zarr's defaults produce a store the streaming reader accepts;
+the warnings only fire when somebody re-encoded a VCZ store with
+non-standard arguments or converted from another zarr layout with
+``sample_chunk`` too large.
 
 Converting a scikit-allel store
 -------------------------------
 
-Older biobank releases (e.g. the Ag1000G ``AgamP3.phased.zarr``)
-ship in scikit-allel zarr layout (``calldata/GT``, ``variants/POS``,
+Older data releases (e.g. the Ag1000G ``AgamP3.phased.zarr``) ship
+in scikit-allel zarr layout (``calldata/GT``, ``variants/POS``,
 ``samples``) rather than VCZ. ``pg_gpu.zarr_io.allel_zarr_to_vcz``
 reads the source in variant blocks -- so the conversion itself
 does not need to hold the full matrix in memory -- and writes a
@@ -161,10 +227,10 @@ VCZ store the streaming reader can consume:
    from pg_gpu.zarr_io import allel_zarr_to_vcz
 
    allel_zarr_to_vcz(
-       "AgamP3.phased.zarr",                    # scikit-allel layout
-       "AgamP3.phased.3R.vcz",                  # output VCZ
-       contig="3R",                              # required for grouped allel stores
-       region="3R:1_000_000-2_000_000",          # optional sub-range
+       "AgamP3.phased.zarr",                # scikit-allel layout
+       "AgamP3.phased.3R.vcz",              # output VCZ
+       contig="3R",                         # required for grouped allel stores
+       region="3R:1_000_000-2_000_000",     # optional sub-range
        variant_chunk=10_000, sample_chunk=1_000,
    )
 
@@ -181,34 +247,37 @@ Disk, CPU memory, and GPU memory
   into roughly 12 GB of GPU memory.
 * The background read-ahead holds one extra decompressed chunk in
   CPU memory (~12 GB for the parameters above), so peak CPU memory
-  use is ``(prefetch + 1) × chunk_size``. Set ``prefetch=0`` to
-  read each chunk only when it is needed.
+  use is ``(prefetch + 1) * chunk_size``. ``prefetch=1`` is the
+  default (one chunk read in parallel with the previous chunk's
+  GPU work); set ``prefetch=0`` to read each chunk only when
+  needed.
 * The ``(n_indiv, n_indiv)`` output of ``ibs`` and ``grm`` lives in
   CPU memory as a numpy array. At 50,000 diploids that is about
   20 GB for ``grm``; ``ibs`` keeps three such matrices and needs
-  ~60 GB. The ``block_size`` argument controls how many rows of
-  the output sit on the GPU at any one time.
+  ~60 GB. The ``block_size`` argument controls how many rows of the
+  output sit on the GPU at any one time.
 
 Worked example
 --------------
 
-A complete biobank-scale scan -- per-window diversity and
-divergence at three window sizes (10 kb, 100 kb, 1 Mb), marginal
-and joint SFS, Garud's H per population, moments-LD decay across
+A worked end-to-end scan -- per-window diversity and divergence at
+three window sizes (10 kb, 100 kb, 1 Mb), marginal SFS,
+:math:`200 \times 200`-projected joint SFS, moments-LD decay across
 probe regions, and a pairwise-:math:`r^2` heatmap of a 1 Mb
-sub-region -- ships as
-``06_simulated_genome_scan/scripts/genome_scan_ooa.py`` in the
-companion paper-analysis repository. On chr15 from ``stdpopsim``'s
-``OutOfAfrica_2T12`` simulated at 50,000 diploids per population
-(200,000 haplotypes, 11.6 M variants, 7.9 GB on disk) the script
-completes in about 16 minutes on a single A100 80 GB.
+sub-region -- ships as ``examples/biobank_streaming_scan.py`` in
+this repository. It uses the streaming reader for the
+per-chunk-reducible kernels and ``materialize`` for the
+pairwise-:math:`r^2` heatmap; on chr15 from ``stdpopsim``'s
+``OutOfAfrica_2T12`` at 50,000 diploids per population (200,000
+haplotypes, 11.6 M variants, 7.9 GB on disk) it completes in about
+16 minutes on a single A100 80 GB.
 
 When streaming is not the right choice
 --------------------------------------
 
-* Your data already fits on the GPU in one piece. ``streaming='auto'``
-  will pick the in-memory path automatically; that path is faster
-  per call because there is no per-chunk overhead.
+* Your data already fits on the GPU in one shot. ``streaming='auto'``
+  picks the single-shot path automatically; that path is faster per
+  call because there is no per-chunk overhead.
 * Your statistic needs every variant at once and the whole
   chromosome is too big to load. Use ``materialize(region=...)`` to
   read a smaller sub-region instead.

--- a/docs/source/tutorials/biobank_streaming.rst
+++ b/docs/source/tutorials/biobank_streaming.rst
@@ -1,56 +1,75 @@
 Biobank-Scale Streaming from VCZ
 ================================
 
-For stores too large to fit on the GPU eagerly -- biobank-scale VCZ
-(bio2zarr) datasets with tens to hundreds of thousands of haplotypes
--- ``HaplotypeMatrix.from_zarr`` (and ``GenotypeMatrix.from_zarr``)
-returns a *streaming matrix* that walks the chromosome chunk by
-chunk. The streaming object plugs into every scalar / windowed /
-pair-bin / pairwise kernel that already accepts an eager matrix; GPU
-peak memory scales with one chunk, not the chromosome length.
+When a VCZ (bio2zarr) dataset has too many haplotypes to fit on the
+GPU all at once -- tens to hundreds of thousands --
+``HaplotypeMatrix.from_zarr`` (and ``GenotypeMatrix.from_zarr``)
+gives you a *streaming matrix* that reads the chromosome one chunk
+at a time. The streaming object works with every per-window, SFS,
+LD, and pairwise relatedness function in pg_gpu with no change to
+your code; GPU memory use scales with one chunk, not the whole
+chromosome.
 
 Background
 ----------
 
-The eager path materializes the full ``(n_haplotypes, n_variants)``
-haplotype matrix on the GPU before any statistic runs. At biobank
-sample counts the matrix alone is dozens of gigabytes per chromosome
--- before any working memory for the kernel itself -- and on a 100k-
-diploid store an A100 80 GB will OOM at the load step. Streaming
-solves this by:
+Normally pg_gpu loads the entire ``(n_haplotypes, n_variants)``
+genotype matrix onto the GPU before any statistic runs. At biobank
+sample sizes that matrix is dozens of gigabytes per chromosome --
+and that is before pg_gpu allocates any working memory for the
+statistic itself. On a store with 100,000 diploids an A100 80 GB
+will run out of memory just trying to load the data.
 
-* Opening the zarr store as a ``ZarrGenotypeSource`` and probing the
-  on-disk chunking + codec.
-* Returning a ``StreamingHaplotypeMatrix`` (or
-  ``StreamingGenotypeMatrix``) instead of an eager
-  ``HaplotypeMatrix``.
-* Iterating that object yields per-chunk *eager* matrices on the
-  GPU; the next chunk's host read overlaps the current chunk's
-  compute through a producer thread.
-* Per-chunk reducible statistics (windowed diversity / divergence /
-  Garud H, SFS, joint SFS, moments-LD pair bins) are *dispatched
-  through the existing function names* -- you do not write a chunk
-  loop yourself.
-* Cross-window or pairwise kernels (``pairwise_r2``,
-  per-individual-pair distance, custom recipes that need every
-  variant simultaneously) get a sub-region eager matrix via
-  ``streaming_matrix.materialize(region=..., sample_subset=...)``
-  and run on that.
+Streaming avoids that by reading the chromosome in genomic chunks
+(e.g. 500 kb at a time). Each chunk is decompressed onto the GPU,
+the statistic is computed for that chunk, the result is added to a
+running total, and the chunk is freed before the next one is read.
+The next chunk is read on a background thread while the current
+chunk is being processed, so disk I/O and GPU compute overlap.
 
-The store layout that gets the on-GPU codec decode path is
-*bio2zarr-style sample chunking* (small enough chunks on the sample
-axis that each chunk fits in a kvikio + nvCOMP decompression buffer).
-A store whose sample axis is one chunk falls back to the host fetcher
-with a one-time ``BadlyChunkedWarning``; everything else still works.
+Statistics that combine naturally across chunks --
 
-When ``HaplotypeMatrix.from_zarr`` returns a streaming object
---------------------------------------------------------------
+* per-window diversity and divergence,
+* the site frequency spectrum,
+* the joint SFS,
+* Garud's H,
+* moments-LD pair bins (``DD``, ``Dz``, ``pi2``, derived
+  :math:`\sigma_D^2`),
+* identity by state (``ibs``) and the genetic relationship matrix
+  (``grm``)
 
-``streaming='auto'`` (the default) picks based on whether the eager
-matrix fits in roughly half the free GPU memory. ``streaming='always'``
-forces it; ``streaming='never'`` forces eager. The streaming object
-is a drop-in for the eager class for every kernel below -- the
-calling code is the same.
+-- are handled automatically: you call the same function as on a
+small in-memory matrix and pg_gpu takes care of the chunk-by-chunk
+accumulation.
+
+For statistics that need every variant in scope at the same time
+(a pairwise-:math:`r^2` heatmap, a Garud's H hash table, a per-
+individual-pair distance matrix), call
+``streaming_matrix.materialize(region=..., sample_subset=...)`` to
+read a smaller piece -- a sub-region of the chromosome, restricted
+to a subset of haplotypes -- into a regular in-memory
+``HaplotypeMatrix`` and run the statistic on that.
+
+The streaming reader needs a VCZ store with bio2zarr-style chunking
+on the sample axis (the standard layout produced by
+``bio2zarr explode``). A store that puts the entire sample axis in
+a single chunk still works, but falls back to a slower read path
+with a one-time ``BadlyChunkedWarning``.
+
+When you get a streaming object back
+------------------------------------
+
+``HaplotypeMatrix.from_zarr`` chooses between in-memory and
+streaming based on the ``streaming`` argument:
+
+* ``streaming='auto'`` (default): in-memory if the data fits in
+  roughly half of the free GPU memory; streaming otherwise.
+* ``streaming='always'``: always streaming.
+* ``streaming='never'``: always in-memory (raises if the data does
+  not fit).
+
+Either way, the object you get back accepts the same pg_gpu
+functions:
 
 .. code-block:: python
 
@@ -65,118 +84,126 @@ calling code is the same.
        pop_file="biobank/chr15.pops.tsv",   # optional sample -> pop TSV
    )
 
-   # Per-window diversity + divergence: one streaming pass per call.
+   # Per-window diversity + divergence, one streaming pass per call.
    df = windowed_analysis(stream, window_size=100_000, step_size=100_000,
                           statistics=["pi", "theta_w", "tajimas_d",
                                        "fst", "dxy"],
                           populations=["AFR", "EUR"])
 
-   # Marginal + joint SFS: per-chunk reduction.
+   # Marginal and joint SFS.
    sfs_afr = sfs.sfs(stream, population="AFR")
    joint   = sfs.joint_sfs(stream, pop1=list(stream.sample_sets["AFR"][:200]),
                                    pop2=list(stream.sample_sets["EUR"][:200]))
 
-   # moments-LD bin sums with tail-buffer cross-chunk pair handling.
+   # moments-LD pair-bin statistics. Pairs that fall on opposite
+   # sides of a chunk boundary are handled correctly via a tail
+   # buffer that carries the last max(bp_bins) of variants forward.
    ld = stream.compute_ld_statistics_gpu_two_pops(
        bp_bins=[0, 1_000, 10_000, 100_000], pop1="AFR", pop2="EUR",
    )
 
-   # Pairwise relatedness: variant axis streamed, (n_ind, n_ind)
-   # accumulators on host so the output can exceed GPU memory.
+   # Pairwise relatedness. The variant axis is streamed; the
+   # (n_indiv, n_indiv) output lives in CPU memory so the result
+   # itself can be larger than the GPU can hold.
    ibs_mat = ibs(stream)
    grm_mat = grm(stream)
 
-The same code on an eager ``HaplotypeMatrix`` (small store) runs
-unchanged -- the only difference is which class ``from_zarr`` returns.
+The same code on a small in-memory ``HaplotypeMatrix`` runs
+unchanged -- the only difference is which kind of object
+``from_zarr`` returns.
 
-Sub-region eager builds for pairwise kernels
---------------------------------------------
+Pulling a sub-region into memory for pairwise statistics
+--------------------------------------------------------
 
-A pairwise-r² heatmap, a Garud's H hash table, or a per-individual-pair
-distance over an entire chromosome would not fit eagerly at biobank
-scale, but a single 1 Mb sub-region with a haplotype subsample does:
+Some statistics -- a pairwise-:math:`r^2` heatmap, Garud's H, per-
+individual distance matrices -- need every variant present at the
+same time. The full chromosome at biobank scale will not fit in
+GPU memory for those, but a single 1 Mb sub-region with a
+haplotype subsample easily will:
 
 .. code-block:: python
 
    # Pull a 1 Mb region restricted to 5,000 haplotypes from one pop.
    region = (50_000_000, 51_000_000)
    subsample = list(stream.sample_sets["AFR"][:5_000])
-   eager = stream.materialize(region=region, sample_subset=subsample)
+   region_hm = stream.materialize(region=region, sample_subset=subsample)
 
-   # Run any pairwise kernel on the eager view.
-   r2 = eager.pairwise_r2()
+   # Run any pairwise statistic on the regular in-memory matrix.
+   r2 = region_hm.pairwise_r2()
 
-``materialize(sample_subset=...)`` routes the read through
-``slice_subsample_gpu`` when the streaming source uses the kvikio
-backend -- the (variants × subsample × 2) call_genotype block is
-decompressed directly on the GPU rather than going through zarr's
-sync host-side ``oindex``. At biobank scale this drops a 5 Mb / 10 k-
-haplotype probe from ~170 s to ~3 s.
+``materialize(sample_subset=...)`` reads the (variants × subsample)
+genotype block directly onto the GPU when the store is set up for
+it (zstd / blosc / lz4 / deflate compressed bio2zarr chunks decoded
+through kvikio + nvCOMP). At biobank scale this is roughly 60×
+faster than the equivalent CPU-side path: a 5 Mb / 10,000-haplotype
+block drops from ~170 seconds to ~3 seconds.
 
 Converting a scikit-allel store
 -------------------------------
 
-Empirical biobank data often arrives in scikit-allel zarr layout
-(``calldata/GT``, ``variants/POS``, ``samples``) -- e.g. the
-Ag1000G ``AgamP3.phased.zarr`` release. ``pg_gpu.zarr_io.allel_zarr_to_vcz``
-streams the source in variant blocks (so the conversion does not
-materialize the full matrix) and writes a VCZ store with
-bio2zarr-style sample chunking the streaming reader can consume:
+Older biobank releases (e.g. the Ag1000G ``AgamP3.phased.zarr``)
+ship in scikit-allel zarr layout (``calldata/GT``, ``variants/POS``,
+``samples``) rather than VCZ. ``pg_gpu.zarr_io.allel_zarr_to_vcz``
+reads the source in variant blocks -- so the conversion itself
+does not need to hold the full matrix in memory -- and writes a
+VCZ store the streaming reader can consume:
 
 .. code-block:: python
 
    from pg_gpu.zarr_io import allel_zarr_to_vcz
 
    allel_zarr_to_vcz(
-       "AgamP3.phased.zarr",          # scikit-allel layout
-       "AgamP3.phased.3R.vcz",        # output VCZ
-       contig="3R",                    # required for grouped allel stores
-       region="3R:1_000_000-2_000_000",  # optional sub-range
+       "AgamP3.phased.zarr",                    # scikit-allel layout
+       "AgamP3.phased.3R.vcz",                  # output VCZ
+       contig="3R",                              # required for grouped allel stores
+       region="3R:1_000_000-2_000_000",          # optional sub-range
        variant_chunk=10_000, sample_chunk=1_000,
    )
 
-The resulting store is what ``HaplotypeMatrix.from_zarr`` opens for
-streaming.
+The resulting store is then opened the normal way through
+``HaplotypeMatrix.from_zarr``.
 
-Storage and host RAM footprints
--------------------------------
+Disk, CPU memory, and GPU memory
+--------------------------------
 
-* A 100 k-diploid / 11.6 M-variant chr15 store at zstd-compressed
-  bio2zarr chunking lives on disk at ~8 GB; the same chromosome
-  uncompressed is ~2.3 TB. Streaming reads the compressed bytes from
-  disk and decompresses one chunk at a time into ~12 GB GPU memory.
-* The producer thread holds one extra decompressed chunk in host RAM
-  (~12 GB for the parameters above), so peak host = ``(prefetch + 1)
-  * chunk_bytes``. ``prefetch=0`` disables the read-ahead and reads
-  serially.
-* The ``(n_ind, n_ind)`` outputs of ``ibs`` and ``grm`` live on host
-  as numpy arrays. At 50 k diploids that is ~20 GB of host RAM for
-  ``grm``; ``ibs`` carries three such accumulators (~60 GB). The
-  ``block_size=`` kwarg controls how many rows of the output are
-  resident on the GPU at a time.
+* A 100,000-diploid / 11.6 M-variant chr15 store at zstd-compressed
+  bio2zarr chunking takes about 8 GB on disk; the same chromosome
+  uncompressed would be about 2.3 TB. Streaming reads the
+  compressed bytes from disk and decompresses one chunk at a time
+  into roughly 12 GB of GPU memory.
+* The background read-ahead holds one extra decompressed chunk in
+  CPU memory (~12 GB for the parameters above), so peak CPU memory
+  use is ``(prefetch + 1) × chunk_size``. Set ``prefetch=0`` to
+  read each chunk only when it is needed.
+* The ``(n_indiv, n_indiv)`` output of ``ibs`` and ``grm`` lives in
+  CPU memory as a numpy array. At 50,000 diploids that is about
+  20 GB for ``grm``; ``ibs`` keeps three such matrices and needs
+  ~60 GB. The ``block_size`` argument controls how many rows of
+  the output sit on the GPU at any one time.
 
-End-to-end paper example
-------------------------
+Worked example
+--------------
 
-A complete biobank-scale scan -- per-window diversity + divergence
-at three scales, marginal + joint SFS, Garud's H per pop, moments-LD
-decay across probe regions, and a pairwise-r² heatmap of a 1 Mb
+A complete biobank-scale scan -- per-window diversity and
+divergence at three window sizes (10 kb, 100 kb, 1 Mb), marginal
+and joint SFS, Garud's H per population, moments-LD decay across
+probe regions, and a pairwise-:math:`r^2` heatmap of a 1 Mb
 sub-region -- ships as
 ``06_simulated_genome_scan/scripts/genome_scan_ooa.py`` in the
-companion paper-analysis repository. On chr15 from ``stdpopsim``
-``OutOfAfrica_2T12`` simulated at 50 k diploids per population (200 k
-haplotypes, 11.6 M variants, 7.9 GB on disk) the script completes
-in ~16 minutes on a single A100 80 GB.
+companion paper-analysis repository. On chr15 from ``stdpopsim``'s
+``OutOfAfrica_2T12`` simulated at 50,000 diploids per population
+(200,000 haplotypes, 11.6 M variants, 7.9 GB on disk) the script
+completes in about 16 minutes on a single A100 80 GB.
 
-When streaming is not what you want
------------------------------------
+When streaming is not the right choice
+--------------------------------------
 
-* The data already fits on the GPU eagerly. ``streaming='auto'``
-  picks eager automatically; the eager path is faster per call
-  because there is no per-chunk dispatch overhead.
-* The kernel needs every variant simultaneously and the chromosome
-  cannot be partitioned (e.g. a chromosome-wide pairwise r² heatmap
-  on the full sample axis). Use ``materialize(region=...)`` to scope
-  it to a tractable sub-region.
-* The store is in scikit-allel layout, not VCZ. Convert it first
-  with ``allel_zarr_to_vcz``; the streaming reader is VCZ-only.
+* Your data already fits on the GPU in one piece. ``streaming='auto'``
+  will pick the in-memory path automatically; that path is faster
+  per call because there is no per-chunk overhead.
+* Your statistic needs every variant at once and the whole
+  chromosome is too big to load. Use ``materialize(region=...)`` to
+  read a smaller sub-region instead.
+* Your store is in scikit-allel layout rather than VCZ. Convert it
+  first with ``allel_zarr_to_vcz``; the streaming reader only
+  accepts VCZ.

--- a/docs/source/tutorials/biobank_streaming.rst
+++ b/docs/source/tutorials/biobank_streaming.rst
@@ -90,10 +90,18 @@ functions:
                                        "fst", "dxy"],
                           populations=["AFR", "EUR"])
 
-   # Marginal and joint SFS.
+   # Marginal SFS uses the full panel (1D output, fits anywhere).
    sfs_afr = sfs.sfs(stream, population="AFR")
-   joint   = sfs.joint_sfs(stream, pop1=list(stream.sample_sets["AFR"][:200]),
-                                   pop2=list(stream.sample_sets["EUR"][:200]))
+
+   # Joint SFS at biobank scale: the full (n1+1, n2+1) histogram is
+   # 80 GB at 100k haps per population, so use project_joint_sfs
+   # instead. It applies a hypergeometric projection per variant and
+   # accumulates straight into the small target grid -- every variant
+   # from every haplotype contributes, no subsampling.
+   joint_projected = sfs.project_joint_sfs(
+       stream, pop1="AFR", pop2="EUR",
+       target_n1=200, target_n2=200,
+   )
 
    # moments-LD pair-bin statistics. Pairs that fall on opposite
    # sides of a chunk boundary are handled correctly via a tail

--- a/docs/source/tutorials/biobank_streaming.rst
+++ b/docs/source/tutorials/biobank_streaming.rst
@@ -46,6 +46,12 @@ Both steps are parallelized; the encode step is what produces the
 sample-by-variant chunking the streaming reader needs (see
 *Required Zarr format* below).
 
+The store must hold **diploid** genotypes. The eager and streaming
+readers, the kvikio sample-subset gather, and the
+``(n_dip, 2) -> 2 * n_dip`` haplotype layout all assume ploidy 2;
+haploid and polyploid stores are rejected with a ``ValueError``
+at construction time.
+
 How chunk-by-chunk accumulation works
 -------------------------------------
 

--- a/docs/source/tutorials/biobank_streaming.rst
+++ b/docs/source/tutorials/biobank_streaming.rst
@@ -89,11 +89,10 @@ Statistics that combine across chunks naturally:
 * identity by state (``relatedness.ibs``) and the genetic
   relationship matrix (``relatedness.grm``).
 
-Statistics that need every variant present at the same time --
-pairwise :math:`r^2` heatmaps, Garud's H hash tables -- cannot be
-streamed end to end. The *Pulling a sub-region into memory*
-section below shows how to pull a smaller piece into a regular
-fully loaded matrix and run those.
+Statistics that need every variant present at the same time
+cannot be streamed end to end. The *Pulling a sub-region into
+memory* section below shows how to pull a smaller piece into a
+regular fully loaded matrix and run those.
 
 streaming='auto' vs 'always' vs 'never'
 ---------------------------------------

--- a/docs/source/tutorials/biobank_streaming.rst
+++ b/docs/source/tutorials/biobank_streaming.rst
@@ -184,7 +184,7 @@ biobank scale will not fit in GPU memory for those, but a single
 
 ``materialize(sample_subset=...)`` reads the (variants × subsample)
 genotype block directly onto the GPU when the store is set up for
-it. At biobank-scale sample sizes this is roughly 60× faster than
+it. At sample sizes > 10,000 haplotypes this is roughly 60× faster than
 the CPU-side path: a 5 Mb / 10,000-haplotype block drops from
 ~170 seconds to ~3 seconds.
 

--- a/docs/source/tutorials/biobank_streaming.rst
+++ b/docs/source/tutorials/biobank_streaming.rst
@@ -89,10 +89,11 @@ Statistics that combine across chunks naturally:
 * identity by state (``relatedness.ibs``) and the genetic
   relationship matrix (``relatedness.grm``).
 
-Statistics that need every variant present at the same time
-cannot be streamed end to end. The *Pulling a sub-region into
-memory* section below shows how to pull a smaller piece into a
-regular fully loaded matrix and run those.
+Statistics that need every variant present at the same time --
+pairwise :math:`r^2` heatmaps, Garud's H hash tables -- cannot be
+streamed end to end. The *Pulling a sub-region into memory*
+section below shows how to pull a smaller piece into a regular
+fully loaded matrix and run those.
 
 streaming='auto' vs 'always' vs 'never'
 ---------------------------------------

--- a/docs/source/tutorials/biobank_streaming.rst
+++ b/docs/source/tutorials/biobank_streaming.rst
@@ -184,10 +184,9 @@ biobank scale will not fit in GPU memory for those, but a single
 
 ``materialize(sample_subset=...)`` reads the (variants × subsample)
 genotype block directly onto the GPU when the store is set up for
-it (zstd / blosc / lz4 / deflate compressed bio2zarr chunks decoded
-through kvikio + nvCOMP). At biobank-scale sample sizes this is
-roughly 60× faster than the CPU-side path: a 5 Mb / 10,000-haplotype
-block drops from ~170 seconds to ~3 seconds.
+it. At biobank-scale sample sizes this is roughly 60× faster than
+the CPU-side path: a 5 Mb / 10,000-haplotype block drops from
+~170 seconds to ~3 seconds.
 
 Required Zarr format
 --------------------

--- a/examples/biobank_streaming_scan.py
+++ b/examples/biobank_streaming_scan.py
@@ -1,0 +1,195 @@
+"""End-to-end biobank-scale scan of a single chromosome from a VCZ store.
+
+Streams the chromosome through the GPU one genomic chunk at a time
+and accumulates, in a single pass over ``stream.iter_gpu_chunks()``:
+
+* Per-window diversity / divergence at three scales (10 kb, 100 kb,
+  1 Mb).
+* Marginal SFS per population.
+* Joint SFS projected from the full panel to a small display grid
+  via per-variant hypergeometric sampling -- every variant from
+  every haplotype contributes, no subsampling.
+* Garud's H per population (uses a 1,000-haplotype subsample because
+  the fused Garud kernel caps near 1024 haplotypes).
+
+Then -- after the streaming walk -- materializes a 1 Mb sub-region
+with a 5,000-haplotype subsample so the pairwise-r^2 heatmap can
+see every variant simultaneously.
+
+Output:
+
+    {OUT_DIR}/chr{CHROM}_pi_100kb.csv
+    {OUT_DIR}/chr{CHROM}_sfs_{pop}.csv
+    {OUT_DIR}/chr{CHROM}_joint_sfs.npy
+    {OUT_DIR}/chr{CHROM}_garud.csv
+    {OUT_DIR}/chr{CHROM}_r2_heatmap.npy
+
+A larger version of this scan (with multiscale plots, moments-LD
+decay across probe regions, and figure output) lives at
+``pg_gpu-paper-analysis/06_simulated_genome_scan/scripts/genome_scan_ooa.py``.
+
+Run inside the pg_gpu pixi environment with a free GPU:
+
+    CUDA_VISIBLE_DEVICES=0 pixi run python examples/biobank_streaming_scan.py \\
+        --vcz path/to/chr15.vcz --out-dir scan_out
+"""
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from pg_gpu import HaplotypeMatrix, sfs, windowed_analysis
+# Pop names are whatever the store / pop_file declares.
+POPS = ("AFR", "EUR")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--vcz", required=True, help="path to a chr*.vcz store")
+    p.add_argument("--pop-file", default=None,
+                   help="optional path/dict/zarr-key for sample -> pop "
+                        "assignments. Default: auto-load <vcz>.pops.tsv")
+    p.add_argument("--out-dir", default="scan_out", help="output directory")
+    p.add_argument("--chunk-bp", type=int, default=500_000,
+                   help="streaming chunk size in bp (default 500 kb)")
+    p.add_argument("--heatmap-region", default=None,
+                   help="region 'start-end' bp to materialize for the "
+                        "pairwise-r^2 heatmap (default: 1 Mb at chrom "
+                        "midpoint)")
+    p.add_argument("--heatmap-subsample", type=int, default=5_000,
+                   help="haplotypes drawn from one population for the "
+                        "pairwise-r^2 heatmap (default 5,000)")
+    p.add_argument("--joint-sfs-target", type=int, default=200,
+                   help="hypergeometric projection target for the joint "
+                        "SFS, in haplotypes per population")
+    p.add_argument("--garud-subsample", type=int, default=1_000,
+                   help="haplotypes drawn per population for Garud's H "
+                        "(kernel caps near 1024)")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    stream = HaplotypeMatrix.from_zarr(
+        args.vcz, streaming="always",
+        chunk_bp=args.chunk_bp,
+        pop_file=args.pop_file,  # None -> autoload <vcz>.pops.tsv
+    )
+    chrom = stream.chrom
+    chrom_len = stream.chrom_end - stream.chrom_start
+
+    full_pop = {p: [int(i) for i in stream.sample_sets[p]] for p in POPS}
+    n_haps = {p: len(full_pop[p]) for p in POPS}
+    sub_g = {p: full_pop[p][:args.garud_subsample] for p in POPS}
+
+    # Containers populated by the streaming walk.
+    win_parts = {"10kb": [], "100kb": [], "1mb": []}
+    garud_parts = []
+    marginal = {p: None for p in POPS}
+    joint = None
+
+    t_scan = time.perf_counter()
+    n_chunks = len(stream._chunks)
+    for ci, (left, right, chunk) in enumerate(stream.iter_gpu_chunks()):
+        t_chunk = time.perf_counter()
+
+        # Garud uses a registered subsample per chunk; the rest of
+        # the kernels see every haplotype in the chunk.
+        chunk.sample_sets = {**full_pop,
+                              **{f"{p}_g": sub_g[p] for p in POPS}}
+
+        # Per-window diversity + divergence at three scales.
+        for label, bp in (("10kb", 10_000), ("100kb", 100_000),
+                          ("1mb", 1_000_000)):
+            div = windowed_analysis(chunk, window_size=bp, step_size=bp,
+                                     statistics=["pi", "theta_w",
+                                                  "tajimas_d", "fst",
+                                                  "dxy"],
+                                     populations=list(POPS))
+            if not div.empty:
+                win_parts[label].append(div.reset_index(drop=True))
+
+        # Garud's H per pop in 10 kb windows, on the small subsample.
+        g_parts = [windowed_analysis(chunk, window_size=10_000,
+                                      step_size=10_000,
+                                      statistics=["garud_h12",
+                                                   "haplotype_count"],
+                                      populations=[f"{p}_g"])
+                   for p in POPS]
+        gdf = g_parts[0][["chrom", "start", "end", "center"]].copy()
+        for i, p in enumerate(POPS):
+            gdf[f"garud_h12_{p}"] = g_parts[i]["garud_h12"].values
+        garud_parts.append(gdf.reset_index(drop=True))
+
+        # Marginal SFS per pop (one bincount per chunk, summed at the
+        # end).
+        for p in POPS:
+            s = np.asarray(sfs.sfs(chunk, population=p))
+            marginal[p] = s if marginal[p] is None else marginal[p] + s
+
+        # Joint SFS projected to the small display grid as we go.
+        # The full (n_hap+1, n_hap+1) histogram would be ~80 GB at
+        # 100k haps per pop and would not fit on the GPU.
+        j = np.asarray(sfs.project_joint_sfs(
+            chunk, pop1=POPS[0], pop2=POPS[1],
+            target_n1=args.joint_sfs_target,
+            target_n2=args.joint_sfs_target,
+        ))
+        joint = j if joint is None else joint + j
+
+        print(f"  chunk {ci + 1}/{n_chunks} "
+              f"[{left / 1e6:.1f}-{right / 1e6:.1f} Mb] in "
+              f"{time.perf_counter() - t_chunk:.1f}s", flush=True)
+
+    print(f"\nStreaming walk: {time.perf_counter() - t_scan:.1f}s total")
+
+    # Concat per-scale window frames, dump tables / arrays.
+    for label, parts in win_parts.items():
+        df = pd.concat(parts, ignore_index=True) if parts else pd.DataFrame()
+        df.to_csv(out_dir / f"chr{chrom}_{label}.csv", index=False)
+    pd.concat(garud_parts, ignore_index=True).to_csv(
+        out_dir / f"chr{chrom}_garud.csv", index=False)
+    for p in POPS:
+        np.savetxt(out_dir / f"chr{chrom}_sfs_{p}.csv",
+                   marginal[p], delimiter=",", fmt="%d")
+    np.save(out_dir / f"chr{chrom}_joint_sfs.npy", joint)
+
+    # Pairwise-r^2 heatmap of a 1 Mb sub-region: needs every variant
+    # simultaneously, so we materialize it eagerly with a haplotype
+    # subsample from one pop.
+    if args.heatmap_region:
+        lo, hi = (int(x) for x in args.heatmap_region.split("-"))
+    else:
+        mid = stream.chrom_start + chrom_len // 2
+        lo, hi = mid - 500_000, mid + 500_000
+    sub = list(stream.sample_sets[POPS[0]][:args.heatmap_subsample])
+    region_hm = stream.materialize(region=(lo, hi), sample_subset=sub)
+    r2 = region_hm.pairwise_r2()
+    np.save(out_dir / f"chr{chrom}_r2_heatmap.npy", np.asarray(r2))
+
+    # One-line summary.
+    summary = {
+        "chromosome": chrom,
+        "chromosome_length_bp": int(chrom_len),
+        "n_variants": int(stream.num_variants),
+        "haplotypes_per_pop": n_haps,
+        "joint_sfs_target": args.joint_sfs_target,
+        "garud_subsample": args.garud_subsample,
+        "heatmap_region": [lo, hi],
+        "heatmap_subsample": args.heatmap_subsample,
+    }
+    (out_dir / f"chr{chrom}_summary.json").write_text(
+        json.dumps(summary, indent=2))
+    print(f"\nWrote outputs to {out_dir}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/biobank_streaming_scan.py
+++ b/examples/biobank_streaming_scan.py
@@ -18,11 +18,18 @@ see every variant simultaneously.
 
 Output:
 
-    {OUT_DIR}/chr{CHROM}_pi_100kb.csv
+    {OUT_DIR}/chr{CHROM}_{10kb,100kb,1mb}.csv
+    {OUT_DIR}/chr{CHROM}_garud.csv
     {OUT_DIR}/chr{CHROM}_sfs_{pop}.csv
     {OUT_DIR}/chr{CHROM}_joint_sfs.npy
-    {OUT_DIR}/chr{CHROM}_garud.csv
     {OUT_DIR}/chr{CHROM}_r2_heatmap.npy
+    {OUT_DIR}/chr{CHROM}_summary.json
+
+Important: ``--chunk-bp`` must be a multiple of every ``WINDOW_SCALES``
+entry. The default (1 Mb) covers the 10 kb / 100 kb / 1 Mb scales used
+here; for finer or coarser scales pick a chunk_bp that divides them
+all. The example errors early on a mismatch instead of silently
+emitting empty (or chunk-clipped) output.
 
 A larger version of this scan (with multiscale plots, moments-LD
 decay across probe regions, and figure output) lives at
@@ -39,12 +46,20 @@ import json
 import time
 from pathlib import Path
 
+import cupy as cp
 import numpy as np
 import pandas as pd
 
 from pg_gpu import HaplotypeMatrix, sfs, windowed_analysis
-# Pop names are whatever the store / pop_file declares.
-POPS = ("AFR", "EUR")
+
+# Per-window diversity / divergence scales: every bp here must divide
+# the streaming chunk_bp, otherwise the per-chunk windowed_analysis
+# call gets no complete window per chunk and silently emits a clipped
+# (chunk-sized) row labeled with the scale's name. The default
+# chunk_bp below is sized to cover all three scales.
+WINDOW_SCALES = (("10kb", 10_000),
+                 ("100kb", 100_000),
+                 ("1mb", 1_000_000))
 
 
 def parse_args():
@@ -54,9 +69,14 @@ def parse_args():
     p.add_argument("--pop-file", default=None,
                    help="optional path/dict/zarr-key for sample -> pop "
                         "assignments. Default: auto-load <vcz>.pops.tsv")
+    p.add_argument("--pops", nargs=2, metavar=("POP1", "POP2"), default=None,
+                   help="two population names to scan. Default: take the "
+                        "first two names from the store's sample_sets.")
     p.add_argument("--out-dir", default="scan_out", help="output directory")
-    p.add_argument("--chunk-bp", type=int, default=500_000,
-                   help="streaming chunk size in bp (default 500 kb)")
+    p.add_argument("--chunk-bp", type=int, default=1_000_000,
+                   help="streaming chunk size in bp. Must be a multiple "
+                        "of every window size (default 1 Mb, which "
+                        "covers the 10 kb / 100 kb / 1 Mb scales).")
     p.add_argument("--heatmap-region", default=None,
                    help="region 'start-end' bp to materialize for the "
                         "pairwise-r^2 heatmap (default: 1 Mb at chrom "
@@ -86,14 +106,39 @@ def main():
     chrom = stream.chrom
     chrom_len = stream.chrom_end - stream.chrom_start
 
-    full_pop = {p: [int(i) for i in stream.sample_sets[p]] for p in POPS}
-    n_haps = {p: len(full_pop[p]) for p in POPS}
-    sub_g = {p: full_pop[p][:args.garud_subsample] for p in POPS}
+    # Catch the chunk_bp / window_size mismatch before the chunk loop:
+    # a per-chunk windowed_analysis call with window_size > chunk_bp
+    # would silently emit no complete window and the output csv would
+    # be just headers under a misleading label.
+    bad = [name for name, bp in WINDOW_SCALES if args.chunk_bp % bp != 0]
+    if bad:
+        raise SystemExit(
+            f"chunk_bp={args.chunk_bp} is not a multiple of every "
+            f"WINDOW_SCALES entry; the {bad} scale(s) would emit no "
+            f"data. Either drop those scales or pass --chunk-bp "
+            f"covering the largest scale.")
+
+    sample_set_names = list(stream.sample_sets or {})
+    if args.pops:
+        pops = tuple(args.pops)
+    elif "all" in sample_set_names and len(sample_set_names) == 1:
+        raise SystemExit(
+            "No pop file found alongside the store and --pops not given; "
+            f"the streaming reader fell back to a single 'all' pop and "
+            f"this example needs two named populations. Either provide "
+            f"--pop-file or --pops.")
+    else:
+        pops = tuple(sample_set_names[:2])
+    print(f"populations: {pops}")
+
+    full_pop = {p: [int(i) for i in stream.sample_sets[p]] for p in pops}
+    n_haps = {p: len(full_pop[p]) for p in pops}
+    sub_g = {p: full_pop[p][:args.garud_subsample] for p in pops}
 
     # Containers populated by the streaming walk.
-    win_parts = {"10kb": [], "100kb": [], "1mb": []}
+    win_parts = {name: [] for name, _ in WINDOW_SCALES}
     garud_parts = []
-    marginal = {p: None for p in POPS}
+    marginal = {p: None for p in pops}
     joint = None
 
     t_scan = time.perf_counter()
@@ -104,16 +149,15 @@ def main():
         # Garud uses a registered subsample per chunk; the rest of
         # the kernels see every haplotype in the chunk.
         chunk.sample_sets = {**full_pop,
-                              **{f"{p}_g": sub_g[p] for p in POPS}}
+                              **{f"{p}_g": sub_g[p] for p in pops}}
 
-        # Per-window diversity + divergence at three scales.
-        for label, bp in (("10kb", 10_000), ("100kb", 100_000),
-                          ("1mb", 1_000_000)):
+        # Per-window diversity + divergence at every scale.
+        for label, bp in WINDOW_SCALES:
             div = windowed_analysis(chunk, window_size=bp, step_size=bp,
                                      statistics=["pi", "theta_w",
                                                   "tajimas_d", "fst",
                                                   "dxy"],
-                                     populations=list(POPS))
+                                     populations=list(pops))
             if not div.empty:
                 win_parts[label].append(div.reset_index(drop=True))
 
@@ -123,15 +167,15 @@ def main():
                                       statistics=["garud_h12",
                                                    "haplotype_count"],
                                       populations=[f"{p}_g"])
-                   for p in POPS]
+                   for p in pops]
         gdf = g_parts[0][["chrom", "start", "end", "center"]].copy()
-        for i, p in enumerate(POPS):
+        for i, p in enumerate(pops):
             gdf[f"garud_h12_{p}"] = g_parts[i]["garud_h12"].values
         garud_parts.append(gdf.reset_index(drop=True))
 
         # Marginal SFS per pop (one bincount per chunk, summed at the
         # end).
-        for p in POPS:
+        for p in pops:
             s = np.asarray(sfs.sfs(chunk, population=p))
             marginal[p] = s if marginal[p] is None else marginal[p] + s
 
@@ -139,7 +183,7 @@ def main():
         # The full (n_hap+1, n_hap+1) histogram would be ~80 GB at
         # 100k haps per pop and would not fit on the GPU.
         j = np.asarray(sfs.project_joint_sfs(
-            chunk, pop1=POPS[0], pop2=POPS[1],
+            chunk, pop1=pops[0], pop2=pops[1],
             target_n1=args.joint_sfs_target,
             target_n2=args.joint_sfs_target,
         ))
@@ -157,7 +201,7 @@ def main():
         df.to_csv(out_dir / f"chr{chrom}_{label}.csv", index=False)
     pd.concat(garud_parts, ignore_index=True).to_csv(
         out_dir / f"chr{chrom}_garud.csv", index=False)
-    for p in POPS:
+    for p in pops:
         np.savetxt(out_dir / f"chr{chrom}_sfs_{p}.csv",
                    marginal[p], delimiter=",", fmt="%d")
     np.save(out_dir / f"chr{chrom}_joint_sfs.npy", joint)
@@ -170,10 +214,12 @@ def main():
     else:
         mid = stream.chrom_start + chrom_len // 2
         lo, hi = mid - 500_000, mid + 500_000
-    sub = list(stream.sample_sets[POPS[0]][:args.heatmap_subsample])
+    sub = list(stream.sample_sets[pops[0]][:args.heatmap_subsample])
     region_hm = stream.materialize(region=(lo, hi), sample_subset=sub)
-    r2 = region_hm.pairwise_r2()
-    np.save(out_dir / f"chr{chrom}_r2_heatmap.npy", np.asarray(r2))
+    # pairwise_r2 returns a cupy array; pull it to host before
+    # serializing.
+    r2 = cp.asnumpy(region_hm.pairwise_r2())
+    np.save(out_dir / f"chr{chrom}_r2_heatmap.npy", r2)
 
     # One-line summary.
     summary = {

--- a/examples/biobank_streaming_scan.py
+++ b/examples/biobank_streaming_scan.py
@@ -124,9 +124,9 @@ def main():
     elif "all" in sample_set_names and len(sample_set_names) == 1:
         raise SystemExit(
             "No pop file found alongside the store and --pops not given; "
-            f"the streaming reader fell back to a single 'all' pop and "
-            f"this example needs two named populations. Either provide "
-            f"--pop-file or --pops.")
+            "the streaming reader fell back to a single 'all' pop and "
+            "this example needs two named populations. Either provide "
+            "--pop-file or --pops.")
     else:
         pops = tuple(sample_set_names[:2])
     print(f"populations: {pops}")

--- a/pg_gpu/__init__.py
+++ b/pg_gpu/__init__.py
@@ -63,7 +63,8 @@ from .decomposition import (
     corners,
 )
 from .resampling import block_jackknife, block_bootstrap
+from ._biobank_warning import BiobankScaleWarning
 
-__all__ = ['ld_statistics', 'diversity', 'divergence', 'windowed_analysis', 'selection', 'sfs', 'admixture', 'decomposition', 'plotting', 'distance_stats', 'resampling', 'HaplotypeMatrix', 'GenotypeMatrix', 'WindowedAnalyzer', 'windowed_analysis', 'AccessibleMask', 'bed_to_mask', 'parse_bed', 'LocalPCAResult', 'LostructResult', 'local_pca', 'local_pca_jackknife', 'lostruct', 'pc_dist', 'corners', 'block_jackknife', 'block_bootstrap']
+__all__ = ['ld_statistics', 'diversity', 'divergence', 'windowed_analysis', 'selection', 'sfs', 'admixture', 'decomposition', 'plotting', 'distance_stats', 'resampling', 'HaplotypeMatrix', 'GenotypeMatrix', 'WindowedAnalyzer', 'windowed_analysis', 'AccessibleMask', 'bed_to_mask', 'parse_bed', 'LocalPCAResult', 'LostructResult', 'local_pca', 'local_pca_jackknife', 'lostruct', 'pc_dist', 'corners', 'block_jackknife', 'block_bootstrap', 'BiobankScaleWarning']
 
 __version__ = '0.1.0'

--- a/pg_gpu/__init__.py
+++ b/pg_gpu/__init__.py
@@ -63,8 +63,8 @@ from .decomposition import (
     corners,
 )
 from .resampling import block_jackknife, block_bootstrap
-from ._biobank_warning import BiobankScaleWarning
+from ._memory_warning import MemoryLimitedWarning
 
-__all__ = ['ld_statistics', 'diversity', 'divergence', 'windowed_analysis', 'selection', 'sfs', 'admixture', 'decomposition', 'plotting', 'distance_stats', 'resampling', 'HaplotypeMatrix', 'GenotypeMatrix', 'WindowedAnalyzer', 'windowed_analysis', 'AccessibleMask', 'bed_to_mask', 'parse_bed', 'LocalPCAResult', 'LostructResult', 'local_pca', 'local_pca_jackknife', 'lostruct', 'pc_dist', 'corners', 'block_jackknife', 'block_bootstrap', 'BiobankScaleWarning']
+__all__ = ['ld_statistics', 'diversity', 'divergence', 'windowed_analysis', 'selection', 'sfs', 'admixture', 'decomposition', 'plotting', 'distance_stats', 'resampling', 'HaplotypeMatrix', 'GenotypeMatrix', 'WindowedAnalyzer', 'windowed_analysis', 'AccessibleMask', 'bed_to_mask', 'parse_bed', 'LocalPCAResult', 'LostructResult', 'local_pca', 'local_pca_jackknife', 'lostruct', 'pc_dist', 'corners', 'block_jackknife', 'block_bootstrap', 'MemoryLimitedWarning']
 
 __version__ = '0.1.0'

--- a/pg_gpu/_biobank_warning.py
+++ b/pg_gpu/_biobank_warning.py
@@ -1,0 +1,143 @@
+"""``BiobankScaleWarning`` and the size check ``from_vcf`` uses to fire it.
+
+VCF text parsing is single-threaded in htslib and dominates loading
+wall time at biobank scale. ``HaplotypeMatrix.from_vcf`` and
+``GenotypeMatrix.from_vcf`` call ``_maybe_biobank_warn`` before
+parsing so users with very large VCFs get pointed at the
+one-time-conversion path -- ``HaplotypeMatrix.vcf_to_zarr`` builds a
+VCZ store, and subsequent reads via ``from_zarr`` are seconds to
+minutes instead of hours.
+"""
+
+import gzip
+import os
+import warnings
+
+
+class BiobankScaleWarning(UserWarning):
+    """A VCF load that will be slow because of its size or sample count.
+
+    Emitted before parsing by ``HaplotypeMatrix.from_vcf`` and
+    ``GenotypeMatrix.from_vcf``. The text includes a copy-pastable
+    recipe for converting the VCF to VCZ via
+    ``HaplotypeMatrix.vcf_to_zarr``. Silence with::
+
+        import warnings
+        from pg_gpu import BiobankScaleWarning
+        warnings.filterwarnings("ignore", category=BiobankScaleWarning)
+    """
+
+
+#: Trigger thresholds. Above these sizes / sample counts a VCF load is
+#: slow enough that converting to VCZ once pays for itself within a
+#: single re-read. The constants are kwargs on ``_maybe_biobank_warn``
+#: so tests can lower them without a global monkeypatch.
+BIOBANK_VCF_WARN_BYTES = 10 * 1024 ** 3      # 10 GiB on disk
+BIOBANK_VCF_WARN_SAMPLES = 5_000
+BIOBANK_VCF_WARN_REGION_BP = 5_000_000       # 5 Mb
+
+
+_warned_paths = set()
+
+
+def _vcf_header_sample_count(path):
+    """Return the number of samples in a VCF's ``#CHROM`` header line,
+    or ``None`` if the file cannot be opened or has no header.
+
+    Reads the header only -- stops at the first non-``##`` line. On a
+    biobank-scale VCF that finishes in milliseconds even when the file
+    is hundreds of GB."""
+    opener = (gzip.open if path.endswith(".gz") or path.endswith(".bgz")
+              else open)
+    try:
+        with opener(path, "rt") as f:
+            for line in f:
+                if line.startswith("#CHROM"):
+                    parts = line.rstrip("\n").rstrip("\r").split("\t")
+                    # columns 0-8 are CHROM, POS, ..., FORMAT; samples
+                    # start at column 9.
+                    return max(0, len(parts) - 9)
+                if not line.startswith("##"):
+                    return None
+    except OSError:
+        return None
+    return None
+
+
+def _region_span_bp(region):
+    """Width of a ``'chrom:start-end'`` string in bp, or 0 on a parse
+    failure. Used to decide whether a region argument is small enough
+    that VCF loading is the right tool even on a large file."""
+    if region is None:
+        return 0
+    from .zarr_io import _parse_region
+    try:
+        _, start, end = _parse_region(region)
+    except (ValueError, AttributeError, TypeError):
+        return 0
+    return max(0, end - start)
+
+
+def _format_warning_text(path, size_bytes, n_samples):
+    return (
+        f"{path} is {size_bytes / 1e9:.1f} GB"
+        f"{f' with {n_samples:,} samples' if n_samples is not None else ''}. "
+        "Loading this VCF will be slow because VCF text parsing is "
+        "single-threaded in htslib. For biobank-scale repeated "
+        "analysis, convert once to VCZ and use "
+        "HaplotypeMatrix.from_zarr() instead -- subsequent reads finish "
+        "in seconds rather than hours, and the kvikio backend can "
+        "speed up sample-subset reads by 100x+.\n\n"
+        "One-time conversion:\n"
+        "    from pg_gpu import HaplotypeMatrix\n"
+        f"    HaplotypeMatrix.vcf_to_zarr({path!r},\n"
+        f"                                {(path.rsplit('.', 1)[0] + '.vcz')!r})\n\n"
+        "Then in pg_gpu:\n"
+        f"    hm = HaplotypeMatrix.from_zarr({(path.rsplit('.', 1)[0] + '.vcz')!r})\n\n"
+        "To silence:\n"
+        "    import warnings\n"
+        "    from pg_gpu import BiobankScaleWarning\n"
+        "    warnings.filterwarnings('ignore', category=BiobankScaleWarning)\n"
+    )
+
+
+def _maybe_biobank_warn(path, *, region=None,
+                       warn_bytes=BIOBANK_VCF_WARN_BYTES,
+                       warn_samples=BIOBANK_VCF_WARN_SAMPLES,
+                       warn_region_bp=BIOBANK_VCF_WARN_REGION_BP,
+                       stacklevel=3):
+    """Emit ``BiobankScaleWarning`` if loading ``path`` will be slow.
+
+    Triggers when either:
+
+    * The on-disk file size exceeds ``warn_bytes`` AND either no
+      ``region`` was passed or the region's span exceeds
+      ``warn_region_bp``. A tabix-region read of a few Mb from a 50 GB
+      VCF is fine and does not warn.
+    * The ``#CHROM`` header lists more than ``warn_samples`` samples.
+
+    Cached per path within a process so repeat loads of the same file
+    only warn once. Used by both ``HaplotypeMatrix.from_vcf`` and
+    ``GenotypeMatrix.from_vcf``.
+    """
+    if path in _warned_paths:
+        return
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        return
+
+    n_samples = _vcf_header_sample_count(path)
+
+    big_file = size > warn_bytes
+    region_big = (region is None
+                  or _region_span_bp(region) > warn_region_bp)
+    too_many_samples = (n_samples is not None and n_samples > warn_samples)
+
+    if (big_file and region_big) or too_many_samples:
+        warnings.warn(
+            _format_warning_text(path, size, n_samples),
+            BiobankScaleWarning,
+            stacklevel=stacklevel,
+        )
+        _warned_paths.add(path)

--- a/pg_gpu/_biobank_warning.py
+++ b/pg_gpu/_biobank_warning.py
@@ -9,6 +9,7 @@ VCZ store, and subsequent reads via ``from_zarr`` are seconds to
 minutes instead of hours.
 """
 
+import collections
 import gzip
 import os
 import warnings
@@ -37,7 +38,15 @@ BIOBANK_VCF_WARN_SAMPLES = 5_000
 BIOBANK_VCF_WARN_REGION_BP = 5_000_000       # 5 Mb
 
 
-_warned_paths = set()
+#: Maximum number of distinct VCF paths the in-process warn cache will
+#: track before it starts evicting the oldest entries. Caps memory in
+#: long-running processes (Jupyter, servers) that hit many unique VCFs.
+_WARN_CACHE_MAX = 1000
+
+#: Cache of already-warned paths -- keys are canonicalized via
+#: ``os.path.realpath`` so ``./foo.vcf`` and ``/abs/foo.vcf`` collapse.
+#: Insertion-ordered: when full, the oldest entry is popped first.
+_warned_paths = collections.OrderedDict()
 
 
 def _vcf_header_sample_count(path):
@@ -120,24 +129,41 @@ def _maybe_biobank_warn(path, *, region=None,
     only warn once. Used by both ``HaplotypeMatrix.from_vcf`` and
     ``GenotypeMatrix.from_vcf``.
     """
-    if path in _warned_paths:
+    # Symlinks and relative paths to the same inode should only warn
+    # once; canonicalize before consulting the cache. Stat is cheap and
+    # only runs on a path we have not warned on yet.
+    try:
+        canonical = os.path.realpath(path)
+    except OSError:
+        canonical = path
+    if canonical in _warned_paths:
         return
     try:
-        size = os.path.getsize(path)
+        size = os.path.getsize(canonical)
     except OSError:
         return
-
-    n_samples = _vcf_header_sample_count(path)
 
     big_file = size > warn_bytes
     region_big = (region is None
                   or _region_span_bp(region) > warn_region_bp)
+
+    # The sample-count check requires opening the VCF header, which on a
+    # gzipped biobank-scale file decompresses several KB of metadata
+    # lines. Skip it when the size check already cannot trigger -- a
+    # below-threshold file with a too-small region cannot warn on
+    # sample count alone either, so the read is pure waste.
+    if not big_file and (region is not None and not region_big):
+        return
+
+    n_samples = _vcf_header_sample_count(canonical)
     too_many_samples = (n_samples is not None and n_samples > warn_samples)
 
     if (big_file and region_big) or too_many_samples:
         warnings.warn(
-            _format_warning_text(path, size, n_samples),
+            _format_warning_text(canonical, size, n_samples),
             BiobankScaleWarning,
             stacklevel=stacklevel,
         )
-        _warned_paths.add(path)
+        _warned_paths[canonical] = None
+        while len(_warned_paths) > _WARN_CACHE_MAX:
+            _warned_paths.popitem(last=False)

--- a/pg_gpu/_gpu_genotype_prep.py
+++ b/pg_gpu/_gpu_genotype_prep.py
@@ -1,18 +1,27 @@
-"""GPU-side preparation of raw VCZ-shape genotype blocks for HaplotypeMatrix.
+"""GPU-side preparation of raw VCZ-shape genotype blocks for HaplotypeMatrix
+and GenotypeMatrix.
 
-The VCZ ``call_genotype`` array is ``(n_var, n_dip, 2)`` int8. HaplotypeMatrix
-expects ``(n_hap, n_var)`` int8 with haps ``0..n_dip-1`` carrying ploidy 0 and
-haps ``n_dip..2*n_dip-1`` carrying ploidy 1. The host-side numpy version of
-that transform allocates a fresh ``2 * chunk_bytes`` of host memory and runs
-a single-threaded strided int8 copy; on a 1 Mb / 200k-haplotype block that is
-~60 s of wall and a 56 GB allocation. The GPU version uses cupy's tiled
-transpose kernel after a single PCIe upload and runs in seconds with a fixed
-memory footprint.
+The VCZ ``call_genotype`` array is ``(n_var, n_dip, 2)`` int8. The two matrix
+classes consume it differently:
 
-Missing / multiallelic rows (gt = -1) are preserved -- the downstream pg_gpu
-kernels handle them via their ``'include'`` / ``'exclude'`` missing-data
-modes, so dropping them here would silently change semantics for callers
-that opted into 'include'.
+* ``HaplotypeMatrix`` wants ``(n_hap, n_var)`` int8 with haps
+  ``0..n_dip-1`` carrying ploidy 0 and haps ``n_dip..2*n_dip-1`` carrying
+  ploidy 1. ``build_haplotype_matrix`` does the ploidy interleave +
+  transpose on the GPU.
+* ``GenotypeMatrix`` wants ``(n_indiv, n_var)`` int8 dosages (0/1/2 with
+  ``-1`` for missing). ``build_genotype_matrix`` sums the two ploidies on
+  the GPU and propagates missing.
+
+Both helpers take the same raw input shape and exist to keep the
+host-side numpy reshape (which on a 1 Mb / 200k-haplotype block is
+~60 s of single-threaded strided int8 copy and a 56 GB allocation)
+off the per-chunk hot path. cupy's tiled transpose / fused add runs in
+seconds with a fixed memory footprint.
+
+Missing / multiallelic cells (gt = -1) are preserved by both helpers --
+downstream kernels handle them via the ``'include'`` / ``'exclude'``
+missing-data modes, and dropping them at build time would silently
+change semantics for callers that opted into 'include'.
 """
 
 import cupy as cp
@@ -67,6 +76,63 @@ def build_haplotype_matrix(gt, pos, *,
 
     return HaplotypeMatrix(
         haps, positions,
+        chrom_start=chrom_start, chrom_end=chrom_end,
+        sample_sets=sample_sets, n_total_sites=n_total_sites,
+        samples=samples, accessible_mask=accessible_mask,
+    )
+
+
+def build_genotype_matrix(gt, pos, *,
+                          chrom_start=None, chrom_end=None,
+                          sample_sets=None, n_total_sites=None,
+                          samples=None, accessible_mask=None):
+    """Build a GenotypeMatrix from a raw VCZ-style genotype block.
+
+    Parameters
+    ----------
+    gt : ndarray, shape (n_var, n_dip, 2)
+        Raw call_genotype block. ``-1`` marks multiallelic / missing
+        cells; a row is treated as missing for a given diploid if
+        either ploidy is ``-1``. Host or device.
+    pos : ndarray, shape (n_var,)
+        Variant positions. Host or device.
+
+    The remaining kwargs are forwarded to ``GenotypeMatrix.__init__``.
+
+    Returns
+    -------
+    GenotypeMatrix
+        With genotypes on the GPU in ``(n_indiv, n_var)`` int8 layout.
+        Each cell is ``0/1/2`` (dosage) or ``-1`` when either ploidy
+        on that variant was missing in the input.
+    """
+    from .genotype_matrix import GenotypeMatrix
+
+    if gt.ndim != 3 or gt.shape[2] != 2:
+        raise ValueError(
+            f"gt must have shape (n_var, n_dip, 2); got {gt.shape}"
+        )
+    if gt.shape[0] != pos.shape[0]:
+        raise ValueError(
+            f"gt and pos disagree on n_var: gt={gt.shape[0]}, pos={pos.shape[0]}"
+        )
+
+    gt_gpu = cp.asarray(gt)
+    # Dosage = sum of ploidies, clamping -1 to 0 first so the sum
+    # makes sense before we paint missing back in.
+    missing = (gt_gpu < 0).any(axis=2)
+    geno = cp.maximum(gt_gpu, 0).sum(axis=2).astype(cp.int8)
+    geno = cp.where(missing, cp.int8(-1), geno)
+    # transpose to the (n_indiv, n_var) layout GenotypeMatrix kernels
+    # expect; cupy's tiled transpose handles the strided write
+    # efficiently.
+    geno = cp.ascontiguousarray(geno.T)
+    del gt_gpu
+
+    positions = cp.asarray(pos)
+
+    return GenotypeMatrix(
+        geno, positions,
         chrom_start=chrom_start, chrom_end=chrom_end,
         sample_sets=sample_sets, n_total_sites=n_total_sites,
         samples=samples, accessible_mask=accessible_mask,

--- a/pg_gpu/_gpu_genotype_prep.py
+++ b/pg_gpu/_gpu_genotype_prep.py
@@ -1,0 +1,73 @@
+"""GPU-side preparation of raw VCZ-shape genotype blocks for HaplotypeMatrix.
+
+The VCZ ``call_genotype`` array is ``(n_var, n_dip, 2)`` int8. HaplotypeMatrix
+expects ``(n_hap, n_var)`` int8 with haps ``0..n_dip-1`` carrying ploidy 0 and
+haps ``n_dip..2*n_dip-1`` carrying ploidy 1. The host-side numpy version of
+that transform allocates a fresh ``2 * chunk_bytes`` of host memory and runs
+a single-threaded strided int8 copy; on a 1 Mb / 200k-haplotype block that is
+~60 s of wall and a 56 GB allocation. The GPU version uses cupy's tiled
+transpose kernel after a single PCIe upload and runs in seconds with a fixed
+memory footprint.
+
+Missing / multiallelic rows (gt = -1) are preserved -- the downstream pg_gpu
+kernels handle them via their ``'include'`` / ``'exclude'`` missing-data
+modes, so dropping them here would silently change semantics for callers
+that opted into 'include'.
+"""
+
+import cupy as cp
+
+
+def build_haplotype_matrix(gt, pos, *,
+                           chrom_start=None, chrom_end=None,
+                           sample_sets=None, n_total_sites=None,
+                           samples=None, accessible_mask=None):
+    """Build a HaplotypeMatrix from a raw VCZ-style genotype block.
+
+    Parameters
+    ----------
+    gt : ndarray, shape (n_var, n_dip, 2)
+        Raw call_genotype block. ``-1`` marks multiallelic / missing
+        cells; rows are preserved. Host or device.
+    pos : ndarray, shape (n_var,)
+        Variant positions. Host or device.
+
+    The remaining kwargs are forwarded to ``HaplotypeMatrix.__init__``.
+
+    Returns
+    -------
+    HaplotypeMatrix
+        With haplotypes on the GPU in ``(n_hap, n_var)`` layout.
+    """
+    from .haplotype_matrix import HaplotypeMatrix
+
+    if gt.ndim != 3 or gt.shape[2] != 2:
+        raise ValueError(
+            f"gt must have shape (n_var, n_dip, 2); got {gt.shape}"
+        )
+    if gt.shape[0] != pos.shape[0]:
+        raise ValueError(
+            f"gt and pos disagree on n_var: gt={gt.shape[0]}, pos={pos.shape[0]}"
+        )
+
+    n_var, n_dip, _ = gt.shape
+    gt_gpu = cp.asarray(gt)
+
+    # transpose (n_var, n_dip, 2) -> (2, n_dip, n_var) puts ploidy outermost,
+    # then the reshape concatenates: hap[0..n_dip-1] = ploidy 0 samples,
+    # hap[n_dip..2*n_dip-1] = ploidy 1 samples. This matches the layout
+    # HaplotypeMatrix.load_pop_file builds, so sample_sets indices line up
+    # without a permutation.
+    haps = cp.ascontiguousarray(
+        gt_gpu.transpose(2, 1, 0).reshape(2 * n_dip, n_var)
+    )
+    del gt_gpu
+
+    positions = cp.asarray(pos)
+
+    return HaplotypeMatrix(
+        haps, positions,
+        chrom_start=chrom_start, chrom_end=chrom_end,
+        sample_sets=sample_sets, n_total_sites=n_total_sites,
+        samples=samples, accessible_mask=accessible_mask,
+    )

--- a/pg_gpu/_memory_warning.py
+++ b/pg_gpu/_memory_warning.py
@@ -1,12 +1,14 @@
-"""``BiobankScaleWarning`` and the size check ``from_vcf`` uses to fire it.
+"""``MemoryLimitedWarning`` and the size check ``from_vcf`` uses to fire it.
 
-VCF text parsing is single-threaded in htslib and dominates loading
-wall time at biobank scale. ``HaplotypeMatrix.from_vcf`` and
-``GenotypeMatrix.from_vcf`` call ``_maybe_biobank_warn`` before
-parsing so users with very large VCFs get pointed at the
-one-time-conversion path -- ``HaplotypeMatrix.vcf_to_zarr`` builds a
-VCZ store, and subsequent reads via ``from_zarr`` are seconds to
-minutes instead of hours.
+VCF text parsing is single-threaded in htslib and the whole genotype
+matrix gets pulled into host memory at once, so a very large VCF
+either takes hours to load or exhausts RAM outright.
+``HaplotypeMatrix.from_vcf`` and ``GenotypeMatrix.from_vcf`` call
+``_maybe_memory_warn`` before parsing so users with too-large VCFs
+get pointed at the one-time-conversion path --
+``HaplotypeMatrix.vcf_to_zarr`` builds a VCZ store, and subsequent
+reads via ``from_zarr`` are seconds to minutes instead of hours and
+can stream a chromosome that doesn't fit in memory.
 """
 
 import collections
@@ -15,27 +17,30 @@ import os
 import warnings
 
 
-class BiobankScaleWarning(UserWarning):
-    """A VCF load that will be slow because of its size or sample count.
+class MemoryLimitedWarning(UserWarning):
+    """A load that is at risk of exhausting memory or taking far longer
+    than the VCZ path would.
 
     Emitted before parsing by ``HaplotypeMatrix.from_vcf`` and
-    ``GenotypeMatrix.from_vcf``. The text includes a copy-pastable
-    recipe for converting the VCF to VCZ via
+    ``GenotypeMatrix.from_vcf`` when the VCF on disk is large enough,
+    or has enough samples, that VCF text parsing will be slow and the
+    full-matrix host load may not even fit. The warning text includes
+    a copy-pastable recipe for converting the VCF to VCZ via
     ``HaplotypeMatrix.vcf_to_zarr``. Silence with::
 
         import warnings
-        from pg_gpu import BiobankScaleWarning
-        warnings.filterwarnings("ignore", category=BiobankScaleWarning)
+        from pg_gpu import MemoryLimitedWarning
+        warnings.filterwarnings("ignore", category=MemoryLimitedWarning)
     """
 
 
 #: Trigger thresholds. Above these sizes / sample counts a VCF load is
 #: slow enough that converting to VCZ once pays for itself within a
-#: single re-read. The constants are kwargs on ``_maybe_biobank_warn``
+#: single re-read. The constants are kwargs on ``_maybe_memory_warn``
 #: so tests can lower them without a global monkeypatch.
-BIOBANK_VCF_WARN_BYTES = 10 * 1024 ** 3      # 10 GiB on disk
-BIOBANK_VCF_WARN_SAMPLES = 5_000
-BIOBANK_VCF_WARN_REGION_BP = 5_000_000       # 5 Mb
+VCF_WARN_BYTES = 10 * 1024 ** 3      # 10 GiB on disk
+VCF_WARN_SAMPLES = 5_000
+VCF_WARN_REGION_BP = 5_000_000       # 5 Mb
 
 
 #: Maximum number of distinct VCF paths the in-process warn cache will
@@ -54,7 +59,7 @@ def _vcf_header_sample_count(path):
     or ``None`` if the file cannot be opened or has no header.
 
     Reads the header only -- stops at the first non-``##`` line. On a
-    biobank-scale VCF that finishes in milliseconds even when the file
+    very large VCF this finishes in milliseconds even when the file
     is hundreds of GB."""
     opener = (gzip.open if path.endswith(".gz") or path.endswith(".bgz")
               else open)
@@ -92,11 +97,11 @@ def _format_warning_text(path, size_bytes, n_samples):
         f"{path} is {size_bytes / 1e9:.1f} GB"
         f"{f' with {n_samples:,} samples' if n_samples is not None else ''}. "
         "Loading this VCF will be slow because VCF text parsing is "
-        "single-threaded in htslib. For biobank-scale repeated "
-        "analysis, convert once to VCZ and use "
+        "single-threaded in htslib, and the full genotype matrix "
+        "must fit in host memory. Convert once to VCZ and use "
         "HaplotypeMatrix.from_zarr() instead -- subsequent reads finish "
-        "in seconds rather than hours, and the kvikio backend can "
-        "speed up sample-subset reads by 100x+.\n\n"
+        "in seconds rather than hours, and the streaming path can "
+        "walk a chromosome larger than memory chunk by chunk.\n\n"
         "One-time conversion:\n"
         "    from pg_gpu import HaplotypeMatrix\n"
         f"    HaplotypeMatrix.vcf_to_zarr({path!r},\n"
@@ -105,17 +110,17 @@ def _format_warning_text(path, size_bytes, n_samples):
         f"    hm = HaplotypeMatrix.from_zarr({(path.rsplit('.', 1)[0] + '.vcz')!r})\n\n"
         "To silence:\n"
         "    import warnings\n"
-        "    from pg_gpu import BiobankScaleWarning\n"
-        "    warnings.filterwarnings('ignore', category=BiobankScaleWarning)\n"
+        "    from pg_gpu import MemoryLimitedWarning\n"
+        "    warnings.filterwarnings('ignore', category=MemoryLimitedWarning)\n"
     )
 
 
-def _maybe_biobank_warn(path, *, region=None,
-                       warn_bytes=BIOBANK_VCF_WARN_BYTES,
-                       warn_samples=BIOBANK_VCF_WARN_SAMPLES,
-                       warn_region_bp=BIOBANK_VCF_WARN_REGION_BP,
+def _maybe_memory_warn(path, *, region=None,
+                       warn_bytes=VCF_WARN_BYTES,
+                       warn_samples=VCF_WARN_SAMPLES,
+                       warn_region_bp=VCF_WARN_REGION_BP,
                        stacklevel=3):
-    """Emit ``BiobankScaleWarning`` if loading ``path`` will be slow.
+    """Emit ``MemoryLimitedWarning`` if loading ``path`` will be slow.
 
     Triggers when either:
 
@@ -148,7 +153,7 @@ def _maybe_biobank_warn(path, *, region=None,
                   or _region_span_bp(region) > warn_region_bp)
 
     # The sample-count check requires opening the VCF header, which on a
-    # gzipped biobank-scale file decompresses several KB of metadata
+    # gzipped multi-GB file decompresses several KB of metadata
     # lines. Skip it when the size check already cannot trigger -- a
     # below-threshold file with a too-small region cannot warn on
     # sample count alone either, so the read is pure waste.
@@ -161,7 +166,7 @@ def _maybe_biobank_warn(path, *, region=None,
     if (big_file and region_big) or too_many_samples:
         warnings.warn(
             _format_warning_text(canonical, size, n_samples),
-            BiobankScaleWarning,
+            MemoryLimitedWarning,
             stacklevel=stacklevel,
         )
         _warned_paths[canonical] = None

--- a/pg_gpu/_memutil.py
+++ b/pg_gpu/_memutil.py
@@ -43,6 +43,11 @@ def estimate_indiv_block_size(n_ind, bytes_per_element=8,
 
     Returns at least 1 and at most ``n_ind`` (a single block covers
     every individual, equivalent to no tiling).
+
+    The ``cp.cuda.Device().mem_info`` read is single-shot per call;
+    pg_gpu's streaming pipelines run on the default CUDA stream from
+    one Python thread so no other code is touching the memory pool
+    concurrently while this estimate is being computed.
     """
     free = cp.cuda.Device().mem_info[0]
     budget = int(free * memory_fraction)

--- a/pg_gpu/_memutil.py
+++ b/pg_gpu/_memutil.py
@@ -30,6 +30,27 @@ def estimate_variant_chunk_size(n_hap, bytes_per_element=4, n_intermediates=3,
     return chunk
 
 
+def estimate_indiv_block_size(n_ind, bytes_per_element=8,
+                              n_intermediates=4, memory_fraction=0.25):
+    """Pick how many individuals to process per row block when streaming
+    relatedness kernels accumulate an (n_ind, n_ind) output by tiling
+    the individual axis.
+
+    Each row block holds ~``n_intermediates`` working arrays of shape
+    ``(block_size, n_ind)`` on the GPU (typically the row-block slice
+    of the indicator matmul plus the matmul output). Budgets the
+    requested fraction of free GPU memory for those.
+
+    Returns at least 1 and at most ``n_ind`` (a single block covers
+    every individual, equivalent to no tiling).
+    """
+    free = cp.cuda.Device().mem_info[0]
+    budget = int(free * memory_fraction)
+    per_row = n_ind * bytes_per_element * n_intermediates
+    block = max(1, budget // per_row)
+    return min(block, n_ind)
+
+
 def estimate_fused_chunk_size(n_hap, memory_fraction=0.35):
     """Estimate max variants for a transposed int8 chunk in fused kernels.
 

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -357,8 +357,8 @@ class GenotypeMatrix:
         GenotypeMatrix
         """
         import allel
-        from ._biobank_warning import _maybe_biobank_warn
-        _maybe_biobank_warn(path)
+        from ._memory_warning import _maybe_memory_warn
+        _maybe_memory_warn(path)
         callset = allel.read_vcf(path)
         gt = callset['calldata/GT']  # (n_variants, n_samples, 2)
         pos = callset['variants/POS']
@@ -401,36 +401,24 @@ class GenotypeMatrix:
                   backend: str = "auto"):
         """Construct a GenotypeMatrix from a Zarr store.
 
-        Supports both VCZ (bio2zarr) and scikit-allel zarr layouts.
+        Identical interface to ``HaplotypeMatrix.from_zarr``;
+        see that method's docstring for the meaning of every kwarg
+        (``streaming``, ``pop_file`` flexibility, ``chunk_bp``,
+        ``prefetch``, ``backend``). The only difference is the
+        returned type: this returns ``GenotypeMatrix`` (or
+        ``StreamingGenotypeMatrix`` on the streaming path) where
+        each row is a (n_indiv, ploidy) genotype call, versus
+        ``HaplotypeMatrix`` which presents the same data as a
+        (n_haplotypes, n_variants) phased matrix.
 
         Parameters
         ----------
-        path : str
-            Path to Zarr store directory.
-        region : str, optional
-            Genomic region 'chrom:start-end'.
-        accessible_bed : str, optional
-            Path to a BED file defining accessible/callable regions.
         include_invariant : bool
-            If True, set n_total_sites from loaded variant count.
-        pop_file : str or False, optional
-            Tab-delimited file mapping ``sample`` -> ``pop`` in the
-            format ``GenotypeMatrix.load_pop_file`` expects. Default
-            (``None``) looks for ``<path>.pops.tsv`` next to the
-            store and loads it if present. Pass ``False`` to disable
-            the auto-load.
-        streaming : {'auto', 'always', 'never'}, optional
-            Whether to return a ``StreamingGenotypeMatrix`` that
-            iterates the store chunk-by-chunk through the GPU
-            (suitable for biobank-scale stores that do not fit
-            eagerly on the device). ``'auto'`` (default) checks the
-            projected eager footprint against free GPU memory and
-            picks streaming when the eager matrix would consume more
-            than half the device. Scikit-allel layouts always route
-            to eager because the streaming source is VCZ-only.
-        chunk_bp, prefetch, backend
-            See ``HaplotypeMatrix.from_zarr``; ignored on the eager
-            path.
+            If True, set ``n_total_sites`` from the loaded variant
+            count. Unique to this entry point (the haplotype matrix
+            does not need it).
+        path, region, accessible_bed, pop_file, streaming, chunk_bp, prefetch, backend
+            See ``HaplotypeMatrix.from_zarr``.
 
         Returns
         -------
@@ -477,9 +465,8 @@ class GenotypeMatrix:
     @classmethod
     def _build_eager(cls, path, *, region, accessible_bed,
                      include_invariant, pop_file):
-        from .zarr_io import read_genotypes
+        from .zarr_io import read_genotypes, normalize_pop_input
         from ._gpu_genotype_prep import build_genotype_matrix
-        from .haplotype_matrix import _resolve_companion_pop_file
 
         data = read_genotypes(path, region)
         gt = data['gt']  # (n_variants, n_samples, ploidy)
@@ -499,9 +486,19 @@ class GenotypeMatrix:
         if accessible_bed is not None:
             gm.set_accessible_mask(accessible_bed, chrom=chrom)
 
-        resolved_pop = _resolve_companion_pop_file(path, pop_file)
-        if resolved_pop is not None:
-            gm.load_pop_file(resolved_pop)
+        try:
+            import zarr
+            store = zarr.open_group(path, mode="r")
+        except Exception:
+            store = None
+        pop_map = normalize_pop_input(
+            pop_file, zarr_path=path,
+            sample_names=gm.samples or [],
+            zarr_store=store,
+            announce_prefix="GenotypeMatrix.from_zarr",
+        )
+        if pop_map is not None:
+            gm.load_pop_file(pop_map)
 
         return gm
 
@@ -562,24 +559,30 @@ class GenotypeMatrix:
             )
 
     def load_pop_file(self, pop_file, pops=None):
-        """Load population assignments from a tab-delimited file.
+        """Load population assignments from a tab-delimited file or
+        an already-resolved sample->population mapping.
 
         Parameters
         ----------
-        pop_file : str
-            Tab-delimited file with columns: sample, pop.
+        pop_file : str or dict
+            Either a path to a tab-delimited file with columns
+            ``sample\tpop``, or a dict mapping sample names to
+            population labels.
         pops : list of str, optional
             Populations to include. If None, includes all found.
         """
         if self.samples is None:
             raise ValueError("No sample names stored. Use from_vcf() to load data.")
 
-        pop_map = {}
-        with open(pop_file) as f:
-            for line in f:
-                parts = line.strip().split()
-                if len(parts) >= 2 and parts[0] != 'sample':
-                    pop_map[parts[0]] = parts[1]
+        if isinstance(pop_file, dict):
+            pop_map = {str(k): str(v) for k, v in pop_file.items() if v}
+        else:
+            pop_map = {}
+            with open(pop_file) as f:
+                for line in f:
+                    parts = line.strip().split()
+                    if len(parts) >= 2 and parts[0] != 'sample':
+                        pop_map[parts[0]] = parts[1]
 
         if pops is None:
             pops = sorted(set(pop_map.values()))

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -393,7 +393,12 @@ class GenotypeMatrix:
 
     @classmethod
     def from_zarr(cls, path, region=None, accessible_bed=None,
-                  include_invariant=False):
+                  include_invariant=False,
+                  pop_file=None,
+                  streaming: str = "auto",
+                  chunk_bp: int = 1_500_000,
+                  prefetch: int = 1,
+                  backend: str = "auto"):
         """Construct a GenotypeMatrix from a Zarr store.
 
         Supports both VCZ (bio2zarr) and scikit-allel zarr layouts.
@@ -408,33 +413,115 @@ class GenotypeMatrix:
             Path to a BED file defining accessible/callable regions.
         include_invariant : bool
             If True, set n_total_sites from loaded variant count.
+        pop_file : str or False, optional
+            Tab-delimited file mapping ``sample`` -> ``pop`` in the
+            format ``GenotypeMatrix.load_pop_file`` expects. Default
+            (``None``) looks for ``<path>.pops.tsv`` next to the
+            store and loads it if present. Pass ``False`` to disable
+            the auto-load.
+        streaming : {'auto', 'always', 'never'}, optional
+            Whether to return a ``StreamingGenotypeMatrix`` that
+            iterates the store chunk-by-chunk through the GPU
+            (suitable for biobank-scale stores that do not fit
+            eagerly on the device). ``'auto'`` (default) checks the
+            projected eager footprint against free GPU memory and
+            picks streaming when the eager matrix would consume more
+            than half the device. Scikit-allel layouts always route
+            to eager because the streaming source is VCZ-only.
+        chunk_bp, prefetch, backend
+            See ``HaplotypeMatrix.from_zarr``; ignored on the eager
+            path.
 
         Returns
         -------
-        GenotypeMatrix
+        GenotypeMatrix or StreamingGenotypeMatrix
         """
+        if streaming not in ("auto", "always", "never"):
+            raise ValueError(
+                f"streaming must be 'auto', 'always', or 'never'; "
+                f"got {streaming!r}"
+            )
+        if backend not in ("auto", "host", "kvikio"):
+            raise ValueError(
+                f"backend must be 'auto', 'host', or 'kvikio'; "
+                f"got {backend!r}"
+            )
+
+        if streaming == "always":
+            return cls._build_streaming(
+                path, region=region, pop_file=pop_file,
+                chunk_bp=chunk_bp, prefetch=prefetch,
+                backend=backend,
+            )
+
+        # 'auto' and 'never' both want eager when the matrix fits;
+        # 'auto' falls back to streaming when it doesn't, 'never'
+        # raises. The decision needs the matrix's projected size,
+        # which is only available via ZarrGenotypeSource (VCZ-only).
+        # Scikit-allel stores always route to eager.
+        from .haplotype_matrix import _decide_streaming_mode
+        choice, source = _decide_streaming_mode(path, region=region,
+                                                streaming=streaming,
+                                                pop_file=pop_file)
+        if choice == "streaming":
+            return cls._build_streaming(
+                path, region=region, pop_file=pop_file,
+                chunk_bp=chunk_bp, prefetch=prefetch,
+                backend=backend, source=source,
+            )
+        return cls._build_eager(path, region=region,
+                                accessible_bed=accessible_bed,
+                                include_invariant=include_invariant,
+                                pop_file=pop_file)
+
+    @classmethod
+    def _build_eager(cls, path, *, region, accessible_bed,
+                     include_invariant, pop_file):
         from .zarr_io import read_genotypes
+        from ._gpu_genotype_prep import build_genotype_matrix
+        from .haplotype_matrix import _resolve_companion_pop_file
 
         data = read_genotypes(path, region)
         gt = data['gt']  # (n_variants, n_samples, ploidy)
         positions = data['positions']
         samples = data['samples']
 
-        missing = np.any(gt < 0, axis=2)
-        geno = np.sum(np.maximum(gt, 0), axis=2).astype(np.int8)
-        geno[missing] = -1
-        geno = geno.T  # (n_individuals, n_variants)
-
-        n_total_sites = geno.shape[1] if include_invariant else None
+        n_total_sites = gt.shape[0] if include_invariant else None
         chrom = region.split(':')[0] if region else None
 
-        gm = cls(geno, positions, chrom_start=int(positions[0]),
-                 chrom_end=int(positions[-1]),
-                 n_total_sites=n_total_sites,
-                 samples=list(samples) if samples else None)
+        gm = build_genotype_matrix(
+            gt, positions,
+            chrom_start=int(positions[0]),
+            chrom_end=int(positions[-1]),
+            n_total_sites=n_total_sites,
+            samples=list(samples) if samples else None,
+        )
         if accessible_bed is not None:
             gm.set_accessible_mask(accessible_bed, chrom=chrom)
+
+        resolved_pop = _resolve_companion_pop_file(path, pop_file)
+        if resolved_pop is not None:
+            gm.load_pop_file(resolved_pop)
+
         return gm
+
+    @classmethod
+    def _build_streaming(cls, path, *, region, pop_file, chunk_bp, prefetch,
+                         backend="auto", source=None):
+        from .streaming_matrix import (
+            StreamingGenotypeMatrix, _pick_chunk_fetcher,
+        )
+        from .zarr_source import ZarrGenotypeSource
+
+        if source is None:
+            source = ZarrGenotypeSource(path, region=region, pop_file=pop_file)
+        else:
+            source.pop_cols = source._resolve_pop_file(pop_file)
+        fetcher = _pick_chunk_fetcher(source, backend=backend)
+        return StreamingGenotypeMatrix(
+            source, fetcher,
+            chunk_bp=chunk_bp, prefetch=prefetch,
+        )
 
     def to_zarr(self, zarr_path, format='vcz', contig_name=None):
         """Save genotype data to Zarr format.

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -357,6 +357,8 @@ class GenotypeMatrix:
         GenotypeMatrix
         """
         import allel
+        from ._biobank_warning import _maybe_biobank_warn
+        _maybe_biobank_warn(path)
         callset = allel.read_vcf(path)
         gt = callset['calldata/GT']  # (n_variants, n_samples, 2)
         pos = callset['variants/POS']

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -22,15 +22,16 @@ def _decide_streaming_mode(zarr_path, region, streaming, pop_file,
     Returns ``(mode, source)`` where ``source`` is the
     ``ZarrGenotypeSource`` opened for the size probe and reused
     downstream (when ``mode == 'streaming'``), or ``None`` when no
-    source was opened (scikit-allel layout, missing store, or the
-    eager-fits branch where the caller's eager path opens its own
-    store via ``read_genotypes``).
+    source was opened: scikit-allel layout, missing store, or the
+    branch that picked ``'eager'`` because the matrix fits (in which
+    case the caller's eager path opens its own store via
+    ``read_genotypes``).
 
     Scikit-allel layouts always return ``('eager', None)``: the
-    streaming source is VCZ-only, so the size check would refuse a
+    streaming format is VCZ-only, so the size check would refuse a
     large allel store with nowhere to fall back to.
 
-    ``free_gpu_bytes`` is exposed for tests; production callers leave
+    ``free_gpu_bytes`` is exposed for tests; typical invocation will leave
     it None to let ``cp.cuda.Device().mem_info`` provide it.
     """
     import zarr
@@ -40,8 +41,9 @@ def _decide_streaming_mode(zarr_path, region, streaming, pop_file,
         layout = detect_zarr_layout(store)
     except (FileNotFoundError, KeyError, ValueError):
         # Store path is missing, missing required arrays, or has an
-        # unrecognized layout. Defer to the eager path so its richer
-        # error messages (read_genotypes, layout-specific) surface.
+        # unrecognized layout. Don't raise here -- return 'eager' so the
+        # caller proceeds into ``read_genotypes`` and its layout-specific
+        # checks emit a more actionable error for the user.
         return "eager", None
     if layout != "vcz":
         return "eager", None
@@ -59,21 +61,13 @@ def _decide_streaming_mode(zarr_path, region, streaming, pop_file,
         return "eager", None
     if streaming == "never":
         raise MemoryError(
-            f"streaming='never' but the eager matrix would be "
+            f"streaming='never' but the full matrix would be "
             f"{eager_bytes / 1e9:.1f} GB on a device with "
             f"{free_gpu_bytes / 1e9:.1f} GB free (limit: "
             f"{fraction:.0%}). Use streaming='auto' or 'always' to "
             f"return a StreamingHaplotypeMatrix instead."
         )
     return "streaming", source
-
-
-def _resolve_companion_pop_file(zarr_path, pop_file):
-    """Wrapper around ``zarr_io.resolve_pop_file_path`` tagged for the
-    ``HaplotypeMatrix.from_zarr`` auto-load announce message."""
-    from .zarr_io import resolve_pop_file_path
-    return resolve_pop_file_path(zarr_path, pop_file,
-                                 announce_prefix="HaplotypeMatrix.from_zarr")
 
 
 class HaplotypeMatrix:
@@ -383,8 +377,8 @@ class HaplotypeMatrix:
         HaplotypeMatrix
             Phased haplotype data with sample names stored.
         """
-        from ._biobank_warning import _maybe_biobank_warn
-        _maybe_biobank_warn(path, region=region)
+        from ._memory_warning import _maybe_memory_warn
+        _maybe_memory_warn(path, region=region)
         vcf = allel.read_vcf(path, region=region, samples=samples)
         if vcf is None:
             raise ValueError(f"No variants found in {path}"
@@ -451,30 +445,44 @@ class HaplotypeMatrix:
             Genomic region 'chrom:start-end' to load a subset.
         accessible_bed : str, optional
             Path to a BED file defining accessible/callable regions.
-        pop_file : str or False, optional
-            Tab-delimited file mapping ``sample`` -> ``pop`` in the
-            format ``HaplotypeMatrix.load_pop_file`` expects. Default
-            (``None``) looks for ``<path>.pops.tsv`` next to the
-            store and loads it if present, announcing the auto-load
-            to stderr. Pass ``False`` to disable the auto-load.
+        pop_file : str, numpy.ndarray, list, dict, or False, optional
+            Sample-to-population assignments. Accepted forms:
+
+            * ``str`` -- path to a tab-delimited file with a header
+              row and ``sample\tpop`` columns, in the format that
+              ``HaplotypeMatrix.load_pop_file`` expects.
+            * ``numpy.ndarray`` or ``list`` of length ``n_samples``
+              -- one population label per sample, in the same order
+              as the store's sample axis.
+            * ``dict`` mapping sample id to population label. Any
+              sample not in the dict is left unassigned.
+            * ``False`` -- skip the auto-load.
+
+            Default (``None``) looks for ``<path>.pops.tsv`` next to
+            the store and loads it if present, announcing the
+            auto-load to stderr.
         streaming : {'auto', 'always', 'never'}, optional
             Whether to return a ``StreamingHaplotypeMatrix`` that
             iterates the store chunk-by-chunk through the GPU
-            (suitable for biobank-scale stores that do not fit
-            eagerly on the device). ``'always'`` forces streaming;
-            ``'never'`` forces eager (and raises ``MemoryError`` if
-            the matrix would not fit in free GPU memory). ``'auto'``
-            (default) checks the projected eager footprint against
-            free GPU memory and picks streaming when the eager
-            matrix would consume more than half the device.
-            Scikit-allel layouts always route to eager because the
-            streaming source is VCZ-only.
+            (suitable for large-scale stores that do not fit
+            entirely in GPU memory). ``'always'`` forces streaming;
+            ``'never'`` forces a single-shot load (and raises
+            ``MemoryError`` if the matrix would not fit in free GPU
+            memory). ``'auto'`` (default) checks the projected
+            footprint of the haplotype matrix against free GPU
+            memory and picks streaming when the full matrix would
+            consume more than half the device. Scikit-allel-formatted
+            zarr always routes to the single-shot path because the
+            only allowed format for ``'streaming'`` is VCZ.
         chunk_bp : int, optional
             Genomic chunk size in bp for the streaming path. Ignored
-            on the eager path.
+            when the data are loaded into GPU memory in one shot.
         prefetch : int, optional
-            Read-ahead depth for the streaming path. Ignored on the
-            eager path.
+            Number of chunks to read ahead on a background thread
+            while the current chunk is being processed -- 0 disables
+            read-ahead; 1 (default) overlaps one chunk's disk read
+            with the previous chunk's GPU work. Ignored when the
+            data are loaded into GPU memory in one shot.
         backend : {'auto', 'host', 'kvikio'}, optional
             Streaming chunk-fetch backend. ``'kvikio'`` decodes the
             store's codec on the GPU via ``kvikio + nvCOMP``; only
@@ -539,7 +547,13 @@ class HaplotypeMatrix:
         sample_names = data['samples']
 
         if gt.shape[2] != 2:
-            raise ValueError(f"expected ploidy 2; got {gt.shape[2]}")
+            # The eager and streaming readers, the kvikio sample-subset
+            # gather, and the (n_dip, 2) -> 2 * n_dip haplotype layout all
+            # assume diploid. Haploid / polyploid stores need a different
+            # gather path and are not currently supported.
+            raise ValueError(
+                f"HaplotypeMatrix.from_zarr requires diploid (ploidy 2) "
+                f"genotypes; got ploidy {gt.shape[2]}.")
 
         hm = build_haplotype_matrix(
             gt, positions,
@@ -552,9 +566,20 @@ class HaplotypeMatrix:
         if accessible_bed is not None:
             hm.set_accessible_mask(accessible_bed, chrom=chrom)
 
-        resolved_pop = _resolve_companion_pop_file(path, pop_file)
-        if resolved_pop is not None:
-            hm.load_pop_file(resolved_pop)
+        from .zarr_io import normalize_pop_input
+        try:
+            import zarr
+            store = zarr.open_group(path, mode="r")
+        except Exception:
+            store = None
+        pop_map = normalize_pop_input(
+            pop_file, zarr_path=path,
+            sample_names=hm.samples or [],
+            zarr_store=store,
+            announce_prefix="HaplotypeMatrix.from_zarr",
+        )
+        if pop_map is not None:
+            hm.load_pop_file(pop_map)
 
         return hm
 
@@ -650,17 +675,21 @@ class HaplotypeMatrix:
         gt[:, :, 1] = hap[n_samples:, :].T
         return gt
 
-    def load_pop_file(self, pop_file: str, pops: list = None):
-        """Load population assignments from a tab-delimited file.
+    def load_pop_file(self, pop_file, pops: list = None):
+        """Load population assignments from a tab-delimited file or
+        an already-resolved sample->population mapping.
 
-        Sets sample_sets from a file mapping sample names to populations.
-        Requires that sample names were stored during from_vcf().
+        Sets sample_sets from a file (or dict) mapping sample names to
+        populations. Requires that sample names were stored during
+        ``from_vcf`` / ``from_zarr``.
 
         Parameters
         ----------
-        pop_file : str
-            Tab-delimited file with columns: sample, pop.
-            Header line starting with 'sample' is skipped.
+        pop_file : str or dict
+            Either a path to a tab-delimited file with columns
+            ``sample\tpop`` (header line starting with ``sample`` is
+            skipped), or a dict mapping sample names to population
+            labels.
         pops : list of str, optional
             Populations to include. If None, includes all found populations.
         """
@@ -668,12 +697,15 @@ class HaplotypeMatrix:
             raise ValueError("No sample names stored. Use from_vcf() to load data.")
 
         n_samples = len(self.samples)
-        pop_map = {}
-        with open(pop_file) as f:
-            for line in f:
-                parts = line.strip().split()
-                if len(parts) >= 2 and parts[0] != 'sample':
-                    pop_map[parts[0]] = parts[1]
+        if isinstance(pop_file, dict):
+            pop_map = {str(k): str(v) for k, v in pop_file.items() if v}
+        else:
+            pop_map = {}
+            with open(pop_file) as f:
+                for line in f:
+                    parts = line.strip().split()
+                    if len(parts) >= 2 and parts[0] != 'sample':
+                        pop_map[parts[0]] = parts[1]
 
         # Build sample_sets
         found_pops = set(pop_map.values())

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -17,38 +17,38 @@ STREAMING_AUTO_EAGER_FRACTION = 0.5
 def _decide_streaming_mode(zarr_path, region, streaming, pop_file,
                            free_gpu_bytes=None,
                            fraction=STREAMING_AUTO_EAGER_FRACTION):
-    """Pick 'eager' vs 'streaming' based on the projected matrix size.
+    """Pick ``'eager'`` vs ``'streaming'`` based on the projected matrix size.
 
-    A VCZ-layout store gets a quick metadata probe through
-    ``ZarrGenotypeSource`` to read ``num_variants`` and
-    ``num_haplotypes`` without materializing any genotypes. The
-    projected eager footprint (``num_variants * num_haplotypes`` int8
-    bytes) is compared against the free GPU memory pool: above
-    ``fraction`` of it, ``'auto'`` returns ``'streaming'`` and
-    ``'never'`` raises ``MemoryError``.
+    Returns ``(mode, source)`` where ``source`` is the
+    ``ZarrGenotypeSource`` opened for the size probe and reused
+    downstream (when ``mode == 'streaming'``), or ``None`` when no
+    source was opened (scikit-allel layout, missing store, or the
+    eager-fits branch where the caller's eager path opens its own
+    store via ``read_genotypes``).
 
-    Scikit-allel layout stores always return ``'eager'``: the
+    Scikit-allel layouts always return ``('eager', None)``: the
     streaming source is VCZ-only, so the size check would refuse a
-    large allel store that has no streaming path available. The
-    caller's eager path will then run through the existing
-    ``read_genotypes`` and either succeed or hit a real OOM.
+    large allel store with nowhere to fall back to.
 
-    ``free_gpu_bytes`` is exposed for tests; production callers
-    leave it None to let ``cp.cuda.Device().mem_info`` provide it.
+    ``free_gpu_bytes`` is exposed for tests; production callers leave
+    it None to let ``cp.cuda.Device().mem_info`` provide it.
     """
     import zarr
     from .zarr_io import detect_zarr_layout
     try:
         store = zarr.open_group(zarr_path, mode="r")
         layout = detect_zarr_layout(store)
-    except Exception:
-        layout = None
+    except (FileNotFoundError, KeyError, ValueError):
+        # Store path is missing, missing required arrays, or has an
+        # unrecognized layout. Defer to the eager path so its richer
+        # error messages (read_genotypes, layout-specific) surface.
+        return "eager", None
     if layout != "vcz":
-        return "eager"  # scikit-allel: streaming unsupported, defer to eager
+        return "eager", None
 
     from .zarr_source import ZarrGenotypeSource
     source = ZarrGenotypeSource(zarr_path, region=region,
-                                pop_file=False)  # cheap header probe
+                                pop_file=False)
     eager_bytes = int(source.num_variants) * int(source.num_haplotypes)
 
     if free_gpu_bytes is None:
@@ -56,7 +56,7 @@ def _decide_streaming_mode(zarr_path, region, streaming, pop_file,
         free_gpu_bytes = int(_cp.cuda.Device().mem_info[0])
 
     if eager_bytes <= fraction * free_gpu_bytes:
-        return "eager"
+        return "eager", None
     if streaming == "never":
         raise MemoryError(
             f"streaming='never' but the eager matrix would be "
@@ -65,29 +65,15 @@ def _decide_streaming_mode(zarr_path, region, streaming, pop_file,
             f"{fraction:.0%}). Use streaming='auto' or 'always' to "
             f"return a StreamingHaplotypeMatrix instead."
         )
-    return "streaming"
+    return "streaming", source
 
 
 def _resolve_companion_pop_file(zarr_path, pop_file):
-    """Resolve ``from_zarr``'s ``pop_file`` argument to a path or None.
-
-    The user can pass an explicit path, ``False`` to disable the
-    auto-load, or ``None`` (default) to look for ``<zarr_path>.pops.tsv``
-    next to the store. The auto-load announces to stderr so the choice
-    is visible to the caller.
-    """
-    import os
-    import sys
-    if pop_file is False:
-        return None
-    if pop_file is not None:
-        return pop_file
-    companion = str(zarr_path).rstrip("/") + ".pops.tsv"
-    if not os.path.exists(companion):
-        return None
-    print(f"HaplotypeMatrix.from_zarr: auto-loaded pop file {companion}",
-          file=sys.stderr, flush=True)
-    return companion
+    """Wrapper around ``zarr_io.resolve_pop_file_path`` tagged for the
+    ``HaplotypeMatrix.from_zarr`` auto-load announce message."""
+    from .zarr_io import resolve_pop_file_path
+    return resolve_pop_file_path(zarr_path, pop_file,
+                                 announce_prefix="HaplotypeMatrix.from_zarr")
 
 
 class HaplotypeMatrix:
@@ -506,16 +492,17 @@ class HaplotypeMatrix:
         # 'auto' and 'never' both want eager when the matrix fits; 'auto'
         # falls back to streaming when it doesn't, 'never' raises. The
         # decision needs the matrix's projected size, which is only
-        # available via ZarrGenotypeSource (VCZ-only). For scikit-allel
-        # stores the layout doesn't support streaming yet, so the answer
-        # is always eager regardless of size.
-        choice = _decide_streaming_mode(path, region=region,
-                                        streaming=streaming,
-                                        pop_file=pop_file)
+        # available via ZarrGenotypeSource (VCZ-only). Scikit-allel
+        # stores always route to eager because there is no streaming
+        # source for that layout.
+        choice, source = _decide_streaming_mode(path, region=region,
+                                                streaming=streaming,
+                                                pop_file=pop_file)
         if choice == "streaming":
             return cls._build_streaming(
                 path, region=region, pop_file=pop_file,
                 chunk_bp=chunk_bp, prefetch=prefetch,
+                source=source,
             )
         return cls._build_eager(path, region=region,
                                 accessible_bed=accessible_bed,
@@ -552,11 +539,18 @@ class HaplotypeMatrix:
         return hm
 
     @classmethod
-    def _build_streaming(cls, path, *, region, pop_file, chunk_bp, prefetch):
+    def _build_streaming(cls, path, *, region, pop_file, chunk_bp, prefetch,
+                         source=None):
         from .streaming_matrix import HostChunkFetcher, StreamingHaplotypeMatrix
         from .zarr_source import ZarrGenotypeSource
 
-        source = ZarrGenotypeSource(path, region=region, pop_file=pop_file)
+        if source is None:
+            source = ZarrGenotypeSource(path, region=region, pop_file=pop_file)
+        else:
+            # _decide_streaming_mode opens the source with pop_file=False
+            # to keep its size probe cheap; resolve the caller's pop_file
+            # now without re-opening the zarr store.
+            source.pop_cols = source._resolve_pop_file(pop_file)
         fetcher = HostChunkFetcher(source)
         return StreamingHaplotypeMatrix(
             source, fetcher,

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -1807,91 +1807,33 @@ class HaplotypeMatrix:
         >>> stats = hm.compute_ld_statistics_gpu_single_pop(bp_bins)
         >>> stats[(0.0, 10000.0)]  # (DD, Dz, pi2) for first bin
         """
-        # Apply biallelic filter if requested
         if ac_filter:
             filtered_self = self.apply_biallelic_filter()
             return filtered_self.compute_ld_statistics_gpu_single_pop(
                 bp_bins=bp_bins, raw=raw, ac_filter=False, chunk_size=chunk_size
             )
-
-        # Ensure GPU setup
         if self.device == 'CPU':
             self.transfer_to_gpu()
 
-        from pg_gpu import ld_statistics
+        bp_bins_arr = np.array(bp_bins)
+        max_dist = float(bp_bins_arr[-1])
+        n_bins = len(bp_bins_arr) - 1
+        bp_bins_cp = cp.array(bp_bins_arr)
+        if chunk_size == 'auto':
+            chunk_size = _estimate_ld_chunk_size(self.num_haplotypes)
 
-        # Get positions and compute max distance
         pos = self.positions
         if not isinstance(pos, cp.ndarray):
             pos = cp.array(pos)
-
-        bp_bins = np.array(bp_bins)
-        max_dist = float(bp_bins[-1])
-        n_bins = len(bp_bins) - 1
-
-        # Handle chunk_size='auto'
-        if chunk_size == 'auto':
-            n_haps = self.num_haplotypes
-            chunk_size = _estimate_ld_chunk_size(n_haps)
-
-        # Bin assignment constants
-        bp_bins_cp = cp.array(bp_bins)
-
-        # Initialize accumulators: sums and counts per bin
-        # 3 statistics: DD, Dz, pi2
         bin_sums = cp.zeros((n_bins, 3), dtype=cp.float64)
         bin_counts = cp.zeros(n_bins, dtype=cp.float64)
-
-        # Stream distance-filtered pair chunks
-        for chunk_idx_i, chunk_idx_j in _iter_pairs_within_distance(
-                pos, max_dist, chunk_size):
-            distances = pos[chunk_idx_j] - pos[chunk_idx_i]
-            chunk_bin_inds = cp.digitize(distances, bp_bins_cp) - 1
-            del distances
-
-            counts, n_valid = _compute_counts_for_pairs(
-                self.haplotypes, chunk_idx_i, chunk_idx_j, pop_indices=None
-            )
-
-            chunk_stats = _compute_single_pop_statistics_batch(
-                counts, n_valid, ld_statistics
-            )
-
-            valid_mask = (chunk_bin_inds >= 0) & (chunk_bin_inds < n_bins)
-            valid_bin_inds = chunk_bin_inds[valid_mask]
-            valid_stats = chunk_stats[valid_mask]
-
-            for stat_idx in range(3):
-                cp.add.at(bin_sums[:, stat_idx], valid_bin_inds, valid_stats[:, stat_idx])
-
-            cp.add.at(bin_counts, valid_bin_inds, cp.ones(len(valid_bin_inds), dtype=cp.float64))
-
-            del counts, n_valid, chunk_stats, chunk_bin_inds, valid_stats
-
-        # Build output dictionary
-        out = {}
-        for i in range(n_bins):
-            bin_start = float(bp_bins[i])
-            bin_end = float(bp_bins[i + 1])
-            count = int(bin_counts[i].get())
-
-            if raw:
-                out[(bin_start, bin_end)] = (
-                    float(bin_sums[i, 0].get()),
-                    float(bin_sums[i, 1].get()),
-                    float(bin_sums[i, 2].get())
-                )
-            else:
-                if count > 0:
-                    out[(bin_start, bin_end)] = (
-                        float((bin_sums[i, 0] / bin_counts[i]).get()),
-                        float((bin_sums[i, 1] / bin_counts[i]).get()),
-                        float((bin_sums[i, 2] / bin_counts[i]).get())
-                    )
-                else:
-                    out[(bin_start, bin_end)] = (0.0, 0.0, 0.0)
-
-        return out
+        _accumulate_pair_bins(
+            self.haplotypes, pos, bp_bins_cp, n_bins,
+            max_dist, int(chunk_size), n_tail=0,
+            bin_sums=bin_sums, bin_counts=bin_counts,
+            pop1_indices=None, pop2_indices=None,
+        )
+        return _format_ld_single_pop(bp_bins_arr, bin_sums, bin_counts, raw)
 
 
     def compute_ld_statistics_gpu_two_pops(
@@ -1943,105 +1885,263 @@ class HaplotypeMatrix:
         >>> stats = hm.compute_ld_statistics_gpu_two_pops(bp_bins, 'pop1', 'pop2')
         >>> stats[(0.0, 10000.0)]['DD_0_0']  # D^2 for pop1 in first bin
         """
-        # Apply biallelic filter if requested
         if ac_filter:
             filtered_self = self.apply_biallelic_filter()
             return filtered_self.compute_ld_statistics_gpu_two_pops(
                 bp_bins=bp_bins, pop1=pop1, pop2=pop2, raw=raw,
                 ac_filter=False, chunk_size=chunk_size
             )
-
-        # Ensure GPU setup
         if self.device == 'CPU':
             self.transfer_to_gpu()
 
-        from pg_gpu import ld_statistics
+        bp_bins_arr = np.array(bp_bins)
+        max_dist = float(bp_bins_arr[-1])
+        n_bins = len(bp_bins_arr) - 1
+        bp_bins_cp = cp.array(bp_bins_arr)
+        pop1_indices = self._sample_sets[pop1]
+        pop2_indices = self._sample_sets[pop2]
+        if chunk_size == 'auto':
+            chunk_size = _estimate_ld_chunk_size(
+                max(len(pop1_indices), len(pop2_indices))
+            )
 
-        # Get positions and compute max distance
         pos = self.positions
         if not isinstance(pos, cp.ndarray):
             pos = cp.array(pos)
-
-        bp_bins = np.array(bp_bins)
-        max_dist = float(bp_bins[-1])
-        n_bins = len(bp_bins) - 1
-
-        # Get population indices
-        pop1_indices = self._sample_sets[pop1]
-        pop2_indices = self._sample_sets[pop2]
-
-        # Handle chunk_size='auto'
-        if chunk_size == 'auto':
-            n_haps = max(len(pop1_indices), len(pop2_indices))
-            chunk_size = _estimate_ld_chunk_size(n_haps)
-
-        # Bin assignment constants
-        bp_bins_cp = cp.array(bp_bins)
-
-        stat_names = [
-            'DD_0_0', 'DD_0_1', 'DD_1_1',
-            'Dz_0_0_0', 'Dz_0_0_1', 'Dz_0_1_1', 'Dz_1_0_0', 'Dz_1_0_1', 'Dz_1_1_1',
-            'pi2_0_0_0_0', 'pi2_0_0_0_1', 'pi2_0_0_1_1', 'pi2_0_1_0_1', 'pi2_0_1_1_1', 'pi2_1_1_1_1'
-        ]
         bin_sums = cp.zeros((n_bins, 15), dtype=cp.float64)
         bin_counts = cp.zeros(n_bins, dtype=cp.float64)
+        _accumulate_pair_bins(
+            self.haplotypes, pos, bp_bins_cp, n_bins,
+            max_dist, int(chunk_size), n_tail=0,
+            bin_sums=bin_sums, bin_counts=bin_counts,
+            pop1_indices=pop1_indices, pop2_indices=pop2_indices,
+        )
+        return _format_ld_two_pops(bp_bins_arr, bin_sums, bin_counts, raw)
 
-        # Stream distance-filtered pair chunks
-        for chunk_idx_i, chunk_idx_j in _iter_pairs_within_distance(
-                pos, max_dist, chunk_size):
-            distances = pos[chunk_idx_j] - pos[chunk_idx_i]
-            chunk_bin_inds = cp.digitize(distances, bp_bins_cp) - 1
-            del distances
 
-            counts_pop1, n_valid1 = _compute_counts_for_pairs(
-                self.haplotypes, chunk_idx_i, chunk_idx_j, pop1_indices
+# =============================================================================
+# LD pair-bin accumulator: shared by eager and streaming paths
+# =============================================================================
+#
+# Per-chunk bin sums are sum-reducible: pair counts (n11/n10/n01/n00) at
+# a variant pair are independent of every other pair, and the per-bin
+# DD / Dz / pi2 numerators are polynomials in those counts, so totals
+# decompose by pair set. The streaming path takes advantage of this by
+# carrying a tail of the last ``max_bp_dist`` of variants from the
+# previous chunk; pairs whose both endpoints fall inside that tail are
+# masked out, since they were summed on the previous chunk's pass.
+
+def _new_tail(stitched_haps, stitched_pos, max_bp_dist):
+    """Carry forward variants within ``max_bp_dist`` of the right edge
+    for the next chunk's stitch. Tail size is bounded by
+    ``max_bp_dist`` worth of variants regardless of chunk width."""
+    if stitched_pos.size == 0:
+        return None, None
+    cutoff = stitched_pos[-1] - max_bp_dist
+    keep = stitched_pos > cutoff
+    return stitched_haps[:, keep], stitched_pos[keep]
+
+
+def _stitch_with_tail(chunk_haps, chunk_pos, tail_haps, tail_pos):
+    """Return ``(stitched_haps, stitched_pos, n_tail)`` for the pair
+    iteration. ``n_tail`` is the number of leading variants drawn from
+    the previous chunk's tail; the pair mask keys off this offset."""
+    if tail_haps is None or tail_haps.shape[1] == 0:
+        return chunk_haps, chunk_pos, 0
+    stitched_haps = cp.concatenate([tail_haps, chunk_haps], axis=1)
+    stitched_pos = cp.concatenate([tail_pos, chunk_pos])
+    return stitched_haps, stitched_pos, tail_haps.shape[1]
+
+
+def _missing_flag(haps, pop_indices):
+    """Whether the (optionally pop-subset) haplotype matrix contains any
+    missing data. Cached once per chunk so ``compute_counts_for_pairs``
+    can skip its per-batch full-matrix reduction."""
+    if pop_indices is None:
+        return bool(cp.any(haps == -1))
+    if isinstance(pop_indices, list):
+        pop_indices = cp.array(pop_indices, dtype=cp.int32)
+    return bool(cp.any(haps[pop_indices] == -1))
+
+
+def _accumulate_pair_bins(
+    haps, pos, bp_bins_cp, n_bins, max_dist, chunk_size, n_tail,
+    bin_sums, bin_counts, *, pop1_indices, pop2_indices,
+):
+    """Walk pair batches on ``haps`` / ``pos``, drop already-counted
+    (tail, tail) pairs, and scatter-add per-pair statistics into
+    ``bin_sums`` / ``bin_counts``. ``pop2_indices=None`` selects the
+    single-population path; otherwise both pops feed the two-population
+    batch kernel."""
+    from pg_gpu import ld_statistics
+    two_pop = pop2_indices is not None
+    has_miss_p1 = _missing_flag(haps, pop1_indices)
+    has_miss_p2 = _missing_flag(haps, pop2_indices) if two_pop else False
+    for chunk_idx_i, chunk_idx_j in _iter_pairs_within_distance(
+            pos, max_dist, chunk_size):
+        if n_tail > 0:
+            keep = ~((chunk_idx_i < n_tail) & (chunk_idx_j < n_tail))
+            chunk_idx_i = chunk_idx_i[keep]
+            chunk_idx_j = chunk_idx_j[keep]
+            if chunk_idx_i.size == 0:
+                continue
+        distances = pos[chunk_idx_j] - pos[chunk_idx_i]
+        chunk_bin_inds = cp.digitize(distances, bp_bins_cp) - 1
+        del distances
+
+        if two_pop:
+            counts1, n_valid1 = _compute_counts_for_pairs(
+                haps, chunk_idx_i, chunk_idx_j, pop1_indices,
+                has_missing=has_miss_p1,
             )
-            counts_pop2, n_valid2 = _compute_counts_for_pairs(
-                self.haplotypes, chunk_idx_i, chunk_idx_j, pop2_indices
+            counts2, n_valid2 = _compute_counts_for_pairs(
+                haps, chunk_idx_i, chunk_idx_j, pop2_indices,
+                has_missing=has_miss_p2,
             )
-
             chunk_stats = _compute_two_pop_statistics_batch(
-                counts_pop1, counts_pop2, n_valid1, n_valid2, ld_statistics
+                counts1, counts2, n_valid1, n_valid2, ld_statistics
+            )
+        else:
+            counts, n_valid = _compute_counts_for_pairs(
+                haps, chunk_idx_i, chunk_idx_j, pop1_indices,
+                has_missing=has_miss_p1,
+            )
+            chunk_stats = _compute_single_pop_statistics_batch(
+                counts, n_valid, ld_statistics
             )
 
-            valid_mask = (chunk_bin_inds >= 0) & (chunk_bin_inds < n_bins)
-            valid_bin_inds = chunk_bin_inds[valid_mask]
-            valid_stats = chunk_stats[valid_mask]
+        valid_mask = (chunk_bin_inds >= 0) & (chunk_bin_inds < n_bins)
+        valid_bin_inds = chunk_bin_inds[valid_mask]
+        valid_stats = chunk_stats[valid_mask]
+        for s in range(chunk_stats.shape[1]):
+            cp.add.at(bin_sums[:, s], valid_bin_inds, valid_stats[:, s])
+        cp.add.at(
+            bin_counts, valid_bin_inds,
+            cp.ones(len(valid_bin_inds), dtype=cp.float64),
+        )
 
-            for stat_idx in range(15):
-                cp.add.at(bin_sums[:, stat_idx], valid_bin_inds, valid_stats[:, stat_idx])
 
-            cp.add.at(bin_counts, valid_bin_inds, cp.ones(len(valid_bin_inds), dtype=cp.float64))
+def _stream_ld_single_pop(streaming_hm, *, bp_bins, raw, ac_filter,
+                          chunk_size):
+    """Chunk-streamed dispatch for ``compute_ld_statistics_gpu_single_pop``."""
+    bp_bins_arr = np.array(bp_bins)
+    max_dist = float(bp_bins_arr[-1])
+    n_bins = len(bp_bins_arr) - 1
+    bp_bins_cp = cp.array(bp_bins_arr)
+    if chunk_size == 'auto':
+        chunk_size_int = _estimate_ld_chunk_size(streaming_hm.num_haplotypes)
+    else:
+        chunk_size_int = int(chunk_size)
+    bin_sums = cp.zeros((n_bins, 3), dtype=cp.float64)
+    bin_counts = cp.zeros(n_bins, dtype=cp.float64)
 
-            del counts_pop1, counts_pop2, n_valid1, n_valid2, chunk_stats
-            del chunk_bin_inds, valid_stats
+    tail_haps, tail_pos = None, None
+    for _, _, chunk_hm in streaming_hm.iter_gpu_chunks():
+        if ac_filter:
+            chunk_hm = chunk_hm.apply_biallelic_filter()
+        chunk_haps = chunk_hm.haplotypes
+        chunk_pos = chunk_hm.positions
+        if not isinstance(chunk_pos, cp.ndarray):
+            chunk_pos = cp.array(chunk_pos)
+        if chunk_haps.shape[1] == 0:
+            continue
+        stitched_haps, stitched_pos, n_tail = _stitch_with_tail(
+            chunk_haps, chunk_pos, tail_haps, tail_pos
+        )
+        _accumulate_pair_bins(
+            stitched_haps, stitched_pos, bp_bins_cp, n_bins,
+            max_dist, chunk_size_int, n_tail,
+            bin_sums=bin_sums, bin_counts=bin_counts,
+            pop1_indices=None, pop2_indices=None,
+        )
+        tail_haps, tail_pos = _new_tail(stitched_haps, stitched_pos, max_dist)
+        del stitched_haps, stitched_pos, chunk_haps, chunk_pos
 
-        # Build output dictionary
-        out = {}
-        for i in range(n_bins):
-            bin_start = float(bp_bins[i])
-            bin_end = float(bp_bins[i + 1])
-            count = int(bin_counts[i].get())
+    return _format_ld_single_pop(bp_bins_arr, bin_sums, bin_counts, raw)
 
-            if raw:
-                stats_dict = OrderedDict([
-                    (name, float(bin_sums[i, j].get()))
-                    for j, name in enumerate(stat_names)
-                ])
-            else:
-                if count > 0:
-                    stats_dict = OrderedDict([
-                        (name, float((bin_sums[i, j] / bin_counts[i]).get()))
-                        for j, name in enumerate(stat_names)
-                    ])
-                else:
-                    stats_dict = OrderedDict([
-                        (name, 0.0) for name in stat_names
-                    ])
 
-            out[(bin_start, bin_end)] = stats_dict
+def _stream_ld_two_pops(streaming_hm, *, bp_bins, pop1, pop2, raw,
+                        ac_filter, chunk_size):
+    """Chunk-streamed dispatch for ``compute_ld_statistics_gpu_two_pops``."""
+    bp_bins_arr = np.array(bp_bins)
+    max_dist = float(bp_bins_arr[-1])
+    n_bins = len(bp_bins_arr) - 1
+    bp_bins_cp = cp.array(bp_bins_arr)
+    pop1_indices = streaming_hm.sample_sets[pop1]
+    pop2_indices = streaming_hm.sample_sets[pop2]
+    if chunk_size == 'auto':
+        chunk_size_int = _estimate_ld_chunk_size(
+            max(len(pop1_indices), len(pop2_indices))
+        )
+    else:
+        chunk_size_int = int(chunk_size)
+    bin_sums = cp.zeros((n_bins, 15), dtype=cp.float64)
+    bin_counts = cp.zeros(n_bins, dtype=cp.float64)
 
-        return out
+    tail_haps, tail_pos = None, None
+    for _, _, chunk_hm in streaming_hm.iter_gpu_chunks():
+        if ac_filter:
+            chunk_hm = chunk_hm.apply_biallelic_filter()
+        chunk_haps = chunk_hm.haplotypes
+        chunk_pos = chunk_hm.positions
+        if not isinstance(chunk_pos, cp.ndarray):
+            chunk_pos = cp.array(chunk_pos)
+        if chunk_haps.shape[1] == 0:
+            continue
+        stitched_haps, stitched_pos, n_tail = _stitch_with_tail(
+            chunk_haps, chunk_pos, tail_haps, tail_pos
+        )
+        _accumulate_pair_bins(
+            stitched_haps, stitched_pos, bp_bins_cp, n_bins,
+            max_dist, chunk_size_int, n_tail,
+            bin_sums=bin_sums, bin_counts=bin_counts,
+            pop1_indices=pop1_indices, pop2_indices=pop2_indices,
+        )
+        tail_haps, tail_pos = _new_tail(stitched_haps, stitched_pos, max_dist)
+        del stitched_haps, stitched_pos, chunk_haps, chunk_pos
+
+    return _format_ld_two_pops(bp_bins_arr, bin_sums, bin_counts, raw)
+
+
+def _format_ld_single_pop(bp_bins_arr, bin_sums, bin_counts, raw):
+    # One device->host transfer for each accumulator; per-bin format
+    # then reads from host memory rather than syncing per element.
+    sums = cp.asnumpy(bin_sums)
+    counts = cp.asnumpy(bin_counts)
+    out = {}
+    for i in range(len(bp_bins_arr) - 1):
+        key = (float(bp_bins_arr[i]), float(bp_bins_arr[i + 1]))
+        if raw:
+            out[key] = (float(sums[i, 0]), float(sums[i, 1]), float(sums[i, 2]))
+        elif counts[i] > 0:
+            inv = 1.0 / float(counts[i])
+            out[key] = (
+                float(sums[i, 0]) * inv,
+                float(sums[i, 1]) * inv,
+                float(sums[i, 2]) * inv,
+            )
+        else:
+            out[key] = (0.0, 0.0, 0.0)
+    return out
+
+
+def _format_ld_two_pops(bp_bins_arr, bin_sums, bin_counts, raw):
+    sums = cp.asnumpy(bin_sums)
+    counts = cp.asnumpy(bin_counts)
+    names = _ld_names(2)
+    out = {}
+    for i in range(len(bp_bins_arr) - 1):
+        key = (float(bp_bins_arr[i]), float(bp_bins_arr[i + 1]))
+        if raw:
+            row = sums[i]
+        elif counts[i] > 0:
+            row = sums[i] / float(counts[i])
+        else:
+            row = np.zeros(len(names))
+        out[key] = OrderedDict(
+            (name, float(row[j])) for j, name in enumerate(names)
+        )
+    return out
 
 
 # =============================================================================

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -680,12 +680,21 @@ class HaplotypeMatrix:
         if pops is None:
             pops = sorted(found_pops)
 
-        pop_sets = {p: [] for p in pops}
+        # Block ordering: ploidy-0 indices first, then ploidy-1 indices.
+        # _get_genotype_data and _get_diploid_genotypes split the
+        # haplotype axis at hap.shape[0] // 2 to recover diploid pairs,
+        # which only gives correct pairing under this layout. Matches
+        # what ZarrGenotypeSource produces from a pop file too, so the
+        # streaming and eager paths agree.
+        pop_dips = {p: [] for p in pops}
         for i, name in enumerate(self.samples):
             pop = pop_map.get(name)
-            if pop in pop_sets:
-                pop_sets[pop].append(i)
-                pop_sets[pop].append(i + n_samples)
+            if pop in pop_dips:
+                pop_dips[pop].append(i)
+        pop_sets = {
+            p: dips + [d + n_samples for d in dips]
+            for p, dips in pop_dips.items()
+        }
 
         self.sample_sets = pop_sets
 

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -7,6 +7,28 @@ from collections import Counter, OrderedDict
 from .accessible import AccessibleMask, bed_to_mask, resolve_accessible_mask
 
 
+def _resolve_companion_pop_file(zarr_path, pop_file):
+    """Resolve ``from_zarr``'s ``pop_file`` argument to a path or None.
+
+    The user can pass an explicit path, ``False`` to disable the
+    auto-load, or ``None`` (default) to look for ``<zarr_path>.pops.tsv``
+    next to the store. The auto-load announces to stderr so the choice
+    is visible to the caller.
+    """
+    import os
+    import sys
+    if pop_file is False:
+        return None
+    if pop_file is not None:
+        return pop_file
+    companion = str(zarr_path).rstrip("/") + ".pops.tsv"
+    if not os.path.exists(companion):
+        return None
+    print(f"HaplotypeMatrix.from_zarr: auto-loaded pop file {companion}",
+          file=sys.stderr, flush=True)
+    return companion
+
+
 class HaplotypeMatrix:
     """Haplotype matrix for population genetics analysis.
 
@@ -360,12 +382,17 @@ class HaplotypeMatrix:
 
     @classmethod
     def from_zarr(cls, path: str, region: str = None,
-                  accessible_bed: str = None):
+                  accessible_bed: str = None,
+                  pop_file=None):
         """Construct a HaplotypeMatrix from a Zarr store.
 
         Supports both VCZ (bio2zarr) and scikit-allel zarr layouts.
         Layout is auto-detected. For multi-chromosome stores, region
         must be specified.
+
+        Multiallelic / missing rows (genotype = -1) are dropped from
+        the returned matrix -- pg_gpu's haplotype kernels are
+        calibrated for biallelic sites.
 
         Parameters
         ----------
@@ -375,31 +402,43 @@ class HaplotypeMatrix:
             Genomic region 'chrom:start-end' to load a subset.
         accessible_bed : str, optional
             Path to a BED file defining accessible/callable regions.
+        pop_file : str or False, optional
+            Tab-delimited file mapping ``sample`` -> ``pop`` in the
+            format ``HaplotypeMatrix.load_pop_file`` expects. Default
+            (``None``) looks for ``<path>.pops.tsv`` next to the
+            store and loads it if present, announcing the auto-load
+            to stderr. Pass ``False`` to disable the auto-load.
 
         Returns
         -------
         HaplotypeMatrix
         """
         from .zarr_io import read_genotypes
+        from ._gpu_genotype_prep import build_haplotype_matrix
 
         data = read_genotypes(path, region)
         gt = data['gt']
         positions = data['positions']
         sample_names = data['samples']
 
-        num_variants, num_samples, ploidy = gt.shape
-        assert ploidy == 2
+        if gt.shape[2] != 2:
+            raise ValueError(f"expected ploidy 2; got {gt.shape[2]}")
 
-        haplotypes = np.empty((num_variants, 2 * num_samples), dtype=gt.dtype)
-        haplotypes[:, :num_samples] = gt[:, :, 0]
-        haplotypes[:, num_samples:] = gt[:, :, 1]
-        haplotypes = haplotypes.T
+        hm = build_haplotype_matrix(
+            gt, positions,
+            chrom_start=int(positions[0]),
+            chrom_end=int(positions[-1]),
+            samples=list(sample_names) if sample_names is not None else None,
+        )
 
         chrom = region.split(':')[0] if region else None
-        hm = cls(haplotypes, positions, int(positions[0]), int(positions[-1]),
-                 samples=sample_names)
         if accessible_bed is not None:
             hm.set_accessible_mask(accessible_bed, chrom=chrom)
+
+        resolved_pop = _resolve_companion_pop_file(path, pop_file)
+        if resolved_pop is not None:
+            hm.load_pop_file(resolved_pop)
+
         return hm
 
     def to_zarr(self, zarr_path: str, format: str = 'vcz',

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -383,16 +383,15 @@ class HaplotypeMatrix:
     @classmethod
     def from_zarr(cls, path: str, region: str = None,
                   accessible_bed: str = None,
-                  pop_file=None):
+                  pop_file=None,
+                  streaming: str = "auto",
+                  chunk_bp: int = 1_500_000,
+                  prefetch: int = 1):
         """Construct a HaplotypeMatrix from a Zarr store.
 
         Supports both VCZ (bio2zarr) and scikit-allel zarr layouts.
         Layout is auto-detected. For multi-chromosome stores, region
         must be specified.
-
-        Multiallelic / missing rows (genotype = -1) are dropped from
-        the returned matrix -- pg_gpu's haplotype kernels are
-        calibrated for biallelic sites.
 
         Parameters
         ----------
@@ -408,11 +407,45 @@ class HaplotypeMatrix:
             (``None``) looks for ``<path>.pops.tsv`` next to the
             store and loads it if present, announcing the auto-load
             to stderr. Pass ``False`` to disable the auto-load.
+        streaming : {'auto', 'always', 'never'}, optional
+            Whether to return a ``StreamingHaplotypeMatrix`` that
+            iterates the store chunk-by-chunk through the GPU
+            (suitable for biobank-scale stores that do not fit
+            eagerly on the device). ``'always'`` forces streaming;
+            ``'never'`` forces eager. The ``'auto'`` default
+            currently routes to eager and is reserved for the
+            device-memory heuristic added in a follow-up.
+        chunk_bp : int, optional
+            Genomic chunk size in bp for the streaming path. Ignored
+            on the eager path.
+        prefetch : int, optional
+            Read-ahead depth for the streaming path. Ignored on the
+            eager path.
 
         Returns
         -------
-        HaplotypeMatrix
+        HaplotypeMatrix or StreamingHaplotypeMatrix
         """
+        if streaming not in ("auto", "always", "never"):
+            raise ValueError(
+                f"streaming must be 'auto', 'always', or 'never'; "
+                f"got {streaming!r}"
+            )
+
+        if streaming == "always":
+            return cls._build_streaming(
+                path, region=region, pop_file=pop_file,
+                chunk_bp=chunk_bp, prefetch=prefetch,
+            )
+
+        # 'auto' and 'never' both eager today; 'auto' will pick up the
+        # device-memory check in a follow-up.
+        return cls._build_eager(path, region=region,
+                                accessible_bed=accessible_bed,
+                                pop_file=pop_file)
+
+    @classmethod
+    def _build_eager(cls, path, *, region, accessible_bed, pop_file):
         from .zarr_io import read_genotypes
         from ._gpu_genotype_prep import build_haplotype_matrix
 
@@ -440,6 +473,18 @@ class HaplotypeMatrix:
             hm.load_pop_file(resolved_pop)
 
         return hm
+
+    @classmethod
+    def _build_streaming(cls, path, *, region, pop_file, chunk_bp, prefetch):
+        from .streaming_matrix import HostChunkFetcher, StreamingHaplotypeMatrix
+        from .zarr_source import ZarrGenotypeSource
+
+        source = ZarrGenotypeSource(path, region=region, pop_file=pop_file)
+        fetcher = HostChunkFetcher(source)
+        return StreamingHaplotypeMatrix(
+            source, fetcher,
+            chunk_bp=chunk_bp, prefetch=prefetch,
+        )
 
     def to_zarr(self, zarr_path: str, format: str = 'vcz',
                 contig_name: str = None):

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -383,6 +383,8 @@ class HaplotypeMatrix:
         HaplotypeMatrix
             Phased haplotype data with sample names stored.
         """
+        from ._biobank_warning import _maybe_biobank_warn
+        _maybe_biobank_warn(path, region=region)
         vcf = allel.read_vcf(path, region=region, samples=samples)
         if vcf is None:
             raise ValueError(f"No variants found in {path}"

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -7,6 +7,67 @@ from collections import Counter, OrderedDict
 from .accessible import AccessibleMask, bed_to_mask, resolve_accessible_mask
 
 
+#: Fraction of free GPU memory the eager matrix is allowed to consume
+#: before ``streaming='auto'`` falls back to streaming. 0.5 leaves room
+#: for the haplotype matrix plus the working memory each statistic kernel
+#: needs (windowed scatter buffers, pairwise outputs, etc.).
+STREAMING_AUTO_EAGER_FRACTION = 0.5
+
+
+def _decide_streaming_mode(zarr_path, region, streaming, pop_file,
+                           free_gpu_bytes=None,
+                           fraction=STREAMING_AUTO_EAGER_FRACTION):
+    """Pick 'eager' vs 'streaming' based on the projected matrix size.
+
+    A VCZ-layout store gets a quick metadata probe through
+    ``ZarrGenotypeSource`` to read ``num_variants`` and
+    ``num_haplotypes`` without materializing any genotypes. The
+    projected eager footprint (``num_variants * num_haplotypes`` int8
+    bytes) is compared against the free GPU memory pool: above
+    ``fraction`` of it, ``'auto'`` returns ``'streaming'`` and
+    ``'never'`` raises ``MemoryError``.
+
+    Scikit-allel layout stores always return ``'eager'``: the
+    streaming source is VCZ-only, so the size check would refuse a
+    large allel store that has no streaming path available. The
+    caller's eager path will then run through the existing
+    ``read_genotypes`` and either succeed or hit a real OOM.
+
+    ``free_gpu_bytes`` is exposed for tests; production callers
+    leave it None to let ``cp.cuda.Device().mem_info`` provide it.
+    """
+    import zarr
+    from .zarr_io import detect_zarr_layout
+    try:
+        store = zarr.open_group(zarr_path, mode="r")
+        layout = detect_zarr_layout(store)
+    except Exception:
+        layout = None
+    if layout != "vcz":
+        return "eager"  # scikit-allel: streaming unsupported, defer to eager
+
+    from .zarr_source import ZarrGenotypeSource
+    source = ZarrGenotypeSource(zarr_path, region=region,
+                                pop_file=False)  # cheap header probe
+    eager_bytes = int(source.num_variants) * int(source.num_haplotypes)
+
+    if free_gpu_bytes is None:
+        import cupy as _cp
+        free_gpu_bytes = int(_cp.cuda.Device().mem_info[0])
+
+    if eager_bytes <= fraction * free_gpu_bytes:
+        return "eager"
+    if streaming == "never":
+        raise MemoryError(
+            f"streaming='never' but the eager matrix would be "
+            f"{eager_bytes / 1e9:.1f} GB on a device with "
+            f"{free_gpu_bytes / 1e9:.1f} GB free (limit: "
+            f"{fraction:.0%}). Use streaming='auto' or 'always' to "
+            f"return a StreamingHaplotypeMatrix instead."
+        )
+    return "streaming"
+
+
 def _resolve_companion_pop_file(zarr_path, pop_file):
     """Resolve ``from_zarr``'s ``pop_file`` argument to a path or None.
 
@@ -412,9 +473,13 @@ class HaplotypeMatrix:
             iterates the store chunk-by-chunk through the GPU
             (suitable for biobank-scale stores that do not fit
             eagerly on the device). ``'always'`` forces streaming;
-            ``'never'`` forces eager. The ``'auto'`` default
-            currently routes to eager and is reserved for the
-            device-memory heuristic added in a follow-up.
+            ``'never'`` forces eager (and raises ``MemoryError`` if
+            the matrix would not fit in free GPU memory). ``'auto'``
+            (default) checks the projected eager footprint against
+            free GPU memory and picks streaming when the eager
+            matrix would consume more than half the device.
+            Scikit-allel layouts always route to eager because the
+            streaming source is VCZ-only.
         chunk_bp : int, optional
             Genomic chunk size in bp for the streaming path. Ignored
             on the eager path.
@@ -438,8 +503,20 @@ class HaplotypeMatrix:
                 chunk_bp=chunk_bp, prefetch=prefetch,
             )
 
-        # 'auto' and 'never' both eager today; 'auto' will pick up the
-        # device-memory check in a follow-up.
+        # 'auto' and 'never' both want eager when the matrix fits; 'auto'
+        # falls back to streaming when it doesn't, 'never' raises. The
+        # decision needs the matrix's projected size, which is only
+        # available via ZarrGenotypeSource (VCZ-only). For scikit-allel
+        # stores the layout doesn't support streaming yet, so the answer
+        # is always eager regardless of size.
+        choice = _decide_streaming_mode(path, region=region,
+                                        streaming=streaming,
+                                        pop_file=pop_file)
+        if choice == "streaming":
+            return cls._build_streaming(
+                path, region=region, pop_file=pop_file,
+                chunk_bp=chunk_bp, prefetch=prefetch,
+            )
         return cls._build_eager(path, region=region,
                                 accessible_bed=accessible_bed,
                                 pop_file=pop_file)

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -433,7 +433,8 @@ class HaplotypeMatrix:
                   pop_file=None,
                   streaming: str = "auto",
                   chunk_bp: int = 1_500_000,
-                  prefetch: int = 1):
+                  prefetch: int = 1,
+                  backend: str = "auto"):
         """Construct a HaplotypeMatrix from a Zarr store.
 
         Supports both VCZ (bio2zarr) and scikit-allel zarr layouts.
@@ -472,6 +473,17 @@ class HaplotypeMatrix:
         prefetch : int, optional
             Read-ahead depth for the streaming path. Ignored on the
             eager path.
+        backend : {'auto', 'host', 'kvikio'}, optional
+            Streaming chunk-fetch backend. ``'kvikio'`` decodes the
+            store's codec on the GPU via ``kvikio + nvCOMP``; only
+            works when ``call_genotype``'s codec is in the
+            nvCOMP-supported list (zstd, blosc, lz4, deflate) and
+            the sample-axis chunking is bio2zarr-shaped (sample chunk
+            smaller than the full sample axis). ``'host'`` is the
+            host-buffer fallback. ``'auto'`` (default) picks
+            ``'kvikio'`` when both conditions hold and warns +
+            ``'host'`` when chunks are whole-sample-axis (the kvikio
+            path gives no speedup at that chunking).
 
         Returns
         -------
@@ -482,11 +494,17 @@ class HaplotypeMatrix:
                 f"streaming must be 'auto', 'always', or 'never'; "
                 f"got {streaming!r}"
             )
+        if backend not in ("auto", "host", "kvikio"):
+            raise ValueError(
+                f"backend must be 'auto', 'host', or 'kvikio'; "
+                f"got {backend!r}"
+            )
 
         if streaming == "always":
             return cls._build_streaming(
                 path, region=region, pop_file=pop_file,
                 chunk_bp=chunk_bp, prefetch=prefetch,
+                backend=backend,
             )
 
         # 'auto' and 'never' both want eager when the matrix fits; 'auto'
@@ -502,7 +520,7 @@ class HaplotypeMatrix:
             return cls._build_streaming(
                 path, region=region, pop_file=pop_file,
                 chunk_bp=chunk_bp, prefetch=prefetch,
-                source=source,
+                source=source, backend=backend,
             )
         return cls._build_eager(path, region=region,
                                 accessible_bed=accessible_bed,
@@ -540,8 +558,11 @@ class HaplotypeMatrix:
 
     @classmethod
     def _build_streaming(cls, path, *, region, pop_file, chunk_bp, prefetch,
-                         source=None):
-        from .streaming_matrix import HostChunkFetcher, StreamingHaplotypeMatrix
+                         source=None, backend="auto"):
+        from .streaming_matrix import (
+            HostChunkFetcher, KvikioChunkFetcher, StreamingHaplotypeMatrix,
+            _pick_chunk_fetcher,
+        )
         from .zarr_source import ZarrGenotypeSource
 
         if source is None:
@@ -551,7 +572,7 @@ class HaplotypeMatrix:
             # to keep its size probe cheap; resolve the caller's pop_file
             # now without re-opening the zarr store.
             source.pop_cols = source._resolve_pop_file(pop_file)
-        fetcher = HostChunkFetcher(source)
+        fetcher = _pick_chunk_fetcher(source, backend=backend)
         return StreamingHaplotypeMatrix(
             source, fetcher,
             chunk_bp=chunk_bp, prefetch=prefetch,

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -19,17 +19,18 @@ def _decide_streaming_mode(zarr_path, region, streaming, pop_file,
                            fraction=STREAMING_AUTO_EAGER_FRACTION):
     """Pick ``'eager'`` vs ``'streaming'`` based on the projected matrix size.
 
-    Returns ``(mode, source)`` where ``source`` is the
-    ``ZarrGenotypeSource`` opened for the size probe and reused
-    downstream (when ``mode == 'streaming'``), or ``None`` when no
-    source was opened: scikit-allel layout, missing store, or the
-    branch that picked ``'eager'`` because the matrix fits (in which
-    case the caller's eager path opens its own store via
-    ``read_genotypes``).
+    Returns ``(mode, source)``. ``source`` is a
+    ``ZarrGenotypeSource`` already opened for the size probe and
+    handed off to the streaming reader; ``None`` means the caller
+    should open its own store. Three cases produce
+    ``(mode='eager', source=None)``:
 
-    Scikit-allel layouts always return ``('eager', None)``: the
-    streaming format is VCZ-only, so the size check would refuse a
-    large allel store with nowhere to fall back to.
+    * the matrix fits in free GPU memory at the requested
+      ``fraction`` budget,
+    * the store is a scikit-allel layout (the streaming reader is
+      VCZ-only, so there's no source to hand off),
+    * the store path / layout couldn't be opened at all and the
+      caller's eager path will surface a more actionable error.
 
     ``free_gpu_bytes`` is exposed for tests; typical invocation will leave
     it None to let ``cp.cuda.Device().mem_info`` provide it.

--- a/pg_gpu/ld_pipeline.py
+++ b/pg_gpu/ld_pipeline.py
@@ -127,7 +127,8 @@ def iter_pairs_within_distance(positions, max_dist, chunk_size):
 # ---------------------------------------------------------------------------
 
 
-def compute_counts_for_pairs(haplotypes, idx_i, idx_j, pop_indices=None):
+def compute_counts_for_pairs(haplotypes, idx_i, idx_j, pop_indices=None,
+                             has_missing=None):
     """
     Compute haplotype counts [n11, n10, n01, n00] for specific pairs.
 
@@ -139,6 +140,12 @@ def compute_counts_for_pairs(haplotypes, idx_i, idx_j, pop_indices=None):
         Pair indices, shape (n_pairs,)
     pop_indices : list or cp.ndarray, optional
         Indices of samples to include (for population-specific counts)
+    has_missing : bool, optional
+        Pre-computed missing-data flag for the (already pop-sliced)
+        haplotype matrix. Callers that iterate many pair batches over
+        the same matrix should compute this once and pass it in -- the
+        default ``None`` reduces over the whole matrix on every call,
+        which is the dominant cost for many small batches.
 
     Returns
     -------
@@ -155,7 +162,8 @@ def compute_counts_for_pairs(haplotypes, idx_i, idx_j, pop_indices=None):
     hap_i = haplotypes[:, idx_i]
     hap_j = haplotypes[:, idx_j]
 
-    has_missing = cp.any(haplotypes == -1)
+    if has_missing is None:
+        has_missing = cp.any(haplotypes == -1)
 
     if has_missing:
         valid_mask = (hap_i >= 0) & (hap_j >= 0)

--- a/pg_gpu/relatedness.py
+++ b/pg_gpu/relatedness.py
@@ -10,21 +10,6 @@ import cupy as cp
 from typing import Optional, Union
 
 
-def _raise_on_streaming_matrix(matrix, fn_name):
-    """``grm`` needs chromosome-wide allele frequencies in scope before
-    it can standardize per-variant outer products, which the current
-    eager kernel does in one pass. Raise with the ``.materialize`` hint
-    rather than letting ``.haplotypes`` / ``.genotypes`` blow up later."""
-    from .streaming_matrix import _StreamingMatrixBase
-    if isinstance(matrix, _StreamingMatrixBase):
-        raise NotImplementedError(
-            f"{fn_name}() needs the full variant axis in scope at once "
-            f"and is not streamable chunk-by-chunk. Pull a sub-region "
-            f"eagerly via matrix.materialize(region=(lo, hi)) and call "
-            f"{fn_name}() on that."
-        )
-
-
 def grm(genotype_matrix_or_haplotype_matrix,
         population: Optional[Union[str, list]] = None,
         missing_data: str = 'include') -> np.ndarray:
@@ -57,7 +42,11 @@ def grm(genotype_matrix_or_haplotype_matrix,
         coefficients + 1. Off-diagonal entries are pairwise relatedness.
     """
     from ._memutil import estimate_variant_chunk_size
-    _raise_on_streaming_matrix(genotype_matrix_or_haplotype_matrix, "grm")
+    from .streaming_matrix import _StreamingMatrixBase
+    if isinstance(genotype_matrix_or_haplotype_matrix, _StreamingMatrixBase):
+        return _stream_grm(genotype_matrix_or_haplotype_matrix,
+                            population=population,
+                            missing_data=missing_data)
 
     geno, n_ind = _get_genotype_data(genotype_matrix_or_haplotype_matrix,
                                       population)
@@ -420,3 +409,106 @@ def _stream_n_ind(streaming_matrix, population):
                 else streaming_matrix.num_individuals)
     pop_set = streaming_matrix.sample_sets[population]
     return len(pop_set) // 2 if is_hap else len(pop_set)
+
+
+# ---------------------------------------------------------------------------
+# Streaming GRM: two-pass + indiv-axis row-block tile
+# ---------------------------------------------------------------------------
+#
+# GRM standardizes each variant by its allele frequency before forming the
+# (n_ind, n_ind) outer product, so the eager kernel computes p over the
+# whole chromosome up front. Two-pass form for the streaming path:
+# pass 1 walks chunks to accumulate per-variant DAC + n_valid into
+# chromosome-wide host arrays; pass 2 walks the same chunks, slicing the
+# precomputed p into chunk-local pieces, standardizing on GPU, and
+# accumulating A = g @ g.T on host with row-block tiling on the
+# individual axis (same scheme as the IBS streaming path).
+
+def _stream_grm(streaming_matrix, *, population, missing_data,
+                block_size=None):
+    from ._memutil import estimate_indiv_block_size
+
+    # Pass 1: per-variant DAC / n_valid into per-chunk host arrays.
+    dac_parts = []
+    nvalid_parts = []
+    n_ind = None
+    for _, _, chunk in streaming_matrix.iter_gpu_chunks():
+        geno, n_ind = _get_genotype_data(chunk, population)
+        valid = (geno >= 0)
+        nvalid_parts.append(
+            cp.sum(valid, axis=0, dtype=cp.int32).get()
+        )
+        dac_parts.append(
+            cp.sum(cp.where(valid, geno, 0), axis=0, dtype=cp.int32).get()
+        )
+        del geno, valid
+
+    if n_ind is None:
+        # No chunks at all.
+        n_ind = _stream_n_ind(streaming_matrix, population)
+        return np.zeros((n_ind, n_ind), dtype=np.float64)
+
+    chunk_var_counts = [p.size for p in dac_parts]
+    chunk_offsets = np.cumsum([0] + chunk_var_counts)
+    dac_chrom = np.concatenate(dac_parts) if dac_parts else np.zeros(0, np.int32)
+    nvalid_chrom = (np.concatenate(nvalid_parts)
+                    if nvalid_parts else np.zeros(0, np.int32))
+
+    p_chrom = np.where(
+        nvalid_chrom > 0,
+        dac_chrom.astype(np.float64) / (2.0 * nvalid_chrom.astype(np.float64)),
+        0.0,
+    )
+    if missing_data == 'exclude':
+        poly_mask = (nvalid_chrom == n_ind) & (p_chrom > 0) & (p_chrom < 1)
+    else:
+        poly_mask = (p_chrom > 0) & (p_chrom < 1)
+    n_snps_used = int(poly_mask.sum())
+    if n_snps_used == 0:
+        return np.zeros((n_ind, n_ind), dtype=np.float64)
+
+    if block_size is None:
+        # standardized g + matmul output + slack.
+        block_size = estimate_indiv_block_size(n_ind, n_intermediates=3)
+
+    A_host = np.zeros((n_ind, n_ind), dtype=np.float64)
+
+    # Pass 2: standardize each chunk and accumulate the outer product.
+    # Chunk iteration order must match pass 1 so the chunk-local slice
+    # of p_chrom lines up with the chunk's variants.
+    for chunk_i, (_, _, chunk) in enumerate(
+            streaming_matrix.iter_gpu_chunks()):
+        c_lo, c_hi = chunk_offsets[chunk_i], chunk_offsets[chunk_i + 1]
+        chunk_poly = poly_mask[c_lo:c_hi]
+        if not chunk_poly.any():
+            continue
+        chunk_p_full = p_chrom[c_lo:c_hi]
+
+        geno, _ = _get_genotype_data(chunk, population)
+        if chunk_poly.all():
+            # At biobank-scale MAF distributions essentially every site
+            # is polymorphic; bypass the fancy index in that case so
+            # the matmul sees a contiguous column block.
+            chunk_p_gpu = cp.asarray(chunk_p_full)
+            g = geno
+        else:
+            chunk_p_gpu = cp.asarray(chunk_p_full[chunk_poly])
+            chunk_idx_gpu = cp.asarray(np.where(chunk_poly)[0],
+                                        dtype=cp.int32)
+            g = geno[:, chunk_idx_gpu]
+        valid = (g >= 0)
+        g_std = cp.where(valid, g, 0).astype(cp.float64)
+        del g
+        scale = cp.sqrt(2.0 * chunk_p_gpu * (1.0 - chunk_p_gpu))
+        g_std -= 2.0 * chunk_p_gpu
+        g_std *= valid
+        g_std /= scale
+        del valid, scale
+
+        for r0 in range(0, n_ind, block_size):
+            r1 = min(r0 + block_size, n_ind)
+            A_host[r0:r1] += (g_std[r0:r1] @ g_std.T).get()
+        del g_std, geno
+
+    A_host /= n_snps_used
+    return A_host

--- a/pg_gpu/relatedness.py
+++ b/pg_gpu/relatedness.py
@@ -10,6 +10,23 @@ import cupy as cp
 from typing import Optional, Union
 
 
+def _raise_on_streaming_matrix(matrix, fn_name):
+    """``grm`` / ``ibs`` are inherently pairwise across the full sample
+    axis -- they need every variant in scope to compute an (n_indiv,
+    n_indiv) matrix. A streaming matrix can't be reduced chunk-by-chunk
+    without aggregating across the whole pair grid, which the current
+    kernels don't do. Raise with the ``.materialize`` hint instead of
+    failing later when the kernel touches ``.haplotypes`` / ``.genotypes``."""
+    from .streaming_matrix import _StreamingMatrixBase
+    if isinstance(matrix, _StreamingMatrixBase):
+        raise NotImplementedError(
+            f"{fn_name}() needs the full variant axis in scope at once "
+            f"and is not streamable chunk-by-chunk. Pull a sub-region "
+            f"eagerly via matrix.materialize(region=(lo, hi)) and call "
+            f"{fn_name}() on that."
+        )
+
+
 def grm(genotype_matrix_or_haplotype_matrix,
         population: Optional[Union[str, list]] = None,
         missing_data: str = 'include') -> np.ndarray:
@@ -42,6 +59,7 @@ def grm(genotype_matrix_or_haplotype_matrix,
         coefficients + 1. Off-diagonal entries are pairwise relatedness.
     """
     from ._memutil import estimate_variant_chunk_size
+    _raise_on_streaming_matrix(genotype_matrix_or_haplotype_matrix, "grm")
 
     geno, n_ind = _get_genotype_data(genotype_matrix_or_haplotype_matrix,
                                       population)
@@ -135,6 +153,7 @@ def ibs(genotype_matrix_or_haplotype_matrix,
         Diagonal is always 1.
     """
     from ._memutil import estimate_variant_chunk_size
+    _raise_on_streaming_matrix(genotype_matrix_or_haplotype_matrix, "ibs")
 
     geno, n_ind = _get_genotype_data(genotype_matrix_or_haplotype_matrix,
                                       population)

--- a/pg_gpu/relatedness.py
+++ b/pg_gpu/relatedness.py
@@ -11,12 +11,10 @@ from typing import Optional, Union
 
 
 def _raise_on_streaming_matrix(matrix, fn_name):
-    """``grm`` / ``ibs`` are inherently pairwise across the full sample
-    axis -- they need every variant in scope to compute an (n_indiv,
-    n_indiv) matrix. A streaming matrix can't be reduced chunk-by-chunk
-    without aggregating across the whole pair grid, which the current
-    kernels don't do. Raise with the ``.materialize`` hint instead of
-    failing later when the kernel touches ``.haplotypes`` / ``.genotypes``."""
+    """``grm`` needs chromosome-wide allele frequencies in scope before
+    it can standardize per-variant outer products, which the current
+    eager kernel does in one pass. Raise with the ``.materialize`` hint
+    rather than letting ``.haplotypes`` / ``.genotypes`` blow up later."""
     from .streaming_matrix import _StreamingMatrixBase
     if isinstance(matrix, _StreamingMatrixBase):
         raise NotImplementedError(
@@ -153,7 +151,11 @@ def ibs(genotype_matrix_or_haplotype_matrix,
         Diagonal is always 1.
     """
     from ._memutil import estimate_variant_chunk_size
-    _raise_on_streaming_matrix(genotype_matrix_or_haplotype_matrix, "ibs")
+    from .streaming_matrix import _StreamingMatrixBase
+    if isinstance(genotype_matrix_or_haplotype_matrix, _StreamingMatrixBase):
+        return _stream_ibs(genotype_matrix_or_haplotype_matrix,
+                            population=population,
+                            missing_data=missing_data)
 
     geno, n_ind = _get_genotype_data(genotype_matrix_or_haplotype_matrix,
                                       population)
@@ -303,3 +305,118 @@ def _get_diploid_genotypes(matrix, population=None):
         return geno
     else:
         raise TypeError(f"Expected HaplotypeMatrix or GenotypeMatrix, got {type(matrix)}")
+
+
+# ---------------------------------------------------------------------------
+# Streaming IBS: variant-axis stream + indiv-axis row-block tile
+# ---------------------------------------------------------------------------
+#
+# The three accumulators (ibs2, ibs1, n_joint) are each (n_ind, n_ind) and
+# decompose by sum over variants, so the variant axis can be streamed
+# chunk-by-chunk. The output itself can exceed GPU memory (80 GB at 100k
+# diploids), so the individual axis is tiled into row blocks and the
+# accumulators live on host -- only one row-block's (block_size, n_ind)
+# matmul output sits on the GPU at a time.
+
+def _stream_ibs(streaming_matrix, *, population, missing_data,
+                block_size=None):
+    from ._memutil import estimate_indiv_block_size
+
+    chunks = iter(streaming_matrix.iter_gpu_chunks())
+    first = next(chunks, None)
+    if first is None:
+        # No variants at all; mirror the eager identity-on-diagonal
+        # convention so callers don't have to special-case the empty
+        # source.
+        n_ind = _stream_n_ind(streaming_matrix, population)
+        ibs_mat = np.zeros((n_ind, n_ind), dtype=np.float64)
+        np.fill_diagonal(ibs_mat, 1.0)
+        return ibs_mat
+
+    geno_first, n_ind = _get_genotype_data(first[2], population)
+    if block_size is None:
+        # block_ibs2 + block_ibs1 + transient matmul output + slack.
+        block_size = estimate_indiv_block_size(n_ind, n_intermediates=4)
+
+    ibs2_host = np.zeros((n_ind, n_ind), dtype=np.float64)
+    ibs1_host = np.zeros((n_ind, n_ind), dtype=np.float64)
+    n_joint_host = np.zeros((n_ind, n_ind), dtype=np.float64)
+
+    _accumulate_ibs_chunk(geno_first, ibs2_host, ibs1_host, n_joint_host,
+                          block_size=block_size, missing_data=missing_data)
+    del geno_first
+    for _, _, chunk in chunks:
+        geno, _ = _get_genotype_data(chunk, population)
+        _accumulate_ibs_chunk(geno, ibs2_host, ibs1_host, n_joint_host,
+                              block_size=block_size,
+                              missing_data=missing_data)
+        del geno
+
+    ibs_mat = np.where(n_joint_host > 0,
+                        (2.0 * ibs2_host + ibs1_host) / (2.0 * n_joint_host),
+                        0.0)
+    np.fill_diagonal(ibs_mat, 1.0)
+    return ibs_mat
+
+
+def _accumulate_ibs_chunk(geno, ibs2_host, ibs1_host, n_joint_host, *,
+                          block_size, missing_data):
+    """Add one variant-chunk's contribution to the three host accumulators.
+
+    ``geno`` is ``(n_ind, n_var_chunk)`` on GPU. The genotype-value loop
+    is outermost so each full-pop indicator ``ind_full`` is built once
+    per chunk rather than once per chunk per row block; the row-block
+    loop only does matmuls and host transfers.
+
+    In the eager kernel ``ibs1 += cross + cross.T`` where
+    ``cross = (g==gval) @ (g==gval+1).T``; here the row-block slice of
+    ``cross`` is ``ind_curr[r0:r1] @ ind_next.T`` and the row-block
+    slice of ``cross.T`` is ``ind_next[r0:r1] @ ind_curr.T``.
+    """
+    valid_full = (geno >= 0).astype(cp.float64)
+    g = cp.where(geno >= 0, geno, 0).astype(cp.float64)
+    if missing_data == 'exclude':
+        site_complete = cp.all(valid_full > 0, axis=0)
+        valid_full = valid_full[:, site_complete]
+        g = g[:, site_complete]
+        if g.shape[1] == 0:
+            return
+
+    n_ind = g.shape[0]
+    for r0 in range(0, n_ind, block_size):
+        r1 = min(r0 + block_size, n_ind)
+        n_joint_host[r0:r1] += (valid_full[r0:r1] @ valid_full.T).get()
+
+    # Two indicator matrices live at a time: the current g==k and the
+    # next g==k+1 needed for the ibs1 cross. Reuse ``ind_next`` from
+    # the previous iter as the next ``ind_curr`` so g==1 is built once.
+    ind_curr = (g == 0) * valid_full
+    for gval in (0, 1, 2):
+        if gval < 2:
+            ind_next = (g == (gval + 1)) * valid_full
+        for r0 in range(0, n_ind, block_size):
+            r1 = min(r0 + block_size, n_ind)
+            ibs2_host[r0:r1] += (ind_curr[r0:r1] @ ind_curr.T).get()
+            if gval < 2:
+                ibs1_host[r0:r1] += (
+                    ind_curr[r0:r1] @ ind_next.T
+                ).get()
+                ibs1_host[r0:r1] += (
+                    ind_next[r0:r1] @ ind_curr.T
+                ).get()
+        del ind_curr
+        if gval < 2:
+            ind_curr = ind_next
+
+
+def _stream_n_ind(streaming_matrix, population):
+    """Best-effort individual count for the empty-source fallback. Uses
+    the streaming source's diploid count (halved for haplotype-layout)
+    and a population subset if requested."""
+    from .streaming_matrix import StreamingHaplotypeMatrix
+    is_hap = isinstance(streaming_matrix, StreamingHaplotypeMatrix)
+    if population is None:
+        return (streaming_matrix.num_haplotypes // 2 if is_hap
+                else streaming_matrix.num_individuals)
+    pop_set = streaming_matrix.sample_sets[population]
+    return len(pop_set) // 2 if is_hap else len(pop_set)

--- a/pg_gpu/sfs.py
+++ b/pg_gpu/sfs.py
@@ -5,6 +5,8 @@ This module provides functions for computing unfolded, folded, scaled, and
 joint site frequency spectra from haplotype data.
 """
 
+from functools import lru_cache
+
 import numpy as np
 import cupy as cp
 from typing import Union, Optional
@@ -266,6 +268,144 @@ def joint_sfs(haplotype_matrix: HaplotypeMatrix,
     tmp = (dac1 * y + dac2).astype(cp.int32)
     s = cp.bincount(tmp, minlength=x * y)
     return s[:x * y].reshape(x, y).get()
+
+
+@lru_cache(maxsize=16)
+def _projection_matrix_vec(n_from, n_to):
+    """Hypergeometric projection matrix from ``n_from`` to ``n_to``.
+
+    Output shape ``(n_to + 1, n_from + 1)``; element ``[a, i]`` is the
+    probability of drawing ``a`` derived alleles in a size-``n_to``
+    sample without replacement from a size-``n_from`` population with
+    ``i`` derived alleles. Vectorized via ``scipy.special.gammaln`` so
+    it scales to ``n_from`` in the 10^5+ range without the per-cell
+    big-int comb of the exact ``diversity._projection_matrix``.
+    Cached on ``(n_from, n_to)`` so repeated per-chunk calls inside a
+    streaming scan reuse one host-side build.
+    """
+    from scipy.special import gammaln
+    if n_to < 0 or n_to > n_from:
+        raise ValueError(
+            f"need 0 <= n_to <= n_from, got n_to={n_to}, n_from={n_from}")
+    if n_to == 0:
+        out = np.zeros((1, n_from + 1))
+        out[0, :] = 1.0  # all mass at the empty-sample bin
+        return out
+    k_from = np.arange(n_from + 1, dtype=np.int64)[None, :]
+    k_to = np.arange(n_to + 1, dtype=np.int64)[:, None]
+    valid = (k_to <= k_from) & ((n_to - k_to) <= (n_from - k_from))
+    # Outside the hypergeometric support, k_from - k_to or
+    # (n_from-k_from) - (n_to-k_to) is negative; clamp before gammaln
+    # and zero out post-exp.
+    kt = np.where(valid, k_to, 0)
+    kfk = np.where(valid, k_from - k_to, 0)
+    ntk = np.where(valid, n_to - k_to, 0)
+    nfk = n_from - k_from
+    nfk_ntk = np.where(valid, nfk - ntk, 0)
+    log_P = (gammaln(k_from + 1) - gammaln(kt + 1) - gammaln(kfk + 1)
+             + gammaln(nfk + 1) - gammaln(ntk + 1) - gammaln(nfk_ntk + 1)
+             - (gammaln(n_from + 1) - gammaln(n_to + 1)
+                - gammaln(n_from - n_to + 1)))
+    # Outside the hypergeometric support, the clamped-zero arguments
+    # leave a meaningless residual in log_P that can overflow ``exp``;
+    # mask first, then exp, so out-of-support cells stay zero.
+    log_P = np.where(valid, log_P, -np.inf)
+    return np.exp(log_P)
+
+
+def project_joint_sfs(haplotype_matrix: HaplotypeMatrix,
+                       pop1: Union[str, list],
+                       pop2: Union[str, list],
+                       target_n1: int,
+                       target_n2: int,
+                       missing_data: str = 'include'):
+    """Joint SFS projected to ``(target_n1+1, target_n2+1)`` via
+    hypergeometric sampling.
+
+    Mathematically identical to ``P1 @ joint_sfs(...) @ P2.T`` with
+    hypergeometric projection matrices ``P1, P2``, but applied
+    per-variant so the ``(n1+1, n2+1)`` full histogram is never
+    materialized. That intermediate would be 80 GB at 100k haps per
+    population; the projected output stays small regardless of source
+    size. Use this whenever the source size is too large for
+    ``joint_sfs`` to allocate its bincount.
+
+    Parameters
+    ----------
+    haplotype_matrix : HaplotypeMatrix or StreamingHaplotypeMatrix
+    pop1, pop2 : str or list
+        Population names or explicit sample-index lists.
+    target_n1, target_n2 : int
+        Projection targets; each must be <= the corresponding source
+        population size.
+    missing_data : str
+
+    Returns
+    -------
+    ndarray, float64, shape ``(target_n1 + 1, target_n2 + 1)``
+    """
+    if isinstance(haplotype_matrix, StreamingHaplotypeMatrix):
+        sample_sets = haplotype_matrix.sample_sets or {}
+        pop1_list = sample_sets[pop1] if isinstance(pop1, str) else pop1
+        pop2_list = sample_sets[pop2] if isinstance(pop2, str) else pop2
+        n1, n2 = len(pop1_list), len(pop2_list)
+        if target_n1 > n1 or target_n2 > n2:
+            raise ValueError(
+                f"Cannot project up: target_n1={target_n1} > n1={n1} "
+                f"or target_n2={target_n2} > n2={n2}")
+        # Build P1, P2 once on host (cheap with gammaln) then push to
+        # GPU. Per-chunk work is one gather + one small matmul.
+        P1 = cp.asarray(_projection_matrix_vec(n1, target_n1))
+        P2 = cp.asarray(_projection_matrix_vec(n2, target_n2))
+        acc = cp.zeros((target_n1 + 1, target_n2 + 1), dtype=cp.float64)
+        for _, _, chunk in haplotype_matrix.iter_gpu_chunks():
+            acc += _project_joint_sfs_chunk_gpu(chunk, pop1, pop2,
+                                                 P1, P2, missing_data)
+        return acc.get()
+
+    # Eager path: compute (dac1, dac2) once then apply the same gather.
+    m1 = _get_population_matrix(haplotype_matrix, pop1)
+    m2 = _get_population_matrix(haplotype_matrix, pop2)
+    dac1, n1 = _derived_allele_counts(m1, missing_data)
+    dac2, n2 = _derived_allele_counts(m2, missing_data)
+    if missing_data == 'exclude':
+        valid = (dac1 >= 0) & (dac2 >= 0)
+        dac1 = dac1[valid]
+        dac2 = dac2[valid]
+    if isinstance(n1, cp.ndarray):
+        n1 = int(cp.max(n1).get()) if n1.size > 0 else 0
+    if isinstance(n2, cp.ndarray):
+        n2 = int(cp.max(n2).get()) if n2.size > 0 else 0
+    if target_n1 > n1 or target_n2 > n2:
+        raise ValueError(
+            f"Cannot project up: target_n1={target_n1} > n1={n1} "
+            f"or target_n2={target_n2} > n2={n2}")
+    P1 = cp.asarray(_projection_matrix_vec(n1, target_n1))
+    P2 = cp.asarray(_projection_matrix_vec(n2, target_n2))
+    A = P1[:, dac1.astype(cp.int64)]
+    B = P2[:, dac2.astype(cp.int64)]
+    return (A @ B.T).get()
+
+
+def _project_joint_sfs_chunk_gpu(chunk_hm, pop1, pop2, P1, P2,
+                                  missing_data):
+    """Per-chunk projected contribution; returns a GPU array.
+
+    Factored out so the streaming dispatch can accumulate on-device
+    without round-tripping each chunk's contribution through host
+    memory.
+    """
+    m1 = _get_population_matrix(chunk_hm, pop1)
+    m2 = _get_population_matrix(chunk_hm, pop2)
+    dac1, _ = _derived_allele_counts(m1, missing_data)
+    dac2, _ = _derived_allele_counts(m2, missing_data)
+    if missing_data == 'exclude':
+        valid = (dac1 >= 0) & (dac2 >= 0)
+        dac1 = dac1[valid]
+        dac2 = dac2[valid]
+    A = P1[:, dac1.astype(cp.int64)]
+    B = P2[:, dac2.astype(cp.int64)]
+    return A @ B.T
 
 
 def joint_sfs_folded(haplotype_matrix: HaplotypeMatrix,

--- a/pg_gpu/sfs.py
+++ b/pg_gpu/sfs.py
@@ -10,6 +10,7 @@ import cupy as cp
 from typing import Union, Optional
 from .haplotype_matrix import HaplotypeMatrix
 from ._utils import get_population_matrix as _get_population_matrix
+from .streaming_matrix import StreamingHaplotypeMatrix, _stream_sum
 
 
 def _derived_allele_counts(haplotype_matrix, missing_data='include'):
@@ -93,6 +94,12 @@ def sfs(haplotype_matrix: HaplotypeMatrix,
     ndarray, int64, shape (n_chromosomes + 1,)
         Element k = number of variants with k derived alleles.
     """
+    if isinstance(haplotype_matrix, StreamingHaplotypeMatrix):
+        return _stream_sum(
+            haplotype_matrix,
+            lambda chunk: sfs(chunk, population=population,
+                              missing_data=missing_data),
+        )
 
     if population is not None:
         matrix = _get_population_matrix(haplotype_matrix, population)
@@ -231,6 +238,12 @@ def joint_sfs(haplotype_matrix: HaplotypeMatrix,
         Element [i, j] = number of variants with i derived alleles in pop1
         and j derived alleles in pop2.
     """
+    if isinstance(haplotype_matrix, StreamingHaplotypeMatrix):
+        return _stream_sum(
+            haplotype_matrix,
+            lambda chunk: joint_sfs(chunk, pop1=pop1, pop2=pop2,
+                                    missing_data=missing_data),
+        )
 
     m1 = _get_population_matrix(haplotype_matrix, pop1)
     m2 = _get_population_matrix(haplotype_matrix, pop2)

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -594,6 +594,24 @@ class StreamingHaplotypeMatrix(_StreamingMatrixBase):
     def _repr_sample_axis(self):
         return f"num_haplotypes={self.num_haplotypes}"
 
+    def compute_ld_statistics_gpu_single_pop(self, bp_bins, raw=False,
+                                              ac_filter=True,
+                                              chunk_size='auto'):
+        from .haplotype_matrix import _stream_ld_single_pop
+        return _stream_ld_single_pop(
+            self, bp_bins=bp_bins, raw=raw,
+            ac_filter=ac_filter, chunk_size=chunk_size,
+        )
+
+    def compute_ld_statistics_gpu_two_pops(self, bp_bins, pop1, pop2,
+                                            raw=False, ac_filter=True,
+                                            chunk_size='auto'):
+        from .haplotype_matrix import _stream_ld_two_pops
+        return _stream_ld_two_pops(
+            self, bp_bins=bp_bins, pop1=pop1, pop2=pop2, raw=raw,
+            ac_filter=ac_filter, chunk_size=chunk_size,
+        )
+
 
 class StreamingGenotypeMatrix(_StreamingMatrixBase):
     """Chunked view over a ``ZarrGenotypeSource``, yielding per-chunk

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -252,8 +252,75 @@ class StreamingHaplotypeMatrix:
             "StreamingHaplotypeMatrix has no materialized .haplotypes "
             "array; the matrix is too big to fit eagerly, which is why "
             "from_zarr returned this class instead of HaplotypeMatrix. "
-            "Iterate chunks via .iter_gpu_chunks(), or pass this object "
-            "to a streaming-aware kernel."
+            "For pairwise / cross-window statistics over a sub-region, "
+            "call .materialize(region=(lo, hi)) to get an eager "
+            "HaplotypeMatrix over that slice. For per-window streaming "
+            "stats, iterate .iter_gpu_chunks() directly or pass this "
+            "object to a streaming-aware kernel like windowed_analysis."
+        )
+
+    def materialize(self, *, region=None, sample_subset=None):
+        """Build an eager ``HaplotypeMatrix`` over a sub-region.
+
+        Pairwise kernels (``pairwise_r2``, the r^2 heatmap path,
+        ``locate_unlinked``) can't be evaluated chunk-by-chunk because
+        they need every (variant, variant) pair simultaneously. Use
+        this to pull the slice you want into one device-resident
+        HaplotypeMatrix and run those kernels on it.
+
+        Parameters
+        ----------
+        region : tuple of int, optional
+            ``(left, right)`` bp interval to materialize.
+            ``right`` is exclusive. ``None`` materializes the full
+            mappable range, which on a biobank-scale store will OOM.
+        sample_subset : sequence of int, optional
+            Haplotype-axis indices to keep. ``None`` keeps every
+            haplotype.
+
+        Returns
+        -------
+        HaplotypeMatrix
+            Eager, device-resident, ready for any pg_gpu kernel.
+        """
+        from ._gpu_genotype_prep import build_haplotype_matrix
+
+        if region is None:
+            left, right = self.chrom_start, self.chrom_end
+        else:
+            left, right = int(region[0]), int(region[1])
+
+        if sample_subset is None:
+            gt, pos = self._source.slice_region(left, right)
+        else:
+            # slice_subsample returns a 2-D (n_var, n_hap_subset) int8
+            # block; HaplotypeMatrix wants (n_hap, n_var). Reshape on
+            # the GPU via build_haplotype_matrix's same prep path by
+            # promoting the 2-D subsample to a (n_var, n_dip', 2)
+            # block. The subsample's ploidy ordering follows the
+            # convention build_haplotype_matrix produces: haps
+            # 0..n_dip-1 = ploidy 0, n_dip..2*n_dip-1 = ploidy 1.
+            import numpy as _np
+            gm, pos = self._source.slice_subsample(left, right, sample_subset)
+            n_var, n_hap = gm.shape
+            # round n_hap to even for the (n_dip, 2) reshape -- if the
+            # caller picked an odd subset count we error out rather
+            # than silently splitting a diploid in half.
+            if n_hap % 2 != 0:
+                raise ValueError(
+                    f"materialize(sample_subset=...) requires an even "
+                    f"count to round-trip through (n_dip, 2) layout; "
+                    f"got {n_hap}."
+                )
+            n_dip_sub = n_hap // 2
+            gt = _np.empty((n_var, n_dip_sub, 2), dtype=gm.dtype)
+            gt[:, :, 0] = gm[:, :n_dip_sub]
+            gt[:, :, 1] = gm[:, n_dip_sub:]
+
+        return build_haplotype_matrix(
+            gt, pos,
+            chrom_start=left, chrom_end=right,
+            sample_sets=self._sample_sets,
         )
 
     def iter_gpu_chunks(self):

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -1,0 +1,232 @@
+"""Chunk-streamed view over a VCZ store, used by HaplotypeMatrix.from_zarr
+at biobank scale.
+
+A ``StreamingHaplotypeMatrix`` does not materialize the full genotype
+matrix; it iterates the store in genomic chunks via ``iter_gpu_chunks()``.
+Each chunk arrives as an eager ``HaplotypeMatrix`` on the GPU covering
+one slice of the chromosome. Compute-side overlap with the next chunk's
+read happens through a ``ChunkFetcher`` -- ``HostChunkFetcher`` runs a
+producer thread that calls ``ZarrGenotypeSource.slice_region`` while the
+GPU is working on the current chunk, with one chunk of read-ahead by
+default.
+
+Kernels accept this class via dispatch in a follow-up; until then,
+calling a kernel directly raises a clear error. Use ``iter_gpu_chunks``
+to walk chunks manually if you need to.
+"""
+
+import queue
+import threading
+import time
+from abc import ABC, abstractmethod
+
+from ._gpu_genotype_prep import build_haplotype_matrix
+
+
+class ChunkFetcher(ABC):
+    """Pluggable producer that yields per-chunk genotype blocks.
+
+    Implementations are responsible for whatever async / parallelism
+    strategy they want; the consumer (``StreamingHaplotypeMatrix``)
+    only consumes the yielded tuples. Errors raised inside the
+    producer must be forwarded to the consumer with their traceback
+    preserved.
+    """
+
+    @abstractmethod
+    def iter_chunks(self, chunks, prefetch):
+        """Yield ``(ci, left, right, gt, pos, t_read_s)`` per chunk.
+
+        Parameters
+        ----------
+        chunks : list of (int, int)
+            Half-open ``(left, right)`` bp intervals.
+        prefetch : int
+            Read-ahead depth. ``0`` means serial; >=1 means a worker
+            thread reads ahead of the consumer.
+        """
+
+
+class HostChunkFetcher(ChunkFetcher):
+    """Read chunks through the source's host-buffer ``slice_region``.
+
+    ``prefetch >= 1`` spawns a daemon producer thread that fills a
+    bounded queue with the next chunk while the consumer is computing
+    on the current chunk. This is the right baseline for any local
+    zarr store; the kvikio fetcher in a follow-up swaps the same
+    interface for GPU-side codec decode.
+    """
+
+    def __init__(self, source):
+        self._source = source
+
+    def iter_chunks(self, chunks, prefetch):
+        if prefetch <= 0:
+            yield from self._iter_serial(chunks)
+            return
+        yield from self._iter_with_producer(chunks, prefetch)
+
+    def _iter_serial(self, chunks):
+        for ci, (left, right) in enumerate(chunks):
+            t0 = time.perf_counter()
+            gt, pos = self._source.slice_region(left, right)
+            yield ci, left, right, gt, pos, time.perf_counter() - t0
+
+    def _iter_with_producer(self, chunks, prefetch):
+        # Use a bounded queue so the producer blocks once it is `prefetch`
+        # chunks ahead, preventing unbounded host RAM growth on slow
+        # consumers. _END is a private sentinel; ("ERR", exc) forwards
+        # producer-side exceptions to the consumer's call stack.
+        q = queue.Queue(maxsize=prefetch)
+        stop = threading.Event()
+        _END = object()
+
+        def producer():
+            try:
+                for ci, (left, right) in enumerate(chunks):
+                    if stop.is_set():
+                        return
+                    t0 = time.perf_counter()
+                    gt, pos = self._source.slice_region(left, right)
+                    t_read = time.perf_counter() - t0
+                    if stop.is_set():
+                        return
+                    q.put((ci, left, right, gt, pos, t_read))
+            except BaseException as e:
+                q.put(("ERR", e))
+                return
+            q.put(_END)
+
+        t = threading.Thread(target=producer, daemon=True,
+                             name="zarr-prefetch")
+        t.start()
+        try:
+            while True:
+                item = q.get()
+                if item is _END:
+                    break
+                if isinstance(item, tuple) and item and item[0] == "ERR":
+                    raise item[1]
+                yield item
+        finally:
+            stop.set()
+            # drain so the producer's last put doesn't block forever
+            try:
+                while True:
+                    q.get_nowait()
+            except queue.Empty:
+                pass
+            t.join(timeout=5)
+
+
+class StreamingHaplotypeMatrix:
+    """Chunked view over a ``ZarrGenotypeSource``.
+
+    Used by ``HaplotypeMatrix.from_zarr`` when the requested matrix
+    does not fit eagerly on the GPU. Kernels that consume this class
+    do so by iterating ``iter_gpu_chunks``; each yielded
+    ``HaplotypeMatrix`` is an eager device-resident chunk covering a
+    single genomic interval.
+
+    Direct array access (``.haplotypes``, ``.positions``) is not
+    supported -- the whole point of this class is that the matrix is
+    too big to materialize. The dispatch in the kernels uses the
+    iterator instead.
+
+    Parameters
+    ----------
+    source : ZarrGenotypeSource
+    fetcher : ChunkFetcher
+    chunk_bp : int
+        Genomic span per chunk, in bp.
+    prefetch : int
+        Read-ahead depth handed to the fetcher.
+    align_bp : int, optional
+        Chunk boundaries are snapped to multiples of this so a windowed
+        kernel can guarantee windows never straddle a chunk boundary.
+        Defaults to ``chunk_bp`` (single window per chunk).
+    """
+
+    def __init__(self, source, fetcher, chunk_bp, prefetch, *,
+                 align_bp=None):
+        self._source = source
+        self._fetcher = fetcher
+        self._chunk_bp = int(chunk_bp)
+        self._prefetch = int(prefetch)
+        self._align_bp = int(align_bp) if align_bp is not None else self._chunk_bp
+        self._chunks = list(
+            source.iter_chunks(self._chunk_bp, self._align_bp)
+        )
+        # _sample_sets follows the same idiom as HaplotypeMatrix: store the
+        # explicit value (or None) and let the property fall back to a
+        # default 'all' set when no pop file resolved at source construction.
+        self._sample_sets = source.pop_cols
+
+    @property
+    def num_variants(self):
+        return self._source.num_variants
+
+    @property
+    def num_haplotypes(self):
+        return self._source.num_haplotypes
+
+    @property
+    def chrom(self):
+        return self._source.chrom
+
+    @property
+    def chrom_start(self):
+        return self._source.mappable_lo
+
+    @property
+    def chrom_end(self):
+        return max(0, self._source.mappable_hi - 1)
+
+    @property
+    def sample_sets(self):
+        """Population -> hap-axis indices. Falls back to a single 'all' set
+        when no pop file was resolved."""
+        if self._sample_sets is None:
+            return {"all": list(range(self.num_haplotypes))}
+        return self._sample_sets
+
+    @sample_sets.setter
+    def sample_sets(self, value):
+        self._sample_sets = value
+
+    @property
+    def haplotypes(self):
+        raise NotImplementedError(
+            "StreamingHaplotypeMatrix has no materialized .haplotypes "
+            "array; the matrix is too big to fit eagerly, which is why "
+            "from_zarr returned this class instead of HaplotypeMatrix. "
+            "Iterate chunks via .iter_gpu_chunks(), or pass this object "
+            "to a streaming-aware kernel."
+        )
+
+    def iter_gpu_chunks(self):
+        """Yield ``(left, right, HaplotypeMatrix)`` tuples covering the source.
+
+        Each yielded HaplotypeMatrix lives on the GPU and represents one
+        genomic chunk's variants on the full haplotype axis. Empty
+        chunks (regions with no variants, e.g. an acrocentric arm) are
+        skipped -- callers see only chunks with at least one variant.
+        """
+        for ci, left, right, gt, pos, t_read in self._fetcher.iter_chunks(
+                self._chunks, self._prefetch):
+            if gt.shape[0] == 0:
+                continue
+            hm = build_haplotype_matrix(
+                gt, pos,
+                chrom_start=int(left), chrom_end=int(right) - 1,
+                sample_sets=self._sample_sets,
+            )
+            yield int(left), int(right), hm
+
+    def __repr__(self):
+        return (
+            f"StreamingHaplotypeMatrix(num_variants={self.num_variants}, "
+            f"num_haplotypes={self.num_haplotypes}, "
+            f"chrom={self.chrom!r}, n_chunks={len(self._chunks)}, "
+            f"chunk_bp={self._chunk_bp}, prefetch={self._prefetch})"
+        )

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -20,7 +20,41 @@ import threading
 import time
 from abc import ABC, abstractmethod
 
+import numpy as np
+
 from ._gpu_genotype_prep import build_haplotype_matrix
+
+
+def _pad_to(arr, shape):
+    """Zero-pad ``arr`` to the given (potentially larger) shape."""
+    out = np.zeros(shape, dtype=arr.dtype)
+    out[tuple(slice(0, n) for n in arr.shape)] = arr
+    return out
+
+
+def _stream_sum(streaming_hm, kernel_fn):
+    """Run ``kernel_fn`` on every chunk and sum the per-chunk numpy results.
+
+    Used by SFS-style kernels whose chunk results compose by addition --
+    each chunk contributes its own bincount or joint-bincount, and the
+    chromosome-wide answer is their sum. The padding step covers the
+    edge case where two chunks produce arrays of different shapes (e.g.
+    when one chunk has a population with strictly more valid samples
+    after masking than another, giving it one more bin along that
+    axis).
+    """
+    total = None
+    for _, _, chunk in streaming_hm.iter_gpu_chunks():
+        s = np.asarray(kernel_fn(chunk), dtype=np.int64)
+        if total is None:
+            total = s.copy()
+            continue
+        if s.shape != total.shape:
+            shape = tuple(max(a, b) for a, b in zip(total.shape, s.shape))
+            total = _pad_to(total, shape)
+            s = _pad_to(s, shape)
+        total += s
+    return total
 
 
 class ChunkFetcher(ABC):

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -176,11 +176,29 @@ class StreamingHaplotypeMatrix:
 
     @property
     def chrom_start(self):
-        return self._source.mappable_lo
+        """Leading edge of the analyzed region.
+
+        Returns the chunk grid origin (typically ``0``) rather than the
+        first variant position -- streaming's per-chunk windows are
+        anchored to that grid, so reporting the variant-based origin
+        would be misleading for callers building a comparable eager
+        matrix.
+        """
+        return self._chunks[0][0] if self._chunks else 0
 
     @property
     def chrom_end(self):
-        return max(0, self._source.mappable_hi - 1)
+        """Trailing edge of the analyzed region (chunk-grid right edge).
+
+        Reported as the chunk grid's exclusive upper bound rather than
+        the last-variant-position-inclusive form HaplotypeMatrix uses
+        elsewhere. The streaming path runs windowed_analysis once per
+        chunk and concatenates; using the chunk grid's right edge for
+        each per-chunk chrom_end keeps all interior windows at uniform
+        width. A caller building a comparable eager matrix should set
+        ``eager.chrom_end = stream.chrom_end`` for the same effect.
+        """
+        return self._chunks[-1][1] if self._chunks else 0
 
     @property
     def sample_sets(self):
@@ -218,7 +236,10 @@ class StreamingHaplotypeMatrix:
                 continue
             hm = build_haplotype_matrix(
                 gt, pos,
-                chrom_start=int(left), chrom_end=int(right) - 1,
+                # chrom_end is the chunk's exclusive right edge so the
+                # last window in each chunk does not get clipped to the
+                # last variant position the way an eager matrix would.
+                chrom_start=int(left), chrom_end=int(right),
                 sample_sets=self._sample_sets,
             )
             yield int(left), int(right), hm

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -516,15 +516,19 @@ class _StreamingMatrixBase:
         if sample_subset is None:
             gt, pos = self._source.slice_region(left, right)
         else:
-            # slice_subsample's ploidy gather already lives on the GPU
-            # at biobank-scale sample counts; keep the result there
-            # and assemble the ``(n_var, n_dip', 2)`` layout in cupy so
-            # we don't round-trip through a multi-GB host buffer. The
-            # subsample ploidy ordering matches the source's convention:
-            # haps 0..n_dip-1 = ploidy 0, n_dip..2*n_dip-1 = ploidy 1.
-            gm_gpu, pos = self._source.slice_subsample(
-                left, right, sample_subset, to_gpu=True
-            )
+            # If the fetcher uses kvikio, decompress through it: at
+            # biobank-scale sample subsets the host-side oindex codec
+            # pipeline that ``slice_subsample`` would use is minutes per
+            # probe; the kvikio + nvCOMP path is seconds. Otherwise
+            # fall back to the host stage with the gather on GPU.
+            if isinstance(self._fetcher, KvikioChunkFetcher):
+                gm_gpu, pos = self._read_subsample_via_kvikio(
+                    left, right, sample_subset
+                )
+            else:
+                gm_gpu, pos = self._source.slice_subsample(
+                    left, right, sample_subset, to_gpu=True
+                )
             n_var, n_hap = gm_gpu.shape
             if n_hap % 2 != 0:
                 raise ValueError(
@@ -533,6 +537,10 @@ class _StreamingMatrixBase:
                     f"got {n_hap}."
                 )
             n_dip_sub = n_hap // 2
+            # The subsample ploidy ordering matches the source's
+            # convention: haps 0..n_dip-1 = ploidy 0, n_dip..2*n_dip-1
+            # = ploidy 1. Assemble the (n_var, n_dip', 2) layout in
+            # cupy so we don't round-trip through a multi-GB host buffer.
             gt = cp.empty((n_var, n_dip_sub, 2), dtype=gm_gpu.dtype)
             gt[:, :, 0] = gm_gpu[:, :n_dip_sub]
             gt[:, :, 1] = gm_gpu[:, n_dip_sub:]
@@ -543,6 +551,23 @@ class _StreamingMatrixBase:
             chrom_start=left, chrom_end=right,
             sample_sets=self._sample_sets,
         )
+
+    def _read_subsample_via_kvikio(self, left, right, sample_subset):
+        """Open the fetcher's GDSStore-backed ``call_genotype`` array
+        with the GPU buffer prototype active and route
+        ``slice_subsample_gpu`` through it. The buffer prototype is
+        reset on every exit path so subsequent eager work gets numpy
+        buffers back."""
+        self._fetcher._enable_gpu_buffer()
+        try:
+            cg = zarr.open_group(
+                self._fetcher._gds_store, mode="r"
+            )["call_genotype"]
+            return self._source.slice_subsample_gpu(
+                left, right, sample_subset, cg=cg,
+            )
+        finally:
+            self._fetcher._reset_gpu_buffer()
 
     def _sample_axis_size(self):  # pragma: no cover -- abstract
         raise NotImplementedError

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -114,10 +114,10 @@ def _pick_chunk_fetcher(source, *, backend):
         return KvikioChunkFetcher(source)
 
     codec = _store_call_genotype_codec(source.path)
-    chunks = _store_call_genotype_chunks(source.path)
     if codec is None:
         # codec unreadable or unsupported -> host
         return HostChunkFetcher(source)
+    chunks = source.chunks  # already cached on the source from __init__
     whole_sample_axis = (chunks is not None and len(chunks) >= 2
                          and chunks[1] >= source.num_diploids)
     if whole_sample_axis:
@@ -187,6 +187,71 @@ def _store_call_genotype_chunks(store_path):
         return None
 
 
+def _iter_chunks_with_prefetch(chunks, prefetch, slice_fn, *,
+                                thread_name="chunk-prefetch"):
+    """Shared producer-thread iteration for ``ChunkFetcher`` implementations.
+
+    ``slice_fn(left, right)`` returns ``(gt, pos)`` -- the host fetcher
+    passes a numpy-returning callable, the kvikio fetcher passes a
+    cupy-returning one, and everything else (bounded queue, error
+    propagation, daemon-thread cleanup) is identical.
+
+    Yields ``(ci, left, right, gt, pos, t_read_s)`` tuples. ``prefetch
+    <= 0`` reads serially in the consumer thread; ``prefetch >= 1``
+    runs a daemon producer that fills a bounded queue with ``prefetch``
+    chunks of read-ahead, so the next chunk's read is in flight while
+    the consumer is computing on the current chunk.
+    """
+    if prefetch <= 0:
+        for ci, (left, right) in enumerate(chunks):
+            t0 = time.perf_counter()
+            gt, pos = slice_fn(left, right)
+            yield ci, left, right, gt, pos, time.perf_counter() - t0
+        return
+
+    # bounded queue keeps host RAM at (prefetch + 1) * chunk_bytes;
+    # _END is a private sentinel; ("ERR", exc) forwards producer-side
+    # exceptions to the consumer's call stack with the traceback intact.
+    q = queue.Queue(maxsize=prefetch)
+    stop = threading.Event()
+    _END = object()
+
+    def producer():
+        try:
+            for ci, (left, right) in enumerate(chunks):
+                if stop.is_set():
+                    return
+                t0 = time.perf_counter()
+                gt, pos = slice_fn(left, right)
+                t_read = time.perf_counter() - t0
+                if stop.is_set():
+                    return
+                q.put((ci, left, right, gt, pos, t_read))
+        except BaseException as e:
+            q.put(("ERR", e))
+            return
+        q.put(_END)
+
+    t = threading.Thread(target=producer, daemon=True, name=thread_name)
+    t.start()
+    try:
+        while True:
+            item = q.get()
+            if item is _END:
+                break
+            if isinstance(item, tuple) and item and item[0] == "ERR":
+                raise item[1]
+            yield item
+    finally:
+        stop.set()
+        try:
+            while True:
+                q.get_nowait()
+        except queue.Empty:
+            pass
+        t.join(timeout=5)
+
+
 class HostChunkFetcher(ChunkFetcher):
     """Read chunks through the source's host-buffer ``slice_region``.
 
@@ -201,62 +266,11 @@ class HostChunkFetcher(ChunkFetcher):
         self._source = source
 
     def iter_chunks(self, chunks, prefetch):
-        if prefetch <= 0:
-            yield from self._iter_serial(chunks)
-            return
-        yield from self._iter_with_producer(chunks, prefetch)
-
-    def _iter_serial(self, chunks):
-        for ci, (left, right) in enumerate(chunks):
-            t0 = time.perf_counter()
-            gt, pos = self._source.slice_region(left, right)
-            yield ci, left, right, gt, pos, time.perf_counter() - t0
-
-    def _iter_with_producer(self, chunks, prefetch):
-        # Use a bounded queue so the producer blocks once it is `prefetch`
-        # chunks ahead, preventing unbounded host RAM growth on slow
-        # consumers. _END is a private sentinel; ("ERR", exc) forwards
-        # producer-side exceptions to the consumer's call stack.
-        q = queue.Queue(maxsize=prefetch)
-        stop = threading.Event()
-        _END = object()
-
-        def producer():
-            try:
-                for ci, (left, right) in enumerate(chunks):
-                    if stop.is_set():
-                        return
-                    t0 = time.perf_counter()
-                    gt, pos = self._source.slice_region(left, right)
-                    t_read = time.perf_counter() - t0
-                    if stop.is_set():
-                        return
-                    q.put((ci, left, right, gt, pos, t_read))
-            except BaseException as e:
-                q.put(("ERR", e))
-                return
-            q.put(_END)
-
-        t = threading.Thread(target=producer, daemon=True,
-                             name="zarr-prefetch")
-        t.start()
-        try:
-            while True:
-                item = q.get()
-                if item is _END:
-                    break
-                if isinstance(item, tuple) and item and item[0] == "ERR":
-                    raise item[1]
-                yield item
-        finally:
-            stop.set()
-            # drain so the producer's last put doesn't block forever
-            try:
-                while True:
-                    q.get_nowait()
-            except queue.Empty:
-                pass
-            t.join(timeout=5)
+        yield from _iter_chunks_with_prefetch(
+            chunks, prefetch,
+            self._source.slice_region,
+            thread_name="zarr-prefetch",
+        )
 
 
 class KvikioChunkFetcher(ChunkFetcher):
@@ -284,6 +298,11 @@ class KvikioChunkFetcher(ChunkFetcher):
     """
 
     def __init__(self, source, *, compat_mode="ON", num_threads=8):
+        if compat_mode not in ("ON", "AUTO", "OFF"):
+            raise ValueError(
+                f"compat_mode must be 'ON', 'AUTO', or 'OFF'; "
+                f"got {compat_mode!r}"
+            )
         codec = _store_call_genotype_codec(source.path)
         if codec is None:
             raise ValueError(
@@ -294,10 +313,20 @@ class KvikioChunkFetcher(ChunkFetcher):
             )
         self._source = source
         self._codec = codec
+        # GDSStore is a separate handle from source._store: the codec
+        # pipeline is cached on the zarr group, and we need a group
+        # opened with the GPU buffer prototype active so nvCOMP runs
+        # the decoder on the device. Reusing source._store would
+        # pick up the wrong codec pipeline.
         self._gds_store = GDSStore(source.path)
-        mode_const = (kvikio.CompatMode.ON if compat_mode == "ON"
-                      else kvikio.CompatMode.AUTO if compat_mode == "AUTO"
-                      else kvikio.CompatMode.OFF)
+        mode_const = {"ON": kvikio.CompatMode.ON,
+                      "AUTO": kvikio.CompatMode.AUTO,
+                      "OFF": kvikio.CompatMode.OFF}[compat_mode]
+        # kvikio.defaults.set is process-global; this writes the
+        # config every time a new fetcher is constructed, so the last
+        # fetcher wins if multiple are alive at once. In practice only
+        # one streaming matrix is iterated at a time on biobank-scale
+        # work, so this is acceptable.
         kvikio.defaults.set({"compat_mode": mode_const,
                              "num_threads": int(num_threads)})
         self._gpu_buffer_active = False
@@ -305,13 +334,18 @@ class KvikioChunkFetcher(ChunkFetcher):
     def iter_chunks(self, chunks, prefetch):
         # zarr.config.enable_gpu is process-global; we flip it on for
         # the duration of the iteration and reset on every exit path
-        # so a downstream eager call gets numpy buffers back.
+        # so a downstream eager call gets numpy buffers back. The
+        # call_genotype handle is opened once here (with the GPU
+        # buffer active) and reused for every chunk read.
         self._enable_gpu_buffer()
         try:
-            if prefetch <= 0:
-                yield from self._iter_serial(chunks)
-            else:
-                yield from self._iter_with_producer(chunks, prefetch)
+            cg = zarr.open_group(self._gds_store, mode="r")["call_genotype"]
+            yield from _iter_chunks_with_prefetch(
+                chunks, prefetch,
+                lambda left, right: self._source.slice_region_gpu(
+                    left, right, cg=cg),
+                thread_name="kvikio-prefetch",
+            )
         finally:
             self._reset_gpu_buffer()
 
@@ -320,7 +354,10 @@ class KvikioChunkFetcher(ChunkFetcher):
 
         Called automatically at the end of ``iter_chunks``; exposed for
         tests and for callers that build a fetcher without immediately
-        iterating it.
+        iterating it. There is no ``__del__`` -- Python's GC timing is
+        nondeterministic, so cleanup is via try/finally inside
+        ``iter_chunks`` and explicit ``close()`` for callers that
+        construct without iterating.
         """
         self._reset_gpu_buffer()
 
@@ -329,67 +366,13 @@ class KvikioChunkFetcher(ChunkFetcher):
         self._gpu_buffer_active = True
 
     def _reset_gpu_buffer(self):
-        # __del__ may fire after a constructor raise before
-        # _gpu_buffer_active is set; getattr() guards that path.
-        if not getattr(self, "_gpu_buffer_active", False):
+        if not self._gpu_buffer_active:
             return
         zarr.config.set({
             "buffer": "zarr.core.buffer.cpu.Buffer",
             "ndbuffer": "zarr.core.buffer.cpu.NDBuffer",
         })
         self._gpu_buffer_active = False
-
-    def _iter_serial(self, chunks):
-        for ci, (left, right) in enumerate(chunks):
-            t0 = time.perf_counter()
-            gt, pos = self._source.slice_region_gpu(
-                left, right, gds_store=self._gds_store)
-            yield ci, left, right, gt, pos, time.perf_counter() - t0
-
-    def _iter_with_producer(self, chunks, prefetch):
-        q = queue.Queue(maxsize=prefetch)
-        stop = threading.Event()
-        _END = object()
-
-        def producer():
-            try:
-                for ci, (left, right) in enumerate(chunks):
-                    if stop.is_set():
-                        return
-                    t0 = time.perf_counter()
-                    gt, pos = self._source.slice_region_gpu(
-                left, right, gds_store=self._gds_store)
-                    t_read = time.perf_counter() - t0
-                    if stop.is_set():
-                        return
-                    q.put((ci, left, right, gt, pos, t_read))
-            except BaseException as e:
-                q.put(("ERR", e))
-                return
-            q.put(_END)
-
-        t = threading.Thread(target=producer, daemon=True,
-                             name="kvikio-prefetch")
-        t.start()
-        try:
-            while True:
-                item = q.get()
-                if item is _END:
-                    break
-                if isinstance(item, tuple) and item and item[0] == "ERR":
-                    raise item[1]
-                yield item
-        finally:
-            stop.set()
-            try:
-                while True:
-                    q.get_nowait()
-            except queue.Empty:
-                pass
-            t.join(timeout=5)
-
-    def __del__(self):
-        self._reset_gpu_buffer()
 
 
 class StreamingHaplotypeMatrix:

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -31,7 +31,7 @@ import numpy as np
 import zarr
 from kvikio.zarr import GDSStore
 
-from ._gpu_genotype_prep import build_haplotype_matrix
+from ._gpu_genotype_prep import build_genotype_matrix, build_haplotype_matrix
 
 
 def _pad_to(arr, shape):
@@ -375,19 +375,20 @@ class KvikioChunkFetcher(ChunkFetcher):
         self._gpu_buffer_active = False
 
 
-class StreamingHaplotypeMatrix:
-    """Chunked view over a ``ZarrGenotypeSource``.
+class _StreamingMatrixBase:
+    """Shared chunk-iteration machinery for streaming matrix classes.
 
-    Used by ``HaplotypeMatrix.from_zarr`` when the requested matrix
-    does not fit eagerly on the GPU. Kernels that consume this class
-    do so by iterating ``iter_gpu_chunks``; each yielded
-    ``HaplotypeMatrix`` is an eager device-resident chunk covering a
-    single genomic interval.
+    Subclasses provide the per-chunk ``_build_chunk`` (which decides
+    HaplotypeMatrix vs GenotypeMatrix layout), the sample-axis size
+    that drives the default 'all' sample set, and the data-property
+    raise text (since the eager classes' bulk-data attribute names
+    differ: ``.haplotypes`` vs ``.genotypes``).
 
-    Direct array access (``.haplotypes``, ``.positions``) is not
-    supported -- the whole point of this class is that the matrix is
-    too big to materialize. The dispatch in the kernels uses the
-    iterator instead.
+    Direct array access is not supported -- the whole point of these
+    classes is that the matrix is too big to materialize. Use
+    ``iter_gpu_chunks()`` to walk per-chunk eager matrices, pass the
+    object to a streaming-aware kernel, or call
+    ``.materialize(region=...)`` for a sub-region eager build.
 
     Parameters
     ----------
@@ -398,9 +399,9 @@ class StreamingHaplotypeMatrix:
     prefetch : int
         Read-ahead depth handed to the fetcher.
     align_bp : int, optional
-        Chunk boundaries are snapped to multiples of this so a windowed
-        kernel can guarantee windows never straddle a chunk boundary.
-        Defaults to ``chunk_bp`` (single window per chunk).
+        Chunk boundaries are snapped to multiples of this so a
+        windowed kernel can guarantee windows never straddle a chunk
+        boundary. Defaults to ``chunk_bp`` (single window per chunk).
     """
 
     def __init__(self, source, fetcher, chunk_bp, prefetch, *,
@@ -413,18 +414,14 @@ class StreamingHaplotypeMatrix:
         self._chunks = list(
             source.iter_chunks(self._chunk_bp, self._align_bp)
         )
-        # _sample_sets follows the same idiom as HaplotypeMatrix: store the
-        # explicit value (or None) and let the property fall back to a
-        # default 'all' set when no pop file resolved at source construction.
+        # Mirror the eager classes' idiom: store the explicit value
+        # (or None) and let the property fall back to a default 'all'
+        # set when no pop file resolved at source construction.
         self._sample_sets = source.pop_cols
 
     @property
     def num_variants(self):
         return self._source.num_variants
-
-    @property
-    def num_haplotypes(self):
-        return self._source.num_haplotypes
 
     @property
     def chrom(self):
@@ -443,41 +440,137 @@ class StreamingHaplotypeMatrix:
 
     @property
     def chrom_start(self):
-        """Leading edge of the analyzed region.
-
-        Returns the chunk grid origin (typically ``0``) rather than the
-        first variant position -- streaming's per-chunk windows are
-        anchored to that grid, so reporting the variant-based origin
-        would be misleading for callers building a comparable eager
-        matrix.
-        """
+        """Chunk-grid origin. Not the first variant position --
+        per-chunk windows are anchored to the chunk grid, so reporting
+        the variant-based origin would be misleading for callers
+        building a comparable eager matrix."""
         return self._chunks[0][0] if self._chunks else 0
 
     @property
     def chrom_end(self):
-        """Trailing edge of the analyzed region (chunk-grid right edge).
-
-        Reported as the chunk grid's exclusive upper bound rather than
-        the last-variant-position-inclusive form HaplotypeMatrix uses
-        elsewhere. The streaming path runs windowed_analysis once per
-        chunk and concatenates; using the chunk grid's right edge for
-        each per-chunk chrom_end keeps all interior windows at uniform
-        width. A caller building a comparable eager matrix should set
-        ``eager.chrom_end = stream.chrom_end`` for the same effect.
-        """
+        """Chunk-grid right edge (exclusive). Not the last variant
+        position; per-chunk windows are uniform width within their
+        chunk, so the right edge here is the chunk grid's exclusive
+        upper bound rather than HaplotypeMatrix's last-inclusive
+        convention."""
         return self._chunks[-1][1] if self._chunks else 0
 
     @property
     def sample_sets(self):
-        """Population -> hap-axis indices. Falls back to a single 'all' set
-        when no pop file was resolved."""
+        """Population -> sample-axis indices. Falls back to a single
+        'all' set when no pop file was resolved."""
         if self._sample_sets is None:
-            return {"all": list(range(self.num_haplotypes))}
+            return {"all": list(range(self._sample_axis_size()))}
         return self._sample_sets
 
     @sample_sets.setter
     def sample_sets(self, value):
         self._sample_sets = value
+
+    def iter_gpu_chunks(self):
+        """Yield ``(left, right, eager_matrix)`` tuples covering the source.
+
+        Each yielded eager matrix lives on the GPU and represents one
+        genomic chunk. Empty chunks (regions with no variants, e.g. an
+        acrocentric arm) are skipped -- callers see only chunks with
+        at least one variant.
+        """
+        for ci, left, right, gt, pos, t_read in self._fetcher.iter_chunks(
+                self._chunks, self._prefetch):
+            if gt.shape[0] == 0:
+                continue
+            m = self._build_chunk(
+                gt, pos,
+                # chrom_end is the chunk's exclusive right edge so the
+                # last window in each chunk does not get clipped to the
+                # last variant position the way an eager matrix would.
+                chrom_start=int(left), chrom_end=int(right),
+                sample_sets=self._sample_sets,
+            )
+            yield int(left), int(right), m
+
+    def materialize(self, *, region=None, sample_subset=None):
+        """Build an eager matrix over a sub-region.
+
+        Pairwise / cross-window kernels (``pairwise_r2``, ``grm``,
+        ``ibs``, ``locate_unlinked``, the r^2 heatmap path) can't be
+        evaluated chunk-by-chunk because they need every (variant,
+        variant) pair simultaneously. Pull the slice you want into one
+        device-resident eager matrix and run those kernels on it.
+
+        Parameters
+        ----------
+        region : tuple of int, optional
+            ``(left, right)`` bp interval to materialize. ``right`` is
+            exclusive. ``None`` materializes the full mappable range,
+            which on a biobank-scale store will OOM.
+        sample_subset : sequence of int, optional
+            Haplotype-axis indices to keep. ``None`` keeps every
+            haplotype.
+        """
+        if region is None:
+            left, right = self.chrom_start, self.chrom_end
+        else:
+            left, right = int(region[0]), int(region[1])
+
+        if sample_subset is None:
+            gt, pos = self._source.slice_region(left, right)
+        else:
+            # slice_subsample returns ``(n_var, n_hap_subset)`` int8;
+            # promote back to ``(n_var, n_dip', 2)`` so the eager
+            # build helpers' uniform input shape holds. The subsample
+            # ploidy ordering matches the source's convention: haps
+            # ``0..n_dip-1`` = ploidy 0, ``n_dip..2*n_dip-1`` = ploidy 1.
+            import numpy as _np
+            gm, pos = self._source.slice_subsample(left, right, sample_subset)
+            n_var, n_hap = gm.shape
+            if n_hap % 2 != 0:
+                raise ValueError(
+                    f"materialize(sample_subset=...) requires an even "
+                    f"count to round-trip through (n_dip, 2) layout; "
+                    f"got {n_hap}."
+                )
+            n_dip_sub = n_hap // 2
+            gt = _np.empty((n_var, n_dip_sub, 2), dtype=gm.dtype)
+            gt[:, :, 0] = gm[:, :n_dip_sub]
+            gt[:, :, 1] = gm[:, n_dip_sub:]
+
+        return self._build_chunk(
+            gt, pos,
+            chrom_start=left, chrom_end=right,
+            sample_sets=self._sample_sets,
+        )
+
+    def _sample_axis_size(self):  # pragma: no cover -- abstract
+        raise NotImplementedError
+
+    def _build_chunk(self, gt, pos, **kwargs):  # pragma: no cover -- abstract
+        raise NotImplementedError
+
+    def __repr__(self):
+        return (
+            f"{type(self).__name__}(num_variants={self.num_variants}, "
+            f"{self._repr_sample_axis()}, "
+            f"chrom={self.chrom!r}, n_chunks={len(self._chunks)}, "
+            f"chunk_bp={self._chunk_bp}, prefetch={self._prefetch})"
+        )
+
+    def _repr_sample_axis(self):  # pragma: no cover -- abstract
+        raise NotImplementedError
+
+
+class StreamingHaplotypeMatrix(_StreamingMatrixBase):
+    """Chunked view over a ``ZarrGenotypeSource``, yielding per-chunk
+    ``HaplotypeMatrix`` instances.
+
+    Returned by ``HaplotypeMatrix.from_zarr`` when the requested
+    matrix does not fit eagerly on the GPU. See ``_StreamingMatrixBase``
+    for the iteration / materialize / sample_sets contract.
+    """
+
+    @property
+    def num_haplotypes(self):
+        return self._source.num_haplotypes
 
     @property
     def haplotypes(self):
@@ -492,96 +585,48 @@ class StreamingHaplotypeMatrix:
             "object to a streaming-aware kernel like windowed_analysis."
         )
 
-    def materialize(self, *, region=None, sample_subset=None):
-        """Build an eager ``HaplotypeMatrix`` over a sub-region.
+    def _sample_axis_size(self):
+        return self.num_haplotypes
 
-        Pairwise kernels (``pairwise_r2``, the r^2 heatmap path,
-        ``locate_unlinked``) can't be evaluated chunk-by-chunk because
-        they need every (variant, variant) pair simultaneously. Use
-        this to pull the slice you want into one device-resident
-        HaplotypeMatrix and run those kernels on it.
+    def _build_chunk(self, gt, pos, **kwargs):
+        return build_haplotype_matrix(gt, pos, **kwargs)
 
-        Parameters
-        ----------
-        region : tuple of int, optional
-            ``(left, right)`` bp interval to materialize.
-            ``right`` is exclusive. ``None`` materializes the full
-            mappable range, which on a biobank-scale store will OOM.
-        sample_subset : sequence of int, optional
-            Haplotype-axis indices to keep. ``None`` keeps every
-            haplotype.
+    def _repr_sample_axis(self):
+        return f"num_haplotypes={self.num_haplotypes}"
 
-        Returns
-        -------
-        HaplotypeMatrix
-            Eager, device-resident, ready for any pg_gpu kernel.
-        """
-        from ._gpu_genotype_prep import build_haplotype_matrix
 
-        if region is None:
-            left, right = self.chrom_start, self.chrom_end
-        else:
-            left, right = int(region[0]), int(region[1])
+class StreamingGenotypeMatrix(_StreamingMatrixBase):
+    """Chunked view over a ``ZarrGenotypeSource``, yielding per-chunk
+    ``GenotypeMatrix`` (dosage-coded ``(n_indiv, n_var)``) instances.
 
-        if sample_subset is None:
-            gt, pos = self._source.slice_region(left, right)
-        else:
-            # slice_subsample returns a 2-D (n_var, n_hap_subset) int8
-            # block; HaplotypeMatrix wants (n_hap, n_var). Reshape on
-            # the GPU via build_haplotype_matrix's same prep path by
-            # promoting the 2-D subsample to a (n_var, n_dip', 2)
-            # block. The subsample's ploidy ordering follows the
-            # convention build_haplotype_matrix produces: haps
-            # 0..n_dip-1 = ploidy 0, n_dip..2*n_dip-1 = ploidy 1.
-            import numpy as _np
-            gm, pos = self._source.slice_subsample(left, right, sample_subset)
-            n_var, n_hap = gm.shape
-            # round n_hap to even for the (n_dip, 2) reshape -- if the
-            # caller picked an odd subset count we error out rather
-            # than silently splitting a diploid in half.
-            if n_hap % 2 != 0:
-                raise ValueError(
-                    f"materialize(sample_subset=...) requires an even "
-                    f"count to round-trip through (n_dip, 2) layout; "
-                    f"got {n_hap}."
-                )
-            n_dip_sub = n_hap // 2
-            gt = _np.empty((n_var, n_dip_sub, 2), dtype=gm.dtype)
-            gt[:, :, 0] = gm[:, :n_dip_sub]
-            gt[:, :, 1] = gm[:, n_dip_sub:]
+    Returned by ``GenotypeMatrix.from_zarr`` when the requested matrix
+    does not fit eagerly on the GPU. Sample sets index the diploid
+    axis (``0..num_individuals-1``), not the haplotype axis.
+    Pairwise kernels (``grm``, ``ibs``) are not chunk-streamable; use
+    ``.materialize(region=...)`` to pull a sub-region eagerly first.
+    """
 
-        return build_haplotype_matrix(
-            gt, pos,
-            chrom_start=left, chrom_end=right,
-            sample_sets=self._sample_sets,
+    @property
+    def num_individuals(self):
+        return self._source.num_diploids
+
+    @property
+    def genotypes(self):
+        raise NotImplementedError(
+            "StreamingGenotypeMatrix has no materialized .genotypes "
+            "array; the matrix is too big to fit eagerly, which is why "
+            "from_zarr returned this class instead of GenotypeMatrix. "
+            "For pairwise statistics (grm, ibs) over a sub-region, "
+            "call .materialize(region=(lo, hi)) to get an eager "
+            "GenotypeMatrix over that slice. For per-window streaming "
+            "stats, iterate .iter_gpu_chunks() directly."
         )
 
-    def iter_gpu_chunks(self):
-        """Yield ``(left, right, HaplotypeMatrix)`` tuples covering the source.
+    def _sample_axis_size(self):
+        return self.num_individuals
 
-        Each yielded HaplotypeMatrix lives on the GPU and represents one
-        genomic chunk's variants on the full haplotype axis. Empty
-        chunks (regions with no variants, e.g. an acrocentric arm) are
-        skipped -- callers see only chunks with at least one variant.
-        """
-        for ci, left, right, gt, pos, t_read in self._fetcher.iter_chunks(
-                self._chunks, self._prefetch):
-            if gt.shape[0] == 0:
-                continue
-            hm = build_haplotype_matrix(
-                gt, pos,
-                # chrom_end is the chunk's exclusive right edge so the
-                # last window in each chunk does not get clipped to the
-                # last variant position the way an eager matrix would.
-                chrom_start=int(left), chrom_end=int(right),
-                sample_sets=self._sample_sets,
-            )
-            yield int(left), int(right), hm
+    def _build_chunk(self, gt, pos, **kwargs):
+        return build_genotype_matrix(gt, pos, **kwargs)
 
-    def __repr__(self):
-        return (
-            f"StreamingHaplotypeMatrix(num_variants={self.num_variants}, "
-            f"num_haplotypes={self.num_haplotypes}, "
-            f"chrom={self.chrom!r}, n_chunks={len(self._chunks)}, "
-            f"chunk_bp={self._chunk_bp}, prefetch={self._prefetch})"
-        )
+    def _repr_sample_axis(self):
+        return f"num_individuals={self.num_individuals}"

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -276,19 +276,43 @@ class HostChunkFetcher(ChunkFetcher):
 class KvikioChunkFetcher(ChunkFetcher):
     """Read chunks via ``kvikio.zarr.GDSStore`` with on-GPU codec decode.
 
+    Hardware / software requirements (the kvikio path falls back to
+    ``HostChunkFetcher`` if these are not met):
+
+    * NVIDIA driver and a CUDA-capable GPU; pg_gpu already requires
+      both.
+    * ``kvikio`` and ``nvidia-nvcomp`` Python packages in the same
+      environment as ``pg_gpu`` (the project's pixi env ships these
+      by default).
+    * The VCZ store's ``call_genotype`` chunks compressed with a
+      codec in nvCOMP's GPU-decode list -- currently zstd, blosc,
+      lz4, or deflate. bio2zarr defaults to zstd. Other codecs
+      surface as ``ValueError`` on construction so the caller can
+      re-encode.
+    * Sample-axis chunking smaller than the full sample axis. A
+      store with one whole-sample-axis chunk per variant chunk is
+      still readable but gets no kvikio speedup, so ``backend='auto'``
+      warns and falls back to the host path.
+
+    No special filesystem support is needed: kvikio's compat mode
+    routes reads through posix bounce buffers, so the speedup comes
+    from on-GPU codec decode, not GPU Direct Storage. See
+    ``compat_mode`` below for the exact storage knob.
+
     Reads the store through ``kvikio.zarr.GDSStore`` and enables
     zarr 3's GPU buffer prototype so nvCOMP decodes the codec on the
     GPU. The chunk array therefore lands directly on the device --
     ``build_haplotype_matrix`` skips the host-to-device copy in
     ``cp.asarray(gt)`` because ``gt`` is already a cupy array.
 
-    The win is in the GPU codec decode, not in GPU Direct Storage.
+    The crucial performance gain is in the GPU-accelerated codec decode, not in GPU Direct Storage.
     By default this fetcher sets ``kvikio.defaults.compat_mode=ON``
-    so kvikio reads bytes through posix into bounce buffers without
-    trying to negotiate a real GDS handshake (which is slower on
-    hosts without ``/etc/cufile.json`` configured); pass
-    ``compat_mode=AUTO`` if the storage path is known to be
-    GDS-capable.
+    so kvikio reads bytes through posix into bounce buffers, skipping
+    the GPU-Direct-Storage init path entirely (that path is slower on
+    hosts without ``/etc/cufile.json`` configured because it has to
+    probe the kernel + filesystem for cufile support and fall back
+    when it isn't found); pass ``compat_mode=AUTO`` if the storage
+    path is known to be GDS-capable.
 
     Construction probes the store's call_genotype codec and raises
     ``ValueError`` if it's not in the nvCOMP-supported list, rather

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -10,9 +10,12 @@ producer thread that calls ``ZarrGenotypeSource.slice_region`` while the
 GPU is working on the current chunk, with one chunk of read-ahead by
 default.
 
-Kernels accept this class via dispatch in a follow-up; until then,
-calling a kernel directly raises a clear error. Use ``iter_gpu_chunks``
-to walk chunks manually if you need to.
+Streaming-aware kernels (``windowed_analysis``, ``sfs.sfs``,
+``sfs.joint_sfs``) dispatch on ``isinstance(hm, StreamingHaplotypeMatrix)``
+at the top of the call and run themselves chunk-by-chunk. Kernels
+that have not been adapted yet (Garud, pairwise statistics) raise on
+this class; ``.materialize(region=...)`` returns an eager
+``HaplotypeMatrix`` over a sub-region for those.
 """
 
 import queue
@@ -37,11 +40,11 @@ def _stream_sum(streaming_hm, kernel_fn):
 
     Used by SFS-style kernels whose chunk results compose by addition --
     each chunk contributes its own bincount or joint-bincount, and the
-    chromosome-wide answer is their sum. The padding step covers the
-    edge case where two chunks produce arrays of different shapes (e.g.
-    when one chunk has a population with strictly more valid samples
-    after masking than another, giving it one more bin along that
-    axis).
+    chromosome-wide answer is their sum. Same-shape chunk results take a
+    fast path (in-place add); the slow path only fires on the edge case
+    where two chunks have different shapes (e.g. one chunk's population
+    has strictly more valid samples after masking than another, giving
+    it an extra bin along that axis).
     """
     total = None
     for _, _, chunk in streaming_hm.iter_gpu_chunks():
@@ -49,11 +52,12 @@ def _stream_sum(streaming_hm, kernel_fn):
         if total is None:
             total = s.copy()
             continue
-        if s.shape != total.shape:
-            shape = tuple(max(a, b) for a, b in zip(total.shape, s.shape))
-            total = _pad_to(total, shape)
-            s = _pad_to(s, shape)
-        total += s
+        if s.shape == total.shape:
+            total += s
+            continue
+        shape = tuple(max(a, b) for a, b in zip(total.shape, s.shape))
+        total = _pad_to(total, shape)
+        total += _pad_to(s, shape)
     return total
 
 
@@ -86,9 +90,9 @@ class HostChunkFetcher(ChunkFetcher):
 
     ``prefetch >= 1`` spawns a daemon producer thread that fills a
     bounded queue with the next chunk while the consumer is computing
-    on the current chunk. This is the right baseline for any local
-    zarr store; the kvikio fetcher in a follow-up swaps the same
-    interface for GPU-side codec decode.
+    on the current chunk. A GPU-codec-decode fetcher (kvikio +
+    nvidia-nvcomp) is a drop-in replacement for the same ABC when
+    the store's codec is GPU-decodable.
     """
 
     def __init__(self, source):
@@ -207,6 +211,17 @@ class StreamingHaplotypeMatrix:
     @property
     def chrom(self):
         return self._source.chrom
+
+    @property
+    def align_bp(self):
+        """Chunk-boundary alignment in bp.
+
+        Every chunk has a width that is a multiple of this, so a window
+        whose size also divides ``align_bp`` is guaranteed to fit inside
+        a single chunk. Streaming-aware kernels read this property to
+        validate that the caller's ``window_size`` divides it.
+        """
+        return self._align_bp
 
     @property
     def chrom_start(self):

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -516,14 +516,16 @@ class _StreamingMatrixBase:
         if sample_subset is None:
             gt, pos = self._source.slice_region(left, right)
         else:
-            # slice_subsample returns ``(n_var, n_hap_subset)`` int8;
-            # promote back to ``(n_var, n_dip', 2)`` so the eager
-            # build helpers' uniform input shape holds. The subsample
-            # ploidy ordering matches the source's convention: haps
-            # ``0..n_dip-1`` = ploidy 0, ``n_dip..2*n_dip-1`` = ploidy 1.
-            import numpy as _np
-            gm, pos = self._source.slice_subsample(left, right, sample_subset)
-            n_var, n_hap = gm.shape
+            # slice_subsample's ploidy gather already lives on the GPU
+            # at biobank-scale sample counts; keep the result there
+            # and assemble the ``(n_var, n_dip', 2)`` layout in cupy so
+            # we don't round-trip through a multi-GB host buffer. The
+            # subsample ploidy ordering matches the source's convention:
+            # haps 0..n_dip-1 = ploidy 0, n_dip..2*n_dip-1 = ploidy 1.
+            gm_gpu, pos = self._source.slice_subsample(
+                left, right, sample_subset, to_gpu=True
+            )
+            n_var, n_hap = gm_gpu.shape
             if n_hap % 2 != 0:
                 raise ValueError(
                     f"materialize(sample_subset=...) requires an even "
@@ -531,9 +533,10 @@ class _StreamingMatrixBase:
                     f"got {n_hap}."
                 )
             n_dip_sub = n_hap // 2
-            gt = _np.empty((n_var, n_dip_sub, 2), dtype=gm.dtype)
-            gt[:, :, 0] = gm[:, :n_dip_sub]
-            gt[:, :, 1] = gm[:, n_dip_sub:]
+            gt = cp.empty((n_var, n_dip_sub, 2), dtype=gm_gpu.dtype)
+            gt[:, :, 0] = gm_gpu[:, :n_dip_sub]
+            gt[:, :, 1] = gm_gpu[:, n_dip_sub:]
+            del gm_gpu
 
         return self._build_chunk(
             gt, pos,

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -578,11 +578,11 @@ class StreamingHaplotypeMatrix(_StreamingMatrixBase):
             "StreamingHaplotypeMatrix has no materialized .haplotypes "
             "array; the matrix is too big to fit eagerly, which is why "
             "from_zarr returned this class instead of HaplotypeMatrix. "
-            "For pairwise / cross-window statistics over a sub-region, "
-            "call .materialize(region=(lo, hi)) to get an eager "
-            "HaplotypeMatrix over that slice. For per-window streaming "
-            "stats, iterate .iter_gpu_chunks() directly or pass this "
-            "object to a streaming-aware kernel like windowed_analysis."
+            "For grm or any other kernel that needs every variant in "
+            "scope at once, call .materialize(region=(lo, hi)) to get "
+            "an eager HaplotypeMatrix over a sub-region. For per-window "
+            "streaming stats, ibs, and the LD pair-bin statistics, "
+            "pass this object directly to the kernel."
         )
 
     def _sample_axis_size(self):
@@ -619,9 +619,9 @@ class StreamingGenotypeMatrix(_StreamingMatrixBase):
 
     Returned by ``GenotypeMatrix.from_zarr`` when the requested matrix
     does not fit eagerly on the GPU. Sample sets index the diploid
-    axis (``0..num_individuals-1``), not the haplotype axis.
-    Pairwise kernels (``grm``, ``ibs``) are not chunk-streamable; use
-    ``.materialize(region=...)`` to pull a sub-region eagerly first.
+    axis (``0..num_individuals-1``), not the haplotype axis. ``ibs``
+    accepts this class directly; ``grm`` still needs an eager
+    sub-region via ``.materialize(region=...)``.
     """
 
     @property
@@ -634,10 +634,11 @@ class StreamingGenotypeMatrix(_StreamingMatrixBase):
             "StreamingGenotypeMatrix has no materialized .genotypes "
             "array; the matrix is too big to fit eagerly, which is why "
             "from_zarr returned this class instead of GenotypeMatrix. "
-            "For pairwise statistics (grm, ibs) over a sub-region, "
-            "call .materialize(region=(lo, hi)) to get an eager "
-            "GenotypeMatrix over that slice. For per-window streaming "
-            "stats, iterate .iter_gpu_chunks() directly."
+            "For grm or any other kernel that needs every variant in "
+            "scope at once, call .materialize(region=(lo, hi)) to get "
+            "an eager GenotypeMatrix over a sub-region. For per-window "
+            "streaming stats and ibs, pass this object directly to the "
+            "kernel."
         )
 
     def _sample_axis_size(self):

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -21,9 +21,15 @@ this class; ``.materialize(region=...)`` returns an eager
 import queue
 import threading
 import time
+import warnings
 from abc import ABC, abstractmethod
 
+import cupy as cp
+import kvikio
+import kvikio.defaults
 import numpy as np
+import zarr
+from kvikio.zarr import GDSStore
 
 from ._gpu_genotype_prep import build_haplotype_matrix
 
@@ -83,6 +89,102 @@ class ChunkFetcher(ABC):
             Read-ahead depth. ``0`` means serial; >=1 means a worker
             thread reads ahead of the consumer.
         """
+
+
+#: Codecs the kvikio + nvCOMP path can decode on the GPU. Stores using
+#: anything else fall back to the host fetcher; on-disk pg_gpu / bio2zarr
+#: stores default to zstd, so the common case is GPU-decodable.
+_NVCOMP_SUPPORTED_CODECS = frozenset({"zstd", "blosc", "lz4", "deflate"})
+
+
+class BadlyChunkedWarning(UserWarning):
+    """Emitted when ``backend='auto'`` picks ``host`` on a store whose
+    call_genotype chunking would have defeated the kvikio fetcher's
+    win. The store is functional but a bio2zarr-style re-encode would
+    unlock the GPU-decode fast path."""
+
+
+def _pick_chunk_fetcher(source, *, backend):
+    """Pick a fetcher for ``source``. Errors and warnings reflect what the
+    caller asked for: ``backend='kvikio'`` raises on an incompatible
+    store, while ``backend='auto'`` warns once and falls back."""
+    if backend == "host":
+        return HostChunkFetcher(source)
+    if backend == "kvikio":
+        return KvikioChunkFetcher(source)
+
+    codec = _store_call_genotype_codec(source.path)
+    chunks = _store_call_genotype_chunks(source.path)
+    if codec is None:
+        # codec unreadable or unsupported -> host
+        return HostChunkFetcher(source)
+    whole_sample_axis = (chunks is not None and len(chunks) >= 2
+                         and chunks[1] >= source.num_diploids)
+    if whole_sample_axis:
+        # Whole-sample-axis chunking defeats the kvikio fetcher's win on
+        # full-haplotype reads: zarr's async pipeline already saturates
+        # ~3 cores per chunk decode, so a GPU codec on a single chunk
+        # buys nothing. Only warn when the store is large enough that
+        # the user would actually see the speedup of a rechunk -- on
+        # small test fixtures the warning is noise.
+        warn_threshold_bytes = 1 << 30  # 1 GiB of int8 footprint
+        eager_bytes = int(source.num_variants) * int(source.num_haplotypes)
+        if eager_bytes >= warn_threshold_bytes:
+            warnings.warn(
+                f"{source.path}: call_genotype.chunks={chunks} spans the "
+                f"full sample axis ({source.num_diploids} diploids); the "
+                f"kvikio fetcher gives no speedup at this chunking. "
+                f"Falling back to the host fetcher. Re-encode with "
+                f"bio2zarr-style chunking (sample_chunk ~= 1000) via "
+                f"HaplotypeMatrix.vcf_to_zarr to enable kvikio.",
+                BadlyChunkedWarning, stacklevel=4,
+            )
+        return HostChunkFetcher(source)
+    return KvikioChunkFetcher(source)
+
+
+def _store_call_genotype_codec(store_path):
+    """Return the name of the bytes-encoder codec on the store's
+    call_genotype array (e.g. ``'zstd'``), or None when the codec
+    spec cannot be read.
+
+    The codec name is what matters for picking a fetcher: nvCOMP has
+    GPU decoders for a fixed list, and the rest go through the host
+    path. Reading the spec is cheap (one JSON parse off the
+    ``call_genotype/zarr.json`` blob).
+    """
+    import json
+    import os
+    spec_path = os.path.join(str(store_path), "call_genotype", "zarr.json")
+    if not os.path.exists(spec_path):
+        return None
+    try:
+        with open(spec_path) as f:
+            spec = json.load(f)
+        for entry in spec.get("codecs", []):
+            name = entry.get("name") if isinstance(entry, dict) else None
+            if name in _NVCOMP_SUPPORTED_CODECS:
+                return name
+            if name == "bytes":
+                continue  # transparent reinterpretation; not a real codec
+        return None
+    except (OSError, json.JSONDecodeError, KeyError):
+        return None
+
+
+def _store_call_genotype_chunks(store_path):
+    """Return ``call_genotype.chunks`` as a tuple, or None if unreadable.
+
+    Used to decide whether the store's sample-axis chunking is
+    bio2zarr-shaped (small enough chunks that kvikio's GPU codec
+    decode actually wins on sample-subset reads) or whole-axis
+    chunked (in which case the kvikio path gives no real speedup).
+    """
+    try:
+        store = zarr.open_group(store_path, mode="r")
+        return tuple(store["call_genotype"].chunks)
+    except (FileNotFoundError, KeyError, ValueError):
+        return None
 
 
 class HostChunkFetcher(ChunkFetcher):
@@ -155,6 +257,139 @@ class HostChunkFetcher(ChunkFetcher):
             except queue.Empty:
                 pass
             t.join(timeout=5)
+
+
+class KvikioChunkFetcher(ChunkFetcher):
+    """Read chunks via ``kvikio.zarr.GDSStore`` with on-GPU codec decode.
+
+    Reads the store through ``kvikio.zarr.GDSStore`` and enables
+    zarr 3's GPU buffer prototype so nvCOMP decodes the codec on the
+    GPU. The chunk array therefore lands directly on the device --
+    ``build_haplotype_matrix`` skips the host-to-device copy in
+    ``cp.asarray(gt)`` because ``gt`` is already a cupy array.
+
+    The win is in the GPU codec decode, not in GPU Direct Storage.
+    By default this fetcher sets ``kvikio.defaults.compat_mode=ON``
+    so kvikio reads bytes through posix into bounce buffers without
+    trying to negotiate a real GDS handshake (which is slower on
+    hosts without ``/etc/cufile.json`` configured); pass
+    ``compat_mode=AUTO`` if the storage path is known to be
+    GDS-capable.
+
+    Construction probes the store's call_genotype codec and raises
+    ``ValueError`` if it's not in the nvCOMP-supported list, rather
+    than silently returning incorrect data through a CPU fallback.
+    On close the zarr buffer prototype is reset so subsequent eager
+    calls in the same process get numpy buffers back.
+    """
+
+    def __init__(self, source, *, compat_mode="ON", num_threads=8):
+        codec = _store_call_genotype_codec(source.path)
+        if codec is None:
+            raise ValueError(
+                f"KvikioChunkFetcher requires a call_genotype codec "
+                f"the nvCOMP GPU decoder supports "
+                f"({sorted(_NVCOMP_SUPPORTED_CODECS)}); could not "
+                f"identify one on {source.path}"
+            )
+        self._source = source
+        self._codec = codec
+        self._gds_store = GDSStore(source.path)
+        mode_const = (kvikio.CompatMode.ON if compat_mode == "ON"
+                      else kvikio.CompatMode.AUTO if compat_mode == "AUTO"
+                      else kvikio.CompatMode.OFF)
+        kvikio.defaults.set({"compat_mode": mode_const,
+                             "num_threads": int(num_threads)})
+        self._gpu_buffer_active = False
+
+    def iter_chunks(self, chunks, prefetch):
+        # zarr.config.enable_gpu is process-global; we flip it on for
+        # the duration of the iteration and reset on every exit path
+        # so a downstream eager call gets numpy buffers back.
+        self._enable_gpu_buffer()
+        try:
+            if prefetch <= 0:
+                yield from self._iter_serial(chunks)
+            else:
+                yield from self._iter_with_producer(chunks, prefetch)
+        finally:
+            self._reset_gpu_buffer()
+
+    def close(self):
+        """Reset the zarr buffer prototype.
+
+        Called automatically at the end of ``iter_chunks``; exposed for
+        tests and for callers that build a fetcher without immediately
+        iterating it.
+        """
+        self._reset_gpu_buffer()
+
+    def _enable_gpu_buffer(self):
+        zarr.config.enable_gpu()
+        self._gpu_buffer_active = True
+
+    def _reset_gpu_buffer(self):
+        # __del__ may fire after a constructor raise before
+        # _gpu_buffer_active is set; getattr() guards that path.
+        if not getattr(self, "_gpu_buffer_active", False):
+            return
+        zarr.config.set({
+            "buffer": "zarr.core.buffer.cpu.Buffer",
+            "ndbuffer": "zarr.core.buffer.cpu.NDBuffer",
+        })
+        self._gpu_buffer_active = False
+
+    def _iter_serial(self, chunks):
+        for ci, (left, right) in enumerate(chunks):
+            t0 = time.perf_counter()
+            gt, pos = self._source.slice_region_gpu(
+                left, right, gds_store=self._gds_store)
+            yield ci, left, right, gt, pos, time.perf_counter() - t0
+
+    def _iter_with_producer(self, chunks, prefetch):
+        q = queue.Queue(maxsize=prefetch)
+        stop = threading.Event()
+        _END = object()
+
+        def producer():
+            try:
+                for ci, (left, right) in enumerate(chunks):
+                    if stop.is_set():
+                        return
+                    t0 = time.perf_counter()
+                    gt, pos = self._source.slice_region_gpu(
+                left, right, gds_store=self._gds_store)
+                    t_read = time.perf_counter() - t0
+                    if stop.is_set():
+                        return
+                    q.put((ci, left, right, gt, pos, t_read))
+            except BaseException as e:
+                q.put(("ERR", e))
+                return
+            q.put(_END)
+
+        t = threading.Thread(target=producer, daemon=True,
+                             name="kvikio-prefetch")
+        t.start()
+        try:
+            while True:
+                item = q.get()
+                if item is _END:
+                    break
+                if isinstance(item, tuple) and item and item[0] == "ERR":
+                    raise item[1]
+                yield item
+        finally:
+            stop.set()
+            try:
+                while True:
+                    q.get_nowait()
+            except queue.Empty:
+                pass
+            t.join(timeout=5)
+
+    def __del__(self):
+        self._reset_gpu_buffer()
 
 
 class StreamingHaplotypeMatrix:

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -294,31 +294,27 @@ class KvikioChunkFetcher(ChunkFetcher):
       still readable but gets no kvikio speedup, so ``backend='auto'``
       warns and falls back to the host path.
 
-    No special filesystem support is needed: kvikio's compat mode
-    routes reads through posix bounce buffers, so the speedup comes
-    from on-GPU codec decode, not GPU Direct Storage. See
-    ``compat_mode`` below for the exact storage knob.
+    No special filesystem support is needed. The fetcher opens the
+    store through ``kvikio.zarr.GDSStore`` and switches zarr 3 to its
+    GPU buffer prototype so nvCOMP decodes the codec directly on the
+    device -- ``build_haplotype_matrix`` then skips the
+    host-to-device copy in ``cp.asarray(gt)`` because ``gt`` is
+    already a cupy array. The win is in that on-GPU decode, not in
+    GPU Direct Storage.
 
-    Reads the store through ``kvikio.zarr.GDSStore`` and enables
-    zarr 3's GPU buffer prototype so nvCOMP decodes the codec on the
-    GPU. The chunk array therefore lands directly on the device --
-    ``build_haplotype_matrix`` skips the host-to-device copy in
-    ``cp.asarray(gt)`` because ``gt`` is already a cupy array.
-
-    The crucial performance gain is in the GPU-accelerated codec decode, not in GPU Direct Storage.
     By default this fetcher sets ``kvikio.defaults.compat_mode=ON``
-    so kvikio reads bytes through posix into bounce buffers, skipping
-    the GPU-Direct-Storage init path entirely (that path is slower on
-    hosts without ``/etc/cufile.json`` configured because it has to
-    probe the kernel + filesystem for cufile support and fall back
-    when it isn't found); pass ``compat_mode=AUTO`` if the storage
-    path is known to be GDS-capable.
+    so kvikio reads bytes through posix into bounce buffers rather
+    than trying to use GPU Direct Storage (which would be slower
+    on hosts without ``/etc/cufile.json`` configured because of
+    repeated failed cufile probes). Pass ``compat_mode=AUTO`` if
+    the storage path is known to be GDS-capable.
 
-    Construction probes the store's call_genotype codec and raises
-    ``ValueError`` if it's not in the nvCOMP-supported list, rather
-    than silently returning incorrect data through a CPU fallback.
-    On close the zarr buffer prototype is reset so subsequent eager
-    calls in the same process get numpy buffers back.
+    Construction probes the store's ``call_genotype`` codec and
+    raises ``ValueError`` if it's not in the nvCOMP-supported list,
+    rather than silently returning incorrect data through a CPU
+    fallback. On close the zarr buffer prototype is reset so
+    subsequent eager calls in the same process get numpy buffers
+    back.
     """
 
     def __init__(self, source, *, compat_mode="ON", num_threads=8):

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -1103,17 +1103,16 @@ def _stream_windowed_analysis(streaming_hm, *, window_size, step_size,
     _garud_stats = {"garud_h1", "garud_h12", "garud_h123", "garud_h2h1",
                     "garud_n_distinct", "haplotype_count"}
     if any(s in _garud_stats for s in statistics):
+        # The fused Garud kernel has a known ULP-scale rounding drift
+        # in the distinct-haplotype count under different chunk
+        # prefix-sum orders, so streaming dispatch is currently
+        # disabled for it. Materialize a region to run Garud H at
+        # biobank scale until the rounding is tracked down.
         raise NotImplementedError(
-            "Garud H per-chunk dispatch is correctly basis-stable now "
-            "(weights come from _position_weights and the hashes for a "
-            "given window are byte-equal across chunkings), but the "
-            "fused Garud kernel exhibits second-order rounding "
-            "sensitivity that still causes a few ULP-scale drifts in "
-            "the distinct-haplotype count under different prefix-sum "
-            "trajectories. Tracking this down is a separate concern "
-            "from the streaming infrastructure; materialize the region "
-            "eagerly to run Garud at biobank scale until it lands."
-        )
+            "Garud H statistics are not available on the streaming path; "
+            "materialize the region first via "
+            "StreamingHaplotypeMatrix.materialize(...) and run Garud on "
+            "that.")
 
     # Parse the BED mask once up front and inject the resolved
     # AccessibleMask into each chunk -- otherwise windowed_analysis would
@@ -2499,14 +2498,13 @@ def windowed_statistics_fused_chunked(haplotype_matrix: HaplotypeMatrix,
 def _position_weights(positions, salt):
     """Position-deterministic float64 weights for the Garud H hash basis.
 
-    Replaces the seed=42 RNG draw of length n_var. That draw produced a
-    different weight per variant per call, depending on the matrix's
-    n_variants, so a per-chunk windowed Garud got a different hash basis
-    on every chunk and disagreed with the eager result for the same
-    window. Splitmix64-scrambling the absolute variant position gives a
-    weight that is purely a function of the position and the salt, so two
-    chunks (or two completely different matrices) covering the same
-    variants get the same hash on those variants.
+    Splitmix64-scrambles each absolute variant position to a weight in
+    ``[-1, 1)``. The weight is a pure function of the position and the
+    salt, which is what lets the Garud H kernel produce the same per-
+    window hash whether the surrounding window was computed in one
+    eager pass or split across two streaming chunks; an n_variants-
+    seeded RNG would assign a different weight to the same variant
+    every time the matrix shape changed.
 
     Two salts produce two independent weight columns w1, w2; together
     they make collisions between distinct haplotype patterns vanishingly

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -1100,19 +1100,6 @@ def _stream_windowed_analysis(streaming_hm, *, window_size, step_size,
             "available on the StreamingHaplotypeMatrix path; materialize "
             "the region eagerly to run it."
         )
-    _garud_stats = {"garud_h1", "garud_h12", "garud_h123", "garud_h2h1",
-                    "garud_n_distinct", "haplotype_count"}
-    if any(s in _garud_stats for s in statistics):
-        # The fused Garud kernel has a known ULP-scale rounding drift
-        # in the distinct-haplotype count under different chunk
-        # prefix-sum orders, so streaming dispatch is currently
-        # disabled for it. Materialize a region to run Garud H at
-        # biobank scale until the rounding is tracked down.
-        raise NotImplementedError(
-            "Garud H statistics are not available on the streaming path; "
-            "materialize the region first via "
-            "StreamingHaplotypeMatrix.materialize(...) and run Garud on "
-            "that.")
 
     # Parse the BED mask once up front and inject the resolved
     # AccessibleMask into each chunk -- otherwise windowed_analysis would
@@ -1662,7 +1649,7 @@ _fused_garud_h_kernel = cp.RawKernel(r'''
 extern "C" __global__
 void fused_garud_h(const double* hash1,   // (n_windows, n_hap)
                    const double* hash2,   // (n_windows, n_hap)
-                   int n_hap, int n_windows,
+                   int n_hap, int n_windows, double tol,
                    double* out_h1, double* out_h12,
                    double* out_h123, double* out_h2h1,
                    double* out_n_distinct) {
@@ -1670,16 +1657,18 @@ void fused_garud_h(const double* hash1,   // (n_windows, n_hap)
     if (wid >= n_windows) return;
     int tid = threadIdx.x;
 
-    // Load hashes into shared memory for sorting
-    // Max 1024 haplotypes supported (shared memory limit)
+    // Load hashes into shared memory for sorting. The launcher picks
+    // blockDim.x = ceil(n_hap / 2) rounded up to a power of two so the
+    // odd-even sort has enough threads for every compare-and-swap, but
+    // that leaves blockDim.x < n_hap for many n_hap values -- a strided
+    // load is needed to cover all elements.
     extern __shared__ double shm[];
     double* s_h1 = shm;            // n_hap doubles
     double* s_h2 = shm + n_hap;    // n_hap doubles
 
-    // Each thread loads its element
-    if (tid < n_hap) {
-        s_h1[tid] = hash1[wid * n_hap + tid];
-        s_h2[tid] = hash2[wid * n_hap + tid];
+    for (int i = tid; i < n_hap; i += blockDim.x) {
+        s_h1[i] = hash1[wid * n_hap + i];
+        s_h2[i] = hash2[wid * n_hap + i];
     }
     __syncthreads();
 
@@ -1707,7 +1696,6 @@ void fused_garud_h(const double* hash1,   // (n_windows, n_hap)
     if (tid == 0) {
         // Count distinct haplotypes and collect top-3 frequencies
         double inv_n = 1.0 / (double)n_hap;
-        double tol = 1e-3;
 
         // Walk sorted array, count runs
         // We need: sum(f_i^2), and the top 3 frequencies
@@ -2542,13 +2530,20 @@ def _windowed_mean(values, bin_idx, valid_mask, n_bins):
 def _compute_fused_garud_h(haplotype_matrix, population,
                             win_start, win_stop, n_windows, statistics,
                             results):
-    """Compute windowed Garud's H using prefix-sum hashing + fused GPU kernel.
+    """Compute windowed Garud's H + fused GPU kernel.
 
-    For large data, processes windows in groups to avoid allocating
-    full-size prefix-sum arrays (which would be n_hap * n_var * 8 bytes).
+    Two assembly paths build the per-window haplotype hashes:
+
+    * Tile windows (``win_stop[k] == win_start[k+1]`` for all k) use
+      a per-window scatter-reduce via ``cp.add.reduceat``. Each
+      window's hash is summed from its own variants in index order,
+      so eager and streaming produce bit-identical results and the
+      kernel can use an exact-equality tolerance to bucket haplotypes.
+    * Sliding windows (overlap > 0) still use the prefix-sum trick,
+      which carries the well-known ULP-scale drift the kernel's
+      legacy ``tol=1e-3`` absorbs.
     """
     from ._utils import get_population_matrix
-    from ._memutil import free_gpu_pool
 
     if population is not None:
         matrix = get_population_matrix(haplotype_matrix, population)
@@ -2563,23 +2558,85 @@ def _compute_fused_garud_h(haplotype_matrix, population,
     if not isinstance(pos, cp.ndarray):
         pos = cp.asarray(pos)
 
-    # Memory check: prefix sums need 4 arrays of (n_hap, span+1) float64
-    # Use 30% of free memory as budget for prefix-sum arrays
+    # Tile detection. Both win_start and win_stop arrive as either
+    # numpy or cupy arrays; check on the host so the comparison is
+    # cheap and synchronous.
+    ws = win_start.get() if isinstance(win_start, cp.ndarray) else np.asarray(win_start)
+    we = win_stop.get() if isinstance(win_stop, cp.ndarray) else np.asarray(win_stop)
+    is_tile = (n_windows == 0) or bool(np.all(we[:-1] == ws[1:]))
+
+    if is_tile:
+        _garud_h_per_window_reduceat(hap, pos, win_start, win_stop,
+                                      n_hap, n_windows, statistics,
+                                      results)
+        return
+
+    # Sliding path: keep the existing prefix-sum implementation. Memory
+    # check sized for 4 (n_hap, span+1) float64 arrays (hw1, hw2,
+    # cs1, cs2); fall back to per-group chunking if a full single-pass
+    # buffer would not fit.
     free_mem = cp.cuda.Device().mem_info[0]
     prefix_budget = int(free_mem * 0.3)
-    # Each variant column costs n_hap * 8 * 4 bytes (hw1, hw2, cs1, cs2)
     cost_per_var = n_hap * 8 * 4
     max_span = max(1, prefix_budget // cost_per_var)
 
-    # Check if full prefix sums fit in memory
     if n_var <= max_span:
-        # Original single-pass path
         _garud_h_single_pass(hap, pos, n_hap, n_var, win_start, win_stop,
                              n_windows, statistics, results)
     else:
-        # Chunked path: process groups of windows
         _garud_h_chunked(hap, pos, n_hap, n_var, win_start, win_stop,
                          n_windows, max_span, statistics, results)
+
+
+def _garud_h_per_window_reduceat(hap, pos, win_start, win_stop, n_hap,
+                                   n_windows, statistics, results):
+    """Garud H assembling each window's hash by per-window scatter-reduce.
+
+    Cost is O(n_hap * n_var) -- the same as the prefix-sum approach --
+    but each window's hash is summed from its own variants in index
+    order, so two chunkings covering the same window produce
+    bit-identical results. With deterministic hashes the kernel can
+    bucket haplotypes by a much tighter tolerance (1e-12) than the
+    prefix-sum path's 1e-3, which means the count of distinct
+    haplotypes matches the hand-rolled reference exactly.
+
+    Requires non-overlapping tile windows so each variant is in at
+    most one window; the caller dispatches sliding windows to the
+    prefix-sum path.
+    """
+    if n_windows == 0:
+        return
+    w1 = _position_weights(pos, _GARUD_SALT1)
+    w2 = _position_weights(pos, _GARUD_SALT2)
+
+    # Slice to the variant range covered by any window. Anything left
+    # of win_start[0] and right of win_stop[-1] is not in any window
+    # and should not contribute.
+    if isinstance(win_start, cp.ndarray):
+        ws = win_start.get()
+        we = win_stop.get()
+    else:
+        ws = np.asarray(win_start)
+        we = np.asarray(win_stop)
+    v_lo = int(ws[0])
+    v_hi = int(we[-1])
+
+    hap_slice = hap[:, v_lo:v_hi].astype(cp.float64)
+    hw1 = hap_slice * w1[v_lo:v_hi][cp.newaxis, :]
+    hw2 = hap_slice * w2[v_lo:v_hi][cp.newaxis, :]
+
+    # cp.add.reduceat: bin k sums positions ws[k]-v_lo .. ws[k+1]-v_lo
+    # (exclusive), and the final bin runs to the end of the sliced
+    # array, which equals we[-1]-v_lo for tile windows.
+    rel = (ws - v_lo).astype(np.int64)
+    h1 = cp.add.reduceat(hw1, rel, axis=1)   # (n_hap, n_windows)
+    h2 = cp.add.reduceat(hw2, rel, axis=1)
+
+    all_h1 = cp.ascontiguousarray(h1.T)      # kernel wants (n_windows, n_hap)
+    all_h2 = cp.ascontiguousarray(h2.T)
+
+    _launch_garud_kernel(all_h1, all_h2, n_hap, n_windows, statistics,
+                          results, tol=1e-12)
 
 
 def _garud_h_single_pass(hap, pos, n_hap, n_var, win_start, win_stop,
@@ -2601,7 +2658,8 @@ def _garud_h_single_pass(hap, pos, n_hap, n_var, win_start, win_stop,
     all_h1 = cp.ascontiguousarray(all_h1)
     all_h2 = cp.ascontiguousarray(all_h2)
 
-    _launch_garud_kernel(all_h1, all_h2, n_hap, n_windows, statistics, results)
+    _launch_garud_kernel(all_h1, all_h2, n_hap, n_windows, statistics,
+                          results, tol=1e-3)
 
 
 def _garud_h_chunked(hap, pos, n_hap, n_var, win_start, win_stop,
@@ -2664,7 +2722,7 @@ def _garud_h_chunked(hap, pos, n_hap, n_var, win_start, win_stop,
         # Launch kernel for this group
         grp_results = {}
         _launch_garud_kernel(all_h1, all_h2, n_hap, n_group,
-                             statistics, grp_results)
+                             statistics, grp_results, tol=1e-3)
 
         # Store group results
         for stat_name, out_arr in [('garud_h1', out_h1), ('garud_h12', out_h12),
@@ -2689,8 +2747,18 @@ def _garud_h_chunked(hap, pos, n_hap, n_var, win_start, win_stop,
         results['haplotype_count'] = out_n_distinct.astype(int)
 
 
-def _launch_garud_kernel(all_h1, all_h2, n_hap, n_windows, statistics, results):
-    """Launch the Garud H GPU kernel and store results."""
+def _launch_garud_kernel(all_h1, all_h2, n_hap, n_windows, statistics,
+                          results, *, tol):
+    """Launch the Garud H GPU kernel and store results.
+
+    ``tol`` is the float64 distance below which two sorted hashes are
+    treated as the same haplotype. The per-window scatter-reduce
+    hashing path passes a much tighter tolerance (1e-12) than the
+    prefix-sum path (1e-3) because its hashes are bit-identical for
+    equal haplotypes and far apart for distinct ones; the looser
+    legacy value still absorbs the ULP-scale drift the cumsum-then-
+    subtract trick introduces.
+    """
     out_h1 = cp.empty(n_windows, dtype=cp.float64)
     out_h12 = cp.empty(n_windows, dtype=cp.float64)
     out_h123 = cp.empty(n_windows, dtype=cp.float64)
@@ -2705,6 +2773,7 @@ def _launch_garud_kernel(all_h1, all_h2, n_hap, n_windows, statistics, results):
     _fused_garud_h_kernel(
         (n_windows,), (block,),
         (all_h1, all_h2, np.int32(n_hap), np.int32(n_windows),
+         np.float64(tol),
          out_h1, out_h12, out_h123, out_h2h1, out_n_distinct),
         shared_mem=shm_size)
 

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -1101,15 +1101,18 @@ def _stream_windowed_analysis(streaming_hm, *, window_size, step_size,
             "the region eagerly to run it."
         )
     _garud_stats = {"garud_h1", "garud_h12", "garud_h123", "garud_h2h1",
-                    "garud_n_distinct", "n_distinct_haps"}
+                    "garud_n_distinct", "haplotype_count"}
     if any(s in _garud_stats for s in statistics):
         raise NotImplementedError(
-            "Garud H statistics use a hash basis whose length is set by "
-            "the full matrix's n_variants (windowed_analysis._garud_h_"
-            "single_pass draws w1, w2 of length n_var with seed 42), so "
-            "per-chunk calls produce different hash bases and disagree "
-            "with the eager result. Materialize the region eagerly or "
-            "wait for a position-deterministic Garud hash."
+            "Garud H per-chunk dispatch is correctly basis-stable now "
+            "(weights come from _position_weights and the hashes for a "
+            "given window are byte-equal across chunkings), but the "
+            "fused Garud kernel exhibits second-order rounding "
+            "sensitivity that still causes a few ULP-scale drifts in "
+            "the distinct-haplotype count under different prefix-sum "
+            "trajectories. Tracking this down is a separate concern "
+            "from the streaming infrastructure; materialize the region "
+            "eagerly to run Garud at biobank scale until it lands."
         )
 
     parts = []
@@ -2479,6 +2482,42 @@ def windowed_statistics_fused_chunked(haplotype_matrix: HaplotypeMatrix,
     return results
 
 
+def _position_weights(positions, salt):
+    """Position-deterministic float64 weights for the Garud H hash basis.
+
+    Replaces the seed=42 RNG draw of length n_var. That draw produced a
+    different weight per variant per call, depending on the matrix's
+    n_variants, so a per-chunk windowed Garud got a different hash basis
+    on every chunk and disagreed with the eager result for the same
+    window. Splitmix64-scrambling the absolute variant position gives a
+    weight that is purely a function of the position and the salt, so two
+    chunks (or two completely different matrices) covering the same
+    variants get the same hash on those variants.
+
+    Two salts produce two independent weight columns w1, w2; together
+    they make collisions between distinct haplotype patterns vanishingly
+    rare without changing the Garud H computation downstream.
+
+    The output is uniform in [-1, 1) rather than standard-normal -- the
+    kernel only uses the weights to discriminate haplotype patterns by
+    sorted hash, not to inherit any specific distribution.
+    """
+    s = cp.uint64(salt & 0xFFFFFFFFFFFFFFFF)
+    x = positions.astype(cp.uint64) + s
+    x = (x ^ (x >> cp.uint64(30))) * cp.uint64(0xBF58476D1CE4E5B9)
+    x = (x ^ (x >> cp.uint64(27))) * cp.uint64(0x94D049BB133111EB)
+    x = x ^ (x >> cp.uint64(31))
+    # Mantissa-pack the low 52 bits as a float64 in [1, 2); subtract 1 to
+    # get [0, 1); rescale to [-1, 1).
+    mant = (x & cp.uint64(0x000FFFFFFFFFFFFF)) | cp.uint64(0x3FF0000000000000)
+    u = mant.view(cp.float64) - 1.0
+    return 2.0 * u - 1.0
+
+
+_GARUD_SALT1 = 0x9E3779B97F4A7C15   # golden-ratio constant
+_GARUD_SALT2 = 0xC6BC279692B5C323   # phi^-2-based companion
+
+
 def _windowed_mean(values, bin_idx, valid_mask, n_bins):
     """Compute mean of values per window bin, returning NaN for empty bins."""
     val_sum = _scatter_sum(values[valid_mask], bin_idx[valid_mask], n_bins)
@@ -2508,6 +2547,9 @@ def _compute_fused_garud_h(haplotype_matrix, population,
 
     hap = matrix.haplotypes  # (n_hap, n_var)
     n_hap, n_var = hap.shape
+    pos = matrix.positions
+    if not isinstance(pos, cp.ndarray):
+        pos = cp.asarray(pos)
 
     # Memory check: prefix sums need 4 arrays of (n_hap, span+1) float64
     # Use 30% of free memory as budget for prefix-sum arrays
@@ -2520,21 +2562,20 @@ def _compute_fused_garud_h(haplotype_matrix, population,
     # Check if full prefix sums fit in memory
     if n_var <= max_span:
         # Original single-pass path
-        _garud_h_single_pass(hap, n_hap, n_var, win_start, win_stop,
+        _garud_h_single_pass(hap, pos, n_hap, n_var, win_start, win_stop,
                              n_windows, statistics, results)
     else:
         # Chunked path: process groups of windows
-        _garud_h_chunked(hap, n_hap, n_var, win_start, win_stop,
+        _garud_h_chunked(hap, pos, n_hap, n_var, win_start, win_stop,
                          n_windows, max_span, statistics, results)
 
 
-def _garud_h_single_pass(hap, n_hap, n_var, win_start, win_stop,
+def _garud_h_single_pass(hap, pos, n_hap, n_var, win_start, win_stop,
                           n_windows, statistics, results):
     """Garud H via full prefix-sum hashing (fits in memory)."""
     h_f64 = hap.astype(cp.float64)
-    rng = cp.random.RandomState(seed=42)
-    w1 = rng.standard_normal(n_var, dtype=cp.float64)
-    w2 = rng.standard_normal(n_var, dtype=cp.float64)
+    w1 = _position_weights(pos, _GARUD_SALT1)
+    w2 = _position_weights(pos, _GARUD_SALT2)
 
     hw1 = h_f64 * w1[cp.newaxis, :]
     hw2 = h_f64 * w2[cp.newaxis, :]
@@ -2551,7 +2592,7 @@ def _garud_h_single_pass(hap, n_hap, n_var, win_start, win_stop,
     _launch_garud_kernel(all_h1, all_h2, n_hap, n_windows, statistics, results)
 
 
-def _garud_h_chunked(hap, n_hap, n_var, win_start, win_stop,
+def _garud_h_chunked(hap, pos, n_hap, n_var, win_start, win_stop,
                       n_windows, max_span, statistics, results):
     """Garud H processing windows in groups to limit memory."""
     from ._memutil import free_gpu_pool
@@ -2583,11 +2624,14 @@ def _garud_h_chunked(hap, n_hap, n_var, win_start, win_stop,
         span = group_var_end - group_var_start
         n_group = group_end - wi
 
-        # Compute prefix sums over just this variant span
+        # Compute prefix sums over just this variant span. Weights are
+        # derived from absolute variant positions so the per-span basis
+        # matches the equivalent full-matrix span -- different chunkings
+        # produce identical Garud H values on the same window.
         hap_span = hap[:, group_var_start:group_var_end].astype(cp.float64)
-        rng = cp.random.RandomState(seed=42)
-        w1 = rng.standard_normal(span, dtype=cp.float64)
-        w2 = rng.standard_normal(span, dtype=cp.float64)
+        pos_span = pos[group_var_start:group_var_end]
+        w1 = _position_weights(pos_span, _GARUD_SALT1)
+        w2 = _position_weights(pos_span, _GARUD_SALT2)
 
         hw1 = hap_span * w1[cp.newaxis, :]
         hw2 = hap_span * w2[cp.newaxis, :]

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -1087,7 +1087,7 @@ def _stream_windowed_analysis(streaming_hm, *, window_size, step_size,
             "supply non-overlapping windows or materialize the region "
             "eagerly first."
         )
-    align_bp = streaming_hm._align_bp
+    align_bp = streaming_hm.align_bp
     if window_size > align_bp or align_bp % window_size != 0:
         raise ValueError(
             f"window_size={window_size} must divide the streaming matrix's "
@@ -1115,14 +1115,28 @@ def _stream_windowed_analysis(streaming_hm, *, window_size, step_size,
             "eagerly to run Garud at biobank scale until it lands."
         )
 
+    # Parse the BED mask once up front and inject the resolved
+    # AccessibleMask into each chunk -- otherwise windowed_analysis would
+    # re-open and re-parse the BED for every chunk via
+    # haplotype_matrix.set_accessible_mask.
+    shared_mask = None
+    if accessible_bed is not None:
+        from .accessible import resolve_accessible_mask
+        shared_mask = resolve_accessible_mask(
+            accessible_bed, streaming_hm.chrom_start, streaming_hm.chrom_end,
+            chrom=chrom,
+        )
+
     parts = []
     for left, right, chunk_hm in streaming_hm.iter_gpu_chunks():
+        if shared_mask is not None:
+            chunk_hm.accessible_mask = shared_mask
         df = windowed_analysis(
             chunk_hm,
             window_size=window_size, step_size=step_size,
             statistics=statistics, populations=populations,
             missing_data=missing_data, span_normalize=span_normalize,
-            accessible_bed=accessible_bed, chrom=chrom,
+            accessible_bed=None, chrom=chrom,
             **kwargs,
         )
         if df is not None and len(df):

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -1100,6 +1100,17 @@ def _stream_windowed_analysis(streaming_hm, *, window_size, step_size,
             "available on the StreamingHaplotypeMatrix path; materialize "
             "the region eagerly to run it."
         )
+    _garud_stats = {"garud_h1", "garud_h12", "garud_h123", "garud_h2h1",
+                    "garud_n_distinct", "n_distinct_haps"}
+    if any(s in _garud_stats for s in statistics):
+        raise NotImplementedError(
+            "Garud H statistics use a hash basis whose length is set by "
+            "the full matrix's n_variants (windowed_analysis._garud_h_"
+            "single_pass draws w1, w2 of length n_var with seed 42), so "
+            "per-chunk calls produce different hash bases and disagree "
+            "with the eager result. Materialize the region eagerly or "
+            "wait for a position-deterministic Garud hash."
+        )
 
     parts = []
     for left, right, chunk_hm in streaming_hm.iter_gpu_chunks():

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -1061,6 +1061,73 @@ def _windowed_twopop_scatter(haplotype_matrix, window_size, step_size,
 
 
 # Convenience function for simple usage
+def _stream_windowed_analysis(streaming_hm, *, window_size, step_size,
+                              statistics, populations, missing_data,
+                              span_normalize, accessible_bed, chrom,
+                              **kwargs) -> pd.DataFrame:
+    """Run windowed_analysis chunk-by-chunk over a StreamingHaplotypeMatrix.
+
+    The per-chunk DataFrames are concatenated row-wise. Each chunk's windows
+    are computed in isolation and the chunk boundaries are aligned so a
+    window never straddles two chunks; the StreamingHaplotypeMatrix
+    constructor picked an ``align_bp`` for this reason, so the only
+    contract we have to enforce here is ``window_size`` divides it.
+
+    Sliding windows (``step_size`` != ``window_size``) and the local-PCA
+    dispatch both need cross-chunk state and are not yet supported on the
+    streaming path; both raise rather than silently returning wrong
+    results.
+    """
+    if step_size is None:
+        step_size = window_size
+    if step_size != window_size:
+        raise NotImplementedError(
+            "sliding windows (step_size != window_size) over a "
+            "StreamingHaplotypeMatrix would straddle chunk boundaries; "
+            "supply non-overlapping windows or materialize the region "
+            "eagerly first."
+        )
+    align_bp = streaming_hm._align_bp
+    if window_size > align_bp or align_bp % window_size != 0:
+        raise ValueError(
+            f"window_size={window_size} must divide the streaming matrix's "
+            f"chunk alignment ({align_bp}); pass a smaller window_size or "
+            f"re-open the store with a matching chunk_bp."
+        )
+    if any(s in ("local_pca", "local_pca_jackknife") for s in statistics):
+        raise NotImplementedError(
+            "local_pca requires a chromosome-wide reference and is not "
+            "available on the StreamingHaplotypeMatrix path; materialize "
+            "the region eagerly to run it."
+        )
+
+    parts = []
+    for left, right, chunk_hm in streaming_hm.iter_gpu_chunks():
+        df = windowed_analysis(
+            chunk_hm,
+            window_size=window_size, step_size=step_size,
+            statistics=statistics, populations=populations,
+            missing_data=missing_data, span_normalize=span_normalize,
+            accessible_bed=accessible_bed, chrom=chrom,
+            **kwargs,
+        )
+        if df is not None and len(df):
+            parts.append(df)
+
+    if not parts:
+        # Empty source (e.g. mappable region contains no variants). Return
+        # an empty frame; the eager path would have raised, but for
+        # streaming this is a legitimate "no data in any chunk" outcome.
+        return pd.DataFrame()
+    out = pd.concat(parts, ignore_index=True)
+    # Per-chunk window_id columns restart at 0 inside each chunk; re-number
+    # so concatenated results carry a globally-unique window_id matching
+    # what the eager path produces.
+    if "window_id" in out.columns:
+        out["window_id"] = np.arange(len(out), dtype=out["window_id"].dtype)
+    return out
+
+
 def windowed_analysis(haplotype_matrix: HaplotypeMatrix,
                      window_size: int = 50000,
                      step_size: Optional[int] = None,
@@ -1103,6 +1170,17 @@ def windowed_analysis(haplotype_matrix: HaplotypeMatrix,
     pd.DataFrame
         Windowed statistics results
     """
+    from .streaming_matrix import StreamingHaplotypeMatrix
+    if isinstance(haplotype_matrix, StreamingHaplotypeMatrix):
+        return _stream_windowed_analysis(
+            haplotype_matrix,
+            window_size=window_size, step_size=step_size,
+            statistics=statistics, populations=populations,
+            missing_data=missing_data, span_normalize=span_normalize,
+            accessible_bed=accessible_bed, chrom=chrom,
+            **kwargs,
+        )
+
     if accessible_bed is not None and not haplotype_matrix.has_accessible_mask:
         haplotype_matrix.set_accessible_mask(accessible_bed, chrom=chrom)
     if step_size is None:

--- a/pg_gpu/zarr_io.py
+++ b/pg_gpu/zarr_io.py
@@ -15,13 +15,17 @@ def _parse_region(region):
 
 
 def resolve_pop_file_path(zarr_path, pop_file, *, announce_prefix):
-    """Map a ``pop_file`` kwarg to a filesystem path or None.
+    """Map a ``pop_file`` kwarg that is *only ever a path or auto-load*
+    to a filesystem path or ``None``.
 
-    ``pop_file=False`` disables the auto-load and returns None.
+    ``pop_file=False`` disables the auto-load and returns ``None``.
     ``pop_file=<str>`` returns the path as-is. ``pop_file=None`` looks
     for ``<zarr_path>.pops.tsv`` next to the store; if it exists,
     announces the auto-load to stderr via ``announce_prefix`` and
     returns the companion path.
+
+    For the richer ``pop_file`` accepted by ``HaplotypeMatrix.from_zarr``
+    (numpy arrays, dicts, zarr key names) see ``normalize_pop_input``.
     """
     if pop_file is False:
         return None
@@ -33,6 +37,99 @@ def resolve_pop_file_path(zarr_path, pop_file, *, announce_prefix):
     print(f"{announce_prefix}: auto-loaded pop file {companion}",
           file=sys.stderr, flush=True)
     return companion
+
+
+def normalize_pop_input(pop_file, *, zarr_path, sample_names,
+                         zarr_store=None, announce_prefix=""):
+    """Normalize the flexible ``pop_file`` kwarg into a ``{sample_id ->
+    pop_label}`` dict (or ``None`` to mean "no assignments").
+
+    Accepted forms:
+
+    * ``False`` -- disable both the companion ``.pops.tsv`` auto-load
+      and any other source. Returns ``None``.
+    * ``None`` -- auto-load ``<zarr_path>.pops.tsv`` if it exists.
+      Returns the parsed mapping (or ``None`` if no companion is
+      present). Announces the auto-load to stderr.
+    * ``dict`` -- returned as-is.
+    * ``numpy.ndarray`` / ``list`` of length ``len(sample_names)`` --
+      one population label per sample, in the same order as
+      ``sample_names``. Empty / ``""`` / ``None`` entries are skipped.
+    * ``str`` -- first checked against ``zarr_store`` if provided: a
+      key that resolves to a 1-D string array of the right length is
+      read out of the store. Otherwise interpreted as a filesystem
+      path to a tab-delimited ``sample\\tpop`` file with a header
+      row.
+
+    ``sample_names`` must be the store's sample axis (used both for
+    array-shaped inputs and for path-shaped inputs to filter sample
+    membership). ``zarr_store`` is optional; pass it when the caller
+    has the open store handy so a zarr-key string is preferred over
+    a same-named file on disk.
+    """
+    import numpy as np
+
+    if pop_file is False:
+        return None
+
+    if pop_file is None:
+        companion = str(zarr_path).rstrip("/") + ".pops.tsv"
+        if not os.path.exists(companion):
+            return None
+        print(f"{announce_prefix}: auto-loaded pop file {companion}",
+              file=sys.stderr, flush=True)
+        pop_file = companion
+
+    if isinstance(pop_file, dict):
+        return {str(k): str(v) for k, v in pop_file.items() if v}
+
+    if isinstance(pop_file, (list, tuple, np.ndarray)):
+        labels = np.asarray(pop_file)
+        if labels.ndim != 1:
+            raise ValueError(
+                f"pop_file array must be 1-D; got shape {labels.shape}")
+        if len(labels) != len(sample_names):
+            raise ValueError(
+                f"pop_file array length {len(labels)} does not match "
+                f"sample axis length {len(sample_names)}")
+        return _pop_array_to_map(labels, sample_names)
+
+    if isinstance(pop_file, str):
+        if zarr_store is not None and pop_file in zarr_store:
+            labels = np.asarray(zarr_store[pop_file][:])
+            if labels.ndim != 1 or len(labels) != len(sample_names):
+                raise ValueError(
+                    f"zarr key {pop_file!r} has shape {labels.shape}; "
+                    f"expected 1-D of length {len(sample_names)} to "
+                    f"line up with the sample axis")
+            return _pop_array_to_map(labels, sample_names)
+        return _read_pop_tsv(pop_file)
+
+    raise TypeError(
+        f"pop_file must be a path, dict, array, zarr key, False, or "
+        f"None; got {type(pop_file).__name__}")
+
+
+def _pop_array_to_map(labels, sample_names):
+    out = {}
+    for sample, label in zip(sample_names, labels):
+        if label is None:
+            continue
+        label = str(label)
+        if not label or label.lower() == "nan":
+            continue
+        out[str(sample)] = label
+    return out
+
+
+def _read_pop_tsv(path):
+    out = {}
+    with open(path) as f:
+        for line in f:
+            parts = line.strip().split()
+            if len(parts) >= 2 and parts[0] != "sample":
+                out[parts[0]] = parts[1]
+    return out
 
 
 def detect_zarr_layout(store):

--- a/pg_gpu/zarr_io.py
+++ b/pg_gpu/zarr_io.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+import sys
 
 import numpy as np
 
@@ -11,6 +12,27 @@ def _parse_region(region):
     chrom, coords = region.split(':')
     start, end = [int(x) for x in coords.split('-')]
     return chrom, start, end
+
+
+def resolve_pop_file_path(zarr_path, pop_file, *, announce_prefix):
+    """Map a ``pop_file`` kwarg to a filesystem path or None.
+
+    ``pop_file=False`` disables the auto-load and returns None.
+    ``pop_file=<str>`` returns the path as-is. ``pop_file=None`` looks
+    for ``<zarr_path>.pops.tsv`` next to the store; if it exists,
+    announces the auto-load to stderr via ``announce_prefix`` and
+    returns the companion path.
+    """
+    if pop_file is False:
+        return None
+    if pop_file is not None:
+        return pop_file
+    companion = str(zarr_path).rstrip("/") + ".pops.tsv"
+    if not os.path.exists(companion):
+        return None
+    print(f"{announce_prefix}: auto-loaded pop file {companion}",
+          file=sys.stderr, flush=True)
+    return companion
 
 
 def detect_zarr_layout(store):

--- a/pg_gpu/zarr_io.py
+++ b/pg_gpu/zarr_io.py
@@ -182,7 +182,8 @@ def read_genotypes_allel_grouped(store, region):
     return {'gt': gt, 'positions': positions, 'samples': samples}
 
 
-def write_vcz(zarr_path, gt, positions, samples=None, contig_name=None):
+def write_vcz(zarr_path, gt, positions, samples=None, contig_name=None,
+              chunks=None):
     """Write genotype data in VCZ format.
 
     Parameters
@@ -197,11 +198,30 @@ def write_vcz(zarr_path, gt, positions, samples=None, contig_name=None):
         Sample names.
     contig_name : str, optional
         Chromosome/contig name.
+    chunks : tuple of int, optional
+        Chunk shape for ``call_genotype`` and ``call_genotype_mask``,
+        e.g. ``(10000, 1000, 2)`` to mirror bio2zarr's defaults. When
+        ``None`` (default) zarr picks the chunking, which on a small
+        array is the whole array as a single chunk.
     """
     import zarr
     store = zarr.open(zarr_path, mode='w')
-    store.create_array('call_genotype', data=gt.astype(np.int8))
-    store.create_array('call_genotype_mask', data=(gt < 0))
+    cg_kwargs = {} if chunks is None else {"chunks": chunks}
+    if chunks is None:
+        store.create_array('call_genotype', data=gt.astype(np.int8))
+        store.create_array('call_genotype_mask', data=(gt < 0))
+    else:
+        # create_array with explicit chunks needs shape + dtype rather
+        # than `data=`, so the chunks=... kwarg is honored before any
+        # write resizes the array.
+        cg = store.create_array('call_genotype',
+                                shape=gt.shape, chunks=chunks,
+                                dtype='int8')
+        cg[:] = gt.astype(np.int8)
+        cm = store.create_array('call_genotype_mask',
+                                shape=gt.shape, chunks=chunks,
+                                dtype='bool')
+        cm[:] = (gt < 0)
     store.create_array('variant_position', data=positions.astype(np.int32))
     if samples is not None:
         store.create_array('sample_id', data=np.array(samples, dtype='U'))

--- a/pg_gpu/zarr_io.py
+++ b/pg_gpu/zarr_io.py
@@ -232,6 +232,143 @@ def write_vcz(zarr_path, gt, positions, samples=None, contig_name=None,
                            data=np.zeros(len(positions), dtype=np.int8))
 
 
+def allel_zarr_to_vcz(allel_path, vcz_path, *, contig=None, region=None,
+                      variant_chunk=10_000, sample_chunk=1_000,
+                      progress=False):
+    """Convert a scikit-allel zarr store to vcz (bio2zarr) layout.
+
+    Streams ``calldata/GT`` in variant blocks so chromosome-scale allel
+    stores -- which the eager ``read_genotypes_allel`` would OOM on --
+    can be converted without materializing the full genotype matrix.
+    Writes ``call_genotype`` with bio2zarr-style sample-axis chunking so
+    the pg_gpu streaming reader's kvikio backend can decode chunks on
+    the GPU.
+
+    Parameters
+    ----------
+    allel_path : str
+        Source allel store. Either a flat layout with ``calldata/GT`` at
+        the root, or a chromosome-grouped layout where each
+        ``<contig>/calldata/GT`` is one chromosome. Both are accepted.
+    vcz_path : str
+        Destination vcz store path. Overwritten if it exists.
+    contig : str, optional
+        For grouped stores, the chromosome key to read. Required when
+        the source is grouped and ``region`` does not name a contig.
+        For flat stores, used as the ``contig_id`` label in the output.
+    region : str, optional
+        ``"chrom:start-end"`` (or ``"start-end"`` on a flat store)
+        restricting the conversion to a position range.
+    variant_chunk : int
+        Source variants read per streaming pass. Larger amortizes zarr
+        read overhead; smaller bounds host RAM at biobank sample counts.
+    sample_chunk : int
+        Sample-axis chunk size in the output ``call_genotype``. Smaller
+        chunks let the streaming reader's kvikio + nvCOMP decode overlap
+        with compute on biobank-scale stores.
+    progress : bool
+        Print a one-line status per variant chunk to stderr.
+
+    Notes
+    -----
+    Only the fields pg_gpu's streaming reader requires are written:
+    ``call_genotype``, ``call_genotype_mask``, ``variant_position``,
+    ``sample_id``, ``contig_id``, ``variant_contig``. Other allel
+    columns (REF, ALT, FILTER, etc.) are not preserved.
+    """
+    import sys
+    import zarr
+
+    src = zarr.open_group(allel_path, mode='r')
+    layout = detect_zarr_layout(src)
+    if layout == 'vcz':
+        raise ValueError(
+            f"{allel_path} is already vcz; nothing to convert"
+        )
+    if layout not in ('scikit-allel', 'scikit-allel-grouped'):
+        raise ValueError(
+            f"Expected scikit-allel layout at {allel_path}, got {layout}"
+        )
+
+    # Resolve which chromosome group to read (grouped) or use the root
+    # (flat); derive the contig label that goes into the output.
+    if layout == 'scikit-allel-grouped':
+        chrom_from_region = (region.split(':', 1)[0]
+                              if region and ':' in region else None)
+        contig = contig or chrom_from_region
+        if contig is None:
+            available = [k for k in src if hasattr(src[k], 'keys')]
+            raise ValueError(
+                f"Grouped allel store requires contig=... "
+                f"Available: {available}"
+            )
+        src_grp = src[contig]
+    else:
+        src_grp = src
+        if contig is None:
+            contig = 'unknown'
+
+    gt_arr = src_grp['calldata/GT']
+    pos_arr = src_grp['variants/POS']
+    n_var, n_samp, ploidy = gt_arr.shape
+
+    if region:
+        span = region.split(':', 1)[-1] if ':' in region else region
+        lo, hi = (int(x) for x in span.split('-'))
+        # Loading positions in full is fine -- they're int32, so even a
+        # human-genome-scale chromosome (~10 M sites) is ~40 MB.
+        pos_host = np.asarray(pos_arr[:])
+        lo_idx = int(np.searchsorted(pos_host, lo, side='left'))
+        hi_idx = int(np.searchsorted(pos_host, hi, side='left'))
+        if lo_idx == hi_idx:
+            raise ValueError(f"No variants in region {region}")
+        pos_out = pos_host[lo_idx:hi_idx]
+    else:
+        lo_idx, hi_idx = 0, n_var
+        pos_out = np.asarray(pos_arr[:])
+
+    n_out = hi_idx - lo_idx
+    samples = (np.asarray(src_grp['samples'][:])
+               if 'samples' in src_grp else None)
+
+    dst = zarr.open_group(vcz_path, mode='w')
+    cg = dst.create_array(
+        'call_genotype',
+        shape=(n_out, n_samp, ploidy),
+        chunks=(variant_chunk, sample_chunk, ploidy),
+        dtype='int8',
+    )
+    cm = dst.create_array(
+        'call_genotype_mask',
+        shape=(n_out, n_samp, ploidy),
+        chunks=(variant_chunk, sample_chunk, ploidy),
+        dtype='bool',
+    )
+    for s in range(lo_idx, hi_idx, variant_chunk):
+        e = min(s + variant_chunk, hi_idx)
+        block = np.asarray(gt_arr[s:e])
+        dst_s, dst_e = s - lo_idx, e - lo_idx
+        cg[dst_s:dst_e] = block.astype(np.int8)
+        cm[dst_s:dst_e] = (block < 0)
+        if progress:
+            done = dst_e
+            print(f"[allel_zarr_to_vcz] {done}/{n_out} variants",
+                  file=sys.stderr, flush=True)
+
+    dst.create_array('variant_position', data=pos_out.astype(np.int32))
+    if samples is not None:
+        # Route through plain Python strings: zarr-backed sample arrays
+        # arrive as numpy.StringDType (variable-length) which can't be
+        # cast to fixed-width 'U<n>' without specifying the size; the
+        # list detour lets numpy pick the width itself.
+        dst.create_array(
+            'sample_id',
+            data=np.array([str(s) for s in samples], dtype='U'),
+        )
+    dst.create_array('contig_id', data=np.array([contig], dtype='U'))
+    dst.create_array('variant_contig', data=np.zeros(n_out, dtype=np.int8))
+
+
 def write_allel(zarr_path, gt, positions, samples=None):
     """Write genotype data in scikit-allel format.
 

--- a/pg_gpu/zarr_source.py
+++ b/pg_gpu/zarr_source.py
@@ -85,7 +85,8 @@ class ZarrGenotypeSource:
             chrom, start, end = _parse_region(region)
             if chrom not in contig_ids:
                 raise ValueError(
-                    f"Contig {chrom!r} not in store. Available: {contig_ids}"
+                    f"Contig {chrom!r} not found in store. "
+                    f"Available: {contig_ids}"
                 )
             contig_idx = contig_ids.index(chrom)
             mask = (all_contigs == contig_idx) & (all_pos >= start) & (all_pos < end)
@@ -94,13 +95,15 @@ class ZarrGenotypeSource:
             if len(unique_contigs) > 1 and contig_id is None:
                 names = [contig_ids[i] for i in unique_contigs]
                 raise ValueError(
-                    f"Store contains multiple contigs {names}. Pass "
-                    f"region='chrom:start-end' or contig_id=... to pick one."
+                    f"Store contains {len(unique_contigs)} contigs: "
+                    f"{names}. Pass region='chrom:start-end' or "
+                    f"contig_id=... to pick one."
                 )
             if contig_id is not None:
                 if contig_id not in contig_ids:
                     raise ValueError(
-                        f"Contig {contig_id!r} not in store. Available: {contig_ids}"
+                        f"Contig {contig_id!r} not found in store. "
+                        f"Available: {contig_ids}"
                     )
                 contig_idx = contig_ids.index(contig_id)
             else:

--- a/pg_gpu/zarr_source.py
+++ b/pg_gpu/zarr_source.py
@@ -267,7 +267,7 @@ class ZarrGenotypeSource:
         with open(pop_file) as f:
             for line in f:
                 parts = line.strip().split()
-                if len(parts) < 2 or parts[0] == "sample":
+                if len(parts) < 2 or parts[0] in ("sample", "sample_id"):
                     continue
                 sample, pop = parts[0], parts[1]
                 i = idx_by_name.get(sample)

--- a/pg_gpu/zarr_source.py
+++ b/pg_gpu/zarr_source.py
@@ -14,8 +14,6 @@ that want streaming on those layouts should re-encode via
 ``HaplotypeMatrix.vcf_to_zarr`` or ``HaplotypeMatrix.to_zarr(format='vcz')``.
 """
 
-import os
-import sys
 import warnings
 
 import numpy as np
@@ -223,15 +221,13 @@ class ZarrGenotypeSource:
         return lo, hi
 
     def _resolve_pop_file(self, pop_file):
-        if pop_file is False:
-            return None
+        from .zarr_io import resolve_pop_file_path
+        pop_file = resolve_pop_file_path(
+            self.path, pop_file,
+            announce_prefix="ZarrGenotypeSource",
+        )
         if pop_file is None:
-            companion = self.path.rstrip("/") + ".pops.tsv"
-            if not os.path.exists(companion):
-                return None
-            pop_file = companion
-            print(f"ZarrGenotypeSource: auto-loaded pop file {companion}",
-                  file=sys.stderr, flush=True)
+            return None
 
         # Resolve sample names to diploid indices via the store's sample_id.
         sample_ids = list(np.array(self._store["sample_id"]))

--- a/pg_gpu/zarr_source.py
+++ b/pg_gpu/zarr_source.py
@@ -182,7 +182,7 @@ class ZarrGenotypeSource:
         zhi = int(self._zarr_var_indices[hi - 1]) + 1
         return zlo, zhi
 
-    def slice_subsample(self, left, right, hap_cols):
+    def slice_subsample(self, left, right, hap_cols, *, to_gpu=False):
         """Read variants in ``[left, right)`` restricted to ``hap_cols``.
 
         ``hap_cols`` is an iterable of haplotype-axis indices in
@@ -190,9 +190,20 @@ class ZarrGenotypeSource:
         sample-axis subset; with bio2zarr-style sample chunking only
         the chunks containing the requested diploids are decompressed.
 
+        Parameters
+        ----------
+        to_gpu : bool
+            When ``True`` the returned ``gm`` is a cupy array on the
+            GPU. The ploidy gather is done on the GPU regardless --
+            this kwarg only controls whether ``gm`` gets downloaded
+            back to host before returning. Callers that immediately
+            upload the result (e.g. ``materialize``) should pass
+            ``to_gpu=True`` to avoid the round-trip.
+
         Returns
         -------
-        gm : ndarray, shape (n_var, len(hap_cols)), dtype int8
+        gm : ndarray (host) or cupy.ndarray (device), shape
+             ``(n_var, len(hap_cols))``, dtype ``int8``
             ``-1`` for multiallelic rows.
         pos : ndarray, shape (n_var,), dtype int64
             Variant positions.
@@ -200,8 +211,9 @@ class ZarrGenotypeSource:
         lo, hi = self._site_index_range(left, right)
         hap_cols = np.asarray(hap_cols, dtype=np.int64)
         if hi <= lo:
-            return (np.empty((0, len(hap_cols)), np.int8),
-                    np.empty(0, np.int64))
+            empty = (cp.empty((0, len(hap_cols)), cp.int8) if to_gpu
+                     else np.empty((0, len(hap_cols)), np.int8))
+            return empty, np.empty(0, np.int64)
         zlo, zhi = self._zarr_row_range(lo, hi)
 
         # The haplotype axis indexes a flat (n_dip * 2) layout where hap j
@@ -215,12 +227,24 @@ class ZarrGenotypeSource:
         ploidy = is_p1.astype(np.int64)
         unique_dips, inv = np.unique(dip_idx, return_inverse=True)
 
-        block = np.asarray(
+        block_host = np.asarray(
             self._store["call_genotype"].oindex[zlo:zhi, unique_dips, :]
         )
-        gm = block[:, inv, ploidy]
+        # Ploidy gather on the GPU: at biobank-scale sample subsets
+        # (~10 k samples in ``inv`` over hundreds of thousands of
+        # variants) the equivalent ``block[:, inv, ploidy]`` host
+        # fancy-index is single-threaded numpy and takes tens of
+        # seconds per Mb of variants; the parallel cupy gather is
+        # sub-second.
+        block_gpu = cp.asarray(block_host)
+        del block_host
+        gm_gpu = block_gpu[:, cp.asarray(inv, dtype=cp.int64),
+                            cp.asarray(ploidy, dtype=cp.int64)]
+        del block_gpu
         pos = self.site_pos[lo:hi].copy()
-        return gm, pos
+        if to_gpu:
+            return gm_gpu, pos
+        return cp.asnumpy(gm_gpu), pos
 
     def iter_chunks(self, chunk_bp, align_bp=None, start=None):
         """Yield ``(left, right)`` genomic intervals tiling the source.

--- a/pg_gpu/zarr_source.py
+++ b/pg_gpu/zarr_source.py
@@ -23,6 +23,13 @@ import zarr
 from .zarr_io import _parse_region, detect_zarr_layout
 
 
+#: Maximum contiguous-run count before ``slice_subsample_gpu`` falls
+#: back to the host-staged path. Each run reads one zarr slab, so a
+#: subset scattered across many runs spends more time on kvikio
+#: dispatch than the host oindex path would.
+_SLICE_SUBSAMPLE_GPU_MAX_RUNS = 64
+
+
 class ZarrGenotypeSource:
     """Open a VCZ store and expose chunked + subset read primitives.
 
@@ -181,6 +188,77 @@ class ZarrGenotypeSource:
         zlo = int(self._zarr_var_indices[lo])
         zhi = int(self._zarr_var_indices[hi - 1]) + 1
         return zlo, zhi
+
+    def slice_subsample_gpu(self, left, right, hap_cols, *, cg):
+        """Like ``slice_subsample(to_gpu=True)`` but reads chunks
+        through the caller-provided ``cg`` -- a ``call_genotype``
+        zarr array on a group opened from a ``kvikio.zarr.GDSStore``
+        with the GPU buffer prototype active. Decompression happens
+        on the GPU (nvCOMP) rather than via the synchronous host-side
+        ``oindex`` codec pipeline, which at biobank-scale sample
+        subsets is minutes per call.
+
+        Sample-axis subsetting works by grouping the requested
+        diploids into contiguous runs (typically one or two for a
+        population-subset read), reading each run as a contiguous
+        ``cg[zlo:zhi, rlo:rhi, :]`` slab that kvikio decompresses
+        directly to GPU memory, then doing one GPU fancy-index to
+        assemble the ``(n_var, len(hap_cols))`` result. Pathologically
+        scattered subsets (every dip its own run) fall back to
+        ``slice_subsample(to_gpu=True)``.
+
+        Returns
+        -------
+        gm : cupy.ndarray, shape (n_var, len(hap_cols)), dtype int8
+        pos : ndarray, shape (n_var,), dtype int64
+        """
+        lo, hi = self._site_index_range(left, right)
+        hap_cols = np.asarray(hap_cols, dtype=np.int64)
+        if hi <= lo:
+            return (cp.empty((0, len(hap_cols)), cp.int8),
+                    np.empty(0, np.int64))
+        zlo, zhi = self._zarr_row_range(lo, hi)
+
+        is_p1 = hap_cols >= self.num_diploids
+        dip_idx = np.where(is_p1, hap_cols - self.num_diploids, hap_cols)
+        ploidy = is_p1.astype(np.int64)
+        unique_dips, inv = np.unique(dip_idx, return_inverse=True)
+
+        # Group sorted unique_dips into contiguous diploid-axis runs.
+        # Two for a typical two-population subset, one for single-pop.
+        breaks = np.where(np.diff(unique_dips) != 1)[0]
+        run_lo = np.concatenate([unique_dips[:1], unique_dips[breaks + 1]])
+        run_hi = np.concatenate([unique_dips[breaks] + 1, unique_dips[-1:] + 1])
+
+        # Fall back if the subset is so scattered that per-run slab
+        # reads would no longer amortize. The pair of contiguous runs
+        # typical of LD probes has len(run_lo) == 2.
+        if len(run_lo) > _SLICE_SUBSAMPLE_GPU_MAX_RUNS:
+            return self.slice_subsample(left, right, hap_cols, to_gpu=True)
+
+        # One contiguous slab per run via kvikio's GPU-buffer codec
+        # pipeline, then concatenate. ``slab_offset`` maps each entry
+        # in ``unique_dips`` to its position in the concatenated block.
+        slabs = []
+        slab_offset = np.zeros(unique_dips.size, dtype=np.int64)
+        cum = 0
+        for rlo, rhi in zip(run_lo, run_hi):
+            slabs.append(cg[zlo:zhi, int(rlo):int(rhi), :])
+            in_run = (unique_dips >= rlo) & (unique_dips < rhi)
+            slab_offset[in_run] = unique_dips[in_run] - rlo + cum
+            cum += int(rhi - rlo)
+        block_gpu = (slabs[0] if len(slabs) == 1
+                     else cp.concatenate(slabs, axis=1))
+        del slabs
+
+        # Final GPU fancy-index: for each requested hap_col, pick the
+        # right (dip, ploidy) cell.
+        gm_gpu = block_gpu[:,
+                            cp.asarray(slab_offset[inv], dtype=cp.int64),
+                            cp.asarray(ploidy, dtype=cp.int64)]
+        del block_gpu
+        pos = self.site_pos[lo:hi].copy()
+        return gm_gpu, pos
 
     def slice_subsample(self, left, right, hap_cols, *, to_gpu=False):
         """Read variants in ``[left, right)`` restricted to ``hap_cols``.

--- a/pg_gpu/zarr_source.py
+++ b/pg_gpu/zarr_source.py
@@ -145,11 +145,45 @@ class ZarrGenotypeSource:
         if hi <= lo:
             return (np.empty((0, self.num_diploids, 2), np.int8),
                     np.empty(0, np.int64))
-        zlo = int(self._zarr_var_indices[lo])
-        zhi = int(self._zarr_var_indices[hi - 1]) + 1
+        zlo, zhi = self._zarr_row_range(lo, hi)
         gt = np.asarray(self._store["call_genotype"][zlo:zhi])
         pos = self.site_pos[lo:hi].copy()
         return gt, pos
+
+    def slice_region_gpu(self, left, right, *, gds_store):
+        """Like ``slice_region`` but reads through ``gds_store``
+        (a ``kvikio.zarr.GDSStore`` opened on the same path) so the
+        chunk lands on the GPU via the zarr GPU buffer prototype.
+
+        Caller is responsible for activating
+        ``zarr.config.enable_gpu()`` before iterating chunks and
+        restoring the CPU buffer prototype afterwards; this method
+        does not toggle the global config so it can run inside a
+        producer thread without racing the consumer's eager calls.
+        """
+        import cupy as _cp
+        lo, hi = self._site_index_range(left, right)
+        if hi <= lo:
+            return (_cp.empty((0, self.num_diploids, 2), _cp.int8),
+                    np.empty(0, np.int64))
+        zlo, zhi = self._zarr_row_range(lo, hi)
+        # Open a fresh group on each call -- the group caches the
+        # codec pipeline against the active zarr.config snapshot, so
+        # reopening picks up the GPU buffer prototype the consumer
+        # enabled outside this call.
+        import zarr
+        cg = zarr.open_group(gds_store, mode="r")["call_genotype"]
+        gt = cg[zlo:zhi]
+        pos = self.site_pos[lo:hi].copy()
+        return gt, pos
+
+    def _zarr_row_range(self, lo, hi):
+        """Map an in-source row range ``[lo, hi)`` to the underlying
+        zarr ``call_genotype`` row range, accounting for the region
+        filter applied at construction."""
+        zlo = int(self._zarr_var_indices[lo])
+        zhi = int(self._zarr_var_indices[hi - 1]) + 1
+        return zlo, zhi
 
     def slice_subsample(self, left, right, hap_cols):
         """Read variants in ``[left, right)`` restricted to ``hap_cols``.

--- a/pg_gpu/zarr_source.py
+++ b/pg_gpu/zarr_source.py
@@ -1,0 +1,261 @@
+"""Lazy view over a VCZ zarr store for chunked / subset reads.
+
+``ZarrGenotypeSource`` opens a VCZ store and exposes the read patterns the
+streaming HaplotypeMatrix path needs: ``slice_region`` for the full-haplotype
+windowed-scan chunks, ``slice_subsample`` for the sample-subset reads (LD
+probes, joint SFS subsamples), and ``iter_chunks`` for generating the
+genomic intervals a streaming loop walks. No genotype data is materialized
+at construction -- each slice call reads exactly the variants and samples
+the caller asked for.
+
+Currently supports VCZ (bio2zarr) layout only. Flat / grouped scikit-allel
+layouts are detected and rejected with a clear conversion hint; callers
+that want streaming on those layouts should re-encode via
+``HaplotypeMatrix.vcf_to_zarr`` or ``HaplotypeMatrix.to_zarr(format='vcz')``.
+"""
+
+import os
+import sys
+import warnings
+
+import numpy as np
+import zarr
+
+from .zarr_io import _parse_region, detect_zarr_layout
+
+
+class ZarrGenotypeSource:
+    """Open a VCZ store and expose chunked + subset read primitives.
+
+    Parameters
+    ----------
+    path : str
+        Filesystem path to a VCZ zarr store.
+    region : str, optional
+        ``'chrom:start-end'`` to restrict the source to a single
+        sub-region. The source is single-contig regardless: a
+        multi-contig store without ``region`` raises.
+    pop_file : str, optional
+        Tab-delimited file mapping ``sample`` -> ``pop`` (same format as
+        ``HaplotypeMatrix.load_pop_file``). Default ``None`` looks for
+        ``<path>.pops.tsv`` next to the store and uses it if present;
+        emits a one-line stderr note so the auto-load isn't invisible.
+        Pass ``pop_file=False`` to disable the auto-load entirely.
+    contig_id : str, optional
+        Pick a contig by name when ``region`` is not given and the store
+        has multiple contigs. Ignored otherwise.
+
+    Attributes
+    ----------
+    num_variants : int
+        Variants inside ``region`` (or the whole store), after contig
+        selection.
+    num_diploids : int
+        Sample-axis length.
+    num_haplotypes : int
+        ``2 * num_diploids``.
+    site_pos : ndarray
+        Variant positions (host), length ``num_variants``.
+    chrom : str
+        Selected contig name.
+    chunks : tuple
+        ``call_genotype`` chunk shape.
+    pop_cols : dict or None
+        ``{pop_name: ndarray[hap_axis_indices]}`` when a pop file was
+        resolved, else None.
+    """
+
+    def __init__(self, path, *, region=None, pop_file=None, contig_id=None):
+        self.path = str(path)
+        self._store = zarr.open_group(self.path, mode="r")
+
+        layout = detect_zarr_layout(self._store)
+        if layout != "vcz":
+            raise ValueError(
+                f"ZarrGenotypeSource currently supports VCZ layout only; "
+                f"got {layout!r}. Re-encode via HaplotypeMatrix.vcf_to_zarr "
+                f"or HaplotypeMatrix.to_zarr(format='vcz')."
+            )
+
+        contig_ids = list(np.array(self._store["contig_id"]))
+        all_contigs = np.array(self._store["variant_contig"])
+        all_pos = np.array(self._store["variant_position"])
+
+        if region is not None:
+            chrom, start, end = _parse_region(region)
+            if chrom not in contig_ids:
+                raise ValueError(
+                    f"Contig {chrom!r} not in store. Available: {contig_ids}"
+                )
+            contig_idx = contig_ids.index(chrom)
+            mask = (all_contigs == contig_idx) & (all_pos >= start) & (all_pos < end)
+        else:
+            unique_contigs = np.unique(all_contigs)
+            if len(unique_contigs) > 1 and contig_id is None:
+                names = [contig_ids[i] for i in unique_contigs]
+                raise ValueError(
+                    f"Store contains multiple contigs {names}. Pass "
+                    f"region='chrom:start-end' or contig_id=... to pick one."
+                )
+            if contig_id is not None:
+                if contig_id not in contig_ids:
+                    raise ValueError(
+                        f"Contig {contig_id!r} not in store. Available: {contig_ids}"
+                    )
+                contig_idx = contig_ids.index(contig_id)
+            else:
+                contig_idx = int(unique_contigs[0])
+            chrom = contig_ids[contig_idx]
+            mask = all_contigs == contig_idx
+
+        self._zarr_var_indices = np.where(mask)[0]
+        self.site_pos = all_pos[mask]
+        self.chrom = chrom
+
+        cg = self._store["call_genotype"]
+        self.chunks = tuple(cg.chunks)
+        self.num_diploids = int(cg.shape[1])
+        self.num_haplotypes = 2 * self.num_diploids
+        self.num_variants = int(self.site_pos.size)
+
+        self.pop_cols = self._resolve_pop_file(pop_file)
+
+    @property
+    def mappable_lo(self):
+        """Position of the first variant in the source (or 0 if empty)."""
+        return int(self.site_pos[0]) if self.num_variants else 0
+
+    @property
+    def mappable_hi(self):
+        """One past the position of the last variant in the source."""
+        return int(self.site_pos[-1]) + 1 if self.num_variants else 0
+
+    def slice_region(self, left, right):
+        """Read every haplotype for variants in ``[left, right)``.
+
+        Returns
+        -------
+        gt : ndarray, shape (n_var, num_diploids, 2), dtype int8
+            Raw call_genotype block, ``-1`` for multiallelic rows.
+        pos : ndarray, shape (n_var,), dtype int64
+            Variant positions.
+        """
+        lo, hi = self._site_index_range(left, right)
+        if hi <= lo:
+            return (np.empty((0, self.num_diploids, 2), np.int8),
+                    np.empty(0, np.int64))
+        zlo = int(self._zarr_var_indices[lo])
+        zhi = int(self._zarr_var_indices[hi - 1]) + 1
+        gt = np.asarray(self._store["call_genotype"][zlo:zhi])
+        pos = self.site_pos[lo:hi].copy()
+        return gt, pos
+
+    def slice_subsample(self, left, right, hap_cols):
+        """Read variants in ``[left, right)`` restricted to ``hap_cols``.
+
+        ``hap_cols`` is an iterable of haplotype-axis indices in
+        ``[0, 2 * num_diploids)``. Uses zarr's ``oindex`` for the
+        sample-axis subset; with bio2zarr-style sample chunking only
+        the chunks containing the requested diploids are decompressed.
+
+        Returns
+        -------
+        gm : ndarray, shape (n_var, len(hap_cols)), dtype int8
+            ``-1`` for multiallelic rows.
+        pos : ndarray, shape (n_var,), dtype int64
+            Variant positions.
+        """
+        lo, hi = self._site_index_range(left, right)
+        hap_cols = np.asarray(hap_cols, dtype=np.int64)
+        if hi <= lo:
+            return (np.empty((0, len(hap_cols)), np.int8),
+                    np.empty(0, np.int64))
+        zlo = int(self._zarr_var_indices[lo])
+        zhi = int(self._zarr_var_indices[hi - 1]) + 1
+
+        # The haplotype axis indexes a flat (n_dip * 2) layout where hap j
+        # = (ploidy j // n_dip, dip j % n_dip). VCZ stores (n_var, n_dip, 2)
+        # so we have to translate each requested hap index into (dip, ploidy)
+        # and feed unique dips through oindex (zarr's oindex on a 3-D axis
+        # does not de-duplicate, and requesting the same dip twice would
+        # double-decompress its sample chunk).
+        is_p1 = hap_cols >= self.num_diploids
+        dip_idx = np.where(is_p1, hap_cols - self.num_diploids, hap_cols)
+        ploidy = is_p1.astype(np.int64)
+        unique_dips, inv = np.unique(dip_idx, return_inverse=True)
+
+        block = np.asarray(
+            self._store["call_genotype"].oindex[zlo:zhi, unique_dips, :]
+        )
+        gm = block[:, inv, ploidy]
+        pos = self.site_pos[lo:hi].copy()
+        return gm, pos
+
+    def iter_chunks(self, chunk_bp, align_bp=None, start=None):
+        """Yield ``(left, right)`` genomic intervals tiling the source.
+
+        Intervals are sized as multiples of ``align_bp`` (defaults to
+        ``chunk_bp``) so a caller running window-based stats can
+        guarantee windows never straddle a chunk boundary. Empty
+        regions at the start of the contig (e.g. acrocentric arm) are
+        yielded as well -- the caller can detect and skip them via the
+        cheap ``gt.shape[0] == 0`` check.
+        """
+        if align_bp is None:
+            align_bp = chunk_bp
+        windows_per_chunk = max(1, chunk_bp // align_bp)
+        step = windows_per_chunk * align_bp
+        end = self.mappable_hi
+        s = 0 if start is None else int(start)
+        if end == 0:
+            return
+        while s < end:
+            yield s, min(s + step, end)
+            s += step
+
+    def _site_index_range(self, left, right):
+        """Half-open ``[lo, hi)`` row range covering positions in [left, right)."""
+        lo = int(np.searchsorted(self.site_pos, left, side="left"))
+        hi = int(np.searchsorted(self.site_pos, right, side="left"))
+        return lo, hi
+
+    def _resolve_pop_file(self, pop_file):
+        if pop_file is False:
+            return None
+        if pop_file is None:
+            companion = self.path.rstrip("/") + ".pops.tsv"
+            if not os.path.exists(companion):
+                return None
+            pop_file = companion
+            print(f"ZarrGenotypeSource: auto-loaded pop file {companion}",
+                  file=sys.stderr, flush=True)
+
+        # Resolve sample names to diploid indices via the store's sample_id.
+        sample_ids = list(np.array(self._store["sample_id"]))
+        idx_by_name = {str(s): i for i, s in enumerate(sample_ids)}
+
+        pop_to_dips = {}
+        with open(pop_file) as f:
+            for line in f:
+                parts = line.strip().split()
+                if len(parts) < 2 or parts[0] == "sample":
+                    continue
+                sample, pop = parts[0], parts[1]
+                i = idx_by_name.get(sample)
+                if i is None:
+                    warnings.warn(
+                        f"pop_file sample {sample!r} not in store; skipping",
+                        stacklevel=2,
+                    )
+                    continue
+                pop_to_dips.setdefault(pop, []).append(i)
+
+        # Map diploid indices to haplotype-axis indices: dip i lives at
+        # haps i (ploidy 0) and i + num_diploids (ploidy 1). Matches the
+        # layout build_haplotype_matrix produces and load_pop_file expects.
+        n_dip = self.num_diploids
+        pop_cols = {}
+        for pop, dips in pop_to_dips.items():
+            dips = np.asarray(sorted(dips), dtype=np.int64)
+            pop_cols[pop] = np.concatenate([dips, dips + n_dip])
+        return pop_cols

--- a/pg_gpu/zarr_source.py
+++ b/pg_gpu/zarr_source.py
@@ -16,6 +16,7 @@ that want streaming on those layouts should re-encode via
 
 import warnings
 
+import cupy as cp
 import numpy as np
 import zarr
 
@@ -150,29 +151,25 @@ class ZarrGenotypeSource:
         pos = self.site_pos[lo:hi].copy()
         return gt, pos
 
-    def slice_region_gpu(self, left, right, *, gds_store):
-        """Like ``slice_region`` but reads through ``gds_store``
-        (a ``kvikio.zarr.GDSStore`` opened on the same path) so the
-        chunk lands on the GPU via the zarr GPU buffer prototype.
+    def slice_region_gpu(self, left, right, *, cg):
+        """Like ``slice_region`` but reads through a caller-provided
+        ``cg`` -- the ``call_genotype`` zarr array on a group opened
+        from a ``kvikio.zarr.GDSStore`` with the GPU buffer prototype
+        active. The chunk lands on the GPU via the active buffer
+        prototype.
 
-        Caller is responsible for activating
-        ``zarr.config.enable_gpu()`` before iterating chunks and
-        restoring the CPU buffer prototype afterwards; this method
-        does not toggle the global config so it can run inside a
-        producer thread without racing the consumer's eager calls.
+        ``cg`` is passed in (not opened here) because zarr caches the
+        codec pipeline on the group at open time; the caller opens
+        the group once after toggling ``zarr.config.enable_gpu()``
+        and reuses the resulting array across every chunk in the
+        iteration. Per-call opens would cost ~ms per chunk and add
+        nothing.
         """
-        import cupy as _cp
         lo, hi = self._site_index_range(left, right)
         if hi <= lo:
-            return (_cp.empty((0, self.num_diploids, 2), _cp.int8),
+            return (cp.empty((0, self.num_diploids, 2), cp.int8),
                     np.empty(0, np.int64))
         zlo, zhi = self._zarr_row_range(lo, hi)
-        # Open a fresh group on each call -- the group caches the
-        # codec pipeline against the active zarr.config snapshot, so
-        # reopening picks up the GPU buffer prototype the consumer
-        # enabled outside this call.
-        import zarr
-        cg = zarr.open_group(gds_store, mode="r")["call_genotype"]
         gt = cg[zlo:zhi]
         pos = self.site_pos[lo:hi].copy()
         return gt, pos
@@ -205,8 +202,7 @@ class ZarrGenotypeSource:
         if hi <= lo:
             return (np.empty((0, len(hap_cols)), np.int8),
                     np.empty(0, np.int64))
-        zlo = int(self._zarr_var_indices[lo])
-        zhi = int(self._zarr_var_indices[hi - 1]) + 1
+        zlo, zhi = self._zarr_row_range(lo, hi)
 
         # The haplotype axis indexes a flat (n_dip * 2) layout where hap j
         # = (ploidy j // n_dip, dip j % n_dip). VCZ stores (n_var, n_dip, 2)

--- a/pg_gpu/zarr_source.py
+++ b/pg_gpu/zarr_source.py
@@ -353,33 +353,35 @@ class ZarrGenotypeSource:
         return lo, hi
 
     def _resolve_pop_file(self, pop_file):
-        from .zarr_io import resolve_pop_file_path
-        pop_file = resolve_pop_file_path(
-            self.path, pop_file,
+        from .zarr_io import normalize_pop_input
+
+        # Defer the sample_id lookup until we actually need it -- some
+        # test fixtures write minimal VCZ stores without a sample_id
+        # array, and a missing companion .pops.tsv should not need it.
+        if "sample_id" in self._store:
+            sample_ids = list(np.array(self._store["sample_id"]))
+        else:
+            sample_ids = []
+        pop_map = normalize_pop_input(
+            pop_file, zarr_path=self.path,
+            sample_names=sample_ids,
+            zarr_store=self._store,
             announce_prefix="ZarrGenotypeSource",
         )
-        if pop_file is None:
+        if pop_map is None:
             return None
 
-        # Resolve sample names to diploid indices via the store's sample_id.
-        sample_ids = list(np.array(self._store["sample_id"]))
         idx_by_name = {str(s): i for i, s in enumerate(sample_ids)}
-
         pop_to_dips = {}
-        with open(pop_file) as f:
-            for line in f:
-                parts = line.strip().split()
-                if len(parts) < 2 or parts[0] in ("sample", "sample_id"):
-                    continue
-                sample, pop = parts[0], parts[1]
-                i = idx_by_name.get(sample)
-                if i is None:
-                    warnings.warn(
-                        f"pop_file sample {sample!r} not in store; skipping",
-                        stacklevel=2,
-                    )
-                    continue
-                pop_to_dips.setdefault(pop, []).append(i)
+        for sample, pop in pop_map.items():
+            i = idx_by_name.get(str(sample))
+            if i is None:
+                warnings.warn(
+                    f"pop_file sample {sample!r} not in store; skipping",
+                    stacklevel=2,
+                )
+                continue
+            pop_to_dips.setdefault(pop, []).append(i)
 
         # Map diploid indices to haplotype-axis indices: dip i lives at
         # haps i (ploidy 0) and i + num_diploids (ploidy 1). Matches the

--- a/pixi.toml
+++ b/pixi.toml
@@ -20,6 +20,17 @@ zarr = ">=2.16"
 pg_gpu = { path = ".", editable = true }
 bio2zarr = { version = ">=0.1", extras = ["vcf"] }
 
+# Streaming-from-zarr uses kvikio + nvCOMP to decode store chunks on the
+# GPU when the codec is GPU-decodable (zstd / blosc / lz4 / deflate).
+# Hard dependency: pg_gpu is GPU-first and the streaming dispatch always
+# imports these unconditionally. Conda-forge's kvikio is cuda13/cp311
+# only at the moment, so we go through NVIDIA's PyPI index.
+"kvikio-cu12" = ">=25.0"
+"nvidia-nvcomp-cu12" = ">=4.0"
+
+[pypi-options]
+extra-index-urls = ["https://pypi.nvidia.com"]
+
 [feature.gpu.dependencies]
 cupy = ">=13.0"
 cuda-version = "12.*"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,3 +104,28 @@ def sample_haplotype_counts():
         'pop1': pop1_counts,
         'pop2': pop2_counts
     }
+
+
+def simulate_hm(n_samples=20, seq_length=100_000, seed=42,
+                mutation_model=None):
+    """Build a small msprime-derived HaplotypeMatrix for tests.
+
+    Centralizes what would otherwise be repeated per-test simulation
+    boilerplate. ``mutation_model=None`` lets msprime pick its default
+    (Jukes-Cantor, which can produce triallelic sites);
+    ``mutation_model='binary'`` forces biallelic, which is what the
+    pg_gpu-vs-allel parity tests want because pg_gpu's pi formula has
+    a known multi-allelic gap (kr-colab/pg_gpu#100).
+    """
+    import msprime
+    from pg_gpu import HaplotypeMatrix
+
+    ts = msprime.sim_ancestry(
+        samples=n_samples, sequence_length=seq_length,
+        recombination_rate=1e-4, random_seed=seed, ploidy=2,
+    )
+    kw = {}
+    if mutation_model is not None:
+        kw["model"] = mutation_model
+    ts = msprime.sim_mutations(ts, rate=1e-3, random_seed=seed, **kw)
+    return HaplotypeMatrix.from_ts(ts)

--- a/tests/test_biobank_streaming_example.py
+++ b/tests/test_biobank_streaming_example.py
@@ -1,0 +1,124 @@
+"""Smoke test for examples/biobank_streaming_scan.py.
+
+The example script doubles as the worked-example link in the
+biobank-scale streaming tutorial. Run it end-to-end against a small
+msprime-derived VCZ fixture so that an unintentional API drift, a
+silently-empty window scale, or a forgotten ``cupy -> numpy``
+conversion is caught here instead of by a reader trying to follow
+the docs.
+
+Skipped when the example script is not present (e.g. trimmed source
+distributions)."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import msprime
+import numpy as np
+import pytest
+
+from pg_gpu import HaplotypeMatrix
+
+EXAMPLE = (Path(__file__).resolve().parent.parent /
+           "examples" / "biobank_streaming_scan.py")
+
+
+@pytest.fixture(scope="module")
+def two_pop_vcz(tmp_path_factory):
+    """Build a 2 Mb / 2-population (AFR, EUR) VCZ store with a
+    companion pop file. 2 Mb is the smallest chromosome length that
+    lets the example's 1 Mb window scale produce multiple windows."""
+    if not EXAMPLE.exists():
+        pytest.skip(f"missing {EXAMPLE}")
+    tmp = tmp_path_factory.mktemp("biobank_example")
+    demo = msprime.Demography.island_model([10_000, 10_000],
+                                            migration_rate=1e-4)
+    demo.populations[0].name = "AFR"
+    demo.populations[1].name = "EUR"
+    ts = msprime.sim_ancestry(
+        samples={"AFR": 25, "EUR": 25}, sequence_length=2_000_000,
+        recombination_rate=1e-8, random_seed=11,
+        demography=demo,
+    )
+    ts = msprime.sim_mutations(ts, rate=1e-8, random_seed=11)
+    hm = HaplotypeMatrix.from_ts(ts)
+    hm.samples = [f"s{i}" for i in range(hm.num_haplotypes // 2)]
+    vcz = str(tmp / "chr1.vcz")
+    hm.to_zarr(vcz, format="vcz", contig_name="1")
+    with open(vcz + ".pops.tsv", "w") as f:
+        f.write("sample\tpop\n")
+        for i in range(25):
+            f.write(f"s{i}\tAFR\n")
+        for i in range(25, 50):
+            f.write(f"s{i}\tEUR\n")
+    return vcz, tmp
+
+
+def test_example_runs_end_to_end(two_pop_vcz, tmp_path):
+    vcz, _ = two_pop_vcz
+    out_dir = tmp_path / "out"
+    repo_root = Path(__file__).resolve().parent.parent
+
+    proc = subprocess.run(
+        [sys.executable, str(EXAMPLE),
+         "--vcz", vcz, "--out-dir", str(out_dir),
+         "--chunk-bp", "1000000",
+         "--heatmap-subsample", "10",
+         "--garud-subsample", "20",
+         "--joint-sfs-target", "10"],
+        cwd=str(repo_root),
+        env={**os.environ},
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, (
+        f"example failed:\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+
+    # All declared outputs must exist and be non-trivial.
+    summary = json.loads((out_dir / "chr1_summary.json").read_text())
+    assert summary["chromosome"] == "1"
+    assert summary["haplotypes_per_pop"] == {"AFR": 50, "EUR": 50}
+
+    # Per-scale window counts: 2 Mb chromosome / scale = number of
+    # windows. If any scale silently emits zero or chunk-clipped rows
+    # (the bug that prompted this test), we catch it here.
+    for label, bp in (("10kb", 10_000), ("100kb", 100_000),
+                      ("1mb", 1_000_000)):
+        path = out_dir / f"chr1_{label}.csv"
+        assert path.exists(), f"missing {path}"
+        lines = path.read_text().splitlines()
+        # 1 header + (chromosome_length / window_size) data rows.
+        assert len(lines) - 1 == 2_000_000 // bp, (
+            f"{label}: expected {2_000_000 // bp} windows, got "
+            f"{len(lines) - 1}")
+
+    # Joint SFS shape matches the projection target.
+    joint = np.load(out_dir / "chr1_joint_sfs.npy")
+    assert joint.shape == (11, 11)  # target_n1 + 1 by target_n2 + 1
+
+    # Pairwise r^2 heatmap exists and is a square matrix.
+    r2 = np.load(out_dir / "chr1_r2_heatmap.npy")
+    assert r2.ndim == 2 and r2.shape[0] == r2.shape[1]
+
+
+def test_example_errors_on_bad_chunk_bp(two_pop_vcz, tmp_path):
+    # chunk_bp=500_000 doesn't divide the 1 Mb window scale; the
+    # example must refuse rather than silently emit chunk-clipped
+    # rows.
+    vcz, _ = two_pop_vcz
+    repo_root = Path(__file__).resolve().parent.parent
+    proc = subprocess.run(
+        [sys.executable, str(EXAMPLE),
+         "--vcz", vcz, "--out-dir", str(tmp_path / "bad"),
+         "--chunk-bp", "500000",
+         "--heatmap-subsample", "10",
+         "--garud-subsample", "20",
+         "--joint-sfs-target", "10"],
+        cwd=str(repo_root),
+        capture_output=True, text=True,
+    )
+    assert proc.returncode != 0
+    assert "not a multiple of every WINDOW_SCALES" in proc.stderr

--- a/tests/test_biobank_warning.py
+++ b/tests/test_biobank_warning.py
@@ -131,6 +131,20 @@ class TestMaybeBiobankWarn:
             warnings.simplefilter("ignore", BiobankScaleWarning)
             _maybe_biobank_warn(path, warn_samples=10)
 
+    def test_relative_and_absolute_paths_dedupe(self, tmp_path, monkeypatch):
+        # The cache canonicalizes via os.path.realpath, so a relative
+        # path and the corresponding absolute path collapse to one
+        # entry. Without this, every alias of the same file would
+        # re-warn.
+        path = tmp_path / "alias.vcf"
+        _write_minimal_vcf(str(path), n_samples=20)
+        monkeypatch.chdir(tmp_path)
+        with pytest.warns(BiobankScaleWarning):
+            _maybe_biobank_warn("alias.vcf", warn_samples=10)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", BiobankScaleWarning)
+            _maybe_biobank_warn(str(path.resolve()), warn_samples=10)
+
 
 class TestFromVcfIntegration:
 

--- a/tests/test_biobank_warning.py
+++ b/tests/test_biobank_warning.py
@@ -1,0 +1,162 @@
+"""Tests for ``BiobankScaleWarning`` and ``_maybe_biobank_warn``.
+
+The size thresholds are kwargs on ``_maybe_biobank_warn`` so tests can
+trip them on tiny on-disk fixtures rather than building genuine 10 GiB
+VCFs.
+"""
+
+import os
+import warnings
+
+import pytest
+
+from pg_gpu import BiobankScaleWarning
+from pg_gpu._biobank_warning import (
+    _maybe_biobank_warn, _region_span_bp, _vcf_header_sample_count,
+    _warned_paths,
+)
+
+
+def _write_minimal_vcf(path, n_samples, n_variants=2):
+    """Write a tiny synthetic VCF with the requested sample count and a
+    few variants. Used to drive the header-parse path without needing
+    a real msprime/bcftools roundtrip."""
+    header = (
+        "##fileformat=VCFv4.2\n"
+        "##contig=<ID=1>\n"
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
+    )
+    cols = ["#CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER",
+            "INFO", "FORMAT"] + [f"s{i}" for i in range(n_samples)]
+    header += "\t".join(cols) + "\n"
+
+    variant_lines = []
+    for v in range(n_variants):
+        fields = ["1", str(100 * (v + 1)), ".", "A", "T", ".", "PASS",
+                  ".", "GT"] + ["0|1"] * n_samples
+        variant_lines.append("\t".join(fields))
+
+    with open(path, "w") as f:
+        f.write(header + "\n".join(variant_lines) + "\n")
+
+
+@pytest.fixture(autouse=True)
+def _clear_warned_cache():
+    """``_warned_paths`` is process-global; clear between tests so each
+    test starts from a clean slate."""
+    _warned_paths.clear()
+    yield
+    _warned_paths.clear()
+
+
+class TestHeaderSampleCount:
+
+    def test_counts_samples_in_chrom_line(self, tmp_path):
+        path = str(tmp_path / "small.vcf")
+        _write_minimal_vcf(path, n_samples=7)
+        assert _vcf_header_sample_count(path) == 7
+
+    def test_handles_zero_samples(self, tmp_path):
+        path = str(tmp_path / "nosamples.vcf")
+        _write_minimal_vcf(path, n_samples=0)
+        assert _vcf_header_sample_count(path) == 0
+
+    def test_missing_file_returns_none(self, tmp_path):
+        assert _vcf_header_sample_count(str(tmp_path / "nope.vcf")) is None
+
+
+class TestRegionSpan:
+
+    def test_parses_chrom_start_end(self):
+        assert _region_span_bp("chr1:1000-5000") == 4000
+
+    def test_none_is_zero(self):
+        assert _region_span_bp(None) == 0
+
+    def test_malformed_returns_zero(self):
+        assert _region_span_bp("not a region") == 0
+
+
+class TestMaybeBiobankWarn:
+
+    def test_small_file_no_warn(self, tmp_path):
+        path = str(tmp_path / "small.vcf")
+        _write_minimal_vcf(path, n_samples=10)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", BiobankScaleWarning)
+            _maybe_biobank_warn(path)  # default thresholds; ~few hundred bytes
+
+    def test_big_file_no_region_warns(self, tmp_path):
+        path = str(tmp_path / "big.vcf")
+        _write_minimal_vcf(path, n_samples=10)
+        # tiny file; spoof the byte threshold low so the size check trips
+        size = os.path.getsize(path)
+        with pytest.warns(BiobankScaleWarning, match="will be slow"):
+            _maybe_biobank_warn(path, warn_bytes=size - 1)
+
+    def test_big_file_small_region_does_not_warn(self, tmp_path):
+        # The "right tool" case: huge VCF, but we asked for a small
+        # tabix-region read. Don't warn -- region reads are fast.
+        path = str(tmp_path / "big-tabix.vcf")
+        _write_minimal_vcf(path, n_samples=10)
+        size = os.path.getsize(path)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", BiobankScaleWarning)
+            _maybe_biobank_warn(path, region="1:0-1000",
+                                warn_bytes=size - 1,
+                                warn_region_bp=10_000)
+
+    def test_many_samples_warns_regardless_of_size(self, tmp_path):
+        # Sample count alone trips the warning even on a small file --
+        # 10k-sample VCFs are slow to parse regardless.
+        path = str(tmp_path / "many-samples.vcf")
+        _write_minimal_vcf(path, n_samples=20)
+        with pytest.warns(BiobankScaleWarning, match="20 samples"):
+            _maybe_biobank_warn(path, warn_samples=10)
+
+    def test_cached_per_path(self, tmp_path):
+        path = str(tmp_path / "twice.vcf")
+        _write_minimal_vcf(path, n_samples=20)
+        with pytest.warns(BiobankScaleWarning):
+            _maybe_biobank_warn(path, warn_samples=10)
+        # Same path again should not re-warn within the process.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", BiobankScaleWarning)
+            _maybe_biobank_warn(path, warn_samples=10)
+
+    def test_silenced_by_filter(self, tmp_path):
+        path = str(tmp_path / "silenced.vcf")
+        _write_minimal_vcf(path, n_samples=20)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BiobankScaleWarning)
+            _maybe_biobank_warn(path, warn_samples=10)
+
+
+class TestFromVcfIntegration:
+
+    def test_haplotype_matrix_from_vcf_warns(self, tmp_path):
+        # End-to-end: from_vcf with a small sample threshold trips the
+        # warning before parsing. Uses the existing simple_vcf_file
+        # shape but with enough samples to clear the test threshold.
+        from pg_gpu import HaplotypeMatrix
+        from pg_gpu._biobank_warning import BIOBANK_VCF_WARN_SAMPLES
+        path = str(tmp_path / "hm.vcf")
+        _write_minimal_vcf(path, n_samples=BIOBANK_VCF_WARN_SAMPLES + 10)
+        with pytest.warns(BiobankScaleWarning):
+            HaplotypeMatrix.from_vcf(path)
+
+    def test_genotype_matrix_from_vcf_warns(self, tmp_path):
+        from pg_gpu import GenotypeMatrix
+        from pg_gpu._biobank_warning import BIOBANK_VCF_WARN_SAMPLES
+        path = str(tmp_path / "gm.vcf")
+        _write_minimal_vcf(path, n_samples=BIOBANK_VCF_WARN_SAMPLES + 10)
+        with pytest.warns(BiobankScaleWarning):
+            GenotypeMatrix.from_vcf(path)
+
+    def test_haplotype_matrix_from_vcf_small_does_not_warn(self, tmp_path):
+        from pg_gpu import HaplotypeMatrix
+        path = str(tmp_path / "small.vcf")
+        _write_minimal_vcf(path, n_samples=4)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", BiobankScaleWarning)
+            HaplotypeMatrix.from_vcf(path)

--- a/tests/test_gpu_genotype_prep.py
+++ b/tests/test_gpu_genotype_prep.py
@@ -1,0 +1,88 @@
+"""Tests for build_haplotype_matrix: GPU-side prep of (n_var, n_dip, 2) blocks."""
+
+import numpy as np
+import pytest
+import cupy as cp
+
+from pg_gpu._gpu_genotype_prep import build_haplotype_matrix
+
+
+def _reference_reshape(gt):
+    """Host-only equivalent of build_haplotype_matrix's reshape, used as
+    ground truth in equivalence tests. Matches the layout
+    HaplotypeMatrix.load_pop_file expects (ploidy 0 first, then ploidy 1)."""
+    n_var, n_dip, _ = gt.shape
+    haps = np.empty((n_var, 2 * n_dip), dtype=gt.dtype)
+    haps[:, :n_dip] = gt[:, :, 0]
+    haps[:, n_dip:] = gt[:, :, 1]
+    return haps.T
+
+
+@pytest.fixture
+def synthetic_gt():
+    """A small but representative (n_var, n_dip, 2) int8 block with a couple
+    of missing rows so the -1 propagation path is exercised."""
+    rng = np.random.default_rng(0)
+    n_var, n_dip = 100, 50
+    gt = rng.integers(0, 2, size=(n_var, n_dip, 2), dtype=np.int8)
+    gt[3] = -1
+    gt[17] = -1
+    gt[42] = -1
+    pos = np.arange(n_var, dtype=np.int64) * 100 + 1000
+    return gt, pos
+
+
+class TestBuildHaplotypeMatrix:
+
+    def test_layout_matches_load_pop_file_convention(self, synthetic_gt):
+        gt, pos = synthetic_gt
+        hm = build_haplotype_matrix(gt, pos)
+        haps_host = cp.asnumpy(hm.haplotypes)
+        np.testing.assert_array_equal(haps_host, _reference_reshape(gt))
+
+    def test_missing_rows_preserved(self, synthetic_gt):
+        # downstream kernels use 'include' / 'exclude' missing-data modes,
+        # so the helper must keep -1 cells rather than dropping them.
+        gt, pos = synthetic_gt
+        hm = build_haplotype_matrix(gt, pos)
+        haps_host = cp.asnumpy(hm.haplotypes)
+        # rows 3, 17, 42 should be all -1 across haplotypes.
+        assert (haps_host[:, 3] == -1).all()
+        assert (haps_host[:, 17] == -1).all()
+        assert (haps_host[:, 42] == -1).all()
+
+    def test_positions_passed_through(self, synthetic_gt):
+        gt, pos = synthetic_gt
+        hm = build_haplotype_matrix(gt, pos)
+        pos_host = cp.asnumpy(hm.positions)
+        np.testing.assert_array_equal(pos_host, pos)
+
+    def test_kwargs_forwarded(self, synthetic_gt):
+        gt, pos = synthetic_gt
+        hm = build_haplotype_matrix(
+            gt, pos,
+            chrom_start=1000, chrom_end=20000,
+            samples=[f"s{i}" for i in range(50)],
+            sample_sets={"all": list(range(100))},
+        )
+        assert hm.chrom_start == 1000
+        assert hm.chrom_end == 20000
+        assert hm.samples[0] == "s0"
+        assert "all" in hm.sample_sets
+
+    def test_accepts_device_inputs(self, synthetic_gt):
+        gt, pos = synthetic_gt
+        hm = build_haplotype_matrix(cp.asarray(gt), cp.asarray(pos))
+        np.testing.assert_array_equal(cp.asnumpy(hm.haplotypes),
+                                      _reference_reshape(gt))
+
+    def test_mismatched_shapes_raise(self, synthetic_gt):
+        gt, pos = synthetic_gt
+        with pytest.raises(ValueError, match="disagree on n_var"):
+            build_haplotype_matrix(gt, pos[:50])
+
+    def test_wrong_ploidy_raises(self):
+        gt = np.zeros((10, 5, 3), dtype=np.int8)
+        pos = np.arange(10, dtype=np.int64)
+        with pytest.raises(ValueError, match="must have shape"):
+            build_haplotype_matrix(gt, pos)

--- a/tests/test_gpu_genotype_prep.py
+++ b/tests/test_gpu_genotype_prep.py
@@ -1,10 +1,13 @@
-"""Tests for build_haplotype_matrix: GPU-side prep of (n_var, n_dip, 2) blocks."""
+"""Tests for build_haplotype_matrix and build_genotype_matrix:
+GPU-side prep of (n_var, n_dip, 2) blocks."""
 
 import numpy as np
 import pytest
 import cupy as cp
 
-from pg_gpu._gpu_genotype_prep import build_haplotype_matrix
+from pg_gpu._gpu_genotype_prep import (
+    build_genotype_matrix, build_haplotype_matrix,
+)
 
 
 def _reference_reshape(gt):
@@ -86,3 +89,77 @@ class TestBuildHaplotypeMatrix:
         pos = np.arange(10, dtype=np.int64)
         with pytest.raises(ValueError, match="must have shape"):
             build_haplotype_matrix(gt, pos)
+
+
+def _reference_dosage(gt):
+    """Host-only equivalent of build_genotype_matrix's reshape: sum ploidies
+    with -1 propagated where either ploidy is missing, transposed to
+    ``(n_indiv, n_var)``."""
+    missing = np.any(gt < 0, axis=2)
+    geno = np.sum(np.maximum(gt, 0), axis=2).astype(np.int8)
+    geno[missing] = -1
+    return geno.T
+
+
+class TestBuildGenotypeMatrix:
+
+    def test_layout_matches_dosage_convention(self, synthetic_gt):
+        gt, pos = synthetic_gt
+        gm = build_genotype_matrix(gt, pos)
+        geno_host = cp.asnumpy(gm.genotypes)
+        np.testing.assert_array_equal(geno_host, _reference_dosage(gt))
+
+    def test_missing_propagates_when_either_ploidy_missing(self, synthetic_gt):
+        # build_genotype_matrix should mark a (indiv, variant) cell as -1
+        # whenever EITHER ploidy on that variant was -1 in the input.
+        gt, pos = synthetic_gt
+        gm = build_genotype_matrix(gt, pos)
+        geno_host = cp.asnumpy(gm.genotypes)
+        # rows 3, 17, 42 in gt are all-(-1); every individual at those
+        # variants should be -1 in the (n_indiv, n_var) layout.
+        for v in (3, 17, 42):
+            assert (geno_host[:, v] == -1).all()
+
+    def test_positions_passed_through(self, synthetic_gt):
+        gt, pos = synthetic_gt
+        gm = build_genotype_matrix(gt, pos)
+        np.testing.assert_array_equal(cp.asnumpy(gm.positions), pos)
+
+    def test_dosage_values_in_0_1_2(self):
+        # Build a gt with no missing data; every entry should be 0/1/2.
+        rng = np.random.default_rng(7)
+        gt = rng.integers(0, 2, size=(50, 20, 2), dtype=np.int8)
+        pos = np.arange(50, dtype=np.int64)
+        gm = build_genotype_matrix(gt, pos)
+        geno_host = cp.asnumpy(gm.genotypes)
+        assert set(np.unique(geno_host).tolist()) <= {0, 1, 2}
+
+    def test_kwargs_forwarded(self, synthetic_gt):
+        gt, pos = synthetic_gt
+        gm = build_genotype_matrix(
+            gt, pos,
+            chrom_start=1000, chrom_end=20000,
+            samples=[f"s{i}" for i in range(50)],
+            sample_sets={"all_indiv": list(range(50))},
+        )
+        assert gm.chrom_start == 1000
+        assert gm.chrom_end == 20000
+        assert gm.samples[0] == "s0"
+        assert "all_indiv" in gm.sample_sets
+
+    def test_accepts_device_inputs(self, synthetic_gt):
+        gt, pos = synthetic_gt
+        gm = build_genotype_matrix(cp.asarray(gt), cp.asarray(pos))
+        np.testing.assert_array_equal(cp.asnumpy(gm.genotypes),
+                                      _reference_dosage(gt))
+
+    def test_mismatched_shapes_raise(self, synthetic_gt):
+        gt, pos = synthetic_gt
+        with pytest.raises(ValueError, match="disagree on n_var"):
+            build_genotype_matrix(gt, pos[:50])
+
+    def test_wrong_ploidy_raises(self):
+        gt = np.zeros((10, 5, 3), dtype=np.int8)
+        pos = np.arange(10, dtype=np.int64)
+        with pytest.raises(ValueError, match="must have shape"):
+            build_genotype_matrix(gt, pos)

--- a/tests/test_kvikio_backend.py
+++ b/tests/test_kvikio_backend.py
@@ -170,6 +170,79 @@ class TestKvikioFetcherReads:
             np.testing.assert_array_equal(ph, pk)
 
 
+class TestSliceSubsampleGpu:
+    """``slice_subsample_gpu`` reads sample-axis slabs via kvikio.
+    The bytes it returns must match the host ``slice_subsample`` on
+    the same store + same hap_cols."""
+
+    def _open_cg(self, path):
+        from kvikio.zarr import GDSStore
+        # Match KvikioChunkFetcher: enable_gpu, then open the cg on
+        # a GDSStore-backed group so its codec pipeline writes into
+        # GPU buffers.
+        zarr.config.enable_gpu()
+        gds = GDSStore(path)
+        return gds, zarr.open_group(store=gds, mode="r")["call_genotype"]
+
+    def _close_gpu_buffer(self):
+        zarr.config.set({
+            "buffer": "zarr.core.buffer.cpu.Buffer",
+            "ndbuffer": "zarr.core.buffer.cpu.NDBuffer",
+        })
+
+    def test_single_pop_subset_matches_host(self, bio2zarr_store):
+        source = ZarrGenotypeSource(bio2zarr_store)
+        n_dip = source.num_diploids
+        # Contiguous diploid range -> single run.
+        cols = np.array([0, 1, 2, n_dip, n_dip + 1, n_dip + 2],
+                         dtype=np.int64)
+        gm_host, _ = source.slice_subsample(0, source.mappable_hi, cols)
+        gds, cg = self._open_cg(bio2zarr_store)
+        try:
+            gm_gpu, _ = source.slice_subsample_gpu(
+                0, source.mappable_hi, cols, cg=cg,
+            )
+        finally:
+            self._close_gpu_buffer()
+        assert isinstance(gm_gpu, cp.ndarray)
+        np.testing.assert_array_equal(cp.asnumpy(gm_gpu), gm_host)
+
+    def test_two_pop_subset_matches_host(self, bio2zarr_store):
+        # The non-contiguous case: pop1 = first 3 dips, pop2 = last
+        # 3 dips. Two runs along the diploid axis.
+        source = ZarrGenotypeSource(bio2zarr_store)
+        n_dip = source.num_diploids
+        cols = np.array(
+            [0, 1, 2, n_dip - 3, n_dip - 2, n_dip - 1,
+             n_dip, n_dip + 1, n_dip + 2,
+             2 * n_dip - 3, 2 * n_dip - 2, 2 * n_dip - 1],
+            dtype=np.int64,
+        )
+        gm_host, _ = source.slice_subsample(0, source.mappable_hi, cols)
+        gds, cg = self._open_cg(bio2zarr_store)
+        try:
+            gm_gpu, _ = source.slice_subsample_gpu(
+                0, source.mappable_hi, cols, cg=cg,
+            )
+        finally:
+            self._close_gpu_buffer()
+        np.testing.assert_array_equal(cp.asnumpy(gm_gpu), gm_host)
+
+    def test_empty_region(self, bio2zarr_store):
+        source = ZarrGenotypeSource(bio2zarr_store)
+        gds, cg = self._open_cg(bio2zarr_store)
+        try:
+            gm, pos = source.slice_subsample_gpu(
+                0, max(0, source.mappable_lo - 1),
+                np.array([0, 1]), cg=cg,
+            )
+        finally:
+            self._close_gpu_buffer()
+        assert isinstance(gm, cp.ndarray)
+        assert gm.shape == (0, 2)
+        assert pos.shape == (0,)
+
+
 class TestFromZarrBackendKwarg:
 
     def test_invalid_backend_raises(self, bio2zarr_store):

--- a/tests/test_kvikio_backend.py
+++ b/tests/test_kvikio_backend.py
@@ -8,7 +8,6 @@ import os
 import shutil
 
 import cupy as cp
-import msprime
 import numpy as np
 import pytest
 import zarr
@@ -25,34 +24,19 @@ from .conftest import simulate_hm
 
 
 def _write_vcz_with_sample_chunk(path, hm, *, sample_chunk):
-    """Build a VCZ store at ``path`` with a specific call_genotype
-    sample-axis chunk size, so tests can pick bio2zarr-shaped vs
-    whole-sample-axis chunking explicitly."""
+    """Wrap ``zarr_io.write_vcz`` with explicit sample-axis chunking so
+    tests can opt into bio2zarr-shaped or whole-sample-axis chunking
+    without hand-rolling a VCZ writer."""
+    from pg_gpu.zarr_io import write_vcz
+    if os.path.exists(path):
+        shutil.rmtree(path)
     haps = cp.asnumpy(hm.haplotypes)
     pos = cp.asnumpy(hm.positions)
     gt = HaplotypeMatrix._haplotypes_to_gt(haps)
-    n_var, n_dip, _ = gt.shape
-
-    if os.path.exists(path):
-        shutil.rmtree(path)
-
-    g = zarr.create_group(store=path, overwrite=True)
-    g.create_array("call_genotype",
-                   shape=(n_var, n_dip, 2),
-                   chunks=(min(n_var, 10_000), sample_chunk, 2),
-                   dtype="int8")[:] = gt.astype(np.int8)
-    g.create_array("call_genotype_mask",
-                   shape=(n_var, n_dip, 2),
-                   chunks=(min(n_var, 10_000), sample_chunk, 2),
-                   dtype="bool")[:] = (gt < 0)
-    g.create_array("variant_position", shape=(n_var,),
-                   dtype="int32")[:] = pos.astype(np.int32)
-    g.create_array("variant_contig", shape=(n_var,),
-                   dtype="int32")[:] = np.zeros(n_var, dtype=np.int32)
-    g.create_array("contig_id", shape=(1,), dtype="<U16")[:] = np.asarray(
-        ["1"], dtype="<U16")
-    g.create_array("sample_id", shape=(n_dip,), dtype="<U16")[:] = np.asarray(
-        [f"s{i}" for i in range(n_dip)], dtype="<U16")
+    n_var, n_dip = gt.shape[0], gt.shape[1]
+    samples = [f"s{i}" for i in range(n_dip)]
+    write_vcz(path, gt, pos, samples=samples, contig_name="1",
+              chunks=(min(n_var, 10_000), sample_chunk, 2))
     return path
 
 

--- a/tests/test_kvikio_backend.py
+++ b/tests/test_kvikio_backend.py
@@ -1,0 +1,202 @@
+"""Tests for KvikioChunkFetcher + backend auto-detection.
+
+kvikio + nvidia-nvcomp are hard dependencies, so these tests always
+run -- there is no "skipif kvikio missing" path.
+"""
+
+import os
+import shutil
+
+import cupy as cp
+import msprime
+import numpy as np
+import pytest
+import zarr
+
+from pg_gpu import HaplotypeMatrix
+from pg_gpu.streaming_matrix import (
+    BadlyChunkedWarning, HostChunkFetcher, KvikioChunkFetcher,
+    _pick_chunk_fetcher, _store_call_genotype_chunks,
+    _store_call_genotype_codec,
+)
+from pg_gpu.zarr_source import ZarrGenotypeSource
+
+from .conftest import simulate_hm
+
+
+def _write_vcz_with_sample_chunk(path, hm, *, sample_chunk):
+    """Build a VCZ store at ``path`` with a specific call_genotype
+    sample-axis chunk size, so tests can pick bio2zarr-shaped vs
+    whole-sample-axis chunking explicitly."""
+    haps = cp.asnumpy(hm.haplotypes)
+    pos = cp.asnumpy(hm.positions)
+    gt = HaplotypeMatrix._haplotypes_to_gt(haps)
+    n_var, n_dip, _ = gt.shape
+
+    if os.path.exists(path):
+        shutil.rmtree(path)
+
+    g = zarr.create_group(store=path, overwrite=True)
+    g.create_array("call_genotype",
+                   shape=(n_var, n_dip, 2),
+                   chunks=(min(n_var, 10_000), sample_chunk, 2),
+                   dtype="int8")[:] = gt.astype(np.int8)
+    g.create_array("call_genotype_mask",
+                   shape=(n_var, n_dip, 2),
+                   chunks=(min(n_var, 10_000), sample_chunk, 2),
+                   dtype="bool")[:] = (gt < 0)
+    g.create_array("variant_position", shape=(n_var,),
+                   dtype="int32")[:] = pos.astype(np.int32)
+    g.create_array("variant_contig", shape=(n_var,),
+                   dtype="int32")[:] = np.zeros(n_var, dtype=np.int32)
+    g.create_array("contig_id", shape=(1,), dtype="<U16")[:] = np.asarray(
+        ["1"], dtype="<U16")
+    g.create_array("sample_id", shape=(n_dip,), dtype="<U16")[:] = np.asarray(
+        [f"s{i}" for i in range(n_dip)], dtype="<U16")
+    return path
+
+
+@pytest.fixture
+def bio2zarr_store(tmp_path):
+    """A VCZ store with bio2zarr-style sample chunking (sample chunk
+    smaller than the full sample axis), so the kvikio backend probes
+    treat the chunking as friendly."""
+    hm = simulate_hm()
+    return _write_vcz_with_sample_chunk(
+        str(tmp_path / "bio2zarr.vcz"),
+        hm,
+        sample_chunk=max(1, hm.num_haplotypes // 4),
+    )
+
+
+@pytest.fixture
+def whole_axis_store(tmp_path):
+    """A VCZ store whose sample axis is one chunk (the default zarr
+    writer's behavior). The kvikio path probes this and warns +
+    falls back to host on large enough stores."""
+    hm = simulate_hm()
+    return _write_vcz_with_sample_chunk(
+        str(tmp_path / "wholeaxis.vcz"),
+        hm,
+        sample_chunk=hm.num_haplotypes // 2,  # == n_diploids
+    )
+
+
+class TestStoreProbes:
+
+    def test_codec_probe_picks_zstd(self, bio2zarr_store):
+        # zarr 3's create_array defaults to zstd for int dtypes; the
+        # probe reads call_genotype/zarr.json and returns the name.
+        assert _store_call_genotype_codec(bio2zarr_store) == "zstd"
+
+    def test_chunk_probe_returns_shape(self, bio2zarr_store):
+        chunks = _store_call_genotype_chunks(bio2zarr_store)
+        assert chunks is not None
+        assert len(chunks) == 3
+        assert chunks[2] == 2
+
+    def test_missing_store_probes_return_none(self, tmp_path):
+        nowhere = str(tmp_path / "does-not-exist.vcz")
+        assert _store_call_genotype_codec(nowhere) is None
+        assert _store_call_genotype_chunks(nowhere) is None
+
+
+class TestPickFetcher:
+
+    def test_auto_picks_kvikio_on_bio2zarr_chunks(self, bio2zarr_store):
+        source = ZarrGenotypeSource(bio2zarr_store)
+        fetcher = _pick_chunk_fetcher(source, backend="auto")
+        assert isinstance(fetcher, KvikioChunkFetcher)
+        fetcher.close()
+
+    def test_auto_picks_host_on_whole_axis_chunks(self, whole_axis_store):
+        source = ZarrGenotypeSource(whole_axis_store)
+        fetcher = _pick_chunk_fetcher(source, backend="auto")
+        # whole-sample-axis -> host fallback; warning suppressed below
+        # the 1 GiB threshold on the test fixture's tiny footprint.
+        assert isinstance(fetcher, HostChunkFetcher)
+
+    def test_explicit_host_skips_kvikio_path(self, bio2zarr_store):
+        source = ZarrGenotypeSource(bio2zarr_store)
+        fetcher = _pick_chunk_fetcher(source, backend="host")
+        assert isinstance(fetcher, HostChunkFetcher)
+
+    def test_explicit_kvikio_on_unsupported_codec_raises(self, tmp_path):
+        # A store whose call_genotype is uncompressed (no codec in
+        # the nvCOMP-supported list). Force compressors=None so the
+        # spec ends up with just a bytes codec; the probe then
+        # cannot identify a GPU-decodable codec and the explicit
+        # backend='kvikio' should raise rather than silently produce
+        # wrong output.
+        path = str(tmp_path / "uncompressed.vcz")
+        if os.path.exists(path):
+            shutil.rmtree(path)
+        g = zarr.create_group(store=path, overwrite=True)
+        n_var, n_dip = 100, 8
+        gt = np.zeros((n_var, n_dip, 2), dtype=np.int8)
+        g.create_array(
+            "call_genotype",
+            shape=(n_var, n_dip, 2),
+            chunks=(n_var, n_dip, 2),
+            dtype="int8",
+            compressors=None,
+        )[:] = gt
+        g.create_array("variant_position", shape=(n_var,),
+                       dtype="int32")[:] = np.arange(n_var, dtype=np.int32)
+        g.create_array("variant_contig", shape=(n_var,),
+                       dtype="int32")[:] = np.zeros(n_var, dtype=np.int32)
+        g.create_array("contig_id", shape=(1,), dtype="<U16")[:] = ["1"]
+        g.create_array("sample_id", shape=(n_dip,), dtype="<U16")[:] = [
+            f"s{i}" for i in range(n_dip)]
+
+        source = ZarrGenotypeSource(path)
+        with pytest.raises(ValueError, match="nvCOMP GPU decoder"):
+            _pick_chunk_fetcher(source, backend="kvikio")
+
+
+class TestKvikioFetcherReads:
+    """KvikioChunkFetcher should produce the same per-chunk genotype
+    bytes the host fetcher does on the same store. Same source, same
+    region, same answer -- modulo the result landing on GPU memory."""
+
+    def test_chunks_match_host(self, bio2zarr_store):
+        source = ZarrGenotypeSource(bio2zarr_store)
+
+        host = HostChunkFetcher(source)
+        host_chunks = []
+        for ci, left, right, gt, pos, _ in host.iter_chunks(
+                [(0, 10_000), (10_000, 20_000)], prefetch=0):
+            host_chunks.append((left, right, np.asarray(gt), np.asarray(pos)))
+
+        kvi = KvikioChunkFetcher(source)
+        try:
+            kvi_chunks = []
+            for ci, left, right, gt, pos, _ in kvi.iter_chunks(
+                    [(0, 10_000), (10_000, 20_000)], prefetch=0):
+                kvi_chunks.append((left, right,
+                                   cp.asnumpy(gt) if isinstance(gt, cp.ndarray) else np.asarray(gt),
+                                   np.asarray(pos)))
+        finally:
+            kvi.close()
+
+        assert len(host_chunks) == len(kvi_chunks)
+        for (lh, rh, gth, ph), (lk, rk, gtk, pk) in zip(host_chunks, kvi_chunks):
+            assert (lh, rh) == (lk, rk)
+            np.testing.assert_array_equal(gth, gtk)
+            np.testing.assert_array_equal(ph, pk)
+
+
+class TestFromZarrBackendKwarg:
+
+    def test_invalid_backend_raises(self, bio2zarr_store):
+        with pytest.raises(ValueError, match="backend must be"):
+            HaplotypeMatrix.from_zarr(bio2zarr_store, streaming="always",
+                                      backend="banana")
+
+    def test_streaming_always_with_kvikio_uses_kvikio_fetcher(
+            self, bio2zarr_store):
+        hm = HaplotypeMatrix.from_zarr(bio2zarr_store, streaming="always",
+                                       backend="kvikio", chunk_bp=5_000)
+        from pg_gpu.streaming_matrix import StreamingHaplotypeMatrix
+        assert isinstance(hm, StreamingHaplotypeMatrix)
+        assert isinstance(hm._fetcher, KvikioChunkFetcher)

--- a/tests/test_memory_warning.py
+++ b/tests/test_memory_warning.py
@@ -1,6 +1,6 @@
-"""Tests for ``BiobankScaleWarning`` and ``_maybe_biobank_warn``.
+"""Tests for ``MemoryLimitedWarning`` and ``_maybe_memory_warn``.
 
-The size thresholds are kwargs on ``_maybe_biobank_warn`` so tests can
+The size thresholds are kwargs on ``_maybe_memory_warn`` so tests can
 trip them on tiny on-disk fixtures rather than building genuine 10 GiB
 VCFs.
 """
@@ -10,9 +10,9 @@ import warnings
 
 import pytest
 
-from pg_gpu import BiobankScaleWarning
-from pg_gpu._biobank_warning import (
-    _maybe_biobank_warn, _region_span_bp, _vcf_header_sample_count,
+from pg_gpu import MemoryLimitedWarning
+from pg_gpu._memory_warning import (
+    _maybe_memory_warn, _region_span_bp, _vcf_header_sample_count,
     _warned_paths,
 )
 
@@ -83,16 +83,16 @@ class TestMaybeBiobankWarn:
         path = str(tmp_path / "small.vcf")
         _write_minimal_vcf(path, n_samples=10)
         with warnings.catch_warnings():
-            warnings.simplefilter("error", BiobankScaleWarning)
-            _maybe_biobank_warn(path)  # default thresholds; ~few hundred bytes
+            warnings.simplefilter("error", MemoryLimitedWarning)
+            _maybe_memory_warn(path)  # default thresholds; ~few hundred bytes
 
     def test_big_file_no_region_warns(self, tmp_path):
         path = str(tmp_path / "big.vcf")
         _write_minimal_vcf(path, n_samples=10)
         # tiny file; spoof the byte threshold low so the size check trips
         size = os.path.getsize(path)
-        with pytest.warns(BiobankScaleWarning, match="will be slow"):
-            _maybe_biobank_warn(path, warn_bytes=size - 1)
+        with pytest.warns(MemoryLimitedWarning, match="will be slow"):
+            _maybe_memory_warn(path, warn_bytes=size - 1)
 
     def test_big_file_small_region_does_not_warn(self, tmp_path):
         # The "right tool" case: huge VCF, but we asked for a small
@@ -101,8 +101,8 @@ class TestMaybeBiobankWarn:
         _write_minimal_vcf(path, n_samples=10)
         size = os.path.getsize(path)
         with warnings.catch_warnings():
-            warnings.simplefilter("error", BiobankScaleWarning)
-            _maybe_biobank_warn(path, region="1:0-1000",
+            warnings.simplefilter("error", MemoryLimitedWarning)
+            _maybe_memory_warn(path, region="1:0-1000",
                                 warn_bytes=size - 1,
                                 warn_region_bp=10_000)
 
@@ -111,25 +111,25 @@ class TestMaybeBiobankWarn:
         # 10k-sample VCFs are slow to parse regardless.
         path = str(tmp_path / "many-samples.vcf")
         _write_minimal_vcf(path, n_samples=20)
-        with pytest.warns(BiobankScaleWarning, match="20 samples"):
-            _maybe_biobank_warn(path, warn_samples=10)
+        with pytest.warns(MemoryLimitedWarning, match="20 samples"):
+            _maybe_memory_warn(path, warn_samples=10)
 
     def test_cached_per_path(self, tmp_path):
         path = str(tmp_path / "twice.vcf")
         _write_minimal_vcf(path, n_samples=20)
-        with pytest.warns(BiobankScaleWarning):
-            _maybe_biobank_warn(path, warn_samples=10)
+        with pytest.warns(MemoryLimitedWarning):
+            _maybe_memory_warn(path, warn_samples=10)
         # Same path again should not re-warn within the process.
         with warnings.catch_warnings():
-            warnings.simplefilter("error", BiobankScaleWarning)
-            _maybe_biobank_warn(path, warn_samples=10)
+            warnings.simplefilter("error", MemoryLimitedWarning)
+            _maybe_memory_warn(path, warn_samples=10)
 
     def test_silenced_by_filter(self, tmp_path):
         path = str(tmp_path / "silenced.vcf")
         _write_minimal_vcf(path, n_samples=20)
         with warnings.catch_warnings():
-            warnings.simplefilter("ignore", BiobankScaleWarning)
-            _maybe_biobank_warn(path, warn_samples=10)
+            warnings.simplefilter("ignore", MemoryLimitedWarning)
+            _maybe_memory_warn(path, warn_samples=10)
 
     def test_relative_and_absolute_paths_dedupe(self, tmp_path, monkeypatch):
         # The cache canonicalizes via os.path.realpath, so a relative
@@ -139,11 +139,11 @@ class TestMaybeBiobankWarn:
         path = tmp_path / "alias.vcf"
         _write_minimal_vcf(str(path), n_samples=20)
         monkeypatch.chdir(tmp_path)
-        with pytest.warns(BiobankScaleWarning):
-            _maybe_biobank_warn("alias.vcf", warn_samples=10)
+        with pytest.warns(MemoryLimitedWarning):
+            _maybe_memory_warn("alias.vcf", warn_samples=10)
         with warnings.catch_warnings():
-            warnings.simplefilter("error", BiobankScaleWarning)
-            _maybe_biobank_warn(str(path.resolve()), warn_samples=10)
+            warnings.simplefilter("error", MemoryLimitedWarning)
+            _maybe_memory_warn(str(path.resolve()), warn_samples=10)
 
 
 class TestFromVcfIntegration:
@@ -153,18 +153,18 @@ class TestFromVcfIntegration:
         # warning before parsing. Uses the existing simple_vcf_file
         # shape but with enough samples to clear the test threshold.
         from pg_gpu import HaplotypeMatrix
-        from pg_gpu._biobank_warning import BIOBANK_VCF_WARN_SAMPLES
+        from pg_gpu._memory_warning import VCF_WARN_SAMPLES
         path = str(tmp_path / "hm.vcf")
-        _write_minimal_vcf(path, n_samples=BIOBANK_VCF_WARN_SAMPLES + 10)
-        with pytest.warns(BiobankScaleWarning):
+        _write_minimal_vcf(path, n_samples=VCF_WARN_SAMPLES + 10)
+        with pytest.warns(MemoryLimitedWarning):
             HaplotypeMatrix.from_vcf(path)
 
     def test_genotype_matrix_from_vcf_warns(self, tmp_path):
         from pg_gpu import GenotypeMatrix
-        from pg_gpu._biobank_warning import BIOBANK_VCF_WARN_SAMPLES
+        from pg_gpu._memory_warning import VCF_WARN_SAMPLES
         path = str(tmp_path / "gm.vcf")
-        _write_minimal_vcf(path, n_samples=BIOBANK_VCF_WARN_SAMPLES + 10)
-        with pytest.warns(BiobankScaleWarning):
+        _write_minimal_vcf(path, n_samples=VCF_WARN_SAMPLES + 10)
+        with pytest.warns(MemoryLimitedWarning):
             GenotypeMatrix.from_vcf(path)
 
     def test_haplotype_matrix_from_vcf_small_does_not_warn(self, tmp_path):
@@ -172,5 +172,5 @@ class TestFromVcfIntegration:
         path = str(tmp_path / "small.vcf")
         _write_minimal_vcf(path, n_samples=4)
         with warnings.catch_warnings():
-            warnings.simplefilter("error", BiobankScaleWarning)
+            warnings.simplefilter("error", MemoryLimitedWarning)
             HaplotypeMatrix.from_vcf(path)

--- a/tests/test_sfs_allel_comparison.py
+++ b/tests/test_sfs_allel_comparison.py
@@ -117,6 +117,39 @@ class TestJointSFSComparison:
         np.testing.assert_array_almost_equal(result, expected)
 
 
+class TestProjectionSandwich:
+    """Validate project_joint_sfs against the explicit P1 @ S @ P2.T."""
+
+    def test_eager_matches_sandwich(self, two_pop_data):
+        # Reference: build the full joint SFS with allel, then apply
+        # the exact-integer projection matrix on each axis. The new
+        # function uses a gammaln-based projection matrix instead, but
+        # both should agree to float64 round-off for small n.
+        from pg_gpu.diversity import _projection_matrix
+        matrix, hap, n1, n2 = two_pop_data
+        target1, target2 = 4, 5
+        dac1 = np.sum(hap[:n1], axis=0)
+        dac2 = np.sum(hap[n1:], axis=0)
+        ref_full = allel.joint_sfs(dac1, dac2, n1=n1, n2=n2)
+        P1 = _projection_matrix(n1, target1)
+        P2 = _projection_matrix(n2, target2)
+        expected = P1 @ ref_full @ P2.T
+        result = sfs.project_joint_sfs(matrix, "pop1", "pop2",
+                                        target_n1=target1,
+                                        target_n2=target2)
+        np.testing.assert_allclose(result, expected, rtol=1e-9, atol=1e-9)
+
+    def test_identity_target_recovers_full(self, two_pop_data):
+        # When target_n equals source n, hypergeometric pmf is the
+        # identity so projection collapses to a float cast of joint_sfs.
+        matrix, hap, n1, n2 = two_pop_data
+        result = sfs.project_joint_sfs(matrix, "pop1", "pop2",
+                                        target_n1=n1, target_n2=n2)
+        full = sfs.joint_sfs(matrix, "pop1", "pop2")
+        np.testing.assert_allclose(result, full.astype(np.float64),
+                                    rtol=1e-9, atol=1e-9)
+
+
 class TestScalingComparison:
     """Validate scaling and folding utilities."""
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -163,6 +163,66 @@ class TestProducerThreadErrorPropagation:
                 pass
 
 
+class TestMaterialize:
+    """``.materialize(region=...)`` is the path from streaming to pairwise
+    kernels: pull a sub-region eagerly, then run pairwise_r2 / locate_unlinked
+    / etc. on the eager HaplotypeMatrix it returns."""
+
+    def test_full_region_matches_eager(self, vcz_store):
+        path, _ = vcz_store
+        eager = HaplotypeMatrix.from_zarr(path, streaming="never")
+        stream = HaplotypeMatrix.from_zarr(path, streaming="always",
+                                            chunk_bp=5_000)
+        materialized = stream.materialize()
+        assert isinstance(materialized, HaplotypeMatrix)
+        # same haplotypes (modulo any positions outside the eager matrix's
+        # range -- the streaming chunk grid extends to the chunk-aligned
+        # mappable_hi, but the variants are the same).
+        np.testing.assert_array_equal(cp.asnumpy(eager.haplotypes),
+                                      cp.asnumpy(materialized.haplotypes))
+
+    def test_sub_region(self, vcz_store):
+        path, _ = vcz_store
+        stream = HaplotypeMatrix.from_zarr(path, streaming="always",
+                                            chunk_bp=5_000)
+        sub = stream.materialize(region=(10_000, 30_000))
+        assert isinstance(sub, HaplotypeMatrix)
+        # all positions inside the requested half-open interval
+        pos = cp.asnumpy(sub.positions)
+        assert pos.min() >= 10_000
+        assert pos.max() < 30_000
+        assert sub.chrom_start == 10_000
+        assert sub.chrom_end == 30_000
+
+    def test_pairwise_r2_via_materialize(self, vcz_store):
+        # The intended user pattern: streaming hm -> .materialize(region=)
+        # -> pairwise_r2(). Asserts the composition produces a finite
+        # (n_var x n_var) matrix with the kernel's diagonal zeroed.
+        # r2 values are not bounded to [0, 1] in this test because the
+        # msprime fixture uses the default Jukes-Cantor mutation model;
+        # pg_gpu's binary-allele assumptions in pairwise_r2 inflate the
+        # numerator at triallelic sites (tracked in kr-colab/pg_gpu#100).
+        # The streaming -> materialize -> pairwise_r2 composition is what
+        # this test is for; the r2 numerics are validated elsewhere.
+        path, _ = vcz_store
+        stream = HaplotypeMatrix.from_zarr(path, streaming="always",
+                                            chunk_bp=5_000)
+        sub = stream.materialize(region=(10_000, 30_000))
+        r2 = sub.pairwise_r2()
+        n_var = sub.haplotypes.shape[1]
+        assert r2.shape == (n_var, n_var)
+        assert bool(cp.isfinite(r2).all()), "pairwise_r2 returned NaN / inf"
+        assert float(cp.abs(cp.diag(r2)).sum()) == 0.0
+
+    def test_sample_subset_requires_even(self, vcz_store):
+        path, _ = vcz_store
+        stream = HaplotypeMatrix.from_zarr(path, streaming="always",
+                                            chunk_bp=5_000)
+        with pytest.raises(ValueError, match="even count"):
+            stream.materialize(region=(10_000, 20_000),
+                               sample_subset=[0, 1, 2])  # odd
+
+
 class TestChunkFetcherABC:
 
     def test_cannot_instantiate_abstract(self):

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,6 +1,5 @@
 """Tests for StreamingHaplotypeMatrix + HostChunkFetcher."""
 
-import msprime
 import numpy as np
 import pytest
 import cupy as cp
@@ -11,14 +10,11 @@ from pg_gpu.streaming_matrix import (
 )
 from pg_gpu.zarr_source import ZarrGenotypeSource
 
+from .conftest import simulate_hm
+
 
 def _simulate_hm(n_samples=20, seq_length=50_000, seed=42):
-    ts = msprime.sim_ancestry(
-        samples=n_samples, sequence_length=seq_length,
-        recombination_rate=1e-4, random_seed=seed, ploidy=2,
-    )
-    ts = msprime.sim_mutations(ts, rate=1e-3, random_seed=seed)
-    return HaplotypeMatrix.from_ts(ts)
+    return simulate_hm(n_samples=n_samples, seq_length=seq_length, seed=seed)
 
 
 @pytest.fixture
@@ -97,9 +93,8 @@ class TestStreamingEquivalence:
 
     def test_stream_concat_matches_eager(self, vcz_store):
         # walking every chunk in streaming mode and concatenating the
-        # per-chunk haplotype matrices should reproduce the eager matrix
-        # bit-for-bit. This is the contract kernel dispatch in the follow-up
-        # PR relies on.
+        # per-chunk haplotype matrices reproduces the eager matrix
+        # bit-for-bit -- the invariant streaming-aware kernels rely on.
         path, _ = vcz_store
         eager = HaplotypeMatrix.from_zarr(path, streaming="never")
         smatrix = HaplotypeMatrix.from_zarr(path, streaming="always",
@@ -186,11 +181,14 @@ class TestAutoDetection:
         eager_bytes = hm.haplotypes.size
         # Make the eager footprint look like it doesn't fit by claiming
         # less free GPU memory than the projected size requires.
-        choice = _decide_streaming_mode(
+        choice, source = _decide_streaming_mode(
             path, region=None, streaming="auto", pop_file=False,
-            free_gpu_bytes=int(eager_bytes / 0.5 - 1),  # just below threshold
+            free_gpu_bytes=int(eager_bytes / 0.5 - 1),
         )
         assert choice == "streaming"
+        # source is returned so _build_streaming can reuse it instead of
+        # re-opening the zarr store.
+        assert source is not None
 
     def test_never_raises_when_oversized(self, vcz_store):
         from pg_gpu.haplotype_matrix import _decide_streaming_mode

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,170 @@
+"""Tests for StreamingHaplotypeMatrix + HostChunkFetcher."""
+
+import msprime
+import numpy as np
+import pytest
+import cupy as cp
+
+from pg_gpu import HaplotypeMatrix
+from pg_gpu.streaming_matrix import (
+    ChunkFetcher, HostChunkFetcher, StreamingHaplotypeMatrix,
+)
+from pg_gpu.zarr_source import ZarrGenotypeSource
+
+
+def _simulate_hm(n_samples=20, seq_length=50_000, seed=42):
+    ts = msprime.sim_ancestry(
+        samples=n_samples, sequence_length=seq_length,
+        recombination_rate=1e-4, random_seed=seed, ploidy=2,
+    )
+    ts = msprime.sim_mutations(ts, rate=1e-3, random_seed=seed)
+    return HaplotypeMatrix.from_ts(ts)
+
+
+@pytest.fixture
+def vcz_store(tmp_path):
+    hm = _simulate_hm()
+    hm.samples = [f"s{i}" for i in range(hm.num_haplotypes // 2)]
+    path = str(tmp_path / "stream.vcz")
+    hm.to_zarr(path, format="vcz", contig_name="1")
+    return path, hm
+
+
+def _stream_concat(streaming_hm):
+    """Walk every chunk and concatenate haps + positions into single arrays
+    on the host. Used as the comparison target against the eager from_zarr."""
+    haps_parts, pos_parts = [], []
+    for left, right, chunk_hm in streaming_hm.iter_gpu_chunks():
+        haps_parts.append(cp.asnumpy(chunk_hm.haplotypes))
+        pos_parts.append(cp.asnumpy(chunk_hm.positions))
+    return np.concatenate(haps_parts, axis=1), np.concatenate(pos_parts)
+
+
+class TestStreamingFromZarr:
+
+    def test_streaming_always_returns_streaming_class(self, vcz_store):
+        path, _ = vcz_store
+        hm = HaplotypeMatrix.from_zarr(path, streaming="always", chunk_bp=5_000)
+        assert isinstance(hm, StreamingHaplotypeMatrix)
+
+    def test_streaming_never_returns_eager(self, vcz_store):
+        path, _ = vcz_store
+        hm = HaplotypeMatrix.from_zarr(path, streaming="never")
+        assert isinstance(hm, HaplotypeMatrix)
+
+    def test_auto_defaults_to_eager_today(self, vcz_store):
+        path, _ = vcz_store
+        hm = HaplotypeMatrix.from_zarr(path, streaming="auto")
+        assert isinstance(hm, HaplotypeMatrix)
+
+    def test_invalid_streaming_raises(self, vcz_store):
+        path, _ = vcz_store
+        with pytest.raises(ValueError, match="streaming must be"):
+            HaplotypeMatrix.from_zarr(path, streaming="maybe")
+
+
+class TestStreamingMatrixSurface:
+
+    def test_basic_metadata(self, vcz_store):
+        path, eager = vcz_store
+        smatrix = HaplotypeMatrix.from_zarr(path, streaming="always",
+                                            chunk_bp=5_000)
+        assert smatrix.num_variants == eager.haplotypes.shape[1]
+        assert smatrix.num_haplotypes == eager.haplotypes.shape[0]
+        assert smatrix.chrom == "1"
+        assert smatrix.chrom_start <= smatrix.chrom_end
+        assert "streaming" in repr(smatrix).lower() or "Streaming" in repr(smatrix)
+
+    def test_haplotypes_property_raises(self, vcz_store):
+        path, _ = vcz_store
+        smatrix = HaplotypeMatrix.from_zarr(path, streaming="always",
+                                            chunk_bp=5_000)
+        with pytest.raises(NotImplementedError, match="no materialized"):
+            _ = smatrix.haplotypes
+
+    def test_sample_sets_default_to_all(self, vcz_store):
+        path, _ = vcz_store
+        smatrix = HaplotypeMatrix.from_zarr(path, streaming="always",
+                                            chunk_bp=5_000)
+        # no pop file present -> property returns the same "all" fallback
+        # HaplotypeMatrix uses.
+        assert set(smatrix.sample_sets.keys()) == {"all"}
+        assert len(smatrix.sample_sets["all"]) == smatrix.num_haplotypes
+
+
+class TestStreamingEquivalence:
+
+    def test_stream_concat_matches_eager(self, vcz_store):
+        # walking every chunk in streaming mode and concatenating the
+        # per-chunk haplotype matrices should reproduce the eager matrix
+        # bit-for-bit. This is the contract kernel dispatch in the follow-up
+        # PR relies on.
+        path, _ = vcz_store
+        eager = HaplotypeMatrix.from_zarr(path, streaming="never")
+        smatrix = HaplotypeMatrix.from_zarr(path, streaming="always",
+                                            chunk_bp=5_000, prefetch=1)
+        haps, pos = _stream_concat(smatrix)
+        np.testing.assert_array_equal(haps, cp.asnumpy(eager.haplotypes))
+        np.testing.assert_array_equal(pos, cp.asnumpy(eager.positions))
+
+    def test_prefetch_off_matches_prefetch_on(self, vcz_store):
+        path, _ = vcz_store
+        s0 = HaplotypeMatrix.from_zarr(path, streaming="always",
+                                       chunk_bp=5_000, prefetch=0)
+        s1 = HaplotypeMatrix.from_zarr(path, streaming="always",
+                                       chunk_bp=5_000, prefetch=1)
+        h0, p0 = _stream_concat(s0)
+        h1, p1 = _stream_concat(s1)
+        np.testing.assert_array_equal(h0, h1)
+        np.testing.assert_array_equal(p0, p1)
+
+
+class TestProducerThreadErrorPropagation:
+
+    def test_producer_exception_reaches_consumer(self, vcz_store):
+        # Wrap the source's slice_region in a fetcher that raises on the
+        # second chunk. The producer's exception must surface at the
+        # consumer's next() call, with the original message preserved.
+        path, _ = vcz_store
+        source = ZarrGenotypeSource(path)
+
+        class FlakySource:
+            def __init__(self, inner):
+                self.inner = inner
+                self._calls = 0
+            def slice_region(self, left, right):
+                self._calls += 1
+                if self._calls == 2:
+                    raise RuntimeError("synthetic producer error")
+                return self.inner.slice_region(left, right)
+            def iter_chunks(self, chunk_bp, align_bp=None):
+                return self.inner.iter_chunks(chunk_bp, align_bp)
+            @property
+            def num_variants(self): return self.inner.num_variants
+            @property
+            def num_haplotypes(self): return self.inner.num_haplotypes
+            @property
+            def num_diploids(self): return self.inner.num_diploids
+            @property
+            def chrom(self): return self.inner.chrom
+            @property
+            def mappable_lo(self): return self.inner.mappable_lo
+            @property
+            def mappable_hi(self): return self.inner.mappable_hi
+            @property
+            def pop_cols(self): return self.inner.pop_cols
+
+        flaky = FlakySource(source)
+        fetcher = HostChunkFetcher(flaky)
+        smatrix = StreamingHaplotypeMatrix(flaky, fetcher, chunk_bp=5_000,
+                                           prefetch=1)
+        with pytest.raises(RuntimeError, match="synthetic producer error"):
+            for _ in smatrix.iter_gpu_chunks():
+                pass
+
+
+class TestChunkFetcherABC:
+
+    def test_cannot_instantiate_abstract(self):
+        with pytest.raises(TypeError, match="abstract"):
+            ChunkFetcher()

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -339,11 +339,14 @@ class TestStreamingGenotypeMatrix:
         with pytest.raises(NotImplementedError, match="materialize"):
             grm(gm_stream)
 
-    def test_ibs_raises_on_streaming(self, vcz_store):
+    def test_ibs_streams(self, vcz_store):
         from pg_gpu import GenotypeMatrix
         from pg_gpu.relatedness import ibs
         path, _ = vcz_store
+        gm_eager = GenotypeMatrix.from_zarr(path, streaming="never")
         gm_stream = GenotypeMatrix.from_zarr(path, streaming="always",
                                               chunk_bp=5_000)
-        with pytest.raises(NotImplementedError, match="materialize"):
-            ibs(gm_stream)
+        # ibs streams the variant axis chunk-by-chunk and tiles the
+        # individual axis into row blocks. Result must match eager.
+        np.testing.assert_allclose(ibs(gm_stream), ibs(gm_eager),
+                                    rtol=1e-9, atol=1e-12)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -274,3 +274,76 @@ class TestChunkFetcherABC:
     def test_cannot_instantiate_abstract(self):
         with pytest.raises(TypeError, match="abstract"):
             ChunkFetcher()
+
+
+class TestStreamingGenotypeMatrix:
+    """StreamingGenotypeMatrix mirrors StreamingHaplotypeMatrix's shape but
+    yields per-chunk GenotypeMatrix instances (dosage-coded, n_indiv x
+    n_var) instead of haplotype-coded. Sample sets index the diploid
+    axis (0..n_indiv) rather than the haplotype axis."""
+
+    def test_streaming_always_returns_streaming_class(self, vcz_store):
+        from pg_gpu import GenotypeMatrix
+        from pg_gpu.streaming_matrix import StreamingGenotypeMatrix
+        path, _ = vcz_store
+        gm = GenotypeMatrix.from_zarr(path, streaming="always",
+                                       chunk_bp=5_000)
+        assert isinstance(gm, StreamingGenotypeMatrix)
+
+    def test_chunk_payload_is_genotype_matrix(self, vcz_store):
+        from pg_gpu import GenotypeMatrix
+        path, _ = vcz_store
+        gm_stream = GenotypeMatrix.from_zarr(path, streaming="always",
+                                              chunk_bp=5_000)
+        for left, right, chunk_gm in gm_stream.iter_gpu_chunks():
+            assert isinstance(chunk_gm, GenotypeMatrix)
+            # GenotypeMatrix layout: (n_indiv, n_var) with dosage values
+            assert chunk_gm.genotypes.shape[0] == gm_stream.num_individuals
+            break  # one chunk is enough to verify the contract
+
+    def test_sample_sets_default_to_individual_axis(self, vcz_store):
+        from pg_gpu import GenotypeMatrix
+        path, _ = vcz_store
+        gm_stream = GenotypeMatrix.from_zarr(path, streaming="always",
+                                              chunk_bp=5_000)
+        sets = gm_stream.sample_sets
+        assert set(sets.keys()) == {"all"}
+        # Genotype matrix indexes individuals, not haplotypes -- length
+        # should match num_individuals not 2*num_individuals.
+        assert len(sets["all"]) == gm_stream.num_individuals
+
+    def test_genotypes_property_raises(self, vcz_store):
+        from pg_gpu import GenotypeMatrix
+        path, _ = vcz_store
+        gm_stream = GenotypeMatrix.from_zarr(path, streaming="always",
+                                              chunk_bp=5_000)
+        with pytest.raises(NotImplementedError, match="materialized"):
+            _ = gm_stream.genotypes
+
+    def test_materialize_returns_eager_genotype_matrix(self, vcz_store):
+        from pg_gpu import GenotypeMatrix
+        path, _ = vcz_store
+        gm_stream = GenotypeMatrix.from_zarr(path, streaming="always",
+                                              chunk_bp=5_000)
+        eager = gm_stream.materialize(region=(0, 10_000))
+        assert isinstance(eager, GenotypeMatrix)
+        # genotypes are (n_indiv, n_var) dosage int8
+        assert eager.genotypes.shape[0] == gm_stream.num_individuals
+
+    def test_grm_raises_on_streaming(self, vcz_store):
+        from pg_gpu import GenotypeMatrix
+        from pg_gpu.relatedness import grm
+        path, _ = vcz_store
+        gm_stream = GenotypeMatrix.from_zarr(path, streaming="always",
+                                              chunk_bp=5_000)
+        with pytest.raises(NotImplementedError, match="materialize"):
+            grm(gm_stream)
+
+    def test_ibs_raises_on_streaming(self, vcz_store):
+        from pg_gpu import GenotypeMatrix
+        from pg_gpu.relatedness import ibs
+        path, _ = vcz_store
+        gm_stream = GenotypeMatrix.from_zarr(path, streaming="always",
+                                              chunk_bp=5_000)
+        with pytest.raises(NotImplementedError, match="materialize"):
+            ibs(gm_stream)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -330,14 +330,18 @@ class TestStreamingGenotypeMatrix:
         # genotypes are (n_indiv, n_var) dosage int8
         assert eager.genotypes.shape[0] == gm_stream.num_individuals
 
-    def test_grm_raises_on_streaming(self, vcz_store):
+    def test_grm_streams(self, vcz_store):
         from pg_gpu import GenotypeMatrix
         from pg_gpu.relatedness import grm
         path, _ = vcz_store
+        gm_eager = GenotypeMatrix.from_zarr(path, streaming="never")
         gm_stream = GenotypeMatrix.from_zarr(path, streaming="always",
                                               chunk_bp=5_000)
-        with pytest.raises(NotImplementedError, match="materialize"):
-            grm(gm_stream)
+        # grm uses a two-pass streaming form (per-variant frequencies on
+        # the first pass, standardized outer product on the second) and
+        # tiles the individual axis the same way ibs does.
+        np.testing.assert_allclose(grm(gm_stream), grm(gm_eager),
+                                    rtol=1e-7, atol=1e-10)
 
     def test_ibs_streams(self, vcz_store):
         from pg_gpu import GenotypeMatrix

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -52,7 +52,8 @@ class TestStreamingFromZarr:
         hm = HaplotypeMatrix.from_zarr(path, streaming="never")
         assert isinstance(hm, HaplotypeMatrix)
 
-    def test_auto_defaults_to_eager_today(self, vcz_store):
+    def test_auto_picks_eager_on_small_store(self, vcz_store):
+        # small msprime store, plenty of free GPU memory -> auto goes eager.
         path, _ = vcz_store
         hm = HaplotypeMatrix.from_zarr(path, streaming="auto")
         assert isinstance(hm, HaplotypeMatrix)
@@ -161,6 +162,53 @@ class TestProducerThreadErrorPropagation:
         with pytest.raises(RuntimeError, match="synthetic producer error"):
             for _ in smatrix.iter_gpu_chunks():
                 pass
+
+
+class TestAutoDetection:
+    """``streaming='auto'`` should pick eager for stores that fit on the
+    device and streaming for stores that don't. The size threshold is
+    parameterized so tests can simulate "too big" with a tiny
+    ``free_gpu_bytes`` rather than needing a biobank-scale fixture."""
+
+    def test_auto_picks_eager_when_it_fits(self, vcz_store):
+        # default free GPU memory, tiny msprime store -> eager
+        path, _ = vcz_store
+        hm = HaplotypeMatrix.from_zarr(path, streaming="auto")
+        assert isinstance(hm, HaplotypeMatrix)
+        assert not isinstance(hm, StreamingHaplotypeMatrix)
+
+    def test_auto_picks_streaming_when_oversized(self, vcz_store):
+        # Force the "fits in free GPU memory" check to fail by passing a
+        # free_gpu_bytes too small for the eager footprint. This exercises
+        # the heuristic without needing a multi-GB fixture.
+        from pg_gpu.haplotype_matrix import _decide_streaming_mode
+        path, hm = vcz_store
+        eager_bytes = hm.haplotypes.size
+        # Make the eager footprint look like it doesn't fit by claiming
+        # less free GPU memory than the projected size requires.
+        choice = _decide_streaming_mode(
+            path, region=None, streaming="auto", pop_file=False,
+            free_gpu_bytes=int(eager_bytes / 0.5 - 1),  # just below threshold
+        )
+        assert choice == "streaming"
+
+    def test_never_raises_when_oversized(self, vcz_store):
+        from pg_gpu.haplotype_matrix import _decide_streaming_mode
+        path, hm = vcz_store
+        eager_bytes = hm.haplotypes.size
+        with pytest.raises(MemoryError, match="streaming='never'"):
+            _decide_streaming_mode(
+                path, region=None, streaming="never", pop_file=False,
+                free_gpu_bytes=int(eager_bytes / 0.5 - 1),
+            )
+
+    def test_never_passes_when_it_fits(self, vcz_store):
+        # opposite case: free memory is much larger than the matrix, so
+        # streaming='never' returns eager without raising.
+        path, _ = vcz_store
+        hm = HaplotypeMatrix.from_zarr(path, streaming="never")
+        assert isinstance(hm, HaplotypeMatrix)
+        assert not isinstance(hm, StreamingHaplotypeMatrix)
 
 
 class TestMaterialize:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -91,24 +91,33 @@ class TestStreamingMatrixSurface:
 
 class TestStreamingEquivalence:
 
-    def test_stream_concat_matches_eager(self, vcz_store):
+    @pytest.mark.parametrize("chunk_bp", [1_000, 5_000, 25_000, 200_000])
+    @pytest.mark.parametrize("prefetch", [0, 1, 4])
+    def test_stream_concat_matches_eager(self, vcz_store, chunk_bp, prefetch):
         # walking every chunk in streaming mode and concatenating the
         # per-chunk haplotype matrices reproduces the eager matrix
         # bit-for-bit -- the invariant streaming-aware kernels rely on.
+        # Sweep chunk_bp from one-chunk-per-variant (1 kb) up through
+        # chunks that span the whole fixture (200 kb >> 100 kb store
+        # length) so the chunk-count edge cases are all exercised, and
+        # sweep prefetch off / on / deeper so the producer thread's
+        # ordering is checked under different queue depths.
         path, _ = vcz_store
         eager = HaplotypeMatrix.from_zarr(path, streaming="never")
         smatrix = HaplotypeMatrix.from_zarr(path, streaming="always",
-                                            chunk_bp=5_000, prefetch=1)
+                                            chunk_bp=chunk_bp,
+                                            prefetch=prefetch)
         haps, pos = _stream_concat(smatrix)
         np.testing.assert_array_equal(haps, cp.asnumpy(eager.haplotypes))
         np.testing.assert_array_equal(pos, cp.asnumpy(eager.positions))
 
-    def test_prefetch_off_matches_prefetch_on(self, vcz_store):
+    @pytest.mark.parametrize("chunk_bp", [1_000, 5_000, 25_000])
+    def test_prefetch_off_matches_prefetch_on(self, vcz_store, chunk_bp):
         path, _ = vcz_store
         s0 = HaplotypeMatrix.from_zarr(path, streaming="always",
-                                       chunk_bp=5_000, prefetch=0)
+                                       chunk_bp=chunk_bp, prefetch=0)
         s1 = HaplotypeMatrix.from_zarr(path, streaming="always",
-                                       chunk_bp=5_000, prefetch=1)
+                                       chunk_bp=chunk_bp, prefetch=1)
         h0, p0 = _stream_concat(s0)
         h1, p1 = _stream_concat(s1)
         np.testing.assert_array_equal(h0, h1)

--- a/tests/test_streaming_grm.py
+++ b/tests/test_streaming_grm.py
@@ -1,0 +1,119 @@
+"""Equivalence tests for streaming-aware GRM.
+
+``grm(matrix, ...)`` dispatches at the top: a ``StreamingHaplotypeMatrix``
+/ ``StreamingGenotypeMatrix`` routes through a two-pass streaming
+implementation (chromosome-wide allele frequencies first, then a
+standardized outer-product accumulated on host with row-block tiling
+on the individual axis). Tests assert streaming-vs-eager parity on
+small msprime stores.
+"""
+
+import numpy as np
+import pytest
+
+from pg_gpu import HaplotypeMatrix
+from pg_gpu.genotype_matrix import GenotypeMatrix
+from pg_gpu.relatedness import grm
+
+
+@pytest.fixture
+def vcz_store(tmp_path):
+    from .conftest import simulate_hm
+    hm = simulate_hm(n_samples=16, seq_length=80_000, seed=41,
+                     mutation_model="binary")
+    hm.samples = [f"s{i}" for i in range(hm.num_haplotypes // 2)]
+    path = str(tmp_path / "grm.vcz")
+    hm.to_zarr(path, format="vcz", contig_name="1")
+    return path
+
+
+@pytest.fixture
+def two_pop_vcz_store(tmp_path):
+    from .conftest import simulate_hm
+    hm = simulate_hm(n_samples=18, seq_length=80_000, seed=43,
+                     mutation_model="binary")
+    n_dip = hm.num_haplotypes // 2
+    hm.samples = [f"s{i}" for i in range(n_dip)]
+    path = str(tmp_path / "grm_twopop.vcz")
+    hm.to_zarr(path, format="vcz", contig_name="1")
+    half = n_dip // 2
+    popfile = str(tmp_path / "pops.tsv")
+    with open(popfile, "w") as f:
+        f.write("sample\tpop\n")
+        for i in range(half):
+            f.write(f"s{i}\tpop1\n")
+        for i in range(half, n_dip):
+            f.write(f"s{i}\tpop2\n")
+    return path, popfile
+
+
+class TestGrmStreaming:
+
+    def test_haplotype_parity(self, vcz_store):
+        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                            chunk_bp=10_000)
+        # rtol looser than IBS because GRM has a two-pass float accumulation
+        # (frequencies then standardized outer product) where the chunked
+        # vs whole-matrix orderings can differ at the last ULP.
+        np.testing.assert_allclose(grm(stream), grm(eager),
+                                    rtol=1e-7, atol=1e-10)
+
+    def test_genotype_parity(self, vcz_store):
+        eager = GenotypeMatrix.from_zarr(vcz_store, streaming="never")
+        stream = GenotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                           chunk_bp=10_000)
+        np.testing.assert_allclose(grm(stream), grm(eager),
+                                    rtol=1e-7, atol=1e-10)
+
+    def test_missing_data_exclude(self, vcz_store):
+        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                            chunk_bp=10_000)
+        np.testing.assert_allclose(
+            grm(stream, missing_data='exclude'),
+            grm(eager, missing_data='exclude'),
+            rtol=1e-7, atol=1e-10,
+        )
+
+    def test_population_subset(self, two_pop_vcz_store):
+        path, popfile = two_pop_vcz_store
+        eager = HaplotypeMatrix.from_zarr(path, streaming="never",
+                                            pop_file=popfile)
+        stream = HaplotypeMatrix.from_zarr(path, streaming="always",
+                                             pop_file=popfile,
+                                             chunk_bp=10_000)
+        np.testing.assert_allclose(
+            grm(stream, population='pop1'),
+            grm(eager, population='pop1'),
+            rtol=1e-7, atol=1e-10,
+        )
+
+    @pytest.mark.parametrize("block_size", [1, 4, 1000])
+    def test_block_size_invariance(self, vcz_store, block_size):
+        from pg_gpu.relatedness import _stream_grm
+        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                            chunk_bp=10_000)
+        e = grm(eager)
+        s = _stream_grm(stream, population=None, missing_data='include',
+                         block_size=block_size)
+        np.testing.assert_allclose(s, e, rtol=1e-7, atol=1e-10)
+
+    def test_monomorphic_chunks_dont_break(self, tmp_path):
+        # Build a small store where most variants are monomorphic so
+        # poly_mask is sparse and many chunks contribute nothing. The
+        # eager kernel returns zeros if every site is monomorphic; the
+        # streaming path must not divide by zero or skip a contributing
+        # chunk.
+        from .conftest import simulate_hm
+        hm = simulate_hm(n_samples=8, seq_length=20_000, seed=53,
+                         mutation_model="binary")
+        hm.samples = [f"s{i}" for i in range(hm.num_haplotypes // 2)]
+        path = str(tmp_path / "mono.vcz")
+        hm.to_zarr(path, format="vcz", contig_name="1")
+        eager = HaplotypeMatrix.from_zarr(path, streaming="never")
+        stream = HaplotypeMatrix.from_zarr(path, streaming="always",
+                                            chunk_bp=5_000)
+        np.testing.assert_allclose(grm(stream), grm(eager),
+                                    rtol=1e-7, atol=1e-10)

--- a/tests/test_streaming_ibs.py
+++ b/tests/test_streaming_ibs.py
@@ -1,0 +1,107 @@
+"""Equivalence tests for streaming-aware IBS.
+
+``ibs(matrix, ...)`` dispatches at the top: if the argument is a
+``StreamingHaplotypeMatrix`` / ``StreamingGenotypeMatrix``, the variant
+axis is streamed chunk-by-chunk and the individual axis is tiled into
+row blocks so the (n_ind, n_ind) accumulators never have to fit on the
+GPU. Per-chunk contributions sum on the host; the final ratio is
+applied once. Tests assert that streaming and eager produce the same
+matrix on small msprime stores.
+"""
+
+import numpy as np
+import pytest
+
+from pg_gpu import HaplotypeMatrix
+from pg_gpu.genotype_matrix import GenotypeMatrix
+from pg_gpu.relatedness import ibs
+
+from .conftest import simulate_hm
+
+
+@pytest.fixture
+def vcz_store(tmp_path):
+    hm = simulate_hm(n_samples=16, seq_length=80_000, seed=31,
+                     mutation_model="binary")
+    hm.samples = [f"s{i}" for i in range(hm.num_haplotypes // 2)]
+    path = str(tmp_path / "ibs.vcz")
+    hm.to_zarr(path, format="vcz", contig_name="1")
+    return path
+
+
+@pytest.fixture
+def two_pop_vcz_store(tmp_path):
+    hm = simulate_hm(n_samples=18, seq_length=80_000, seed=37,
+                     mutation_model="binary")
+    n_dip = hm.num_haplotypes // 2
+    hm.samples = [f"s{i}" for i in range(n_dip)]
+    path = str(tmp_path / "ibs_twopop.vcz")
+    hm.to_zarr(path, format="vcz", contig_name="1")
+    half = n_dip // 2
+    popfile = str(tmp_path / "pops.tsv")
+    with open(popfile, "w") as f:
+        f.write("sample\tpop\n")
+        for i in range(half):
+            f.write(f"s{i}\tpop1\n")
+        for i in range(half, n_dip):
+            f.write(f"s{i}\tpop2\n")
+    return path, popfile
+
+
+class TestIbsStreaming:
+
+    def test_haplotype_parity(self, vcz_store):
+        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                            chunk_bp=10_000)
+        e = ibs(eager)
+        s = ibs(stream)
+        np.testing.assert_allclose(s, e, rtol=1e-9, atol=1e-12)
+
+    def test_genotype_parity(self, vcz_store):
+        eager = GenotypeMatrix.from_zarr(vcz_store, streaming="never")
+        stream = GenotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                           chunk_bp=10_000)
+        e = ibs(eager)
+        s = ibs(stream)
+        np.testing.assert_allclose(s, e, rtol=1e-9, atol=1e-12)
+
+    def test_missing_data_exclude(self, vcz_store):
+        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                            chunk_bp=10_000)
+        e = ibs(eager, missing_data='exclude')
+        s = ibs(stream, missing_data='exclude')
+        np.testing.assert_allclose(s, e, rtol=1e-9, atol=1e-12)
+
+    def test_population_subset(self, two_pop_vcz_store):
+        path, popfile = two_pop_vcz_store
+        eager = HaplotypeMatrix.from_zarr(path, streaming="never",
+                                            pop_file=popfile)
+        stream = HaplotypeMatrix.from_zarr(path, streaming="always",
+                                             pop_file=popfile,
+                                             chunk_bp=10_000)
+        e = ibs(eager, population='pop1')
+        s = ibs(stream, population='pop1')
+        np.testing.assert_allclose(s, e, rtol=1e-9, atol=1e-12)
+
+    @pytest.mark.parametrize("block_size", [1, 4, 1000])
+    def test_block_size_invariance(self, vcz_store, block_size):
+        # Streaming output must not depend on the row-block tile size
+        # -- only the (block_size, n_ind) working memory does.
+        from pg_gpu.relatedness import _stream_ibs
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                            chunk_bp=10_000)
+        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
+        e = ibs(eager)
+        s = _stream_ibs(stream, population=None, missing_data='include',
+                        block_size=block_size)
+        np.testing.assert_allclose(s, e, rtol=1e-9, atol=1e-12)
+
+    def test_diagonal_is_one(self, vcz_store):
+        # Eager and streaming both pin the diagonal at 1.0 -- check the
+        # streaming path keeps that invariant.
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                            chunk_bp=10_000)
+        s = ibs(stream)
+        np.testing.assert_allclose(np.diag(s), 1.0)

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -206,6 +206,22 @@ class TestAccessibleBedDispatch:
         _assert_frames_equivalent(df_e, df_s)
 
 
+class TestGarudGuardrail:
+    """Garud is rejected on the streaming path until the fused kernel's
+    rounding sensitivity is addressed. Position-deterministic weights
+    make the hash basis stable, but second-order rounding still drifts
+    the distinct-haplotype count by a few ULP under different prefix
+    trajectories."""
+
+    @pytest.mark.parametrize("stat", ["garud_h1", "garud_h12",
+                                       "garud_h123", "garud_h2h1"])
+    def test_each_stat_rejected(self, vcz_store, stat):
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                            chunk_bp=10_000)
+        with pytest.raises(NotImplementedError, match="Garud"):
+            windowed_analysis(stream, window_size=5_000, statistics=[stat])
+
+
 class TestSFSDispatch:
 
     def test_sfs_equivalent(self, vcz_store):
@@ -260,15 +276,3 @@ class TestStreamingGuardrails:
             windowed_analysis(stream, window_size=5_000,
                               statistics=["local_pca"])
 
-    @pytest.mark.parametrize("stat", ["garud_h1", "garud_h12",
-                                       "garud_h123", "garud_h2h1"])
-    def test_garud_rejected(self, vcz_store, stat):
-        # Garud H's hash basis is sized to the full matrix's n_variants,
-        # so a per-chunk dispatch gets a different basis per chunk and
-        # the H values disagree with the eager result. Reject explicitly
-        # rather than silently returning wrong numbers; once Garud's
-        # hash becomes position-deterministic this guardrail can drop.
-        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
-                                            chunk_bp=10_000)
-        with pytest.raises(NotImplementedError, match="Garud"):
-            windowed_analysis(stream, window_size=5_000, statistics=[stat])

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -248,6 +248,47 @@ class TestSFSDispatch:
         j_s = sfs_module.joint_sfs(stream, pop1="pop1", pop2="pop2")
         np.testing.assert_array_equal(j_e, j_s)
 
+    def test_project_joint_sfs_equivalent(self, vcz_store, tmp_path):
+        # Eager projection (built from full joint_sfs) must match
+        # streaming projection (which never materializes the full
+        # histogram) for both an identity target (target == source,
+        # recovers float-cast joint_sfs) and a strict downsample.
+        n_dip = HaplotypeMatrix.from_zarr(vcz_store).num_haplotypes // 2
+        half = n_dip // 2
+        popfile = str(tmp_path / "pops.tsv")
+        with open(popfile, "w") as f:
+            f.write("sample\tpop\n")
+            for i in range(half):
+                f.write(f"s{i}\tpop1\n")
+            for i in range(half, n_dip):
+                f.write(f"s{i}\tpop2\n")
+
+        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never",
+                                          pop_file=popfile)
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                            pop_file=popfile,
+                                            chunk_bp=10_000)
+        # Each pop has 2 * half haplotypes; pick a strict downsample.
+        n1 = 2 * half
+        n2 = 2 * (n_dip - half)
+        target1 = max(1, n1 - 2)
+        target2 = max(1, n2 - 2)
+        e = sfs_module.project_joint_sfs(eager, pop1="pop1", pop2="pop2",
+                                          target_n1=target1,
+                                          target_n2=target2)
+        s = sfs_module.project_joint_sfs(stream, pop1="pop1", pop2="pop2",
+                                          target_n1=target1,
+                                          target_n2=target2)
+        np.testing.assert_allclose(e, s, rtol=1e-9, atol=1e-9)
+
+        # Identity-target projection of an int joint SFS just casts to
+        # float; pmf collapses to the indicator.
+        full = sfs_module.joint_sfs(eager, pop1="pop1", pop2="pop2")
+        e_id = sfs_module.project_joint_sfs(eager, pop1="pop1", pop2="pop2",
+                                             target_n1=n1, target_n2=n2)
+        np.testing.assert_allclose(e_id, full.astype(np.float64),
+                                    rtol=1e-9, atol=1e-9)
+
 
 class TestStreamingGuardrails:
 

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -62,19 +62,41 @@ def _aligned_pair(vcz_store, **stream_kwargs):
     return eager, stream
 
 
+# (chunk_bp, window_size) combos that exercise the streaming dispatch:
+# * one window per chunk (chunk == window)
+# * a couple of windows per chunk (the typical case)
+# * many windows per chunk (chunk >> window)
+# * the whole-fixture single-chunk case (chunk >= seq_length)
+# Streaming forbids chunk_bp < window_size and chunk_bp % window_size
+# != 0; those are covered by TestStreamingGuardrails below.
+CHUNK_WINDOW_COMBOS = [
+    (5_000, 5_000),     # one window per chunk
+    (10_000, 5_000),    # two windows per chunk
+    (25_000, 5_000),    # five windows per chunk
+    (50_000, 10_000),   # five-window chunk at a larger window
+    (200_000, 5_000),   # everything in one chunk
+]
+
+
 class TestWindowedAnalysisDispatch:
 
-    def test_pi_equivalent(self, vcz_store):
-        eager, stream = _aligned_pair(vcz_store, chunk_bp=10_000)
-        df_e = windowed_analysis(eager, window_size=5_000, statistics=["pi"])
-        df_s = windowed_analysis(stream, window_size=5_000, statistics=["pi"])
+    @pytest.mark.parametrize("chunk_bp,window_size", CHUNK_WINDOW_COMBOS)
+    def test_pi_equivalent(self, vcz_store, chunk_bp, window_size):
+        eager, stream = _aligned_pair(vcz_store, chunk_bp=chunk_bp)
+        df_e = windowed_analysis(eager, window_size=window_size,
+                                  statistics=["pi"])
+        df_s = windowed_analysis(stream, window_size=window_size,
+                                  statistics=["pi"])
         _assert_frames_equivalent(df_e, df_s)
 
-    def test_multiple_stats_equivalent(self, vcz_store):
-        eager, stream = _aligned_pair(vcz_store, chunk_bp=10_000)
+    @pytest.mark.parametrize("chunk_bp,window_size", CHUNK_WINDOW_COMBOS)
+    def test_multiple_stats_equivalent(self, vcz_store, chunk_bp, window_size):
+        eager, stream = _aligned_pair(vcz_store, chunk_bp=chunk_bp)
         stats = ["pi", "theta_w", "tajimas_d", "segregating_sites"]
-        df_e = windowed_analysis(eager, window_size=5_000, statistics=stats)
-        df_s = windowed_analysis(stream, window_size=5_000, statistics=stats)
+        df_e = windowed_analysis(eager, window_size=window_size,
+                                  statistics=stats)
+        df_s = windowed_analysis(stream, window_size=window_size,
+                                  statistics=stats)
         _assert_frames_equivalent(df_e, df_s)
 
     def test_two_pop_divergence_equivalent(self, vcz_store, tmp_path):
@@ -350,6 +372,17 @@ class TestStreamingGuardrails:
         with pytest.raises(ValueError, match="must divide"):
             # 7000 does not divide 10000
             windowed_analysis(stream, window_size=7_000, statistics=["pi"])
+
+    def test_window_larger_than_chunk_rejected(self, vcz_store):
+        # A window that is bigger than the chunk would have to straddle
+        # chunk boundaries; the streaming guardrail rejects it with the
+        # same 'must divide' error path (window > chunk is equivalent
+        # to a non-divisor since chunk_bp % window_size is window_size's
+        # own value, which is greater than zero).
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                            chunk_bp=5_000)
+        with pytest.raises(ValueError, match="must divide"):
+            windowed_analysis(stream, window_size=20_000, statistics=["pi"])
 
     def test_sliding_windows_not_supported(self, vcz_store):
         stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -111,6 +111,101 @@ class TestWindowedAnalysisDispatch:
         _assert_frames_equivalent(df_e, df_s)
 
 
+SINGLE_POP_STATS = [
+    "pi", "theta_w", "tajimas_d", "segregating_sites",
+    "theta_h", "theta_l", "fay_wu_h", "singletons",
+    "normalized_fay_wu_h", "zeng_e", "zeng_dh", "max_daf",
+]
+TWO_POP_STATS = ["fst", "fst_hudson", "dxy", "da"]
+
+
+def _two_pop_pair(vcz_store, tmp_path, **stream_kwargs):
+    n_dip = HaplotypeMatrix.from_zarr(vcz_store, streaming="never").num_haplotypes // 2
+    half = n_dip // 2
+    popfile = str(tmp_path / "two_pops.tsv")
+    with open(popfile, "w") as f:
+        f.write("sample\tpop\n")
+        for i in range(half):
+            f.write(f"s{i}\tpop1\n")
+        for i in range(half, n_dip):
+            f.write(f"s{i}\tpop2\n")
+    eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never",
+                                      pop_file=popfile)
+    stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                       pop_file=popfile,
+                                       **stream_kwargs)
+    eager.chrom_start = stream.chrom_start
+    eager.chrom_end = stream.chrom_end
+    return eager, stream
+
+
+class TestSingleStatParametrized:
+    """Every scatter_single stat individually -- catches dispatch breakage that
+    a multi-stat test would hide via short-circuit columns."""
+
+    @pytest.mark.parametrize("stat", SINGLE_POP_STATS)
+    def test_each_stat_equivalent(self, vcz_store, stat):
+        eager, stream = _aligned_pair(vcz_store, chunk_bp=10_000)
+        df_e = windowed_analysis(eager, window_size=5_000, statistics=[stat])
+        df_s = windowed_analysis(stream, window_size=5_000, statistics=[stat])
+        _assert_frames_equivalent(df_e, df_s)
+
+    @pytest.mark.parametrize("missing_data", ["include", "exclude"])
+    def test_missing_data_modes(self, vcz_store, missing_data):
+        eager, stream = _aligned_pair(vcz_store, chunk_bp=10_000)
+        df_e = windowed_analysis(eager, window_size=5_000, statistics=["pi"],
+                                 missing_data=missing_data)
+        df_s = windowed_analysis(stream, window_size=5_000, statistics=["pi"],
+                                 missing_data=missing_data)
+        _assert_frames_equivalent(df_e, df_s)
+
+    def test_span_normalize_false(self, vcz_store):
+        eager, stream = _aligned_pair(vcz_store, chunk_bp=10_000)
+        df_e = windowed_analysis(eager, window_size=5_000, statistics=["pi"],
+                                 span_normalize=False)
+        df_s = windowed_analysis(stream, window_size=5_000, statistics=["pi"],
+                                 span_normalize=False)
+        _assert_frames_equivalent(df_e, df_s)
+
+
+class TestTwoPopStatParametrized:
+    """Every scatter_twopop stat individually."""
+
+    @pytest.mark.parametrize("stat", TWO_POP_STATS)
+    def test_each_stat_equivalent(self, vcz_store, tmp_path, stat):
+        eager, stream = _two_pop_pair(vcz_store, tmp_path, chunk_bp=10_000)
+        df_e = windowed_analysis(eager, window_size=5_000, statistics=[stat],
+                                 populations=["pop1", "pop2"])
+        df_s = windowed_analysis(stream, window_size=5_000, statistics=[stat],
+                                 populations=["pop1", "pop2"])
+        _assert_frames_equivalent(df_e, df_s)
+
+
+class TestAccessibleBedDispatch:
+    """The streaming path passes accessible_bed through to each per-chunk
+    windowed_analysis call. A BED mask that excludes part of the genome
+    should produce the same per-window n_total_sites / span on both
+    paths."""
+
+    def _write_bed(self, path):
+        # exclude 0-25000 and 75000-100000 (so only the middle 50 kb is
+        # accessible), forcing the mask to be applied at chunk boundaries
+        # rather than only at the matrix edges.
+        with open(path, "w") as f:
+            f.write("1\t25000\t75000\n")
+        return path
+
+    def test_accessible_bed_equivalent(self, vcz_store, tmp_path):
+        bed = self._write_bed(str(tmp_path / "acc.bed"))
+        eager, stream = _aligned_pair(vcz_store, chunk_bp=10_000)
+        # eager_chrom must remain "1" for the BED to match the contig name
+        df_e = windowed_analysis(eager, window_size=5_000, statistics=["pi"],
+                                 accessible_bed=bed, chrom="1")
+        df_s = windowed_analysis(stream, window_size=5_000, statistics=["pi"],
+                                 accessible_bed=bed, chrom="1")
+        _assert_frames_equivalent(df_e, df_s)
+
+
 class TestSFSDispatch:
 
     def test_sfs_equivalent(self, vcz_store):

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -1,0 +1,134 @@
+"""Equivalence tests for kernels that accept a StreamingHaplotypeMatrix.
+
+Each public entry point that gains streaming-aware dispatch is checked
+twice on the same data: once with the eager HaplotypeMatrix and once
+with the StreamingHaplotypeMatrix. Results must agree row-for-row.
+"""
+
+import msprime
+import numpy as np
+import pandas as pd
+import pytest
+
+from pg_gpu import HaplotypeMatrix, windowed_analysis
+
+
+def _simulate_hm(n_samples=20, seq_length=100_000, seed=42):
+    ts = msprime.sim_ancestry(
+        samples=n_samples, sequence_length=seq_length,
+        recombination_rate=1e-4, random_seed=seed, ploidy=2,
+    )
+    ts = msprime.sim_mutations(ts, rate=1e-3, random_seed=seed)
+    return HaplotypeMatrix.from_ts(ts)
+
+
+@pytest.fixture
+def vcz_store(tmp_path):
+    hm = _simulate_hm()
+    hm.samples = [f"s{i}" for i in range(hm.num_haplotypes // 2)]
+    path = str(tmp_path / "kern.vcz")
+    hm.to_zarr(path, format="vcz", contig_name="1")
+    return path
+
+
+def _assert_frames_equivalent(a, b):
+    """Compare two windowed_analysis DataFrames, sorted by start, with
+    numeric tolerance suitable for float32-ish stats."""
+    a = a.sort_values("start").reset_index(drop=True)
+    b = b.sort_values("start").reset_index(drop=True)
+    assert list(a.columns) == list(b.columns)
+    for col in a.columns:
+        if pd.api.types.is_numeric_dtype(a[col]):
+            np.testing.assert_allclose(
+                a[col].to_numpy(), b[col].to_numpy(),
+                rtol=1e-6, atol=1e-9,
+                err_msg=f"column {col!r} disagrees",
+            )
+        else:
+            assert (a[col] == b[col]).all(), f"column {col!r} disagrees"
+
+
+def _aligned_pair(vcz_store, **stream_kwargs):
+    """Return (eager, streaming) pair with their window grids aligned.
+
+    Eager from_zarr uses ``chrom_start = positions[0]`` (the first variant
+    position) by default, while the streaming path uses the chunk-grid
+    origin. Both are legitimate placements; for an apples-to-apples
+    equivalence check we force the eager matrix onto the streaming grid.
+    """
+    eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never",
+                                      **stream_kwargs.get("from_zarr_kwargs", {}))
+    stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                       **stream_kwargs)
+    eager.chrom_start = stream.chrom_start
+    eager.chrom_end = stream.chrom_end
+    return eager, stream
+
+
+class TestWindowedAnalysisDispatch:
+
+    def test_pi_equivalent(self, vcz_store):
+        eager, stream = _aligned_pair(vcz_store, chunk_bp=10_000)
+        df_e = windowed_analysis(eager, window_size=5_000, statistics=["pi"])
+        df_s = windowed_analysis(stream, window_size=5_000, statistics=["pi"])
+        _assert_frames_equivalent(df_e, df_s)
+
+    def test_multiple_stats_equivalent(self, vcz_store):
+        eager, stream = _aligned_pair(vcz_store, chunk_bp=10_000)
+        stats = ["pi", "theta_w", "tajimas_d", "segregating_sites"]
+        df_e = windowed_analysis(eager, window_size=5_000, statistics=stats)
+        df_s = windowed_analysis(stream, window_size=5_000, statistics=stats)
+        _assert_frames_equivalent(df_e, df_s)
+
+    def test_two_pop_divergence_equivalent(self, vcz_store, tmp_path):
+        # Build a two-population pop file so divergence stats have something
+        # to compute. Split samples 50/50.
+        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
+        n_dip = eager.num_haplotypes // 2
+        half = n_dip // 2
+        popfile = str(tmp_path / "pops.tsv")
+        with open(popfile, "w") as f:
+            f.write("sample\tpop\n")
+            for i in range(half):
+                f.write(f"s{i}\tpop1\n")
+            for i in range(half, n_dip):
+                f.write(f"s{i}\tpop2\n")
+
+        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never",
+                                          pop_file=popfile)
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                            pop_file=popfile,
+                                            chunk_bp=10_000)
+        eager.chrom_start = stream.chrom_start
+        eager.chrom_end = stream.chrom_end
+        df_e = windowed_analysis(eager, window_size=5_000,
+                                 statistics=["fst", "dxy"],
+                                 populations=["pop1", "pop2"])
+        df_s = windowed_analysis(stream, window_size=5_000,
+                                 statistics=["fst", "dxy"],
+                                 populations=["pop1", "pop2"])
+        _assert_frames_equivalent(df_e, df_s)
+
+
+class TestStreamingGuardrails:
+
+    def test_window_must_divide_align(self, vcz_store):
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                            chunk_bp=10_000)
+        with pytest.raises(ValueError, match="must divide"):
+            # 7000 does not divide 10000
+            windowed_analysis(stream, window_size=7_000, statistics=["pi"])
+
+    def test_sliding_windows_not_supported(self, vcz_store):
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                            chunk_bp=10_000)
+        with pytest.raises(NotImplementedError, match="sliding windows"):
+            windowed_analysis(stream, window_size=5_000, step_size=2_500,
+                              statistics=["pi"])
+
+    def test_local_pca_rejected(self, vcz_store):
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                            chunk_bp=10_000)
+        with pytest.raises(NotImplementedError, match="local_pca"):
+            windowed_analysis(stream, window_size=5_000,
+                              statistics=["local_pca"])

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -11,6 +11,7 @@ import pandas as pd
 import pytest
 
 from pg_gpu import HaplotypeMatrix, windowed_analysis
+from pg_gpu import sfs as sfs_module
 
 
 def _simulate_hm(n_samples=20, seq_length=100_000, seed=42):
@@ -108,6 +109,37 @@ class TestWindowedAnalysisDispatch:
                                  statistics=["fst", "dxy"],
                                  populations=["pop1", "pop2"])
         _assert_frames_equivalent(df_e, df_s)
+
+
+class TestSFSDispatch:
+
+    def test_sfs_equivalent(self, vcz_store):
+        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                            chunk_bp=10_000)
+        s_e = sfs_module.sfs(eager)
+        s_s = sfs_module.sfs(stream)
+        np.testing.assert_array_equal(s_e, s_s)
+
+    def test_joint_sfs_equivalent(self, vcz_store, tmp_path):
+        n_dip = HaplotypeMatrix.from_zarr(vcz_store).num_haplotypes // 2
+        half = n_dip // 2
+        popfile = str(tmp_path / "pops.tsv")
+        with open(popfile, "w") as f:
+            f.write("sample\tpop\n")
+            for i in range(half):
+                f.write(f"s{i}\tpop1\n")
+            for i in range(half, n_dip):
+                f.write(f"s{i}\tpop2\n")
+
+        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never",
+                                          pop_file=popfile)
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                            pop_file=popfile,
+                                            chunk_bp=10_000)
+        j_e = sfs_module.joint_sfs(eager, pop1="pop1", pop2="pop2")
+        j_s = sfs_module.joint_sfs(stream, pop1="pop1", pop2="pop2")
+        np.testing.assert_array_equal(j_e, j_s)
 
 
 class TestStreamingGuardrails:

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -259,3 +259,16 @@ class TestStreamingGuardrails:
         with pytest.raises(NotImplementedError, match="local_pca"):
             windowed_analysis(stream, window_size=5_000,
                               statistics=["local_pca"])
+
+    @pytest.mark.parametrize("stat", ["garud_h1", "garud_h12",
+                                       "garud_h123", "garud_h2h1"])
+    def test_garud_rejected(self, vcz_store, stat):
+        # Garud H's hash basis is sized to the full matrix's n_variants,
+        # so a per-chunk dispatch gets a different basis per chunk and
+        # the H values disagree with the eager result. Reject explicitly
+        # rather than silently returning wrong numbers; once Garud's
+        # hash becomes position-deterministic this guardrail can drop.
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                            chunk_bp=10_000)
+        with pytest.raises(NotImplementedError, match="Garud"):
+            windowed_analysis(stream, window_size=5_000, statistics=[stat])

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -202,20 +202,72 @@ class TestAccessibleBedDispatch:
         _assert_frames_equivalent(df_e, df_s)
 
 
-class TestGarudGuardrail:
-    """Garud is rejected on the streaming path until the fused kernel's
-    rounding sensitivity is addressed. Position-deterministic weights
-    make the hash basis stable, but second-order rounding still drifts
-    the distinct-haplotype count by a few ULP under different prefix
-    trajectories."""
+class TestGarudStreamingDispatch:
+    """Per-window scatter-reduce assembles each window's hash from the
+    same set of variants regardless of chunking, so eager and streaming
+    Garud H must agree bit-for-bit (no prefix-sum reorder drift to
+    absorb)."""
 
     @pytest.mark.parametrize("stat", ["garud_h1", "garud_h12",
                                        "garud_h123", "garud_h2h1"])
-    def test_each_stat_rejected(self, vcz_store, stat):
-        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
-                                            chunk_bp=10_000)
-        with pytest.raises(NotImplementedError, match="Garud"):
-            windowed_analysis(stream, window_size=5_000, statistics=[stat])
+    def test_each_stat_matches_eager(self, vcz_store, stat):
+        eager, stream = _aligned_pair(vcz_store, chunk_bp=10_000)
+        df_e = windowed_analysis(eager, window_size=5_000, statistics=[stat])
+        df_s = windowed_analysis(stream, window_size=5_000, statistics=[stat])
+        # Sort by window start; demand exact-precision parity on the
+        # numeric column. The whole point of the rewrite is that the
+        # streaming path's per-window hash is identical to the eager
+        # one's, so float jitter is no longer a thing.
+        df_e = df_e.sort_values("start").reset_index(drop=True)
+        df_s = df_s.sort_values("start").reset_index(drop=True)
+        assert list(df_e.columns) == list(df_s.columns)
+        np.testing.assert_array_equal(df_e[stat].to_numpy(),
+                                       df_s[stat].to_numpy())
+
+    def test_garud_with_pi_in_one_call(self, vcz_store):
+        # Mixed stat set -- the streaming dispatch should run pi and
+        # Garud H side by side on the same chunks without either
+        # disturbing the other.
+        eager, stream = _aligned_pair(vcz_store, chunk_bp=10_000)
+        stats = ["pi", "garud_h12"]
+        df_e = windowed_analysis(eager, window_size=5_000, statistics=stats)
+        df_s = windowed_analysis(stream, window_size=5_000, statistics=stats)
+        df_e = df_e.sort_values("start").reset_index(drop=True)
+        df_s = df_s.sort_values("start").reset_index(drop=True)
+        np.testing.assert_array_equal(df_e["garud_h12"].to_numpy(),
+                                       df_s["garud_h12"].to_numpy())
+        np.testing.assert_allclose(df_e["pi"].to_numpy(),
+                                    df_s["pi"].to_numpy(),
+                                    rtol=1e-9, atol=1e-12)
+
+    def test_chunk_boundary_invariance(self, vcz_store):
+        # The most direct stress test for prefix-sum drift used to be
+        # exactly this: change the chunk_bp and the per-window hash
+        # gets accumulated in a different order. After the per-window
+        # scatter-reduce rewrite the two chunkings produce identical
+        # results.
+        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
+        s_a = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                          chunk_bp=10_000)
+        s_b = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                          chunk_bp=20_000)
+        eager.chrom_start = s_a.chrom_start
+        eager.chrom_end = s_a.chrom_end
+        df_e = windowed_analysis(eager, window_size=5_000,
+                                  statistics=["garud_h12"])
+        df_a = windowed_analysis(s_a, window_size=5_000,
+                                  statistics=["garud_h12"])
+        df_b = windowed_analysis(s_b, window_size=5_000,
+                                  statistics=["garud_h12"])
+        for df in (df_a, df_b):
+            df.sort_values("start", inplace=True)
+            df.reset_index(drop=True, inplace=True)
+        df_e.sort_values("start", inplace=True)
+        df_e.reset_index(drop=True, inplace=True)
+        np.testing.assert_array_equal(df_e["garud_h12"].to_numpy(),
+                                       df_a["garud_h12"].to_numpy())
+        np.testing.assert_array_equal(df_a["garud_h12"].to_numpy(),
+                                       df_b["garud_h12"].to_numpy())
 
 
 class TestSFSDispatch:

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -5,7 +5,6 @@ twice on the same data: once with the eager HaplotypeMatrix and once
 with the StreamingHaplotypeMatrix. Results must agree row-for-row.
 """
 
-import msprime
 import numpy as np
 import pandas as pd
 import pytest
@@ -13,14 +12,11 @@ import pytest
 from pg_gpu import HaplotypeMatrix, windowed_analysis
 from pg_gpu import sfs as sfs_module
 
+from .conftest import simulate_hm
+
 
 def _simulate_hm(n_samples=20, seq_length=100_000, seed=42):
-    ts = msprime.sim_ancestry(
-        samples=n_samples, sequence_length=seq_length,
-        recombination_rate=1e-4, random_seed=seed, ploidy=2,
-    )
-    ts = msprime.sim_mutations(ts, rate=1e-3, random_seed=seed)
-    return HaplotypeMatrix.from_ts(ts)
+    return simulate_hm(n_samples=n_samples, seq_length=seq_length, seed=seed)
 
 
 @pytest.fixture

--- a/tests/test_streaming_ld.py
+++ b/tests/test_streaming_ld.py
@@ -1,0 +1,204 @@
+"""Equivalence tests for streaming-aware LD statistics.
+
+``compute_ld_statistics_gpu_single_pop`` and ``_two_pops`` accept a
+``StreamingHaplotypeMatrix`` directly. Per-chunk bin sums are
+sum-reducible (numerators and denominators decompose by pair), and a
+tail buffer of the last ``max_bp_dist`` of variants from the previous
+chunk captures pairs that straddle chunk boundaries.
+
+Tests verify three properties on small msprime-derived stores:
+
+1. Eager and streaming produce the same per-bin (DD, Dz, pi2) tuples
+   (single-pop) and the same 15-stat OrderedDict (two-pop) when chunks
+   tile cleanly and no pair crosses a boundary.
+2. The tail-buffer machinery captures cross-chunk pairs: with
+   ``chunk_bp`` short and ``max_bp_dist`` large enough to span at
+   least one chunk boundary, eager vs streaming still agree.
+3. Per-chunk biallelic filtering produces the same filtered pair set
+   as the global filter the eager path uses.
+"""
+
+import numpy as np
+import pytest
+
+from pg_gpu import HaplotypeMatrix
+
+from .conftest import simulate_hm
+
+
+@pytest.fixture
+def vcz_store(tmp_path):
+    """Single-population vcz with enough variants to populate multiple
+    chunks and several bp bins."""
+    # binary model -- the eager-vs-streaming comparison only needs the
+    # two paths to agree on the same data, so the multi-allelic gap
+    # would be a confounder rather than something we want to exercise.
+    hm = simulate_hm(n_samples=24, seq_length=200_000, seed=11,
+                     mutation_model="binary")
+    hm.samples = [f"s{i}" for i in range(hm.num_haplotypes // 2)]
+    path = str(tmp_path / "ld.vcz")
+    hm.to_zarr(path, format="vcz", contig_name="1")
+    return path
+
+
+@pytest.fixture
+def two_pop_vcz_store(tmp_path):
+    """Vcz store with a two-population pop file split 50/50."""
+    hm = simulate_hm(n_samples=24, seq_length=200_000, seed=23,
+                     mutation_model="binary")
+    n_dip = hm.num_haplotypes // 2
+    hm.samples = [f"s{i}" for i in range(n_dip)]
+    path = str(tmp_path / "ld_twopop.vcz")
+    hm.to_zarr(path, format="vcz", contig_name="1")
+    half = n_dip // 2
+    popfile = str(tmp_path / "pops.tsv")
+    with open(popfile, "w") as f:
+        f.write("sample\tpop\n")
+        for i in range(half):
+            f.write(f"s{i}\tpop1\n")
+        for i in range(half, n_dip):
+            f.write(f"s{i}\tpop2\n")
+    return path, popfile
+
+
+def _aligned_single_pop_pair(vcz_store, **stream_kwargs):
+    eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
+    stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                        **stream_kwargs)
+    return eager, stream
+
+
+def _aligned_two_pop_pair(path, popfile, **stream_kwargs):
+    eager = HaplotypeMatrix.from_zarr(path, streaming="never",
+                                       pop_file=popfile)
+    stream = HaplotypeMatrix.from_zarr(path, streaming="always",
+                                        pop_file=popfile, **stream_kwargs)
+    return eager, stream
+
+
+def _assert_single_pop_equivalent(eager_dict, stream_dict, *, rtol=1e-9):
+    """Compare two single-pop LD dicts of (DD, Dz, pi2) per bin."""
+    assert set(eager_dict.keys()) == set(stream_dict.keys())
+    for key in eager_dict:
+        np.testing.assert_allclose(
+            np.array(stream_dict[key]),
+            np.array(eager_dict[key]),
+            rtol=rtol, atol=1e-12,
+            err_msg=f"bin {key} disagrees",
+        )
+
+
+def _assert_two_pop_equivalent(eager_dict, stream_dict, *, rtol=1e-9):
+    """Compare two two-pop LD dicts of OrderedDict[stat_name, float]."""
+    assert set(eager_dict.keys()) == set(stream_dict.keys())
+    for key in eager_dict:
+        e_stats = eager_dict[key]
+        s_stats = stream_dict[key]
+        assert list(e_stats.keys()) == list(s_stats.keys()), (
+            f"stat-name order disagrees for bin {key}"
+        )
+        np.testing.assert_allclose(
+            np.array(list(s_stats.values())),
+            np.array(list(e_stats.values())),
+            rtol=rtol, atol=1e-12,
+            err_msg=f"bin {key} disagrees",
+        )
+
+
+class TestSinglePopParity:
+
+    @pytest.mark.parametrize("chunk_bp", [50_000, 25_000])
+    def test_parity_single_chunk(self, vcz_store, chunk_bp):
+        # Bin upper edge is short relative to chunk width, so no pair
+        # crosses a chunk boundary -- the tail buffer should be empty
+        # at every chunk and the result must match eager exactly.
+        eager, stream = _aligned_single_pop_pair(vcz_store, chunk_bp=chunk_bp)
+        bp_bins = [0, 1_000, 5_000]  # max_dist 5kb << 25kb chunk
+        e = eager.compute_ld_statistics_gpu_single_pop(bp_bins)
+        s = stream.compute_ld_statistics_gpu_single_pop(bp_bins)
+        _assert_single_pop_equivalent(e, s)
+
+    def test_cross_chunk_pairs_counted(self, vcz_store):
+        # max_bp_dist == chunk_bp guarantees that any chunk's right
+        # half feeds the next chunk's tail. Eager vs streaming must
+        # still agree on every bin -- this is the test that exercises
+        # the tail-buffer pair set.
+        eager, stream = _aligned_single_pop_pair(vcz_store, chunk_bp=10_000)
+        bp_bins = [0, 2_500, 5_000, 10_000]
+        e = eager.compute_ld_statistics_gpu_single_pop(bp_bins)
+        s = stream.compute_ld_statistics_gpu_single_pop(bp_bins)
+        _assert_single_pop_equivalent(e, s)
+
+    def test_raw_sums_parity(self, vcz_store):
+        # raw=True returns per-bin numerator sums. Sum-reducibility is
+        # the strongest claim we make; verify it directly without the
+        # final divide.
+        eager, stream = _aligned_single_pop_pair(vcz_store, chunk_bp=20_000)
+        bp_bins = [0, 5_000, 15_000]
+        e = eager.compute_ld_statistics_gpu_single_pop(bp_bins, raw=True)
+        s = stream.compute_ld_statistics_gpu_single_pop(bp_bins, raw=True)
+        _assert_single_pop_equivalent(e, s)
+
+    def test_ac_filter_parity(self, vcz_store):
+        # Per-chunk apply_biallelic_filter must produce the same kept
+        # variants as the global filter on the eager matrix, because
+        # the filter looks only at allele counts at each variant.
+        eager, stream = _aligned_single_pop_pair(vcz_store, chunk_bp=10_000)
+        bp_bins = [0, 2_500, 7_500]
+        e = eager.compute_ld_statistics_gpu_single_pop(bp_bins, ac_filter=True)
+        s = stream.compute_ld_statistics_gpu_single_pop(bp_bins, ac_filter=True)
+        _assert_single_pop_equivalent(e, s)
+
+    def test_chunk_bp_smaller_than_max_dist(self, vcz_store):
+        # When the chunk width is smaller than max_bp_dist, the tail
+        # buffer ends up spanning multiple prior chunks. The carry-over
+        # logic must still keep every variant whose position is within
+        # max_dist of the right edge.
+        eager, stream = _aligned_single_pop_pair(vcz_store, chunk_bp=5_000)
+        bp_bins = [0, 5_000, 15_000]
+        e = eager.compute_ld_statistics_gpu_single_pop(bp_bins)
+        s = stream.compute_ld_statistics_gpu_single_pop(bp_bins)
+        _assert_single_pop_equivalent(e, s)
+
+
+class TestTwoPopParity:
+
+    def test_parity_single_chunk(self, two_pop_vcz_store):
+        path, popfile = two_pop_vcz_store
+        eager, stream = _aligned_two_pop_pair(path, popfile, chunk_bp=50_000)
+        bp_bins = [0, 1_000, 5_000]
+        e = eager.compute_ld_statistics_gpu_two_pops(bp_bins, "pop1", "pop2")
+        s = stream.compute_ld_statistics_gpu_two_pops(bp_bins, "pop1", "pop2")
+        _assert_two_pop_equivalent(e, s)
+
+    def test_cross_chunk_pairs_counted(self, two_pop_vcz_store):
+        path, popfile = two_pop_vcz_store
+        eager, stream = _aligned_two_pop_pair(path, popfile, chunk_bp=10_000)
+        bp_bins = [0, 2_500, 5_000, 10_000]
+        e = eager.compute_ld_statistics_gpu_two_pops(bp_bins, "pop1", "pop2")
+        s = stream.compute_ld_statistics_gpu_two_pops(bp_bins, "pop1", "pop2")
+        _assert_two_pop_equivalent(e, s)
+
+    def test_raw_sums_parity(self, two_pop_vcz_store):
+        path, popfile = two_pop_vcz_store
+        eager, stream = _aligned_two_pop_pair(path, popfile, chunk_bp=20_000)
+        bp_bins = [0, 5_000, 15_000]
+        e = eager.compute_ld_statistics_gpu_two_pops(
+            bp_bins, "pop1", "pop2", raw=True,
+        )
+        s = stream.compute_ld_statistics_gpu_two_pops(
+            bp_bins, "pop1", "pop2", raw=True,
+        )
+        _assert_two_pop_equivalent(e, s)
+
+    def test_ac_filter_parity(self, two_pop_vcz_store):
+        path, popfile = two_pop_vcz_store
+        eager, stream = _aligned_two_pop_pair(path, popfile, chunk_bp=10_000)
+        bp_bins = [0, 2_500, 7_500]
+        e = eager.compute_ld_statistics_gpu_two_pops(
+            bp_bins, "pop1", "pop2", ac_filter=True,
+        )
+        s = stream.compute_ld_statistics_gpu_two_pops(
+            bp_bins, "pop1", "pop2", ac_filter=True,
+        )
+        _assert_two_pop_equivalent(e, s)

--- a/tests/test_streaming_ld.py
+++ b/tests/test_streaming_ld.py
@@ -202,3 +202,17 @@ class TestTwoPopParity:
             bp_bins, "pop1", "pop2", ac_filter=True,
         )
         _assert_two_pop_equivalent(e, s)
+
+    def test_chunk_bp_smaller_than_max_dist(self, two_pop_vcz_store):
+        # max_bp_dist exceeds chunk_bp, so a chunk's tail buffer must
+        # span more than one earlier chunk to keep every cross-chunk
+        # pair counted exactly once. The single-pop class has the same
+        # test at TestSinglePopParity.test_chunk_bp_smaller_than_max_dist;
+        # this is its two-pop twin so the tail-buffer logic is checked
+        # under the 15-stat batch path too.
+        path, popfile = two_pop_vcz_store
+        eager, stream = _aligned_two_pop_pair(path, popfile, chunk_bp=5_000)
+        bp_bins = [0, 5_000, 15_000]
+        e = eager.compute_ld_statistics_gpu_two_pops(bp_bins, "pop1", "pop2")
+        s = stream.compute_ld_statistics_gpu_two_pops(bp_bins, "pop1", "pop2")
+        _assert_two_pop_equivalent(e, s)

--- a/tests/test_streaming_vs_allel.py
+++ b/tests/test_streaming_vs_allel.py
@@ -22,12 +22,23 @@ from pg_gpu import HaplotypeMatrix, windowed_analysis
 
 @pytest.fixture
 def vcz_store(tmp_path):
-    """A small msprime-derived VCZ store with samples named."""
+    """A small msprime-derived VCZ store with samples named.
+
+    Uses msprime's binary mutation model: pg_gpu's pi formula treats
+    every site as biallelic (counts the sum of int8 values as the
+    derived allele count), so on a triallelic site with hap values in
+    {0, 1, 2} the count is off and pg_gpu disagrees with allel by ~1%
+    per window. That disagreement is a pre-existing pg_gpu vs allel
+    issue on multiallelic data, not anything streaming-specific; the
+    binary model sidesteps it so this test isolates the streaming
+    dispatch.
+    """
     ts = msprime.sim_ancestry(
         samples=20, sequence_length=100_000,
         recombination_rate=1e-4, random_seed=42, ploidy=2,
     )
-    ts = msprime.sim_mutations(ts, rate=1e-3, random_seed=42)
+    ts = msprime.sim_mutations(ts, rate=1e-3, random_seed=42,
+                               model="binary")
     hm = HaplotypeMatrix.from_ts(ts)
     hm.samples = [f"s{i}" for i in range(hm.num_haplotypes // 2)]
     path = str(tmp_path / "trio.vcz")
@@ -94,23 +105,23 @@ class TestStreamingVsAllel:
                                    df_s["pi"].to_numpy(),
                                    rtol=1e-6, atol=1e-9)
 
-        # eager vs allel: same magnitudes, within boundary-convention
-        # tolerance. The 1% rtol is much wider than the typical
-        # eager-vs-allel scalar agreement (~1e-8 on the existing
-        # comparison tests in test_scikit_allel_comparison.py); the
-        # gap comes entirely from how each library assigns a variant
-        # to a window when its position equals a boundary.
+        # eager vs allel: on binary-only data the two libraries
+        # compute the same per-variant pi and agree to FP precision.
+        # The tolerance is loose only because allel and pg_gpu place
+        # one boundary differently for the last window (pg_gpu clips
+        # at chrom_end while allel rounds up to stop), giving a
+        # ~1.5% per-bp difference on that single window.
         ok = np.isfinite(pi_allel)
         np.testing.assert_allclose(
             df_e["pi"].to_numpy()[: len(pi_allel)][ok], pi_allel[ok],
-            rtol=5e-2, atol=1e-7,
+            rtol=2e-2, atol=1e-7,
             err_msg="pg_gpu vs allel windowed pi disagree beyond "
-                    "the boundary-convention envelope; check for a "
+                    "the last-window-boundary envelope; check for a "
                     "real regression",
         )
         # streaming vs allel follows from the two above; assert it
         # explicitly so a failure is unambiguous about which leg drifted.
         np.testing.assert_allclose(
             df_s["pi"].to_numpy()[: len(pi_allel)][ok], pi_allel[ok],
-            rtol=5e-2, atol=1e-7,
+            rtol=2e-2, atol=1e-7,
         )

--- a/tests/test_streaming_vs_allel.py
+++ b/tests/test_streaming_vs_allel.py
@@ -1,0 +1,116 @@
+"""End-to-end parity: streaming + eager + scikit-allel on the same data.
+
+The streaming-equivalence tests in ``test_streaming_kernels.py`` prove
+``windowed_analysis(streaming) == windowed_analysis(eager)``. The
+existing ``test_scikit_allel_comparison.py`` proves the eager scalar
+stats match scikit-allel. This module closes the triangle: a small
+msprime + VCZ fixture is windowed three ways (allel, pg_gpu eager,
+pg_gpu streaming) and all three numbers have to agree per window.
+
+The point is to catch any drift in the streaming dispatch that the
+eager-vs-streaming check would miss because eager and streaming share
+a bug in the underlying kernel.
+"""
+
+import msprime
+import numpy as np
+import allel
+import pytest
+
+from pg_gpu import HaplotypeMatrix, windowed_analysis
+
+
+@pytest.fixture
+def vcz_store(tmp_path):
+    """A small msprime-derived VCZ store with samples named."""
+    ts = msprime.sim_ancestry(
+        samples=20, sequence_length=100_000,
+        recombination_rate=1e-4, random_seed=42, ploidy=2,
+    )
+    ts = msprime.sim_mutations(ts, rate=1e-3, random_seed=42)
+    hm = HaplotypeMatrix.from_ts(ts)
+    hm.samples = [f"s{i}" for i in range(hm.num_haplotypes // 2)]
+    path = str(tmp_path / "trio.vcz")
+    hm.to_zarr(path, format="vcz", contig_name="1")
+    return path, hm
+
+
+def _aligned(vcz_path):
+    eager = HaplotypeMatrix.from_zarr(vcz_path, streaming="never")
+    stream = HaplotypeMatrix.from_zarr(vcz_path, streaming="always",
+                                       chunk_bp=10_000)
+    eager.chrom_start = stream.chrom_start
+    eager.chrom_end = stream.chrom_end
+    return eager, stream
+
+
+def _allel_windowed_diversity(eager, window_size):
+    """Run allel.windowed_diversity over the same grid pg_gpu uses.
+
+    pg_gpu's per-window pi is sum(per-base contributions) / span. allel's
+    ``windowed_diversity`` does the same thing with the same convention,
+    so the two should agree window-by-window inside floating-point tolerance.
+    """
+    import cupy as cp
+    haps = cp.asnumpy(eager.haplotypes)        # (n_hap, n_var)
+    positions = cp.asnumpy(eager.positions)    # (n_var,)
+    h = allel.HaplotypeArray(haps.T)           # allel uses (n_var, n_hap)
+    ac = h.count_alleles()
+    pi, _, _, _ = allel.windowed_diversity(
+        positions, ac,
+        size=window_size, start=eager.chrom_start,
+        stop=eager.chrom_end,
+    )
+    return pi
+
+
+class TestStreamingVsAllel:
+
+    def test_pi_three_way(self, vcz_store):
+        """allel ≈ eager == streaming for windowed pi.
+
+        Eager and streaming must agree byte-for-byte -- that's the
+        streaming dispatch contract. Both must agree with scikit-allel
+        within ~1% relative error: allel uses inclusive [start, stop]
+        windows and pg_gpu uses half-open [start, stop), so a variant
+        whose position lies exactly on a window boundary lands in
+        different windows under the two conventions. Most windows
+        agree to ULP scale; the rest differ by a single boundary
+        variant's contribution.
+        """
+        path, _ = vcz_store
+        eager, stream = _aligned(path)
+        pi_allel = _allel_windowed_diversity(eager, window_size=5_000)
+
+        df_e = windowed_analysis(eager, window_size=5_000, statistics=["pi"])
+        df_s = windowed_analysis(stream, window_size=5_000, statistics=["pi"])
+
+        # streaming vs eager: same numbers up to ULP-scale rounding.
+        # The kernel-parity test in test_streaming_kernels covers this
+        # already at rtol=1e-6; re-asserting here makes the failure
+        # mode obvious if streaming drifts from eager independently
+        # of allel.
+        np.testing.assert_allclose(df_e["pi"].to_numpy(),
+                                   df_s["pi"].to_numpy(),
+                                   rtol=1e-6, atol=1e-9)
+
+        # eager vs allel: same magnitudes, within boundary-convention
+        # tolerance. The 1% rtol is much wider than the typical
+        # eager-vs-allel scalar agreement (~1e-8 on the existing
+        # comparison tests in test_scikit_allel_comparison.py); the
+        # gap comes entirely from how each library assigns a variant
+        # to a window when its position equals a boundary.
+        ok = np.isfinite(pi_allel)
+        np.testing.assert_allclose(
+            df_e["pi"].to_numpy()[: len(pi_allel)][ok], pi_allel[ok],
+            rtol=5e-2, atol=1e-7,
+            err_msg="pg_gpu vs allel windowed pi disagree beyond "
+                    "the boundary-convention envelope; check for a "
+                    "real regression",
+        )
+        # streaming vs allel follows from the two above; assert it
+        # explicitly so a failure is unambiguous about which leg drifted.
+        np.testing.assert_allclose(
+            df_s["pi"].to_numpy()[: len(pi_allel)][ok], pi_allel[ok],
+            rtol=5e-2, atol=1e-7,
+        )

--- a/tests/test_streaming_vs_allel.py
+++ b/tests/test_streaming_vs_allel.py
@@ -12,12 +12,13 @@ eager-vs-streaming check would miss because eager and streaming share
 a bug in the underlying kernel.
 """
 
-import msprime
 import numpy as np
 import allel
 import pytest
 
 from pg_gpu import HaplotypeMatrix, windowed_analysis
+
+from .conftest import simulate_hm
 
 
 @pytest.fixture
@@ -25,21 +26,12 @@ def vcz_store(tmp_path):
     """A small msprime-derived VCZ store with samples named.
 
     Uses msprime's binary mutation model: pg_gpu's pi formula treats
-    every site as biallelic (counts the sum of int8 values as the
-    derived allele count), so on a triallelic site with hap values in
-    {0, 1, 2} the count is off and pg_gpu disagrees with allel by ~1%
-    per window. That disagreement is a pre-existing pg_gpu vs allel
-    issue on multiallelic data, not anything streaming-specific; the
-    binary model sidesteps it so this test isolates the streaming
+    every site as biallelic and disagrees with allel by ~1% per
+    window on triallelic data (kr-colab/pg_gpu#100). Binary
+    mutations sidestep that gap so this test isolates the streaming
     dispatch.
     """
-    ts = msprime.sim_ancestry(
-        samples=20, sequence_length=100_000,
-        recombination_rate=1e-4, random_seed=42, ploidy=2,
-    )
-    ts = msprime.sim_mutations(ts, rate=1e-3, random_seed=42,
-                               model="binary")
-    hm = HaplotypeMatrix.from_ts(ts)
+    hm = simulate_hm(seq_length=100_000, mutation_model="binary")
     hm.samples = [f"s{i}" for i in range(hm.num_haplotypes // 2)]
     path = str(tmp_path / "trio.vcz")
     hm.to_zarr(path, format="vcz", contig_name="1")

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -899,3 +899,47 @@ class TestCanonicalWindowSchema:
                                statistics=['garud_h12'])
         np.testing.assert_array_equal(
             df['window_id'].to_numpy(), np.arange(len(df)))
+
+
+class TestWindowedGarudCorrectness:
+    """Anchor windowed Garud H against scikit-allel's per-window
+    garud_h. ``pg_gpu`` runs the windowed pass on the GPU via a fused
+    kernel; this confirms each window's H1 / H12 / H123 / H2H1 lines
+    up with the canonical implementation."""
+
+    @pytest.mark.parametrize("seed", [1, 2, 3])
+    def test_matches_allel_per_window(self, seed):
+        import allel
+        rng = np.random.default_rng(seed)
+        n_hap = 32
+        n_var = 600
+        window_size_var = 50  # variants per window
+        # Use unit-stride positions so window_size_var-many variants
+        # land in each tile window.
+        positions = np.arange(n_var, dtype=np.int64)
+        chrom_len = int(positions[-1]) + 1
+        haps = rng.integers(0, 2, (n_hap, n_var), dtype=np.int8)
+
+        hm = HaplotypeMatrix(haps, positions, 0, chrom_len)
+        df = windowed_analysis(hm,
+                               window_size=window_size_var,
+                               step_size=window_size_var,
+                               window_type="snp",
+                               statistics=["garud_h1", "garud_h12",
+                                            "garud_h123", "garud_h2h1"])
+
+        # Each tile window is exactly window_size_var variants on the
+        # contiguous range; allel.garud_h expects (n_var, n_hap).
+        for w, row in df.iterrows():
+            v_lo = w * window_size_var
+            v_hi = v_lo + window_size_var
+            h_allel = haps[:, v_lo:v_hi].T.astype(np.int8)
+            h1_a, h12_a, h123_a, h2h1_a = allel.garud_h(h_allel)
+            np.testing.assert_allclose(row["garud_h1"], h1_a, rtol=1e-9,
+                                        err_msg=f"H1 window {w}")
+            np.testing.assert_allclose(row["garud_h12"], h12_a, rtol=1e-9,
+                                        err_msg=f"H12 window {w}")
+            np.testing.assert_allclose(row["garud_h123"], h123_a, rtol=1e-9,
+                                        err_msg=f"H123 window {w}")
+            np.testing.assert_allclose(row["garud_h2h1"], h2h1_a, rtol=1e-9,
+                                        err_msg=f"H2H1 window {w}")

--- a/tests/test_zarr_io.py
+++ b/tests/test_zarr_io.py
@@ -9,7 +9,8 @@ import cupy as cp
 
 from pg_gpu import HaplotypeMatrix, GenotypeMatrix
 from pg_gpu.zarr_io import (
-    detect_zarr_layout, read_genotypes, write_vcz, write_allel, vcf_to_zarr,
+    allel_zarr_to_vcz, detect_zarr_layout, read_genotypes,
+    vcf_to_zarr, write_allel, write_vcz,
 )
 
 
@@ -441,3 +442,136 @@ class TestEdgeCases:
         hm = HaplotypeMatrix.from_zarr(path)
         assert hm.num_variants == 5
         assert np.all(hm.haplotypes == -1)
+
+
+# ── scikit-allel -> vcz conversion ──────────────────────────────────────
+
+
+class TestAllelZarrToVcz:
+
+    def _read_vcz_gt(self, path):
+        """Return (gt, positions, samples, contig_id) from a vcz store."""
+        store = zarr.open(path, mode='r')
+        gt = np.asarray(store['call_genotype'][:])
+        pos = np.asarray(store['variant_position'][:])
+        samples = (np.asarray(store['sample_id'][:])
+                   if 'sample_id' in store else None)
+        contig = np.asarray(store['contig_id'][:])[0]
+        return gt, pos, samples, contig
+
+    def _named_allel_store(self, tmp_path, name="named.allel.zarr"):
+        # Build a small allel store with explicit sample names so the
+        # round-trip test can verify they survive the conversion. The
+        # shared ``allel_store`` fixture is built from a bare msprime
+        # HaplotypeMatrix that has no ``.samples`` attribute set.
+        hm = _simulate_hm()
+        n_dip = hm.num_haplotypes // 2
+        gt = HaplotypeMatrix._haplotypes_to_gt(hm.haplotypes)
+        pos = np.asarray(hm.positions)
+        samples = [f"s{i}" for i in range(n_dip)]
+        path = str(tmp_path / name)
+        write_allel(path, gt, pos, samples=samples)
+        return path, gt, pos, samples
+
+    def test_flat_layout_roundtrip(self, tmp_path):
+        # Convert an allel store with samples set, then re-read the vcz
+        # output and check GT / positions / samples round-trip
+        # byte-for-byte (modulo dtype: vcz keeps int8 / int32).
+        src_path, src_gt, src_pos, src_samples = self._named_allel_store(
+            tmp_path
+        )
+        out = str(tmp_path / "out.vcz")
+        allel_zarr_to_vcz(src_path, out, contig='chr1')
+
+        gt, pos, samples, contig = self._read_vcz_gt(out)
+        np.testing.assert_array_equal(gt, src_gt.astype(np.int8))
+        np.testing.assert_array_equal(pos, src_pos.astype(np.int32))
+        np.testing.assert_array_equal(samples, src_samples)
+        assert contig == 'chr1'
+
+    def test_grouped_layout_one_contig(self, tmp_path, grouped_store):
+        src = zarr.open(grouped_store, mode='r')
+        src_gt = np.asarray(src['chr2/calldata/GT'][:])
+        src_pos = np.asarray(src['chr2/variants/POS'][:])
+
+        out = str(tmp_path / "g.vcz")
+        allel_zarr_to_vcz(grouped_store, out, contig='chr2')
+
+        gt, pos, _, contig = self._read_vcz_gt(out)
+        np.testing.assert_array_equal(gt, src_gt.astype(np.int8))
+        np.testing.assert_array_equal(pos, src_pos.astype(np.int32))
+        assert contig == 'chr2'
+
+    def test_grouped_requires_contig(self, tmp_path, grouped_store):
+        with pytest.raises(ValueError, match="requires contig"):
+            allel_zarr_to_vcz(grouped_store, str(tmp_path / "x.vcz"))
+
+    def test_region_filter(self, tmp_path, allel_store):
+        # Take an interior region by position and check it matches the
+        # equivalent positional slice of the source.
+        src = zarr.open(allel_store, mode='r')
+        src_pos = np.asarray(src['variants/POS'][:])
+        # Pick the middle 50% of the position range.
+        lo = int(np.quantile(src_pos, 0.25))
+        hi = int(np.quantile(src_pos, 0.75))
+        keep = (src_pos >= lo) & (src_pos < hi)
+
+        out = str(tmp_path / "region.vcz")
+        allel_zarr_to_vcz(allel_store, out, contig='chr1',
+                          region=f"chr1:{lo}-{hi}")
+
+        gt, pos, _, _ = self._read_vcz_gt(out)
+        np.testing.assert_array_equal(pos, src_pos[keep].astype(np.int32))
+        expected = np.asarray(src['calldata/GT'][:])[keep]
+        np.testing.assert_array_equal(gt, expected.astype(np.int8))
+
+    def test_call_genotype_uses_sample_axis_chunks(self, tmp_path,
+                                                    allel_store):
+        # The pg_gpu streaming reader's kvikio backend reads call_genotype
+        # one (variant_chunk, sample_chunk, 2) block at a time. Verify the
+        # output store carries that chunking rather than zarr's
+        # whole-array-as-one-chunk default.
+        out = str(tmp_path / "chunks.vcz")
+        allel_zarr_to_vcz(allel_store, out, contig='chr1',
+                          variant_chunk=4, sample_chunk=2)
+        store = zarr.open(out, mode='r')
+        cg = store['call_genotype']
+        assert cg.chunks[0] == 4
+        assert cg.chunks[1] == 2
+        assert cg.chunks[2] == 2
+
+    def test_call_genotype_mask_matches(self, tmp_path):
+        # Build a small allel store that has an explicit missing cell and
+        # check the converter's call_genotype_mask is True there only.
+        path = str(tmp_path / "with_miss.allel.zarr")
+        gt = np.array([
+            [[0, 1], [-1, 0], [1, 1]],
+            [[0, 0], [1, 1], [0, -1]],
+        ], dtype=np.int8)
+        pos = np.array([100, 200], dtype=np.int32)
+        write_allel(path, gt, pos, samples=['a', 'b', 'c'])
+        out = str(tmp_path / "with_miss.vcz")
+        allel_zarr_to_vcz(path, out, contig='chr9')
+        store = zarr.open(out, mode='r')
+        mask = np.asarray(store['call_genotype_mask'][:])
+        expected = (gt < 0)
+        np.testing.assert_array_equal(mask, expected)
+
+    def test_round_trip_through_from_zarr(self, tmp_path, allel_store):
+        # The whole point of the converter: the vcz output should be
+        # consumable by HaplotypeMatrix.from_zarr -- including the
+        # streaming path that only accepts vcz layout.
+        out = str(tmp_path / "rt.vcz")
+        allel_zarr_to_vcz(allel_store, out, contig='chr1')
+        hm = HaplotypeMatrix.from_zarr(out, streaming='never')
+        # Equivalent eager load from the original allel store as the
+        # baseline; both go through the same haplotype-layout build.
+        hm_src = HaplotypeMatrix.from_zarr(allel_store)
+        np.testing.assert_array_equal(_host(hm.haplotypes),
+                                      _host(hm_src.haplotypes))
+        np.testing.assert_array_equal(_host(hm.positions),
+                                      _host(hm_src.positions))
+
+    def test_rejects_vcz_input(self, tmp_path, vcz_store):
+        with pytest.raises(ValueError, match="already vcz"):
+            allel_zarr_to_vcz(vcz_store, str(tmp_path / "x.vcz"))

--- a/tests/test_zarr_io.py
+++ b/tests/test_zarr_io.py
@@ -204,8 +204,10 @@ class TestGenotypeMatrixRoundTrip:
         path = str(tmp_path / "gm.vcz.zarr")
         gm.to_zarr(path, format='vcz', contig_name='chr1')
         gm2 = GenotypeMatrix.from_zarr(path)
-        np.testing.assert_array_equal(gm.genotypes, gm2.genotypes)
-        np.testing.assert_array_equal(gm.positions, gm2.positions)
+        np.testing.assert_array_equal(_host(gm.genotypes),
+                                      _host(gm2.genotypes))
+        np.testing.assert_array_equal(_host(gm.positions),
+                                      _host(gm2.positions))
 
     def test_allel_roundtrip(self, tmp_path, hm):
         from pg_gpu.genotype_matrix import GenotypeMatrix
@@ -213,7 +215,8 @@ class TestGenotypeMatrixRoundTrip:
         path = str(tmp_path / "gm.allel.zarr")
         gm.to_zarr(path, format='scikit-allel')
         gm2 = GenotypeMatrix.from_zarr(path)
-        np.testing.assert_array_equal(gm.genotypes, gm2.genotypes)
+        np.testing.assert_array_equal(_host(gm.genotypes),
+                                      _host(gm2.genotypes))
 
 
 # ── Region Queries ──────────────────────────────────────────────────────
@@ -327,7 +330,8 @@ class TestMissingData:
         path = str(tmp_path / "gm_missing.vcz.zarr")
         gm_missing.to_zarr(path, format='vcz', contig_name='chr1')
         gm2 = GenotypeMatrix.from_zarr(path)
-        np.testing.assert_array_equal(gm_missing.genotypes, gm2.genotypes)
+        np.testing.assert_array_equal(_host(gm_missing.genotypes),
+                                      _host(gm2.genotypes))
 
 
 # ── vcf_to_zarr ─────────────────────────────────────────────────────────

--- a/tests/test_zarr_io.py
+++ b/tests/test_zarr_io.py
@@ -5,10 +5,20 @@ import pytest
 import zarr
 import msprime
 
+import cupy as cp
+
 from pg_gpu import HaplotypeMatrix, GenotypeMatrix
 from pg_gpu.zarr_io import (
     detect_zarr_layout, read_genotypes, write_vcz, write_allel, vcf_to_zarr,
 )
+
+
+def _host(arr):
+    """Bring an array back to the host for byte-equal comparison. from_zarr
+    returns GPU haplotypes after the GPU-side prep refactor; round-trip
+    tests compare against a host-built msprime hm, so callers need to be
+    explicit about which device they're on."""
+    return cp.asnumpy(arr) if isinstance(arr, cp.ndarray) else arr
 
 
 # ── Fixtures ────────────────────────────────────────────────────────────
@@ -105,20 +115,20 @@ class TestHaplotypeMatrixRoundTrip:
         path = str(tmp_path / "rt.vcz.zarr")
         hm.to_zarr(path, format='vcz', contig_name='chr1')
         hm2 = HaplotypeMatrix.from_zarr(path)
-        np.testing.assert_array_equal(hm.haplotypes, hm2.haplotypes)
-        np.testing.assert_array_equal(hm.positions, hm2.positions)
+        np.testing.assert_array_equal(_host(hm.haplotypes), _host(hm2.haplotypes))
+        np.testing.assert_array_equal(_host(hm.positions), _host(hm2.positions))
 
     def test_allel_roundtrip(self, tmp_path, hm):
         path = str(tmp_path / "rt.allel.zarr")
         hm.to_zarr(path, format='scikit-allel')
         hm2 = HaplotypeMatrix.from_zarr(path)
-        np.testing.assert_array_equal(hm.haplotypes, hm2.haplotypes)
-        np.testing.assert_array_equal(hm.positions, hm2.positions)
+        np.testing.assert_array_equal(_host(hm.haplotypes), _host(hm2.haplotypes))
+        np.testing.assert_array_equal(_host(hm.positions), _host(hm2.positions))
 
     def test_cross_format_read(self, allel_store, hm):
         """Write in allel format, read with auto-detect."""
         hm2 = HaplotypeMatrix.from_zarr(allel_store)
-        np.testing.assert_array_equal(hm.haplotypes, hm2.haplotypes)
+        np.testing.assert_array_equal(_host(hm.haplotypes), _host(hm2.haplotypes))
 
     def test_samples_preserved(self, tmp_path):
         """Verify sample names survive round-trip when present."""
@@ -134,6 +144,53 @@ class TestHaplotypeMatrixRoundTrip:
     def test_invalid_format_raises(self, tmp_path, hm):
         with pytest.raises(ValueError, match="Unknown format"):
             hm.to_zarr(str(tmp_path / "bad.zarr"), format='hdf5')
+
+
+class TestPopFileKwarg:
+
+    def _write_pops_tsv(self, path, n_dip):
+        with open(path, "w") as f:
+            f.write("sample\tpop\n")
+            half = n_dip // 2
+            for i in range(half):
+                f.write(f"sample_{i}\tpop1\n")
+            for i in range(half, n_dip):
+                f.write(f"sample_{i}\tpop2\n")
+
+    def _hm_with_samples(self, tmp_path, name):
+        hm = _simulate_hm()
+        n_dip = hm.num_haplotypes // 2
+        hm.samples = [f"sample_{i}" for i in range(n_dip)]
+        path = str(tmp_path / name)
+        hm.to_zarr(path, format='vcz', contig_name='chr1')
+        return path, n_dip
+
+    def test_explicit_pop_file(self, tmp_path):
+        path, n_dip = self._hm_with_samples(tmp_path, "explicit.vcz")
+        popfile = str(tmp_path / "pops.tsv")
+        self._write_pops_tsv(popfile, n_dip)
+        hm = HaplotypeMatrix.from_zarr(path, pop_file=popfile)
+        assert set(hm.sample_sets.keys()) == {"pop1", "pop2"}
+
+    def test_companion_auto_load(self, tmp_path, capsys):
+        path, n_dip = self._hm_with_samples(tmp_path, "auto.vcz")
+        self._write_pops_tsv(path + ".pops.tsv", n_dip)
+        hm = HaplotypeMatrix.from_zarr(path)
+        assert hm.sample_sets is not None
+        assert "auto-loaded" in capsys.readouterr().err
+
+    def test_pop_file_false_disables_companion(self, tmp_path):
+        path, n_dip = self._hm_with_samples(tmp_path, "disabled.vcz")
+        self._write_pops_tsv(path + ".pops.tsv", n_dip)
+        hm = HaplotypeMatrix.from_zarr(path, pop_file=False)
+        # _sample_sets stays None; the .sample_sets property then returns
+        # the default {"all": [...]} fallback rather than custom pops.
+        assert hm._sample_sets is None
+
+    def test_no_companion_no_pop_file(self, tmp_path):
+        path, _ = self._hm_with_samples(tmp_path, "none.vcz")
+        hm = HaplotypeMatrix.from_zarr(path)
+        assert hm._sample_sets is None
 
 
 # ── GenotypeMatrix Round-Trip ───────────────────────────────────────────
@@ -237,7 +294,8 @@ class TestMissingData:
         path = str(tmp_path / "missing.vcz.zarr")
         hm_missing.to_zarr(path, format='vcz', contig_name='chr1')
         hm2 = HaplotypeMatrix.from_zarr(path)
-        np.testing.assert_array_equal(hm_missing.haplotypes, hm2.haplotypes)
+        np.testing.assert_array_equal(_host(hm_missing.haplotypes),
+                                      _host(hm2.haplotypes))
 
     def test_genotype_mask_written(self, tmp_path):
         """Verify call_genotype_mask reflects missing values."""

--- a/tests/test_zarr_source.py
+++ b/tests/test_zarr_source.py
@@ -174,6 +174,33 @@ class TestSliceSubsample:
         assert gm.shape == (0, 2)
         assert pos.shape == (0,)
 
+    def test_to_gpu_matches_host(self, vcz_store):
+        import cupy as cp
+        path, _ = vcz_store
+        src = ZarrGenotypeSource(path)
+        n_dip = src.num_diploids
+        cols = np.array([0, 1, 2, n_dip, n_dip + 1], dtype=np.int64)
+        gm_host, pos_host = src.slice_subsample(
+            0, src.mappable_hi, cols, to_gpu=False
+        )
+        gm_gpu, pos_gpu = src.slice_subsample(
+            0, src.mappable_hi, cols, to_gpu=True
+        )
+        assert isinstance(gm_gpu, cp.ndarray)
+        np.testing.assert_array_equal(cp.asnumpy(gm_gpu), gm_host)
+        np.testing.assert_array_equal(pos_gpu, pos_host)
+
+    def test_to_gpu_empty_region(self, vcz_store):
+        import cupy as cp
+        path, _ = vcz_store
+        src = ZarrGenotypeSource(path)
+        gm, pos = src.slice_subsample(
+            0, max(0, src.mappable_lo - 1), np.array([0, 1]), to_gpu=True,
+        )
+        assert isinstance(gm, cp.ndarray)
+        assert gm.shape == (0, 2)
+        assert pos.shape == (0,)
+
 
 class TestIterChunks:
 

--- a/tests/test_zarr_source.py
+++ b/tests/test_zarr_source.py
@@ -92,7 +92,7 @@ class TestConstruction:
 
     def test_multi_contig_requires_pick(self, multi_contig_store):
         path, _, _ = multi_contig_store
-        with pytest.raises(ValueError, match="multiple contigs"):
+        with pytest.raises(ValueError, match="contigs"):
             ZarrGenotypeSource(path)
 
     def test_multi_contig_with_contig_id(self, multi_contig_store):

--- a/tests/test_zarr_source.py
+++ b/tests/test_zarr_source.py
@@ -264,3 +264,44 @@ class TestPopFileResolution:
             src = ZarrGenotypeSource(path, pop_file=bad_pop)
         assert "pop1" in src.pop_cols
         assert "pop2" not in src.pop_cols
+
+    def test_pop_file_accepts_dict(self, vcz_store):
+        path, _ = vcz_store
+        src = ZarrGenotypeSource(
+            path, pop_file={f"s{i}": "pop1" if i < 5 else "pop2"
+                            for i in range(20)},
+        )
+        assert set(src.pop_cols.keys()) == {"pop1", "pop2"}
+        # pop1 = first 5 diploids -> haps [0..5) plus [n_dip..n_dip+5)
+        n_dip = src.num_diploids
+        expected1 = np.concatenate([np.arange(5), np.arange(5) + n_dip])
+        np.testing.assert_array_equal(np.sort(src.pop_cols["pop1"]),
+                                       expected1)
+
+    def test_pop_file_accepts_array(self, vcz_store):
+        path, _ = vcz_store
+        # 20 diploids in the fixture; first 12 are pop1, rest pop2.
+        labels = np.array(["pop1"] * 12 + ["pop2"] * 8)
+        src = ZarrGenotypeSource(path, pop_file=labels)
+        assert set(src.pop_cols.keys()) == {"pop1", "pop2"}
+        n_dip = src.num_diploids
+        expected1 = np.concatenate([np.arange(12), np.arange(12) + n_dip])
+        np.testing.assert_array_equal(np.sort(src.pop_cols["pop1"]),
+                                       expected1)
+
+    def test_pop_file_rejects_mismatched_array_length(self, vcz_store):
+        path, _ = vcz_store
+        with pytest.raises(ValueError, match="does not match sample"):
+            ZarrGenotypeSource(path, pop_file=np.array(["pop1", "pop2"]))
+
+    def test_pop_file_accepts_zarr_key(self, vcz_store):
+        path, _ = vcz_store
+        # Stamp a 1-D population array onto the store under a non-VCZ
+        # key, then look it up by name. Mirrors the case where bio2zarr
+        # was extended with a sample-axis population field.
+        store = zarr.open_group(path, mode="r+")
+        labels = np.array(["pop1"] * 12 + ["pop2"] * 8)
+        store.create_array("sample_population", shape=labels.shape,
+                            dtype="<U8")[:] = labels
+        src = ZarrGenotypeSource(path, pop_file="sample_population")
+        assert set(src.pop_cols.keys()) == {"pop1", "pop2"}

--- a/tests/test_zarr_source.py
+++ b/tests/test_zarr_source.py
@@ -1,0 +1,239 @@
+"""Tests for ZarrGenotypeSource: chunked + subset reads on a VCZ store."""
+
+import msprime
+import numpy as np
+import pytest
+import zarr
+
+from pg_gpu import HaplotypeMatrix
+from pg_gpu.zarr_source import ZarrGenotypeSource
+
+
+def _simulate_hm(n_samples=20, seq_length=50_000, seed=42):
+    """Build a HaplotypeMatrix with msprime, matching test_zarr_io.py's style."""
+    ts = msprime.sim_ancestry(
+        samples=n_samples, sequence_length=seq_length,
+        recombination_rate=1e-4, random_seed=seed, ploidy=2,
+    )
+    ts = msprime.sim_mutations(ts, rate=1e-3, random_seed=seed)
+    return HaplotypeMatrix.from_ts(ts)
+
+
+@pytest.fixture
+def vcz_store(tmp_path):
+    """Write a single-contig VCZ store with stable sample names."""
+    hm = _simulate_hm()
+    if hm.samples is None:
+        hm.samples = [f"s{i}" for i in range(hm.num_haplotypes // 2)]
+    path = str(tmp_path / "test.vcz")
+    hm.to_zarr(path, format="vcz", contig_name="1")
+    return path, hm
+
+
+@pytest.fixture
+def multi_contig_store(tmp_path):
+    """Two VCZ groups merged into one store so the multi-contig branch is hit.
+    The cleanest way to do this is write two stores and stitch their
+    call_genotype + variant_position together via zarr's own API."""
+    hm1 = _simulate_hm(seed=1)
+    hm2 = _simulate_hm(seed=2)
+    path = str(tmp_path / "multi.vcz")
+    out = zarr.open_group(path, mode="w")
+    n1, n2 = hm1.haplotypes.shape[1], hm2.haplotypes.shape[1]
+    n_dip = hm1.num_haplotypes // 2
+
+    pos = np.concatenate([np.asarray(hm1.positions), np.asarray(hm2.positions)])
+    contig = np.concatenate([np.zeros(n1, np.int32), np.ones(n2, np.int32)])
+    out.create_array("variant_position", shape=pos.shape, dtype="int32")[:] = pos.astype(np.int32)
+    out.create_array("variant_contig", shape=contig.shape, dtype="int32")[:] = contig
+    out.create_array("contig_id", shape=(2,), dtype="<U16")[:] = np.array(["chrA", "chrB"])
+    out.create_array("sample_id", shape=(n_dip,), dtype="<U16")[:] = np.array(
+        [f"s{i}" for i in range(n_dip)]
+    )
+    # Combine genotypes: shape (n1 + n2, n_dip, 2).
+    gt1 = HaplotypeMatrix._haplotypes_to_gt(np.asarray(hm1.haplotypes))
+    gt2 = HaplotypeMatrix._haplotypes_to_gt(np.asarray(hm2.haplotypes))
+    gt = np.concatenate([gt1, gt2], axis=0)
+    out.create_array("call_genotype", shape=gt.shape, dtype="int8",
+                     chunks=(10_000, n_dip, 2))[:] = gt
+    return path, hm1, hm2
+
+
+@pytest.fixture
+def pop_file(tmp_path):
+    """A two-pop TSV in HaplotypeMatrix.load_pop_file's format."""
+    path = str(tmp_path / "pops.tsv")
+    with open(path, "w") as f:
+        f.write("sample\tpop\n")
+        for i in range(10):
+            f.write(f"s{i}\tpop1\n")
+        for i in range(10, 20):
+            f.write(f"s{i}\tpop2\n")
+    return path
+
+
+class TestConstruction:
+
+    def test_single_contig_no_region(self, vcz_store):
+        path, hm = vcz_store
+        src = ZarrGenotypeSource(path)
+        assert src.chrom == "1"
+        assert src.num_diploids == hm.num_haplotypes // 2
+        assert src.num_haplotypes == hm.num_haplotypes
+        assert src.num_variants == hm.haplotypes.shape[1]
+
+    def test_region_subset(self, vcz_store):
+        path, hm = vcz_store
+        full = ZarrGenotypeSource(path)
+        first_half = full.site_pos[len(full.site_pos) // 2]
+        src = ZarrGenotypeSource(path, region=f"1:0-{int(first_half)}")
+        assert src.num_variants < full.num_variants
+        assert int(src.site_pos[-1]) < int(first_half)
+
+    def test_multi_contig_requires_pick(self, multi_contig_store):
+        path, _, _ = multi_contig_store
+        with pytest.raises(ValueError, match="multiple contigs"):
+            ZarrGenotypeSource(path)
+
+    def test_multi_contig_with_contig_id(self, multi_contig_store):
+        path, hm1, _ = multi_contig_store
+        src = ZarrGenotypeSource(path, contig_id="chrA")
+        assert src.chrom == "chrA"
+        assert src.num_variants == hm1.haplotypes.shape[1]
+
+    def test_unknown_contig_raises(self, multi_contig_store):
+        path, _, _ = multi_contig_store
+        with pytest.raises(ValueError, match="chrC"):
+            ZarrGenotypeSource(path, contig_id="chrC")
+
+    def test_rejects_non_vcz_layout(self, tmp_path):
+        hm = _simulate_hm()
+        path = str(tmp_path / "allel.zarr")
+        hm.to_zarr(path, format="scikit-allel")
+        with pytest.raises(ValueError, match="VCZ layout only"):
+            ZarrGenotypeSource(path)
+
+
+class TestSliceRegion:
+
+    def test_shapes_and_dtype(self, vcz_store):
+        path, _ = vcz_store
+        src = ZarrGenotypeSource(path)
+        gt, pos = src.slice_region(0, src.mappable_hi)
+        assert gt.shape == (src.num_variants, src.num_diploids, 2)
+        assert gt.dtype == np.int8
+        assert pos.shape == (src.num_variants,)
+
+    def test_round_trip_to_haplotype_matrix(self, vcz_store):
+        path, hm = vcz_store
+        src = ZarrGenotypeSource(path)
+        gt, pos = src.slice_region(0, src.mappable_hi)
+        # Reproduce the existing eager from_zarr layout (ploidy 0 then ploidy 1
+        # along the hap axis); compare to the original HaplotypeMatrix bytes.
+        n_dip = src.num_diploids
+        haps = np.empty((gt.shape[0], 2 * n_dip), dtype=gt.dtype)
+        haps[:, :n_dip] = gt[:, :, 0]
+        haps[:, n_dip:] = gt[:, :, 1]
+        np.testing.assert_array_equal(haps.T, np.asarray(hm.haplotypes))
+
+    def test_empty_region(self, vcz_store):
+        path, _ = vcz_store
+        src = ZarrGenotypeSource(path)
+        # below the first variant
+        gt, pos = src.slice_region(0, max(0, src.mappable_lo - 1))
+        assert gt.shape[0] == 0
+        assert pos.shape[0] == 0
+
+
+class TestSliceSubsample:
+
+    def test_oindex_matches_full_then_slice(self, vcz_store):
+        path, _ = vcz_store
+        src = ZarrGenotypeSource(path)
+        gt_full, _ = src.slice_region(0, src.mappable_hi)
+
+        # Pick a haplotype subset that crosses the ploidy-0/ploidy-1
+        # boundary so we exercise the (dip, ploidy) translation.
+        n_dip = src.num_diploids
+        cols = np.array([0, 1, 2, n_dip, n_dip + 1], dtype=np.int64)
+
+        gm_sub, _ = src.slice_subsample(0, src.mappable_hi, cols)
+        # Build the expected (n_var, len(cols)) from gt_full.
+        expected = np.empty((gt_full.shape[0], len(cols)), dtype=gt_full.dtype)
+        for j, c in enumerate(cols):
+            ploidy = 1 if c >= n_dip else 0
+            dip = c - n_dip if c >= n_dip else c
+            expected[:, j] = gt_full[:, dip, ploidy]
+        np.testing.assert_array_equal(gm_sub, expected)
+
+    def test_empty_region(self, vcz_store):
+        path, _ = vcz_store
+        src = ZarrGenotypeSource(path)
+        gm, pos = src.slice_subsample(0, max(0, src.mappable_lo - 1),
+                                      np.array([0, 1]))
+        assert gm.shape == (0, 2)
+        assert pos.shape == (0,)
+
+
+class TestIterChunks:
+
+    def test_yields_aligned_intervals(self, vcz_store):
+        path, _ = vcz_store
+        src = ZarrGenotypeSource(path)
+        chunks = list(src.iter_chunks(chunk_bp=10_000, align_bp=10_000))
+        # alignment respected
+        for left, right in chunks:
+            assert left % 10_000 == 0
+            assert right - left <= 10_000
+        # cover the whole mappable range
+        assert chunks[0][0] == 0
+        assert chunks[-1][1] == src.mappable_hi
+
+    def test_alignment_smaller_than_chunk(self, vcz_store):
+        path, _ = vcz_store
+        src = ZarrGenotypeSource(path)
+        chunks = list(src.iter_chunks(chunk_bp=10_000, align_bp=5_000))
+        # chunk_bp / align_bp = 2 windows per chunk, step = 10000
+        assert chunks[0] == (0, min(10_000, src.mappable_hi))
+
+
+class TestPopFileResolution:
+
+    def test_explicit_pop_file(self, vcz_store, pop_file):
+        path, _ = vcz_store
+        src = ZarrGenotypeSource(path, pop_file=pop_file)
+        assert set(src.pop_cols.keys()) == {"pop1", "pop2"}
+        n_dip = src.num_diploids
+        # pop1 = first 10 diploids -> haps [0..10) plus [n_dip..n_dip+10)
+        expected1 = np.concatenate([np.arange(10), np.arange(10) + n_dip])
+        np.testing.assert_array_equal(np.sort(src.pop_cols["pop1"]), expected1)
+
+    def test_auto_load_companion(self, vcz_store, pop_file, tmp_path, capsys):
+        path, _ = vcz_store
+        companion = path + ".pops.tsv"
+        # copy pop_file to companion location
+        with open(pop_file) as src_f, open(companion, "w") as dst:
+            dst.write(src_f.read())
+        src = ZarrGenotypeSource(path)
+        assert src.pop_cols is not None
+        # auto-load announces to stderr so it doesn't pollute pipelines that
+        # capture stdout for table output.
+        assert "auto-loaded" in capsys.readouterr().err
+
+    def test_pop_file_false_disables_autoload(self, vcz_store, pop_file):
+        path, _ = vcz_store
+        companion = path + ".pops.tsv"
+        with open(pop_file) as src_f, open(companion, "w") as dst:
+            dst.write(src_f.read())
+        src = ZarrGenotypeSource(path, pop_file=False)
+        assert src.pop_cols is None
+
+    def test_unknown_sample_in_pop_file_warns(self, vcz_store, tmp_path):
+        path, _ = vcz_store
+        bad_pop = str(tmp_path / "bad.tsv")
+        with open(bad_pop, "w") as f:
+            f.write("sample\tpop\ns0\tpop1\nnobody\tpop2\n")
+        with pytest.warns(UserWarning, match="not in store"):
+            src = ZarrGenotypeSource(path, pop_file=bad_pop)
+        assert "pop1" in src.pop_cols
+        assert "pop2" not in src.pop_cols


### PR DESCRIPTION
## Summary

Adds transparent biobank-scale streaming behind `HaplotypeMatrix.from_zarr` and `GenotypeMatrix.from_zarr`. A store too big to fit eagerly on the GPU now returns a `StreamingHaplotypeMatrix` / `StreamingGenotypeMatrix` that walks the chromosome chunk-by-chunk through the same public APIs: `windowed_analysis`, `sfs.sfs`, `sfs.joint_sfs`, `compute_ld_statistics_gpu_single_pop`/`_two_pops`, `ibs`, `grm`. GPU peak memory scales with one chunk, not the chromosome.

Tested end-to-end on `stdpopsim` `OutOfAfrica_2T12` at chr15 / 50 k diploids per population (200 k haplotypes, 11.6 M variants, 7.9 GB bio2zarr/VCZ store): the full per-window + SFS + Garud + LD-decay + r² heatmap scan completes in about **16 minutes** on a single A100 80 GB.

## What's added

**Streaming infrastructure**
- `pg_gpu/zarr_source.py`: `ZarrGenotypeSource` opens a VCZ store and exposes `slice_region`, `slice_subsample`, `slice_region_gpu` (kvikio GPU-decode), `slice_subsample_gpu` (kvikio + GPU ploidy gather, ~100× faster than the host-side `oindex` at biobank-scale sample subsets).
- `pg_gpu/streaming_matrix.py`: `_StreamingMatrixBase` + `StreamingHaplotypeMatrix` + `StreamingGenotypeMatrix`, plus `ChunkFetcher` with `HostChunkFetcher` and `KvikioChunkFetcher` (zstd / blosc / lz4 / deflate decode on the GPU via nvCOMP).
- `pg_gpu/_gpu_genotype_prep.py`: `build_haplotype_matrix` and `build_genotype_matrix` do the ploidy interleave + transpose on the GPU.
- `pg_gpu/_biobank_warning.py`: `BiobankScaleWarning` on `from_vcf` for stores or sample counts above the biobank threshold.
- `pg_gpu/zarr_io.py`: `allel_zarr_to_vcz` streams a scikit-allel store to vcz layout in fixed-size variant blocks (does not materialize the full matrix), so empirical data in allel layout converts on modest hardware.

**Streaming-aware kernels** (existing call sites work unchanged on a streaming matrix)
- `windowed_analysis(stream, ...)` and `sfs.sfs` / `sfs.joint_sfs(stream, ...)`: per-chunk dispatch with sum reduction.
- `compute_ld_statistics_gpu_single_pop` and `_two_pops` on `StreamingHaplotypeMatrix`: tail-buffer stitch + (tail × tail) pair mask, so pairs that straddle a chunk boundary are captured exactly once.
- `ibs` and `grm` on streaming matrices: variant-stream outer loop + individual-axis row-block tile, host accumulators so the `(n_indiv, n_indiv)` output can be larger than GPU memory. `grm` runs two passes (chromosome-wide allele frequencies, then per-chunk standardized outer product).

**Library hardening**
- `HaplotypeMatrix.load_pop_file` writes `sample_sets` in block (ploidy-0 then ploidy-1) ordering rather than interleaved, fixing a latent pop-subset bug in eager `ibs` / `grm` where the diploid pairing in `_get_genotype_data` silently misaligned.
- `compute_counts_for_pairs` accepts a precomputed `has_missing` so the streaming LD path doesn't re-scan the stitched matrix per pair batch.
- `ZarrGenotypeSource._resolve_pop_file` accepts `sample_id` as a header alias alongside `sample`.

## Performance

Single-A100 chr15 scan (50 k diploids per population, 200 k haplotypes, 11.6 M variants):

| Stage | Wall |
|---|---|
| Per-window diversity + divergence at 10 kb / 100 kb / 1 Mb, marginal + joint SFS, per-pop Garud's H (one chromosome walk) | 905 s |
| LD decay (DD, Dz, π², σ_d²) at 9 bins to 200 kb across 16 probe regions (5 k-hap subsample/pop) | 52 s |
| Pairwise r² heatmap on a 1 Mb sub-region (5 k haps, 2 k SNPs after MAF filter) | 1 s |
| Total wall including figure rendering | ~16 min |

`slice_subsample_gpu` is the dominant win for sample-subset reads: 170 s → 1.8 s on a 5 Mb / 10 k-hap probe.


Validation: `ibs` and `grm` were verified against first-principles numpy on hand-built (4 indiv × 5 site) reference cases and against real Ag1000G 3R data (eager-vs-streaming match to machine precision: max abs diff 0.0 for IBS, 4e-13 for GRM). LD decay's unbiased DD estimator was verified against the formula on the same 2-variant hand-built case.

## Dependencies

`kvikio-cu12 >= 25.0` and `nvidia-nvcomp-cu12 >= 4.0` from `https://pypi.nvidia.com` are added to `pixi.toml`. The GPU-decode path is the default for bio2zarr-style stores; whole-sample-axis chunked stores fall back to the host fetcher with a one-time `BadlyChunkedWarning`.
