### PR TITLE
Rename pop_file kwarg to pop_assignment (multi-type)

### DIFF
--- a/docs/source/tutorials/biobank_streaming.rst
+++ b/docs/source/tutorials/biobank_streaming.rst
@@ -125,7 +125,7 @@ functions:
        "biobank/chr15.vcz",
        streaming="always",
        chunk_bp=500_000,                   # genomic chunk size
-       pop_file="biobank/chr15.pops.tsv",  # optional sample -> pop
+       pop_assignment="biobank/chr15.pops.tsv",  # optional sample -> pop
    )
 
    # Per-window diversity + divergence in a single streaming pass.
@@ -165,7 +165,7 @@ The same code run on a fully loaded ``HaplotypeMatrix`` is
 unchanged -- the only difference is which kind of object
 ``from_zarr`` returns.
 
-The ``pop_file`` kwarg accepts a path to a TSV, a dict mapping
+The ``pop_assignment`` kwarg accepts a path to a TSV, a dict mapping
 sample to population, a numpy array of labels (one per sample), or
 the name of a zarr key in the store that holds a 1-D population
 array. See ``HaplotypeMatrix.from_zarr`` for the full list.

--- a/docs/source/tutorials/moments_integration.rst
+++ b/docs/source/tutorials/moments_integration.rst
@@ -55,7 +55,10 @@ The core swap looks like:
    r_bins = [0, 1e-6, 2e-6, 5e-6, 1e-5, 2e-5, 5e-5, 1e-4]
 
    # Step 1: GPU-accelerated LD parsing (the only line that changes
-   # vs. a pure-moments workflow).
+   # vs. a pure-moments workflow). ``pop_file`` is the same kwarg
+   # name moments.LD.Parsing.compute_ld_statistics uses; pg_gpu
+   # also accepts ``pop_assignment=`` as an alias if you are coming
+   # in from ``HaplotypeMatrix.from_zarr`` and prefer that spelling.
    ld_stats = {}
    for i, vcf in enumerate(vcf_files):
        ld_stats[i] = compute_ld_statistics(

--- a/examples/biobank_streaming_scan.py
+++ b/examples/biobank_streaming_scan.py
@@ -66,7 +66,7 @@ def parse_args():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--vcz", required=True, help="path to a chr*.vcz store")
-    p.add_argument("--pop-file", default=None,
+    p.add_argument("--pop-assignment", default=None,
                    help="optional path/dict/zarr-key for sample -> pop "
                         "assignments. Default: auto-load <vcz>.pops.tsv")
     p.add_argument("--pops", nargs=2, metavar=("POP1", "POP2"), default=None,
@@ -101,7 +101,7 @@ def main():
     stream = HaplotypeMatrix.from_zarr(
         args.vcz, streaming="always",
         chunk_bp=args.chunk_bp,
-        pop_file=args.pop_file,  # None -> autoload <vcz>.pops.tsv
+        pop_assignment=args.pop_assignment,  # None -> autoload <vcz>.pops.tsv
     )
     chrom = stream.chrom
     chrom_len = stream.chrom_end - stream.chrom_start
@@ -126,7 +126,7 @@ def main():
             "No pop file found alongside the store and --pops not given; "
             "the streaming reader fell back to a single 'all' pop and "
             "this example needs two named populations. Either provide "
-            "--pop-file or --pops.")
+            "--pop-assignment or --pops.")
     else:
         pops = tuple(sample_set_names[:2])
     print(f"populations: {pops}")

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -514,7 +514,7 @@ class GenotypeMatrix:
             source = ZarrGenotypeSource(path, region=region,
                                         pop_assignment=pop_assignment)
         else:
-            source.pop_cols = source._resolve_pop_file(pop_assignment)
+            source.pop_cols = source._resolve_pop_assignment(pop_assignment)
         fetcher = _pick_chunk_fetcher(source, backend=backend)
         return StreamingGenotypeMatrix(
             source, fetcher,

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -394,7 +394,7 @@ class GenotypeMatrix:
     @classmethod
     def from_zarr(cls, path, region=None, accessible_bed=None,
                   include_invariant=False,
-                  pop_file=None,
+                  pop_assignment=None,
                   streaming: str = "auto",
                   chunk_bp: int = 1_500_000,
                   prefetch: int = 1,
@@ -403,7 +403,7 @@ class GenotypeMatrix:
 
         Identical interface to ``HaplotypeMatrix.from_zarr``;
         see that method's docstring for the meaning of every kwarg
-        (``streaming``, ``pop_file`` flexibility, ``chunk_bp``,
+        (``streaming``, ``pop_assignment`` flexibility, ``chunk_bp``,
         ``prefetch``, ``backend``). The only difference is the
         returned type: this returns ``GenotypeMatrix`` (or
         ``StreamingGenotypeMatrix`` on the streaming path) where
@@ -417,7 +417,7 @@ class GenotypeMatrix:
             If True, set ``n_total_sites`` from the loaded variant
             count. Unique to this entry point (the haplotype matrix
             does not need it).
-        path, region, accessible_bed, pop_file, streaming, chunk_bp, prefetch, backend
+        path, region, accessible_bed, pop_assignment, streaming, chunk_bp, prefetch, backend
             See ``HaplotypeMatrix.from_zarr``.
 
         Returns
@@ -437,7 +437,7 @@ class GenotypeMatrix:
 
         if streaming == "always":
             return cls._build_streaming(
-                path, region=region, pop_file=pop_file,
+                path, region=region, pop_assignment=pop_assignment,
                 chunk_bp=chunk_bp, prefetch=prefetch,
                 backend=backend,
             )
@@ -450,21 +450,21 @@ class GenotypeMatrix:
         from .haplotype_matrix import _decide_streaming_mode
         choice, source = _decide_streaming_mode(path, region=region,
                                                 streaming=streaming,
-                                                pop_file=pop_file)
+                                                pop_assignment=pop_assignment)
         if choice == "streaming":
             return cls._build_streaming(
-                path, region=region, pop_file=pop_file,
+                path, region=region, pop_assignment=pop_assignment,
                 chunk_bp=chunk_bp, prefetch=prefetch,
                 backend=backend, source=source,
             )
         return cls._build_eager(path, region=region,
                                 accessible_bed=accessible_bed,
                                 include_invariant=include_invariant,
-                                pop_file=pop_file)
+                                pop_assignment=pop_assignment)
 
     @classmethod
     def _build_eager(cls, path, *, region, accessible_bed,
-                     include_invariant, pop_file):
+                     include_invariant, pop_assignment):
         from .zarr_io import read_genotypes, normalize_pop_input
         from ._gpu_genotype_prep import build_genotype_matrix
 
@@ -492,7 +492,7 @@ class GenotypeMatrix:
         except Exception:
             store = None
         pop_map = normalize_pop_input(
-            pop_file, zarr_path=path,
+            pop_assignment, zarr_path=path,
             sample_names=gm.samples or [],
             zarr_store=store,
             announce_prefix="GenotypeMatrix.from_zarr",
@@ -503,17 +503,18 @@ class GenotypeMatrix:
         return gm
 
     @classmethod
-    def _build_streaming(cls, path, *, region, pop_file, chunk_bp, prefetch,
-                         backend="auto", source=None):
+    def _build_streaming(cls, path, *, region, pop_assignment, chunk_bp,
+                         prefetch, backend="auto", source=None):
         from .streaming_matrix import (
             StreamingGenotypeMatrix, _pick_chunk_fetcher,
         )
         from .zarr_source import ZarrGenotypeSource
 
         if source is None:
-            source = ZarrGenotypeSource(path, region=region, pop_file=pop_file)
+            source = ZarrGenotypeSource(path, region=region,
+                                        pop_assignment=pop_assignment)
         else:
-            source.pop_cols = source._resolve_pop_file(pop_file)
+            source.pop_cols = source._resolve_pop_file(pop_assignment)
         fetcher = _pick_chunk_fetcher(source, backend=backend)
         return StreamingGenotypeMatrix(
             source, fetcher,
@@ -558,13 +559,13 @@ class GenotypeMatrix:
                 f"Unknown format: {format!r}. Use 'vcz' or 'scikit-allel'."
             )
 
-    def load_pop_file(self, pop_file, pops=None):
+    def load_pop_file(self, pop_assignment, pops=None):
         """Load population assignments from a tab-delimited file or
         an already-resolved sample->population mapping.
 
         Parameters
         ----------
-        pop_file : str or dict
+        pop_assignment : str or dict
             Either a path to a tab-delimited file with columns
             ``sample\tpop``, or a dict mapping sample names to
             population labels.
@@ -574,11 +575,11 @@ class GenotypeMatrix:
         if self.samples is None:
             raise ValueError("No sample names stored. Use from_vcf() to load data.")
 
-        if isinstance(pop_file, dict):
-            pop_map = {str(k): str(v) for k, v in pop_file.items() if v}
+        if isinstance(pop_assignment, dict):
+            pop_map = {str(k): str(v) for k, v in pop_assignment.items() if v}
         else:
             pop_map = {}
-            with open(pop_file) as f:
+            with open(pop_assignment) as f:
                 for line in f:
                     parts = line.strip().split()
                     if len(parts) >= 2 and parts[0] != 'sample':

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -601,7 +601,7 @@ class HaplotypeMatrix:
             # pop_assignment=False to keep its size probe cheap; resolve
             # the caller's pop_assignment now without re-opening the
             # zarr store.
-            source.pop_cols = source._resolve_pop_file(pop_assignment)
+            source.pop_cols = source._resolve_pop_assignment(pop_assignment)
         fetcher = _pick_chunk_fetcher(source, backend=backend)
         return StreamingHaplotypeMatrix(
             source, fetcher,

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -14,7 +14,7 @@ from .accessible import AccessibleMask, bed_to_mask, resolve_accessible_mask
 STREAMING_AUTO_EAGER_FRACTION = 0.5
 
 
-def _decide_streaming_mode(zarr_path, region, streaming, pop_file,
+def _decide_streaming_mode(zarr_path, region, streaming, pop_assignment,
                            free_gpu_bytes=None,
                            fraction=STREAMING_AUTO_EAGER_FRACTION):
     """Pick ``'eager'`` vs ``'streaming'`` based on the projected matrix size.
@@ -51,7 +51,7 @@ def _decide_streaming_mode(zarr_path, region, streaming, pop_file,
 
     from .zarr_source import ZarrGenotypeSource
     source = ZarrGenotypeSource(zarr_path, region=region,
-                                pop_file=False)
+                                pop_assignment=False)
     eager_bytes = int(source.num_variants) * int(source.num_haplotypes)
 
     if free_gpu_bytes is None:
@@ -427,7 +427,7 @@ class HaplotypeMatrix:
     @classmethod
     def from_zarr(cls, path: str, region: str = None,
                   accessible_bed: str = None,
-                  pop_file=None,
+                  pop_assignment=None,
                   streaming: str = "auto",
                   chunk_bp: int = 1_500_000,
                   prefetch: int = 1,
@@ -446,7 +446,7 @@ class HaplotypeMatrix:
             Genomic region 'chrom:start-end' to load a subset.
         accessible_bed : str, optional
             Path to a BED file defining accessible/callable regions.
-        pop_file : str, numpy.ndarray, list, dict, or False, optional
+        pop_assignment : str, numpy.ndarray, list, dict, or False, optional
             Sample-to-population assignments. Accepted forms:
 
             * ``str`` -- path to a tab-delimited file with a header
@@ -513,7 +513,7 @@ class HaplotypeMatrix:
 
         if streaming == "always":
             return cls._build_streaming(
-                path, region=region, pop_file=pop_file,
+                path, region=region, pop_assignment=pop_assignment,
                 chunk_bp=chunk_bp, prefetch=prefetch,
                 backend=backend,
             )
@@ -526,19 +526,19 @@ class HaplotypeMatrix:
         # source for that layout.
         choice, source = _decide_streaming_mode(path, region=region,
                                                 streaming=streaming,
-                                                pop_file=pop_file)
+                                                pop_assignment=pop_assignment)
         if choice == "streaming":
             return cls._build_streaming(
-                path, region=region, pop_file=pop_file,
+                path, region=region, pop_assignment=pop_assignment,
                 chunk_bp=chunk_bp, prefetch=prefetch,
                 source=source, backend=backend,
             )
         return cls._build_eager(path, region=region,
                                 accessible_bed=accessible_bed,
-                                pop_file=pop_file)
+                                pop_assignment=pop_assignment)
 
     @classmethod
-    def _build_eager(cls, path, *, region, accessible_bed, pop_file):
+    def _build_eager(cls, path, *, region, accessible_bed, pop_assignment):
         from .zarr_io import read_genotypes
         from ._gpu_genotype_prep import build_haplotype_matrix
 
@@ -574,7 +574,7 @@ class HaplotypeMatrix:
         except Exception:
             store = None
         pop_map = normalize_pop_input(
-            pop_file, zarr_path=path,
+            pop_assignment, zarr_path=path,
             sample_names=hm.samples or [],
             zarr_store=store,
             announce_prefix="HaplotypeMatrix.from_zarr",
@@ -585,8 +585,8 @@ class HaplotypeMatrix:
         return hm
 
     @classmethod
-    def _build_streaming(cls, path, *, region, pop_file, chunk_bp, prefetch,
-                         source=None, backend="auto"):
+    def _build_streaming(cls, path, *, region, pop_assignment, chunk_bp,
+                         prefetch, source=None, backend="auto"):
         from .streaming_matrix import (
             HostChunkFetcher, KvikioChunkFetcher, StreamingHaplotypeMatrix,
             _pick_chunk_fetcher,
@@ -594,12 +594,14 @@ class HaplotypeMatrix:
         from .zarr_source import ZarrGenotypeSource
 
         if source is None:
-            source = ZarrGenotypeSource(path, region=region, pop_file=pop_file)
+            source = ZarrGenotypeSource(path, region=region,
+                                        pop_assignment=pop_assignment)
         else:
-            # _decide_streaming_mode opens the source with pop_file=False
-            # to keep its size probe cheap; resolve the caller's pop_file
-            # now without re-opening the zarr store.
-            source.pop_cols = source._resolve_pop_file(pop_file)
+            # _decide_streaming_mode opens the source with
+            # pop_assignment=False to keep its size probe cheap; resolve
+            # the caller's pop_assignment now without re-opening the
+            # zarr store.
+            source.pop_cols = source._resolve_pop_file(pop_assignment)
         fetcher = _pick_chunk_fetcher(source, backend=backend)
         return StreamingHaplotypeMatrix(
             source, fetcher,
@@ -676,7 +678,7 @@ class HaplotypeMatrix:
         gt[:, :, 1] = hap[n_samples:, :].T
         return gt
 
-    def load_pop_file(self, pop_file, pops: list = None):
+    def load_pop_file(self, pop_assignment, pops: list = None):
         """Load population assignments from a tab-delimited file or
         an already-resolved sample->population mapping.
 
@@ -686,7 +688,7 @@ class HaplotypeMatrix:
 
         Parameters
         ----------
-        pop_file : str or dict
+        pop_assignment : str or dict
             Either a path to a tab-delimited file with columns
             ``sample\tpop`` (header line starting with ``sample`` is
             skipped), or a dict mapping sample names to population
@@ -698,11 +700,11 @@ class HaplotypeMatrix:
             raise ValueError("No sample names stored. Use from_vcf() to load data.")
 
         n_samples = len(self.samples)
-        if isinstance(pop_file, dict):
-            pop_map = {str(k): str(v) for k, v in pop_file.items() if v}
+        if isinstance(pop_assignment, dict):
+            pop_map = {str(k): str(v) for k, v in pop_assignment.items() if v}
         else:
             pop_map = {}
-            with open(pop_file) as f:
+            with open(pop_assignment) as f:
                 for line in f:
                     parts = line.strip().split()
                     if len(parts) >= 2 and parts[0] != 'sample':

--- a/pg_gpu/moments_ld.py
+++ b/pg_gpu/moments_ld.py
@@ -78,20 +78,14 @@ def compute_ld_statistics(
         Path to VCF file. Not needed if haplotype_matrix/genotype_matrix provided.
     rec_map_file : str, optional
         Recombination map (tab-delimited: pos, Map(cM)). Required with r_bins.
-    pop_file : str, optional
-        Population file (tab-delimited: sample, pop). Mirrors the
-        kwarg name from ``moments.LD.Parsing.compute_ld_statistics``
-        so existing moments scripts can switch by changing only the
-        import. The rest of pg_gpu spells this kwarg
-        ``pop_assignment``; both names are accepted here and behave
-        identically -- passing both at once is an error.
-    pop_assignment : str, dict, numpy.ndarray, list, or False, optional
-        Same as ``pop_file`` but accepts every form
-        ``HaplotypeMatrix.from_zarr`` accepts (path / sample-to-pop
-        dict / labels array / zarr key name / False to disable).
-        Kept as an alias to ``pop_file`` so callers that move
-        between pg_gpu's primary API and this moments-shaped wrapper
-        don't have to keep switching kwarg names.
+    pop_file, pop_assignment : str, dict, numpy.ndarray, list, or False, optional
+        Sample-to-population assignment in any form
+        ``normalize_pop_input`` accepts (path / sample-to-pop dict /
+        labels array / zarr key name / ``False`` to disable). The
+        two kwargs are aliases; ``pop_file`` is the
+        moments-compatible spelling, ``pop_assignment`` is the
+        spelling the rest of pg_gpu uses. Passing both at once is
+        an error.
     pops : list of str
         Population names (1-4). Defaults to ['pop0', 'pop1'].
     r_bins : array-like, optional
@@ -117,11 +111,6 @@ def compute_ld_statistics(
     -------
     dict with keys 'bins', 'sums', 'stats', 'pops' (moments format).
     """
-    # ``pop_file`` and ``pop_assignment`` are aliases: the first
-    # mirrors moments.LD.Parsing.compute_ld_statistics so existing
-    # moments pipelines drop in unchanged, the second matches the
-    # rest of pg_gpu. Refuse both at once to avoid silent priority
-    # confusion.
     if pop_file is not None and pop_assignment is not None:
         raise TypeError(
             "pass only one of pop_file or pop_assignment; they are "

--- a/pg_gpu/moments_ld.py
+++ b/pg_gpu/moments_ld.py
@@ -42,6 +42,7 @@ def compute_ld_statistics(
     r_bins=None, bp_bins=None, use_genotypes=False,
     report=True, ac_filter=True, haplotype_matrix=None,
     genotype_matrix=None, accessible_bed=None,
+    pop_assignment=None,
 ):
     """GPU-accelerated drop-in replacement for moments.LD.Parsing.compute_ld_statistics.
 
@@ -78,7 +79,19 @@ def compute_ld_statistics(
     rec_map_file : str, optional
         Recombination map (tab-delimited: pos, Map(cM)). Required with r_bins.
     pop_file : str, optional
-        Population file (tab-delimited: sample, pop).
+        Population file (tab-delimited: sample, pop). Mirrors the
+        kwarg name from ``moments.LD.Parsing.compute_ld_statistics``
+        so existing moments scripts can switch by changing only the
+        import. The rest of pg_gpu spells this kwarg
+        ``pop_assignment``; both names are accepted here and behave
+        identically -- passing both at once is an error.
+    pop_assignment : str, dict, numpy.ndarray, list, or False, optional
+        Same as ``pop_file`` but accepts every form
+        ``HaplotypeMatrix.from_zarr`` accepts (path / sample-to-pop
+        dict / labels array / zarr key name / False to disable).
+        Kept as an alias to ``pop_file`` so callers that move
+        between pg_gpu's primary API and this moments-shaped wrapper
+        don't have to keep switching kwarg names.
     pops : list of str
         Population names (1-4). Defaults to ['pop0', 'pop1'].
     r_bins : array-like, optional
@@ -104,6 +117,19 @@ def compute_ld_statistics(
     -------
     dict with keys 'bins', 'sums', 'stats', 'pops' (moments format).
     """
+    # ``pop_file`` and ``pop_assignment`` are aliases: the first
+    # mirrors moments.LD.Parsing.compute_ld_statistics so existing
+    # moments pipelines drop in unchanged, the second matches the
+    # rest of pg_gpu. Refuse both at once to avoid silent priority
+    # confusion.
+    if pop_file is not None and pop_assignment is not None:
+        raise TypeError(
+            "pass only one of pop_file or pop_assignment; they are "
+            "aliases for the same argument."
+        )
+    if pop_assignment is not None:
+        pop_file = pop_assignment
+
     if pops is None:
         pops = ['pop0', 'pop1']
     num_pops = len(pops)

--- a/pg_gpu/zarr_io.py
+++ b/pg_gpu/zarr_io.py
@@ -39,10 +39,11 @@ def resolve_pop_file_path(zarr_path, pop_file, *, announce_prefix):
     return companion
 
 
-def normalize_pop_input(pop_file, *, zarr_path, sample_names,
+def normalize_pop_input(pop_assignment, *, zarr_path, sample_names,
                          zarr_store=None, announce_prefix=""):
-    """Normalize the flexible ``pop_file`` kwarg into a ``{sample_id ->
-    pop_label}`` dict (or ``None`` to mean "no assignments").
+    """Normalize the flexible ``pop_assignment`` kwarg into a
+    ``{sample_id -> pop_label}`` dict (or ``None`` to mean "no
+    assignments").
 
     Accepted forms:
 
@@ -69,45 +70,45 @@ def normalize_pop_input(pop_file, *, zarr_path, sample_names,
     """
     import numpy as np
 
-    if pop_file is False:
+    if pop_assignment is False:
         return None
 
-    if pop_file is None:
+    if pop_assignment is None:
         companion = str(zarr_path).rstrip("/") + ".pops.tsv"
         if not os.path.exists(companion):
             return None
         print(f"{announce_prefix}: auto-loaded pop file {companion}",
               file=sys.stderr, flush=True)
-        pop_file = companion
+        pop_assignment = companion
 
-    if isinstance(pop_file, dict):
-        return {str(k): str(v) for k, v in pop_file.items() if v}
+    if isinstance(pop_assignment, dict):
+        return {str(k): str(v) for k, v in pop_assignment.items() if v}
 
-    if isinstance(pop_file, (list, tuple, np.ndarray)):
-        labels = np.asarray(pop_file)
+    if isinstance(pop_assignment, (list, tuple, np.ndarray)):
+        labels = np.asarray(pop_assignment)
         if labels.ndim != 1:
             raise ValueError(
-                f"pop_file array must be 1-D; got shape {labels.shape}")
+                f"pop_assignment array must be 1-D; got shape {labels.shape}")
         if len(labels) != len(sample_names):
             raise ValueError(
-                f"pop_file array length {len(labels)} does not match "
-                f"sample axis length {len(sample_names)}")
+                f"pop_assignment array length {len(labels)} does not "
+                f"match sample axis length {len(sample_names)}")
         return _pop_array_to_map(labels, sample_names)
 
-    if isinstance(pop_file, str):
-        if zarr_store is not None and pop_file in zarr_store:
-            labels = np.asarray(zarr_store[pop_file][:])
+    if isinstance(pop_assignment, str):
+        if zarr_store is not None and pop_assignment in zarr_store:
+            labels = np.asarray(zarr_store[pop_assignment][:])
             if labels.ndim != 1 or len(labels) != len(sample_names):
                 raise ValueError(
-                    f"zarr key {pop_file!r} has shape {labels.shape}; "
+                    f"zarr key {pop_assignment!r} has shape {labels.shape}; "
                     f"expected 1-D of length {len(sample_names)} to "
                     f"line up with the sample axis")
             return _pop_array_to_map(labels, sample_names)
-        return _read_pop_tsv(pop_file)
+        return _read_pop_tsv(pop_assignment)
 
     raise TypeError(
-        f"pop_file must be a path, dict, array, zarr key, False, or "
-        f"None; got {type(pop_file).__name__}")
+        f"pop_assignment must be a path, dict, array, zarr key, False, "
+        f"or None; got {type(pop_assignment).__name__}")
 
 
 def _pop_array_to_map(labels, sample_names):

--- a/pg_gpu/zarr_io.py
+++ b/pg_gpu/zarr_io.py
@@ -14,31 +14,6 @@ def _parse_region(region):
     return chrom, start, end
 
 
-def resolve_pop_file_path(zarr_path, pop_file, *, announce_prefix):
-    """Map a ``pop_file`` kwarg that is *only ever a path or auto-load*
-    to a filesystem path or ``None``.
-
-    ``pop_file=False`` disables the auto-load and returns ``None``.
-    ``pop_file=<str>`` returns the path as-is. ``pop_file=None`` looks
-    for ``<zarr_path>.pops.tsv`` next to the store; if it exists,
-    announces the auto-load to stderr via ``announce_prefix`` and
-    returns the companion path.
-
-    For the richer ``pop_file`` accepted by ``HaplotypeMatrix.from_zarr``
-    (numpy arrays, dicts, zarr key names) see ``normalize_pop_input``.
-    """
-    if pop_file is False:
-        return None
-    if pop_file is not None:
-        return pop_file
-    companion = str(zarr_path).rstrip("/") + ".pops.tsv"
-    if not os.path.exists(companion):
-        return None
-    print(f"{announce_prefix}: auto-loaded pop file {companion}",
-          file=sys.stderr, flush=True)
-    return companion
-
-
 def normalize_pop_input(pop_assignment, *, zarr_path, sample_names,
                          zarr_store=None, announce_prefix=""):
     """Normalize the flexible ``pop_assignment`` kwarg into a

--- a/pg_gpu/zarr_source.py
+++ b/pg_gpu/zarr_source.py
@@ -41,12 +41,12 @@ class ZarrGenotypeSource:
         ``'chrom:start-end'`` to restrict the source to a single
         sub-region. The source is single-contig regardless: a
         multi-contig store without ``region`` raises.
-    pop_file : str, optional
+    pop_assignment : str, optional
         Tab-delimited file mapping ``sample`` -> ``pop`` (same format as
         ``HaplotypeMatrix.load_pop_file``). Default ``None`` looks for
         ``<path>.pops.tsv`` next to the store and uses it if present;
         emits a one-line stderr note so the auto-load isn't invisible.
-        Pass ``pop_file=False`` to disable the auto-load entirely.
+        Pass ``pop_assignment=False`` to disable the auto-load entirely.
     contig_id : str, optional
         Pick a contig by name when ``region`` is not given and the store
         has multiple contigs. Ignored otherwise.
@@ -71,7 +71,8 @@ class ZarrGenotypeSource:
         resolved, else None.
     """
 
-    def __init__(self, path, *, region=None, pop_file=None, contig_id=None):
+    def __init__(self, path, *, region=None, pop_assignment=None,
+                 contig_id=None):
         self.path = str(path)
         self._store = zarr.open_group(self.path, mode="r")
 
@@ -127,7 +128,7 @@ class ZarrGenotypeSource:
         self.num_haplotypes = 2 * self.num_diploids
         self.num_variants = int(self.site_pos.size)
 
-        self.pop_cols = self._resolve_pop_file(pop_file)
+        self.pop_cols = self._resolve_pop_file(pop_assignment)
 
     @property
     def mappable_lo(self):
@@ -352,7 +353,7 @@ class ZarrGenotypeSource:
         hi = int(np.searchsorted(self.site_pos, right, side="left"))
         return lo, hi
 
-    def _resolve_pop_file(self, pop_file):
+    def _resolve_pop_file(self, pop_assignment):
         from .zarr_io import normalize_pop_input
 
         # Defer the sample_id lookup until we actually need it -- some
@@ -363,7 +364,7 @@ class ZarrGenotypeSource:
         else:
             sample_ids = []
         pop_map = normalize_pop_input(
-            pop_file, zarr_path=self.path,
+            pop_assignment, zarr_path=self.path,
             sample_names=sample_ids,
             zarr_store=self._store,
             announce_prefix="ZarrGenotypeSource",
@@ -377,7 +378,8 @@ class ZarrGenotypeSource:
             i = idx_by_name.get(str(sample))
             if i is None:
                 warnings.warn(
-                    f"pop_file sample {sample!r} not in store; skipping",
+                    f"pop_assignment sample {sample!r} not in store; "
+                    f"skipping",
                     stacklevel=2,
                 )
                 continue

--- a/pg_gpu/zarr_source.py
+++ b/pg_gpu/zarr_source.py
@@ -128,7 +128,7 @@ class ZarrGenotypeSource:
         self.num_haplotypes = 2 * self.num_diploids
         self.num_variants = int(self.site_pos.size)
 
-        self.pop_cols = self._resolve_pop_file(pop_assignment)
+        self.pop_cols = self._resolve_pop_assignment(pop_assignment)
 
     @property
     def mappable_lo(self):
@@ -353,7 +353,7 @@ class ZarrGenotypeSource:
         hi = int(np.searchsorted(self.site_pos, right, side="left"))
         return lo, hi
 
-    def _resolve_pop_file(self, pop_assignment):
+    def _resolve_pop_assignment(self, pop_assignment):
         from .zarr_io import normalize_pop_input
 
         # Defer the sample_id lookup until we actually need it -- some

--- a/tests/test_moments_ld.py
+++ b/tests/test_moments_ld.py
@@ -121,6 +121,34 @@ class TestHeterozygosity:
         assert H_0_1 >= min(H_0_0, H_1_1)
 
 
+class TestPopAssignmentAlias:
+    """``pop_file`` mirrors the moments kwarg name; ``pop_assignment``
+    matches the rest of pg_gpu. The wrapper accepts both and routes
+    them through the same code path."""
+
+    def test_pop_assignment_matches_pop_file(self, gpu_stats):
+        alias = compute_ld_statistics(
+            VCF, pop_assignment=POP_FILE, pops=POPS,
+            bp_bins=BP_BINS, report=False,
+        )
+        # Same VCF + same pop file -> identical structure (bins,
+        # stats, pops) and per-bin sums equal to machine precision.
+        # CUDA reductions reorder additions across runs so two
+        # otherwise-identical invocations can differ by a few ULPs.
+        assert alias["bins"] == gpu_stats["bins"]
+        assert alias["pops"] == gpu_stats["pops"]
+        assert alias["stats"] == gpu_stats["stats"]
+        for a, b in zip(alias["sums"], gpu_stats["sums"]):
+            np.testing.assert_allclose(a, b, rtol=1e-12, atol=0.0)
+
+    def test_both_aliases_rejected(self):
+        with pytest.raises(TypeError, match="pop_file or pop_assignment"):
+            compute_ld_statistics(
+                VCF, pop_file=POP_FILE, pop_assignment=POP_FILE,
+                pops=POPS, bp_bins=BP_BINS, report=False,
+            )
+
+
 class TestMomentsCompatibility:
     """Verify output can be fed into moments downstream functions."""
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -191,7 +191,7 @@ class TestAutoDetection:
         # Make the eager footprint look like it doesn't fit by claiming
         # less free GPU memory than the projected size requires.
         choice, source = _decide_streaming_mode(
-            path, region=None, streaming="auto", pop_file=False,
+            path, region=None, streaming="auto", pop_assignment=False,
             free_gpu_bytes=int(eager_bytes / 0.5 - 1),
         )
         assert choice == "streaming"
@@ -205,7 +205,7 @@ class TestAutoDetection:
         eager_bytes = hm.haplotypes.size
         with pytest.raises(MemoryError, match="streaming='never'"):
             _decide_streaming_mode(
-                path, region=None, streaming="never", pop_file=False,
+                path, region=None, streaming="never", pop_assignment=False,
                 free_gpu_bytes=int(eager_bytes / 0.5 - 1),
             )
 

--- a/tests/test_streaming_grm.py
+++ b/tests/test_streaming_grm.py
@@ -79,9 +79,9 @@ class TestGrmStreaming:
     def test_population_subset(self, two_pop_vcz_store):
         path, popfile = two_pop_vcz_store
         eager = HaplotypeMatrix.from_zarr(path, streaming="never",
-                                            pop_file=popfile)
+                                            pop_assignment=popfile)
         stream = HaplotypeMatrix.from_zarr(path, streaming="always",
-                                             pop_file=popfile,
+                                             pop_assignment=popfile,
                                              chunk_bp=10_000)
         np.testing.assert_allclose(
             grm(stream, population='pop1'),

--- a/tests/test_streaming_ibs.py
+++ b/tests/test_streaming_ibs.py
@@ -77,9 +77,9 @@ class TestIbsStreaming:
     def test_population_subset(self, two_pop_vcz_store):
         path, popfile = two_pop_vcz_store
         eager = HaplotypeMatrix.from_zarr(path, streaming="never",
-                                            pop_file=popfile)
+                                            pop_assignment=popfile)
         stream = HaplotypeMatrix.from_zarr(path, streaming="always",
-                                             pop_file=popfile,
+                                             pop_assignment=popfile,
                                              chunk_bp=10_000)
         e = ibs(eager, population='pop1')
         s = ibs(stream, population='pop1')

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -114,9 +114,9 @@ class TestWindowedAnalysisDispatch:
                 f.write(f"s{i}\tpop2\n")
 
         eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never",
-                                          pop_file=popfile)
+                                          pop_assignment=popfile)
         stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
-                                            pop_file=popfile,
+                                            pop_assignment=popfile,
                                             chunk_bp=10_000)
         eager.chrom_start = stream.chrom_start
         eager.chrom_end = stream.chrom_end
@@ -148,9 +148,9 @@ def _two_pop_pair(vcz_store, tmp_path, **stream_kwargs):
         for i in range(half, n_dip):
             f.write(f"s{i}\tpop2\n")
     eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never",
-                                      pop_file=popfile)
+                                      pop_assignment=popfile)
     stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
-                                       pop_file=popfile,
+                                       pop_assignment=popfile,
                                        **stream_kwargs)
     eager.chrom_start = stream.chrom_start
     eager.chrom_end = stream.chrom_end
@@ -314,9 +314,9 @@ class TestSFSDispatch:
                 f.write(f"s{i}\tpop2\n")
 
         eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never",
-                                          pop_file=popfile)
+                                          pop_assignment=popfile)
         stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
-                                            pop_file=popfile,
+                                            pop_assignment=popfile,
                                             chunk_bp=10_000)
         j_e = sfs_module.joint_sfs(eager, pop1="pop1", pop2="pop2")
         j_s = sfs_module.joint_sfs(stream, pop1="pop1", pop2="pop2")
@@ -338,9 +338,9 @@ class TestSFSDispatch:
                 f.write(f"s{i}\tpop2\n")
 
         eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never",
-                                          pop_file=popfile)
+                                          pop_assignment=popfile)
         stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
-                                            pop_file=popfile,
+                                            pop_assignment=popfile,
                                             chunk_bp=10_000)
         # Each pop has 2 * half haplotypes; pick a strict downsample.
         n1 = 2 * half

--- a/tests/test_streaming_ld.py
+++ b/tests/test_streaming_ld.py
@@ -70,9 +70,9 @@ def _aligned_single_pop_pair(vcz_store, **stream_kwargs):
 
 def _aligned_two_pop_pair(path, popfile, **stream_kwargs):
     eager = HaplotypeMatrix.from_zarr(path, streaming="never",
-                                       pop_file=popfile)
+                                       pop_assignment=popfile)
     stream = HaplotypeMatrix.from_zarr(path, streaming="always",
-                                        pop_file=popfile, **stream_kwargs)
+                                        pop_assignment=popfile, **stream_kwargs)
     return eager, stream
 
 

--- a/tests/test_zarr_io.py
+++ b/tests/test_zarr_io.py
@@ -147,7 +147,7 @@ class TestHaplotypeMatrixRoundTrip:
             hm.to_zarr(str(tmp_path / "bad.zarr"), format='hdf5')
 
 
-class TestPopFileKwarg:
+class TestPopAssignmentKwarg:
 
     def _write_pops_tsv(self, path, n_dip):
         with open(path, "w") as f:
@@ -166,7 +166,7 @@ class TestPopFileKwarg:
         hm.to_zarr(path, format='vcz', contig_name='chr1')
         return path, n_dip
 
-    def test_explicit_pop_file(self, tmp_path):
+    def test_explicit_pop_assignment(self, tmp_path):
         path, n_dip = self._hm_with_samples(tmp_path, "explicit.vcz")
         popfile = str(tmp_path / "pops.tsv")
         self._write_pops_tsv(popfile, n_dip)
@@ -180,7 +180,7 @@ class TestPopFileKwarg:
         assert hm.sample_sets is not None
         assert "auto-loaded" in capsys.readouterr().err
 
-    def test_pop_file_false_disables_companion(self, tmp_path):
+    def test_pop_assignment_false_disables_companion(self, tmp_path):
         path, n_dip = self._hm_with_samples(tmp_path, "disabled.vcz")
         self._write_pops_tsv(path + ".pops.tsv", n_dip)
         hm = HaplotypeMatrix.from_zarr(path, pop_assignment=False)
@@ -188,7 +188,7 @@ class TestPopFileKwarg:
         # the default {"all": [...]} fallback rather than custom pops.
         assert hm._sample_sets is None
 
-    def test_no_companion_no_pop_file(self, tmp_path):
+    def test_no_companion_no_pop_assignment(self, tmp_path):
         path, _ = self._hm_with_samples(tmp_path, "none.vcz")
         hm = HaplotypeMatrix.from_zarr(path)
         assert hm._sample_sets is None

--- a/tests/test_zarr_io.py
+++ b/tests/test_zarr_io.py
@@ -170,7 +170,7 @@ class TestPopFileKwarg:
         path, n_dip = self._hm_with_samples(tmp_path, "explicit.vcz")
         popfile = str(tmp_path / "pops.tsv")
         self._write_pops_tsv(popfile, n_dip)
-        hm = HaplotypeMatrix.from_zarr(path, pop_file=popfile)
+        hm = HaplotypeMatrix.from_zarr(path, pop_assignment=popfile)
         assert set(hm.sample_sets.keys()) == {"pop1", "pop2"}
 
     def test_companion_auto_load(self, tmp_path, capsys):
@@ -183,7 +183,7 @@ class TestPopFileKwarg:
     def test_pop_file_false_disables_companion(self, tmp_path):
         path, n_dip = self._hm_with_samples(tmp_path, "disabled.vcz")
         self._write_pops_tsv(path + ".pops.tsv", n_dip)
-        hm = HaplotypeMatrix.from_zarr(path, pop_file=False)
+        hm = HaplotypeMatrix.from_zarr(path, pop_assignment=False)
         # _sample_sets stays None; the .sample_sets property then returns
         # the default {"all": [...]} fallback rather than custom pops.
         assert hm._sample_sets is None

--- a/tests/test_zarr_source.py
+++ b/tests/test_zarr_source.py
@@ -60,8 +60,8 @@ def multi_contig_store(tmp_path):
 
 
 @pytest.fixture
-def pop_file(tmp_path):
-    """A two-pop TSV in HaplotypeMatrix.load_pop_file's format."""
+def pop_tsv(tmp_path):
+    """A two-pop TSV in the format ``HaplotypeMatrix.load_pop_file`` expects."""
     path = str(tmp_path / "pops.tsv")
     with open(path, "w") as f:
         f.write("sample\tpop\n")
@@ -224,22 +224,22 @@ class TestIterChunks:
         assert chunks[0] == (0, min(10_000, src.mappable_hi))
 
 
-class TestPopFileResolution:
+class TestPopAssignmentResolution:
 
-    def test_explicit_pop_file(self, vcz_store, pop_file):
+    def test_explicit_pop_assignment(self, vcz_store, pop_tsv):
         path, _ = vcz_store
-        src = ZarrGenotypeSource(path, pop_assignment=pop_file)
+        src = ZarrGenotypeSource(path, pop_assignment=pop_tsv)
         assert set(src.pop_cols.keys()) == {"pop1", "pop2"}
         n_dip = src.num_diploids
         # pop1 = first 10 diploids -> haps [0..10) plus [n_dip..n_dip+10)
         expected1 = np.concatenate([np.arange(10), np.arange(10) + n_dip])
         np.testing.assert_array_equal(np.sort(src.pop_cols["pop1"]), expected1)
 
-    def test_auto_load_companion(self, vcz_store, pop_file, tmp_path, capsys):
+    def test_auto_load_companion(self, vcz_store, pop_tsv, tmp_path, capsys):
         path, _ = vcz_store
         companion = path + ".pops.tsv"
-        # copy pop_file to companion location
-        with open(pop_file) as src_f, open(companion, "w") as dst:
+        # copy pop_tsv to companion location
+        with open(pop_tsv) as src_f, open(companion, "w") as dst:
             dst.write(src_f.read())
         src = ZarrGenotypeSource(path)
         assert src.pop_cols is not None
@@ -247,15 +247,15 @@ class TestPopFileResolution:
         # capture stdout for table output.
         assert "auto-loaded" in capsys.readouterr().err
 
-    def test_pop_file_false_disables_autoload(self, vcz_store, pop_file):
+    def test_pop_assignment_false_disables_autoload(self, vcz_store, pop_tsv):
         path, _ = vcz_store
         companion = path + ".pops.tsv"
-        with open(pop_file) as src_f, open(companion, "w") as dst:
+        with open(pop_tsv) as src_f, open(companion, "w") as dst:
             dst.write(src_f.read())
         src = ZarrGenotypeSource(path, pop_assignment=False)
         assert src.pop_cols is None
 
-    def test_unknown_sample_in_pop_file_warns(self, vcz_store, tmp_path):
+    def test_unknown_sample_in_pop_assignment_warns(self, vcz_store, tmp_path):
         path, _ = vcz_store
         bad_pop = str(tmp_path / "bad.tsv")
         with open(bad_pop, "w") as f:
@@ -265,7 +265,7 @@ class TestPopFileResolution:
         assert "pop1" in src.pop_cols
         assert "pop2" not in src.pop_cols
 
-    def test_pop_file_accepts_dict(self, vcz_store):
+    def test_pop_assignment_accepts_dict(self, vcz_store):
         path, _ = vcz_store
         src = ZarrGenotypeSource(
             path, pop_assignment={f"s{i}": "pop1" if i < 5 else "pop2"
@@ -278,7 +278,7 @@ class TestPopFileResolution:
         np.testing.assert_array_equal(np.sort(src.pop_cols["pop1"]),
                                        expected1)
 
-    def test_pop_file_accepts_array(self, vcz_store):
+    def test_pop_assignment_accepts_array(self, vcz_store):
         path, _ = vcz_store
         # 20 diploids in the fixture; first 12 are pop1, rest pop2.
         labels = np.array(["pop1"] * 12 + ["pop2"] * 8)
@@ -289,12 +289,12 @@ class TestPopFileResolution:
         np.testing.assert_array_equal(np.sort(src.pop_cols["pop1"]),
                                        expected1)
 
-    def test_pop_file_rejects_mismatched_array_length(self, vcz_store):
+    def test_pop_assignment_rejects_mismatched_array_length(self, vcz_store):
         path, _ = vcz_store
         with pytest.raises(ValueError, match="does not match sample"):
             ZarrGenotypeSource(path, pop_assignment=np.array(["pop1", "pop2"]))
 
-    def test_pop_file_accepts_zarr_key(self, vcz_store):
+    def test_pop_assignment_accepts_zarr_key(self, vcz_store):
         path, _ = vcz_store
         # Stamp a 1-D population array onto the store under a non-VCZ
         # key, then look it up by name. Mirrors the case where bio2zarr

--- a/tests/test_zarr_source.py
+++ b/tests/test_zarr_source.py
@@ -228,7 +228,7 @@ class TestPopFileResolution:
 
     def test_explicit_pop_file(self, vcz_store, pop_file):
         path, _ = vcz_store
-        src = ZarrGenotypeSource(path, pop_file=pop_file)
+        src = ZarrGenotypeSource(path, pop_assignment=pop_file)
         assert set(src.pop_cols.keys()) == {"pop1", "pop2"}
         n_dip = src.num_diploids
         # pop1 = first 10 diploids -> haps [0..10) plus [n_dip..n_dip+10)
@@ -252,7 +252,7 @@ class TestPopFileResolution:
         companion = path + ".pops.tsv"
         with open(pop_file) as src_f, open(companion, "w") as dst:
             dst.write(src_f.read())
-        src = ZarrGenotypeSource(path, pop_file=False)
+        src = ZarrGenotypeSource(path, pop_assignment=False)
         assert src.pop_cols is None
 
     def test_unknown_sample_in_pop_file_warns(self, vcz_store, tmp_path):
@@ -261,15 +261,15 @@ class TestPopFileResolution:
         with open(bad_pop, "w") as f:
             f.write("sample\tpop\ns0\tpop1\nnobody\tpop2\n")
         with pytest.warns(UserWarning, match="not in store"):
-            src = ZarrGenotypeSource(path, pop_file=bad_pop)
+            src = ZarrGenotypeSource(path, pop_assignment=bad_pop)
         assert "pop1" in src.pop_cols
         assert "pop2" not in src.pop_cols
 
     def test_pop_file_accepts_dict(self, vcz_store):
         path, _ = vcz_store
         src = ZarrGenotypeSource(
-            path, pop_file={f"s{i}": "pop1" if i < 5 else "pop2"
-                            for i in range(20)},
+            path, pop_assignment={f"s{i}": "pop1" if i < 5 else "pop2"
+                                  for i in range(20)},
         )
         assert set(src.pop_cols.keys()) == {"pop1", "pop2"}
         # pop1 = first 5 diploids -> haps [0..5) plus [n_dip..n_dip+5)
@@ -282,7 +282,7 @@ class TestPopFileResolution:
         path, _ = vcz_store
         # 20 diploids in the fixture; first 12 are pop1, rest pop2.
         labels = np.array(["pop1"] * 12 + ["pop2"] * 8)
-        src = ZarrGenotypeSource(path, pop_file=labels)
+        src = ZarrGenotypeSource(path, pop_assignment=labels)
         assert set(src.pop_cols.keys()) == {"pop1", "pop2"}
         n_dip = src.num_diploids
         expected1 = np.concatenate([np.arange(12), np.arange(12) + n_dip])
@@ -292,7 +292,7 @@ class TestPopFileResolution:
     def test_pop_file_rejects_mismatched_array_length(self, vcz_store):
         path, _ = vcz_store
         with pytest.raises(ValueError, match="does not match sample"):
-            ZarrGenotypeSource(path, pop_file=np.array(["pop1", "pop2"]))
+            ZarrGenotypeSource(path, pop_assignment=np.array(["pop1", "pop2"]))
 
     def test_pop_file_accepts_zarr_key(self, vcz_store):
         path, _ = vcz_store
@@ -303,5 +303,5 @@ class TestPopFileResolution:
         labels = np.array(["pop1"] * 12 + ["pop2"] * 8)
         store.create_array("sample_population", shape=labels.shape,
                             dtype="<U8")[:] = labels
-        src = ZarrGenotypeSource(path, pop_file="sample_population")
+        src = ZarrGenotypeSource(path, pop_assignment="sample_population")
         assert set(src.pop_cols.keys()) == {"pop1", "pop2"}


### PR DESCRIPTION
Closes #103. Renames the `pop_file` kwarg to `pop_assignment` everywhere the kwarg accepts the multi-type forms added by #101 (path / dict / numpy array / list / zarr key / False). The old name predates the multi-type extension and now reads as misleading.

## Commits

- `4037695 api: rename pop_file kwarg to pop_assignment (multi-type)` — the sweep proper, 13 files, ~104/-98 lines. Renames the kwarg + matching positional parameter on:
  - `HaplotypeMatrix.from_zarr`, `GenotypeMatrix.from_zarr`
  - `HaplotypeMatrix.load_pop_file`, `GenotypeMatrix.load_pop_file` (param only; method name kept)
  - `ZarrGenotypeSource.__init__`
  - `zarr_io.normalize_pop_input`
  - `examples/biobank_streaming_scan.py` (`--pop-file` CLI flag → `--pop-assignment`)
  - `docs/source/tutorials/biobank_streaming.rst`
  - Every test that passed `pop_file=` as a keyword.

- `8e5f9c6 moments_ld: accept pop_assignment as alias for pop_file (drop-in compat)` — `pg_gpu.moments_ld.compute_ld_statistics` mirrors `moments.LD.Parsing.compute_ld_statistics` so existing moments pipelines drop in unchanged. To keep the rest of pg_gpu's spelling convention available there too, both kwargs are accepted (passing both at once is a `TypeError`). Test asserts the two kwargs produce identical output to machine precision.

- `333c44a simplify: post-rename cleanup` — findings from a `/simplify` review pass on the first two commits:
  - Collapsed `moments_ld` docstring entries and dropped the alias-resolution history-narrating comment.
  - Deleted the now-orphaned `zarr_io.resolve_pop_file_path` helper (zero callers; `normalize_pop_input` is a strict superset).
  - Renamed the private `_resolve_pop_file` method to `_resolve_pop_assignment` so it doesn't drift from its renamed param.
  - Renamed two leaky test classes + 12 test methods + the `test_zarr_source` fixture (`pop_file` → `pop_tsv`, since the fixture returns a path to a TSV file).

## Kept unchanged

These really are path-specific or moments-API-compatible:

- `<vcz>.pops.tsv` companion filename convention.
- `load_pop_file` / `_resolve_pop_assignment` method names (only the first positional param is renamed).
- `pg_gpu.moments_ld.compute_ld_statistics(pop_file=…)` — moments-API parity (also accepts `pop_assignment` via alias).
- `utils/genome_scan.py` `--pop-file` CLI flag — that utility is path-only by design.
- Local test variables / fixtures that hold an actual file path.

## Verification

- `pixi run -e lint ruff check pg_gpu/ tests/ examples/` — `All checks passed!`
- `pixi run pytest tests/test_zarr_io.py tests/test_zarr_source.py tests/test_streaming.py tests/test_streaming_kernels.py tests/test_streaming_ld.py tests/test_streaming_grm.py tests/test_streaming_ibs.py tests/test_memory_warning.py tests/test_biobank_streaming_example.py -q` — 190 passed.
- `pixi run -e moments pytest tests/test_moments_ld.py -q` — 25 passed.
- `pixi run make html` in docs/ — build succeeded, no warnings.

This is an outright rename, no back-compat alias, since the multi-type extension was unreleased.