### PR TITLE
pg_gpu_tour: add Zarr I/O entry to the TOC

### DIFF
--- a/examples/pg_gpu_tour.ipynb
+++ b/examples/pg_gpu_tour.ipynb
@@ -17,7 +17,8 @@
     "5. Windowed genome scans\n",
     "6. Linkage disequilibrium\n",
     "7. PCA and population structure\n",
-    "8. Selection scans"
+    "8. Selection scans\n",
+    "9. Zarr I/O"
    ]
   },
   {


### PR DESCRIPTION
Closes #106.

PR #97 added section 9 (Zarr I/O) to the notebook body but the 'Sections covered' list at the top still stopped at section 8 (Selection scans). One-line fix: add the missing TOC entry so the table of contents matches what the notebook actually delivers.

```
 7. PCA and population structure
 8. Selection scans
+9. Zarr I/O
```

Verified TOC numbers match body H2 numbers (`['1'..'9']` on both sides).