### PR TITLE
Pin allel_zarr_to_vcz output against bio2zarr reference

### DIFF
--- a/tests/test_zarr_io.py
+++ b/tests/test_zarr_io.py
@@ -22,6 +22,28 @@ def _host(arr):
     return cp.asnumpy(arr) if isinstance(arr, cp.ndarray) else arr
 
 
+def _assert_vcz_dtype_compatible(name, ours, theirs):
+    """Compatibility rule for VCZ field dtypes between our converter
+    and bio2zarr. Exact match is fine. Integer fields can be wider on
+    our side -- bio2zarr picks the smallest int dtype that fits the
+    data, so for small fixtures it may write int8 / int16 while our
+    int32 still encodes the same values. String fields can disagree
+    on fixed-vs-variable-width (``U`` vs zarr ``StringDType``) since
+    both store Python ``str``."""
+    if ours == theirs:
+        return
+    if ours.kind in ("U", "T", "O") and theirs.kind in ("U", "T", "O"):
+        return
+    if ours.kind == theirs.kind == "i" and ours.itemsize >= theirs.itemsize:
+        return
+    raise AssertionError(
+        f"{name}: dtype drift between allel_zarr_to_vcz output "
+        f"({ours}) and bio2zarr reference ({theirs}). Either update "
+        f"the converter to match the new canonical type or relax the "
+        f"compatibility helper in this test."
+    )
+
+
 # ── Fixtures ────────────────────────────────────────────────────────────
 
 
@@ -575,3 +597,57 @@ class TestAllelZarrToVcz:
     def test_rejects_vcz_input(self, tmp_path, vcz_store):
         with pytest.raises(ValueError, match="already vcz"):
             allel_zarr_to_vcz(vcz_store, str(tmp_path / "x.vcz"))
+
+    def test_field_set_matches_bio2zarr_reference(self, tmp_path):
+        """Pin our hand-rolled VCZ layout against the canonical layout
+        bio2zarr produces. Catches upstream drift before it surfaces
+        as a silently-wrong VCZ that other readers reject. Issue #102.
+
+        For every field our converter writes, this asserts that
+        ``bio2zarr.tskit.convert`` writes a field with the same name
+        and that the dtype is compatible (exact match, integer
+        widening, or unicode fixed-vs-variable). If bio2zarr renames a
+        field, changes a dtype incompatibly, or starts requiring a
+        field we don't write, this test fails so the converter can
+        be updated."""
+        from bio2zarr.tskit import convert as ts_to_vcz
+
+        # Tiny tree sequence + reference VCZ via bio2zarr.
+        ts = msprime.sim_ancestry(samples=5, sequence_length=10_000,
+                                   random_seed=42)
+        ts = msprime.sim_mutations(ts, rate=1e-4, random_seed=42)
+        assert ts.num_sites > 0, "test fixture produced an empty TS"
+
+        ref_path = str(tmp_path / "ref.vcz")
+        ts_to_vcz(ts, ref_path)
+        ref = zarr.open_group(ref_path, mode="r")
+
+        # Same data routed through scikit-allel zarr -> allel_zarr_to_vcz
+        # so the test exercises the converter end-to-end.
+        n_dip = ts.num_individuals
+        gt = ts.genotype_matrix().reshape(ts.num_sites, n_dip, 2)
+        pos = np.array([s.position for s in ts.sites()], dtype=np.int32)
+        samples = [f"tsk_{i}" for i in range(n_dip)]
+
+        allel_path = str(tmp_path / "src.allel.zarr")
+        write_allel(allel_path, gt.astype(np.int8), pos, samples=samples)
+
+        out_path = str(tmp_path / "out.vcz")
+        allel_zarr_to_vcz(allel_path, out_path, contig="chr1")
+        out = zarr.open_group(out_path, mode="r")
+
+        for name in out.array_keys():
+            assert name in ref.array_keys(), (
+                f"allel_zarr_to_vcz writes {name!r} but the bio2zarr "
+                f"reference does not. The canonical VCZ layout no longer "
+                f"recognises this field -- update the converter."
+            )
+            ours = out[name]
+            theirs = ref[name]
+            _assert_vcz_dtype_compatible(name, ours.dtype, theirs.dtype)
+
+        # And the streaming reader must be able to consume bio2zarr's
+        # own output, so we know we're not over-restricting what we
+        # accept on the read side either.
+        hm_ref = HaplotypeMatrix.from_zarr(ref_path, streaming="never")
+        assert hm_ref.num_variants == ts.num_sites

--- a/tests/test_zarr_io.py
+++ b/tests/test_zarr_io.py
@@ -601,22 +601,18 @@ class TestAllelZarrToVcz:
     def test_field_set_matches_bio2zarr_reference(self, tmp_path):
         """Pin our hand-rolled VCZ layout against the canonical layout
         bio2zarr produces. Catches upstream drift before it surfaces
-        as a silently-wrong VCZ that other readers reject. Issue #102.
+        as a silently-wrong VCZ that other readers reject.
 
         For every field our converter writes, this asserts that
         ``bio2zarr.tskit.convert`` writes a field with the same name
         and that the dtype is compatible (exact match, integer
-        widening, or unicode fixed-vs-variable). If bio2zarr renames a
-        field, changes a dtype incompatibly, or starts requiring a
-        field we don't write, this test fails so the converter can
-        be updated."""
+        widening, or unicode fixed-vs-variable)."""
         from bio2zarr.tskit import convert as ts_to_vcz
 
         # Tiny tree sequence + reference VCZ via bio2zarr.
         ts = msprime.sim_ancestry(samples=5, sequence_length=10_000,
                                    random_seed=42)
         ts = msprime.sim_mutations(ts, rate=1e-4, random_seed=42)
-        assert ts.num_sites > 0, "test fixture produced an empty TS"
 
         ref_path = str(tmp_path / "ref.vcz")
         ts_to_vcz(ts, ref_path)
@@ -624,13 +620,12 @@ class TestAllelZarrToVcz:
 
         # Same data routed through scikit-allel zarr -> allel_zarr_to_vcz
         # so the test exercises the converter end-to-end.
-        n_dip = ts.num_individuals
-        gt = ts.genotype_matrix().reshape(ts.num_sites, n_dip, 2)
-        pos = np.array([s.position for s in ts.sites()], dtype=np.int32)
-        samples = [f"tsk_{i}" for i in range(n_dip)]
-
+        hm = HaplotypeMatrix.from_ts(ts)
+        gt = HaplotypeMatrix._haplotypes_to_gt(hm.haplotypes)
+        samples = [f"tsk_{i}" for i in range(hm.num_haplotypes // 2)]
         allel_path = str(tmp_path / "src.allel.zarr")
-        write_allel(allel_path, gt.astype(np.int8), pos, samples=samples)
+        write_allel(allel_path, gt, np.asarray(hm.positions),
+                    samples=samples)
 
         out_path = str(tmp_path / "out.vcz")
         allel_zarr_to_vcz(allel_path, out_path, contig="chr1")
@@ -638,13 +633,11 @@ class TestAllelZarrToVcz:
 
         for name in out.array_keys():
             assert name in ref.array_keys(), (
-                f"allel_zarr_to_vcz writes {name!r} but the bio2zarr "
-                f"reference does not. The canonical VCZ layout no longer "
-                f"recognises this field -- update the converter."
+                f"allel_zarr_to_vcz writes {name!r} but bio2zarr does "
+                f"not -- the VCZ layouts have drifted."
             )
-            ours = out[name]
-            theirs = ref[name]
-            _assert_vcz_dtype_compatible(name, ours.dtype, theirs.dtype)
+            _assert_vcz_dtype_compatible(name, out[name].dtype,
+                                          ref[name].dtype)
 
         # And the streaming reader must be able to consume bio2zarr's
         # own output, so we know we're not over-restricting what we

--- a/tests/test_zarr_io.py
+++ b/tests/test_zarr_io.py
@@ -23,13 +23,19 @@ def _host(arr):
 
 
 def _assert_vcz_dtype_compatible(name, ours, theirs):
-    """Compatibility rule for VCZ field dtypes between our converter
-    and bio2zarr. Exact match is fine. Integer fields can be wider on
-    our side -- bio2zarr picks the smallest int dtype that fits the
-    data, so for small fixtures it may write int8 / int16 while our
-    int32 still encodes the same values. String fields can disagree
-    on fixed-vs-variable-width (``U`` vs zarr ``StringDType``) since
-    both store Python ``str``."""
+    """Check that two dtypes for the same VCZ field are close enough.
+
+    Two dtypes count as compatible when:
+
+    * they are exactly equal, or
+    * both are some kind of string (the value round-trips as a
+      Python ``str`` either way), or
+    * both are signed integers and ours is at least as wide as
+      theirs (we never lose data by storing a value in a bigger
+      integer).
+
+    Anything else is treated as a real disagreement and raised.
+    """
     if ours == theirs:
         return
     if ours.kind in ("U", "T", "O") and theirs.kind in ("U", "T", "O"):
@@ -599,14 +605,20 @@ class TestAllelZarrToVcz:
             allel_zarr_to_vcz(vcz_store, str(tmp_path / "x.vcz"))
 
     def test_field_set_matches_bio2zarr_reference(self, tmp_path):
-        """Pin our hand-rolled VCZ layout against the canonical layout
-        bio2zarr produces. Catches upstream drift before it surfaces
-        as a silently-wrong VCZ that other readers reject.
+        """Make sure our converter writes the same VCZ field set as
+        bio2zarr.
 
-        For every field our converter writes, this asserts that
-        ``bio2zarr.tskit.convert`` writes a field with the same name
-        and that the dtype is compatible (exact match, integer
-        widening, or unicode fixed-vs-variable)."""
+        Simulates a tiny tree sequence and writes it out two ways:
+
+        1. Through bio2zarr's own VCZ writer, which we treat as the
+           reference for what a valid VCZ store looks like.
+        2. Through a scikit-allel zarr and then our converter
+           (``allel_zarr_to_vcz``).
+
+        Every field our converter writes must also appear in bio2zarr's
+        output, with a dtype the helper above accepts as compatible.
+        The test fails if bio2zarr changes its layout in a way that
+        would make our output look wrong to other VCZ readers."""
         from bio2zarr.tskit import convert as ts_to_vcz
 
         # Tiny tree sequence + reference VCZ via bio2zarr.


### PR DESCRIPTION
Closes #102. Adds a roundtrip test in `tests/test_zarr_io.py` that simulates a tiny tree sequence, writes it through both `bio2zarr.tskit.convert` (canonical reference) and `allel_zarr_to_vcz` (our converter), and asserts every field our converter writes also appears in the bio2zarr output with a compatible dtype. If bio2zarr changes its layout in a way that would make our output look wrong to other VCZ readers, this test fails.

## What's in here

- `09ee70c tests: pin allel_zarr_to_vcz output against bio2zarr reference` — the new test + the `_assert_vcz_dtype_compatible` helper. dtype rule allows exact equality, both-string-flavor (`U` vs zarr `StringDType`), or same-kind integers where ours is at least as wide (bio2zarr picks the smallest int that fits a fixture, our converter is fixed at int32).
- `c501dfa simplify: drop issue # docstring ref, reuse _haplotypes_to_gt + hm.positions` — `/simplify` review findings: drop history reference from docstring, route the test's gt/pos derivation through the existing `HaplotypeMatrix.from_ts` -> `_haplotypes_to_gt` + `hm.positions` path instead of a parallel reshape, drop a redundant defensive assert, neutralize an over-prescriptive error message.
- `8c40cb1 docs: plain-language docstrings on the new VCZ schema test + helper` — both new docstrings rewritten to avoid jargon ("pin", "hand-rolled", "canonical", "widening", "fixed-vs-variable-width") in favor of plain explanations of when the check passes.

## Coverage of the issue

The issue (https://github.com/kr-colab/pg_gpu/issues/102) listed two options:
1. Import the canonical VCZ schema set from bio2zarr and write through that codepath.
2. Add a roundtrip test that opens a freshly-converted store and validates field-set / dtypes against the spec.

This PR takes option 2 — the lighter commitment. The test imports `bio2zarr.tskit.convert` lazily inside the test function so other tests in the file don't pay its import cost. `bio2zarr` is already in the default pixi env (`pixi.toml` line 21), so no new dependency.

## Verification

- `pixi run pytest tests/test_zarr_io.py::TestAllelZarrToVcz::test_field_set_matches_bio2zarr_reference` — 1 passed in 4.64s.
- `pixi run pytest tests/test_zarr_io.py` — 41 passed (was 40 before this PR), 11.33s -> ~16s overall.
- `pixi run -e lint ruff check tests/test_zarr_io.py` — `All checks passed!`