### PR TITLE
feat: VCF/VCZ quality fields, filtering, and clean-VCZ output

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -239,6 +239,42 @@ Compute multiple statistics across thousands of windows without Python loops:
 For end-to-end command-line workflows (``vcf_to_zarr.py``,
 ``genome_scan.py``), see :doc:`workflows`.
 
+Quality-Aware Filtering
+-----------------------
+
+Load VCF / VCZ FORMAT and INFO arrays alongside the genotype matrix,
+build per-variant and per-genotype masks from them, and write the
+filtered survivors back as a clean VCZ that round-trips the same
+arrays. The full walk-through is in
+:doc:`tutorials/qc_fields`; the recipe in one block:
+
+.. code-block:: python
+
+   from pg_gpu import HaplotypeMatrix
+
+   # Bare VCF tags; pg_gpu auto-resolves INFO vs FORMAT from the source.
+   hm = HaplotypeMatrix.from_vcf("cohort.vcf.gz",
+                                  fields=["MQ", "QD", "GQ", "DP"])
+   # or, equivalently, from a bio2zarr-encoded VCZ:
+   # hm = HaplotypeMatrix.from_zarr("cohort.vcz",
+   #                                 fields=["MQ", "QD", "GQ", "DP"])
+
+   # Shape disambiguates per-variant from per-genotype.
+   hm.fields["MQ"]   # (n_var,)             — INFO
+   hm.fields["GQ"]   # (n_var, n_samples)   — FORMAT
+   # Plot directly: plt.hist(hm.fields["GQ"].ravel(), bins=50)
+
+   # Mask-based filter. ``variants`` drops rows; ``genotypes`` sets
+   # per-cell calls to -1 (both allele rows on the haplotype side).
+   hm_clean = hm.filter(
+       variants=(hm.fields["MQ"] >= 40.0) & (hm.fields["QD"] >= 2.0),
+       genotypes=(hm.fields["GQ"] >= 20) & (hm.fields["DP"] >= 10),
+       drop_all_missing=True,
+   )
+
+   # Persist. The surviving QC arrays round-trip into the new store.
+   hm_clean.to_zarr("cohort.clean.vcz", format="vcz", contig_name="chr1")
+
 Missing Data
 ------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,6 +33,7 @@ Key Features
 * **Comprehensive statistics**: LD (D, D-squared, Dz, pi2, r/r-squared), diversity (pi, theta, Tajima's D, heterozygosity, Fay & Wu's H), divergence (FST Hudson/Weir-Cockerham/Nei, Dxy, Da, Snn, Gmin, dd, dd_rank, Zx), selection scans (iHS, XP-EHH, nSL, XP-nSL, Garud's H, EHH decay), SFS (unfolded, folded, joint, scaled), admixture (Patterson's F2, F3, D)
 * **Fused windowed analysis**: compute all statistics across all genomic windows in a single GPU pass -- up to 60x faster than scikit-allel
 * **Automatic missing data handling** across all modules
+* **Quality-aware filtering** -- load VCF FORMAT / INFO arrays (``GQ``, ``DP``, ``MQ``, ...) with ``fields=``, mask variants and genotypes from them, and round-trip the survivors into a clean VCZ. See :doc:`tutorials/qc_fields`.
 * **Multi-population analyses** with flexible population specification
 * **8 theta estimators and 4 neutrality tests** (pi, theta_w, theta_h, theta_l, eta1, eta1_star, minus_eta1, minus_eta1_star, Tajima's D, Fay-Wu's H, Zeng's E, DH)
 * **Validated against scikit-allel** -- 29 statistics verified at machine precision using real Ag1000G data

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -17,6 +17,7 @@ time, see :doc:`examples` instead.
    tutorials/sweep_tajimas_d_bootstrap
    tutorials/admixture_detection
    tutorials/accessibility_mask
+   tutorials/qc_fields
    tutorials/local_pca
    tutorials/ld_blocks
    tutorials/scikit_allel_comparison

--- a/docs/source/tutorials/qc_fields.rst
+++ b/docs/source/tutorials/qc_fields.rst
@@ -16,12 +16,9 @@ Background
 
 Every routine call set comes with per-variant and per-genotype quality
 annotations -- ``INFO/MQ``, ``INFO/QD``, ``FMT/GQ``, ``FMT/DP``, ``FMT/AD``,
-and so on. Acting on them used to mean leaving pg_gpu, running
-``bcftools view -e 'FMT/GQ<20 || FMT/DP<10'`` on a multi-GB VCF, and
-re-encoding the result to VCZ. Every threshold sweep meant another
-bcftools pass.
+and so on. 
 
-bio2zarr already preserves all those FORMAT and INFO fields when it
+bio2zarr preserves all those FORMAT and INFO fields when it
 writes a VCZ; the arrays sit next to ``call_genotype`` on disk. The
 ``fields=`` kwarg on ``HaplotypeMatrix.from_vcf`` / ``from_zarr`` (and
 the same on ``GenotypeMatrix``) surfaces them to Python; ``filter()``
@@ -164,16 +161,12 @@ The returned matrix is a fresh allocation, not a view. ``samples``,
 variant axis changed; if you need span normalization on the result,
 re-attach an accessibility mask explicitly).
 
-Limits and follow-ups
+Current Limitations
 ---------------------
 
 * The streaming opener (``streaming='always'``) does not yet accept
-  ``fields=``; both raise ``NotImplementedError`` when combined. Filter
-  in chunks via the streaming kernels directly, or load eagerly when
-  the matrix fits.
+  ``fields=``; both raise ``NotImplementedError`` when combined. 
 * ``to_zarr(format='scikit-allel')`` does not round-trip ``hm.fields``
   yet; combining the two raises so values are not silently dropped.
   Stick to ``format='vcz'`` (the default) for the clean output.
-* Build-time filtering inside ``vcf_to_zarr`` (encoding fewer fields,
-  per-genotype masking during the VCZ build) is a separate piece of
-  work tracked at issue #108.
+

--- a/docs/source/tutorials/qc_fields.rst
+++ b/docs/source/tutorials/qc_fields.rst
@@ -1,0 +1,179 @@
+Quality-Aware Filtering: GQ, DP, MQ from VCF/VCZ
+================================================
+
+Packaged script: ``examples/vcf_qc_filter.py``
+
+Run it from the repo root:
+
+.. code-block:: bash
+
+   pixi run python examples/vcf_qc_filter.py
+   pixi run python examples/vcf_qc_filter.py --min-mq 40 --min-gq 25 --min-dp 12
+   pixi run python examples/vcf_qc_filter.py --out /tmp/clean.vcz
+
+Background
+----------
+
+Every routine call set comes with per-variant and per-genotype quality
+annotations -- ``INFO/MQ``, ``INFO/QD``, ``FMT/GQ``, ``FMT/DP``, ``FMT/AD``,
+and so on. Acting on them used to mean leaving pg_gpu, running
+``bcftools view -e 'FMT/GQ<20 || FMT/DP<10'`` on a multi-GB VCF, and
+re-encoding the result to VCZ. Every threshold sweep meant another
+bcftools pass.
+
+bio2zarr already preserves all those FORMAT and INFO fields when it
+writes a VCZ; the arrays sit next to ``call_genotype`` on disk. The
+``fields=`` kwarg on ``HaplotypeMatrix.from_vcf`` / ``from_zarr`` (and
+the same on ``GenotypeMatrix``) surfaces them to Python; ``filter()``
+applies the masks; ``to_zarr`` round-trips the survivors so the
+resulting "clean" VCZ is self-describing and re-loadable with the same
+``fields=`` set.
+
+This tutorial walks through that pipeline end to end on simulated data
+(so the script needs no external VCF or VCZ to run). At the end of the
+recipe section there's a code block showing the equivalent against a
+real VCF -- the only line that changes is the loader.
+
+What the script does
+--------------------
+
+1. Simulates a 1 Mb chromosome with msprime (30 diploid individuals).
+2. Writes the result as a VCZ store and stamps in synthetic
+   ``variant_MQ``, ``call_GQ``, and ``call_DP`` arrays. In a real
+   workflow these come straight from bio2zarr converting a VCF that
+   already carries those FORMAT / INFO fields; the injection here keeps
+   the example self-contained.
+3. Reopens the store with ``fields=['MQ', 'GQ', 'DP']`` so the arrays
+   land on ``hm.fields``.
+4. Summarizes each field with a single ``np.percentile`` call. The
+   arrays are plain numpy, so any matplotlib / seaborn snippet works
+   for plotting -- ``plt.hist(hm.fields['GQ'].ravel(), bins=50)`` and
+   you have a quality-score distribution.
+5. Builds a per-variant boolean mask from ``MQ`` and a per-genotype
+   boolean mask from ``GQ`` and ``DP``, then runs ``hm.filter`` to
+   produce a clean matrix. ``drop_all_missing=True`` (the default)
+   also drops any variant whose every call was set to ``-1`` by the
+   per-genotype mask.
+6. Writes the filtered matrix back out via ``to_zarr``. The surviving
+   QC arrays land in the new store under the same field names, so a
+   reload with ``fields=`` returns them unchanged.
+
+A typical run on the default settings looks like:
+
+.. code-block:: text
+
+   31 segregating sites
+   hm.fields keys: ['DP', 'GQ', 'MQ']
+   Field summaries (5 / 25 / 50 / 75 / 95 percentiles):
+       MQ: shape=(31,),    5/25/50/75/95% = 18.14 / 28.67 / 41.00 / 49.88 / 60.11
+       GQ: shape=(31, 30), 5/25/50/75/95% = 4.00 / 25.00 / 49.00 / 75.00 / 94.00
+       DP: shape=(31, 30), 5/25/50/75/95% = 2.00 / 10.00 / 19.00 / 29.00 / 38.00
+   variants kept  (MQ >= 35.0):                       21 / 31   (67.7 %)
+   genotypes masked (GQ >= 20 & DP >= 10):           359 / 930  (38.6 %)
+   21 variants survive both filters
+   Round-trip OK -- reloaded fields match the filtered matrix.
+
+Recipe
+------
+
+The whole pipeline reduces to four method calls:
+
+.. code-block:: python
+
+   from pg_gpu import HaplotypeMatrix
+
+   # 1. Load with quality fields. Bare VCF tags; pg_gpu auto-resolves
+   #    INFO vs FORMAT from the VCF header (or zarr layout).
+   hm = HaplotypeMatrix.from_zarr(
+       "cohort.vcz", fields=["MQ", "QD", "GQ", "DP"], streaming="never",
+   )
+
+   # 2. Inspect. Per-variant fields are (n_var,); per-genotype are
+   #    (n_var, n_samples). Shape tells you which is which.
+   hm.fields["MQ"]   # shape (n_var,)
+   hm.fields["GQ"]   # shape (n_var, n_samples)
+
+   # 3. Filter. ``variants`` drops rows; ``genotypes`` sets cells to -1
+   #    on the haplotype matrix (both allele rows for each sample).
+   hm_clean = hm.filter(
+       variants=(hm.fields["MQ"] >= 40.0) & (hm.fields["QD"] >= 2.0),
+       genotypes=(hm.fields["GQ"] >= 20) & (hm.fields["DP"] >= 10),
+       drop_all_missing=True,
+   )
+
+   # 4. Persist. The surviving QC arrays round-trip into the new VCZ
+   #    under the same field names.
+   hm_clean.to_zarr("cohort.clean.vcz", format="vcz", contig_name="chr1")
+
+The same four lines work against a VCF source -- swap the loader:
+
+.. code-block:: python
+
+   hm = HaplotypeMatrix.from_vcf(
+       "cohort.vcf.gz", fields=["MQ", "QD", "GQ", "DP"],
+   )
+   # ... filter + to_zarr same as above
+
+For very large VCFs the recommended path is "encode once via
+``pg_gpu.zarr_io.vcf_to_zarr`` (bio2zarr under the hood, which
+preserves every FORMAT and INFO field by default), then iterate on
+thresholds against the VCZ." Re-encoding a multi-GB VCF dwarfs every
+other step in the workflow; doing it once and tuning filters
+read-side is a real time saver.
+
+What gets read
+--------------
+
+For each bare tag, pg_gpu probes the source for the per-variant entry
+first and falls back to per-genotype:
+
+* **VCZ** (``bio2zarr`` output): ``variant_<tag>`` then ``call_<tag>``.
+* **scikit-allel zarr**: ``variants/<tag>`` then ``calldata/<tag>``
+  (works for both flat and chromosome-grouped layouts).
+* **VCF** (``allel.read_vcf``): the INFO section first, then FORMAT,
+  resolved via ``allel.read_vcf_headers``.
+
+Tags missing from the source emit a ``UserWarning`` and are silently
+dropped from ``hm.fields``. The shape of each returned array
+disambiguates per-variant (``ndim=1``) from per-genotype (``ndim=2``),
+so a single dict can hold both kinds without parallel namespaces.
+
+When you load with ``region="chr1:1_000_000-2_000_000"``, the QC arrays
+are sliced down to the same variant range as ``hm.haplotypes`` --
+no manual realignment.
+
+Filter semantics
+----------------
+
+``hm.filter(variants=..., genotypes=..., drop_all_missing=True)``:
+
+* ``variants`` -- ``(n_var,)`` bool. False rows are dropped from every
+  array on the returned matrix (haplotypes, positions, every entry in
+  ``fields``).
+* ``genotypes`` -- ``(n_var, n_samples)`` bool. False cells set the
+  haplotype matrix to ``-1`` at that position (both allele rows for
+  the same sample). ``fields`` arrays are *not* zeroed out -- the QC
+  values stay accessible for downstream inspection.
+* ``drop_all_missing`` -- after applying both masks, drop variants
+  whose every call is ``-1``. Default ``True``; turn off when you want
+  the genotype mask to keep variants with at least one valid call.
+
+The returned matrix is a fresh allocation, not a view. ``samples``,
+``sample_sets``, and ``chrom_start`` / ``chrom_end`` are propagated;
+``n_total_sites`` and any attached accessibility mask are not (the
+variant axis changed; if you need span normalization on the result,
+re-attach an accessibility mask explicitly).
+
+Limits and follow-ups
+---------------------
+
+* The streaming opener (``streaming='always'``) does not yet accept
+  ``fields=``; both raise ``NotImplementedError`` when combined. Filter
+  in chunks via the streaming kernels directly, or load eagerly when
+  the matrix fits.
+* ``to_zarr(format='scikit-allel')`` does not round-trip ``hm.fields``
+  yet; combining the two raises so values are not silently dropped.
+  Stick to ``format='vcz'`` (the default) for the clean output.
+* Build-time filtering inside ``vcf_to_zarr`` (encoding fewer fields,
+  per-genotype masking during the VCZ build) is a separate piece of
+  work tracked at issue #108.

--- a/docs/source/tutorials/qc_fields.rst
+++ b/docs/source/tutorials/qc_fields.rst
@@ -8,8 +8,8 @@ Run it from the repo root:
 .. code-block:: bash
 
    pixi run python examples/vcf_qc_filter.py
-   pixi run python examples/vcf_qc_filter.py --min-mq 40 --min-gq 25 --min-dp 12
-   pixi run python examples/vcf_qc_filter.py --out /tmp/clean.vcz
+   pixi run python examples/vcf_qc_filter.py --min-ac 8 --min-aa-prob 0.95
+   pixi run python examples/vcf_qc_filter.py --region X:8000000-12000000
 
 Background
 ----------
@@ -26,48 +26,55 @@ applies the masks; ``to_zarr`` round-trips the survivors so the
 resulting "clean" VCZ is self-describing and re-loadable with the same
 ``fields=`` set.
 
-This tutorial walks through that pipeline end to end on simulated data
-(so the script needs no external VCF or VCZ to run). At the end of the
-recipe section there's a code block showing the equivalent against a
-real VCF -- the only line that changes is the loader.
+This tutorial walks through that pipeline end to end on the real
+Anopheles X-chromosome VCZ that ships under ``examples/data/`` -- a
+5.3 M-variant, 100-diploid store that bio2zarr preserved with all its
+INFO and FORMAT arrays. The packaged script reads a 4 Mb window so a
+single GPU run takes a couple of seconds.
 
 What the script does
 --------------------
 
-1. Simulates a 1 Mb chromosome with msprime (30 diploid individuals).
-2. Writes the result as a VCZ store and stamps in synthetic
-   ``variant_MQ``, ``call_GQ``, and ``call_DP`` arrays. In a real
-   workflow these come straight from bio2zarr converting a VCF that
-   already carries those FORMAT / INFO fields; the injection here keeps
-   the example self-contained.
-3. Reopens the store with ``fields=['MQ', 'GQ', 'DP']`` so the arrays
-   land on ``hm.fields``.
-4. Summarizes each field with a single ``np.percentile`` call. The
-   arrays are plain numpy, so any matplotlib / seaborn snippet works
-   for plotting -- ``plt.hist(hm.fields['GQ'].ravel(), bins=50)`` and
-   you have a quality-score distribution.
-5. Builds a per-variant boolean mask from ``MQ`` and a per-genotype
-   boolean mask from ``GQ`` and ``DP``, then runs ``hm.filter`` to
-   produce a clean matrix. ``drop_all_missing=True`` (the default)
-   also drops any variant whose every call was set to ``-1`` by the
-   per-genotype mask.
-6. Writes the filtered matrix back out via ``to_zarr``. The surviving
-   QC arrays land in the new store under the same field names, so a
-   reload with ``fields=`` returns them unchanged.
+1. Opens a 4 Mb window of ``examples/data/gamb.X.phased.n100.vcz`` with
+   ``fields=['AC', 'AAProb', 'PQ']``. ``AC`` lands as per-variant
+   ``(n_var,)``; ``AAProb`` is per-variant ``(n_var, 1)`` (bio2zarr's
+   shape for INFO with ``Number=A``); ``PQ`` is per-genotype
+   ``(n_var, n_samples)``. The reader auto-resolves which kind each is.
+2. Summarizes each field with one ``np.percentile`` call. The arrays
+   are plain numpy, so any matplotlib / seaborn snippet works for
+   plotting -- e.g. ``plt.hist(hm.fields['AC'], bins=50)`` for the
+   allele-count distribution.
+3. Builds a per-variant mask from ``AC`` and ``AAProb`` -- drop
+   singletons / doubletons (``AC >= 4``) and keep only confidently
+   polarized sites (``AAProb >= 0.9``).
+4. Constructs a per-genotype mask placeholder (``PQ >= -1``). The gamb
+   fixture carries ``-1`` everywhere in ``call_PQ`` because the source
+   VCF didn't populate phasing quality, so this mask is True for every
+   call. On a VCZ derived from a VCF that DID carry ``FMT/GQ`` or
+   ``FMT/DP`` the same line would read
+   ``(hm.fields['GQ'] >= 20) & (hm.fields['DP'] >= 10)``.
+5. Runs ``hm.filter`` and writes the survivor to a fresh VCZ. The
+   surviving ``variant_*`` / ``call_*`` arrays are preserved in the
+   clean store; a reload with the same ``fields=`` set returns them
+   byte-exact.
 
 A typical run on the default settings looks like:
 
 .. code-block:: text
 
-   31 segregating sites
-   hm.fields keys: ['DP', 'GQ', 'MQ']
+   Opening examples/data/gamb.X.phased.n100.vcz
+     region: X:1000000-5000000
+     fields: ['AC', 'AAProb', 'PQ']
+     loaded 1,041,651 variants x 100 diploids
+
    Field summaries (5 / 25 / 50 / 75 / 95 percentiles):
-       MQ: shape=(31,),    5/25/50/75/95% = 18.14 / 28.67 / 41.00 / 49.88 / 60.11
-       GQ: shape=(31, 30), 5/25/50/75/95% = 4.00 / 25.00 / 49.00 / 75.00 / 94.00
-       DP: shape=(31, 30), 5/25/50/75/95% = 2.00 / 10.00 / 19.00 / 29.00 / 38.00
-   variants kept  (MQ >= 35.0):                       21 / 31   (67.7 %)
-   genotypes masked (GQ >= 20 & DP >= 10):           359 / 930  (38.6 %)
-   21 variants survive both filters
+           AC: shape=(1041651,),     5/25/50/75/95% = 0.000 / 0.000 / 0.000 / 1.000 / 4.000
+       AAProb: shape=(1041651, 1),   5/25/50/75/95% = 0.991 / 1.000 / 1.000 / 1.000 / 1.000
+           PQ: shape=(1041651, 100), 5/25/50/75/95% = -1.000 / -1.000 / -1.000 / -1.000 / -1.000
+
+   Filtering: variants kept where AC >= 4 and AAProb >= 0.9
+     variants kept: 52,826 / 1,041,651 (5.1 %)
+     after filter: 52,826 variants
    Round-trip OK -- reloaded fields match the filtered matrix.
 
 Recipe

--- a/examples/vcf_qc_filter.py
+++ b/examples/vcf_qc_filter.py
@@ -1,164 +1,145 @@
 #!/usr/bin/env python
 """
-Load VCF/VCZ FORMAT/INFO quality metrics, filter on them, write a clean VCZ.
+Quality-aware filtering on a real VCZ: load FORMAT / INFO arrays, mask,
+write a clean VCZ.
 
-Walks through the four pieces of the ``fields=`` / ``filter()`` /
-``to_zarr`` workflow that pg_gpu_paper#108 (the GQ / DP / MQ feature)
-added:
+Demonstrates the ``fields=`` / ``filter()`` / ``to_zarr`` workflow added
+to pg_gpu against the empirical Anopheles X-chromosome VCZ that ships
+under ``examples/data/``. The store carries every field bio2zarr
+preserved during VCF encoding -- ``variant_AC`` / ``variant_AF`` /
+``variant_AAProb`` / ``call_PQ`` / ... -- so a real "tune thresholds
+read-side" demo runs without external data.
 
-1. Build a VCZ store from a small msprime simulation and inject
-   synthetic ``variant_MQ`` and ``call_GQ`` / ``call_DP`` arrays. In a
-   real workflow these come straight from bio2zarr converting a VCF
-   that already has ``FMT/GQ``, ``FMT/DP``, and ``INFO/MQ``; the
-   injection here just keeps the example fully self-contained.
-2. Reopen the store with ``fields=['MQ', 'GQ', 'DP']`` so ``hm.fields``
-   is populated.
-3. Summarize each field with one ``np.percentile`` call -- the
-   matrices come back as plain numpy arrays so any matplotlib /
-   seaborn snippet works.
-4. Build per-variant and per-genotype boolean masks from those arrays
-   and feed them to ``hm.filter`` to get a clean matrix.
-5. Save the clean matrix back out as a VCZ. The output round-trips the
-   surviving QC arrays.
+The script:
+
+1. Opens a 4 Mb window of ``examples/data/gamb.X.phased.n100.vcz`` with
+   ``fields=['AC', 'AAProb', 'PQ']``. ``AC`` is per-variant
+   ``(n_var,)``, ``AAProb`` is per-variant ``(n_var, 1)`` (bio2zarr
+   shape for INFO with ``Number=A``), and ``PQ`` is per-genotype
+   ``(n_var, n_samples)``. pg_gpu auto-resolves which kind each is.
+2. Summarizes each loaded field so the chosen thresholds are visible.
+3. Builds a real variant filter -- ``AC >= 4`` to drop singletons and
+   doubletons, ``AAProb >= 0.9`` to keep variants with a confident
+   ancestral-allele call.
+4. Builds a per-genotype mask placeholder (``PQ >= 0``). The gamb
+   fixture carries ``-1`` everywhere in ``call_PQ`` because the source
+   VCF didn't populate phasing quality, so this mask is True for every
+   call. On a VCZ derived from a VCF that DID carry ``FMT/GQ`` or
+   ``FMT/DP`` the same line would read ``(hm.fields['GQ'] >= 20) &
+   (hm.fields['DP'] >= 10)``.
+5. Runs ``hm.filter`` and writes the survivor to a fresh VCZ. The
+   surviving ``variant_*`` / ``call_*`` arrays are preserved in the
+   clean store and reload with the same ``fields=`` set.
 
 Usage
 -----
     pixi run python examples/vcf_qc_filter.py
-    pixi run python examples/vcf_qc_filter.py --seed 7 --min-gq 25
-    pixi run python examples/vcf_qc_filter.py --out /tmp/clean.vcz
+    pixi run python examples/vcf_qc_filter.py --min-ac 8 --min-aa-prob 0.95
+    pixi run python examples/vcf_qc_filter.py --region X:8000000-12000000
 """
 
 import argparse
 import shutil
 from pathlib import Path
 
-import msprime
 import numpy as np
-import zarr
 
 from pg_gpu import HaplotypeMatrix
 
 
-def _simulate(n_samples: int, seq_len: int, seed: int) -> HaplotypeMatrix:
-    """Small msprime fixture so the script needs no external data."""
-    ts = msprime.sim_ancestry(
-        samples=n_samples,
-        sequence_length=seq_len,
-        recombination_rate=1e-7,
-        random_seed=seed,
-        ploidy=2,
-    )
-    ts = msprime.sim_mutations(ts, rate=1e-6, random_seed=seed)
-    return HaplotypeMatrix.from_ts(ts)
+DEFAULT_SRC = "examples/data/gamb.X.phased.n100.vcz"
 
 
-def _write_vcz_with_synthetic_qc(hm: HaplotypeMatrix, path: str, seed: int):
-    """Write a VCZ store and stamp in synthetic MQ / GQ / DP arrays.
-
-    The MQ values are correlated with variant position so the variant
-    filter has something interesting to remove; GQ and DP are random
-    so the per-genotype filter masks a realistic fraction of calls.
-    """
-    if Path(path).exists():
-        shutil.rmtree(path)
-    hm.to_zarr(path, format="vcz", contig_name="chr1")
-    store = zarr.open_group(path, mode="r+")
-    rng = np.random.default_rng(seed)
-    n_var = int(hm.haplotypes.shape[1])
-    n_sam = int(hm.haplotypes.shape[0] // 2)
-    # MQ trends from low (left) to high (right) plus a touch of noise
-    # so a threshold filter has a clear effect.
-    mq = np.linspace(20.0, 60.0, n_var, dtype=np.float32)
-    mq += rng.normal(0.0, 5.0, size=n_var).astype(np.float32)
-    gq = rng.integers(0, 99, size=(n_var, n_sam), dtype=np.int16)
-    dp = rng.integers(1, 40, size=(n_var, n_sam), dtype=np.int16)
-    store.create_array("variant_MQ", data=mq)
-    store.create_array("call_GQ", data=gq)
-    store.create_array("call_DP", data=dp)
-
-
-def _summarize_field(name: str, arr: np.ndarray):
-    """Print median + IQR for a field. Flat for INFO, flattened for FORMAT."""
-    values = arr.ravel()
-    q = np.percentile(values, [5, 25, 50, 75, 95])
-    print(f"  {name:>4}: shape={arr.shape}, "
-          f"5/25/50/75/95% = {q[0]:.2f} / {q[1]:.2f} / "
-          f"{q[2]:.2f} / {q[3]:.2f} / {q[4]:.2f}")
+def _summarize(name, arr):
+    """Median + IQR; works on 1D, 2D INFO (n_var, n_alt), or FORMAT."""
+    flat = arr.ravel()
+    q = np.percentile(flat, [5, 25, 50, 75, 95])
+    print(f"  {name:>8}: shape={arr.shape}, "
+          f"5/25/50/75/95% = {q[0]:.3f} / {q[1]:.3f} / "
+          f"{q[2]:.3f} / {q[3]:.3f} / {q[4]:.3f}")
 
 
 def main():
     p = argparse.ArgumentParser(description=__doc__.splitlines()[1])
-    p.add_argument("--seed", type=int, default=42)
-    p.add_argument("--n-samples", type=int, default=30,
-                   help="Number of diploid individuals (default: 30)")
-    p.add_argument("--seq-len", type=int, default=1_000_000,
-                   help="Simulated chromosome length in bp (default: 1 Mb)")
-    p.add_argument("--min-mq", type=float, default=35.0,
-                   help="Variant-level MQ threshold (default: 35.0)")
-    p.add_argument("--min-gq", type=int, default=20,
-                   help="Per-genotype GQ threshold (default: 20)")
-    p.add_argument("--min-dp", type=int, default=10,
-                   help="Per-genotype DP threshold (default: 10)")
-    p.add_argument("--src", type=str, default="/tmp/vcf_qc_filter.src.vcz",
-                   help="Where to write the source (pre-filter) VCZ.")
-    p.add_argument("--out", type=str, default="/tmp/vcf_qc_filter.clean.vcz",
-                   help="Where to write the filtered (clean) VCZ.")
+    p.add_argument("--src", type=str, default=DEFAULT_SRC,
+                   help=f"Source VCZ (default: {DEFAULT_SRC}). "
+                        "Any VCZ from bio2zarr will work.")
+    p.add_argument("--region", type=str, default="X:1000000-5000000",
+                   help="chrom:start-end window of the source to load. "
+                        "Keep it under ~5 Mb to fit comfortably in memory; "
+                        "the full chromosome is 25 Mb / 5.3M variants.")
+    p.add_argument("--min-ac", type=int, default=4,
+                   help="Drop variants whose allele count is below this. "
+                        "AC=1 are singletons, AC=2 doubletons; default 4 "
+                        "trims everything <0.02 MAF.")
+    p.add_argument("--min-aa-prob", type=float, default=0.9,
+                   help="Drop variants where the ancestral-allele "
+                        "probability is below this (only the most "
+                        "confident polarizations survive). Default 0.9.")
+    p.add_argument("--out", type=str, default="/tmp/gamb.X.clean.vcz",
+                   help="Where to write the filtered VCZ.")
     args = p.parse_args()
 
-    print(f"Simulating ({args.n_samples} diploids, {args.seq_len:,} bp) ...")
-    hm_src = _simulate(args.n_samples, args.seq_len, args.seed)
-    n_var = int(hm_src.haplotypes.shape[1])
-    print(f"  {n_var:,} segregating sites")
+    if not Path(args.src).exists():
+        raise SystemExit(
+            f"Source VCZ not found: {args.src}. The default ships with "
+            f"the repo under examples/data/; if you cloned without LFS "
+            f"you may need to fetch the data fixtures.")
 
-    print(f"Writing VCZ with synthetic MQ / GQ / DP to {args.src} ...")
-    _write_vcz_with_synthetic_qc(hm_src, args.src, args.seed)
-
-    print("Reopening with fields=['MQ', 'GQ', 'DP'] ...")
+    print(f"Opening {args.src}")
+    print(f"  region: {args.region}")
+    print("  fields: ['AC', 'AAProb', 'PQ']")
     hm = HaplotypeMatrix.from_zarr(
-        args.src, fields=["MQ", "GQ", "DP"], streaming="never",
+        args.src, region=args.region,
+        fields=["AC", "AAProb", "PQ"],
+        streaming="never",
     )
-    print(f"  hm.fields keys: {sorted(hm.fields)}")
+    n_var = int(hm.haplotypes.shape[1])
+    n_sam = int(hm.haplotypes.shape[0] // 2)
+    print(f"  loaded {n_var:,} variants x {n_sam} diploids")
+    print()
     print("Field summaries (5 / 25 / 50 / 75 / 95 percentiles):")
-    for name in ("MQ", "GQ", "DP"):
-        _summarize_field(name, hm.fields[name])
+    _summarize("AC", hm.fields["AC"])
+    _summarize("AAProb", hm.fields["AAProb"])
+    _summarize("PQ", hm.fields["PQ"])
+    print()
+    print(f"Filtering: variants kept where AC >= {args.min_ac} and "
+          f"AAProb >= {args.min_aa_prob}")
+    # variant_AAProb arrives as (n_var, 1); .ravel() peels off the
+    # trailing axis so the mask is the (n_var,) bool that filter()
+    # expects.
+    aa_prob = hm.fields["AAProb"].ravel()
+    variants = (hm.fields["AC"] >= args.min_ac) & (aa_prob >= args.min_aa_prob)
+    # In this store call_PQ wasn't populated by the source VCF (all -1);
+    # the per-genotype mask is universally True, so it has no effect
+    # here. On a store derived from a VCF that DID carry FMT/GQ + FMT/DP
+    # the natural line would be:
+    #     genotypes = (hm.fields['GQ'] >= 20) & (hm.fields['DP'] >= 10)
+    genotypes = hm.fields["PQ"] >= -1
+    print(f"  variants kept: {int(variants.sum()):,} / {n_var:,} "
+          f"({100.0 * float(variants.mean()):.1f} %)")
 
-    print("Building masks ...")
-    variants = hm.fields["MQ"] >= args.min_mq
-    genotypes = (hm.fields["GQ"] >= args.min_gq) & (hm.fields["DP"] >= args.min_dp)
-    n_var_keep = int(variants.sum())
-    n_gt_drop = int((~genotypes).sum())
-    n_gt_total = genotypes.size
-    print(f"  variants kept (MQ >= {args.min_mq}): "
-          f"{n_var_keep:,} / {n_var:,} "
-          f"({100.0 * n_var_keep / n_var:.1f} %)")
-    print(f"  genotypes masked (GQ >= {args.min_gq} & DP >= {args.min_dp}): "
-          f"{n_gt_drop:,} / {n_gt_total:,} "
-          f"({100.0 * n_gt_drop / n_gt_total:.1f} %)")
-
-    print("Filtering ...")
     hm_clean = hm.filter(
         variants=variants,
         genotypes=genotypes,
         drop_all_missing=True,
     )
     n_clean = int(hm_clean.haplotypes.shape[1])
-    print(f"  {n_clean:,} variants survive both filters "
-          f"(drop_all_missing rolled in)")
-
-    print(f"Writing clean VCZ to {args.out} ...")
+    print(f"  after filter: {n_clean:,} variants")
+    print()
+    print(f"Writing clean VCZ to {args.out}")
     if Path(args.out).exists():
         shutil.rmtree(args.out)
-    hm_clean.to_zarr(args.out, format="vcz", contig_name="chr1")
+    hm_clean.to_zarr(args.out, format="vcz", contig_name="X")
 
-    # Reload to confirm the round-trip; the surviving QC arrays
-    # are present on the new matrix, byte-equal to the in-memory
-    # filtered version.
+    # Reload and assert the round-trip is byte-exact.
     rt = HaplotypeMatrix.from_zarr(
-        args.out, fields=["MQ", "GQ", "DP"], streaming="never",
+        args.out, fields=["AC", "AAProb", "PQ"], streaming="never",
     )
-    np.testing.assert_array_equal(rt.fields["MQ"], hm_clean.fields["MQ"])
-    np.testing.assert_array_equal(rt.fields["GQ"], hm_clean.fields["GQ"])
-    np.testing.assert_array_equal(rt.fields["DP"], hm_clean.fields["DP"])
+    np.testing.assert_array_equal(rt.fields["AC"], hm_clean.fields["AC"])
+    np.testing.assert_array_equal(rt.fields["AAProb"],
+                                   hm_clean.fields["AAProb"])
+    np.testing.assert_array_equal(rt.fields["PQ"], hm_clean.fields["PQ"])
     print("Round-trip OK -- reloaded fields match the filtered matrix.")
 
 

--- a/examples/vcf_qc_filter.py
+++ b/examples/vcf_qc_filter.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+"""
+Load VCF/VCZ FORMAT/INFO quality metrics, filter on them, write a clean VCZ.
+
+Walks through the four pieces of the ``fields=`` / ``filter()`` /
+``to_zarr`` workflow that pg_gpu_paper#108 (the GQ / DP / MQ feature)
+added:
+
+1. Build a VCZ store from a small msprime simulation and inject
+   synthetic ``variant_MQ`` and ``call_GQ`` / ``call_DP`` arrays. In a
+   real workflow these come straight from bio2zarr converting a VCF
+   that already has ``FMT/GQ``, ``FMT/DP``, and ``INFO/MQ``; the
+   injection here just keeps the example fully self-contained.
+2. Reopen the store with ``fields=['MQ', 'GQ', 'DP']`` so ``hm.fields``
+   is populated.
+3. Summarize each field with one ``np.percentile`` call -- the
+   matrices come back as plain numpy arrays so any matplotlib /
+   seaborn snippet works.
+4. Build per-variant and per-genotype boolean masks from those arrays
+   and feed them to ``hm.filter`` to get a clean matrix.
+5. Save the clean matrix back out as a VCZ. The output round-trips the
+   surviving QC arrays.
+
+Usage
+-----
+    pixi run python examples/vcf_qc_filter.py
+    pixi run python examples/vcf_qc_filter.py --seed 7 --min-gq 25
+    pixi run python examples/vcf_qc_filter.py --out /tmp/clean.vcz
+"""
+
+import argparse
+import shutil
+from pathlib import Path
+
+import msprime
+import numpy as np
+import zarr
+
+from pg_gpu import HaplotypeMatrix
+
+
+def _simulate(n_samples: int, seq_len: int, seed: int) -> HaplotypeMatrix:
+    """Small msprime fixture so the script needs no external data."""
+    ts = msprime.sim_ancestry(
+        samples=n_samples,
+        sequence_length=seq_len,
+        recombination_rate=1e-7,
+        random_seed=seed,
+        ploidy=2,
+    )
+    ts = msprime.sim_mutations(ts, rate=1e-6, random_seed=seed)
+    return HaplotypeMatrix.from_ts(ts)
+
+
+def _write_vcz_with_synthetic_qc(hm: HaplotypeMatrix, path: str, seed: int):
+    """Write a VCZ store and stamp in synthetic MQ / GQ / DP arrays.
+
+    The MQ values are correlated with variant position so the variant
+    filter has something interesting to remove; GQ and DP are random
+    so the per-genotype filter masks a realistic fraction of calls.
+    """
+    if Path(path).exists():
+        shutil.rmtree(path)
+    hm.to_zarr(path, format="vcz", contig_name="chr1")
+    store = zarr.open_group(path, mode="r+")
+    rng = np.random.default_rng(seed)
+    n_var = int(hm.haplotypes.shape[1])
+    n_sam = int(hm.haplotypes.shape[0] // 2)
+    # MQ trends from low (left) to high (right) plus a touch of noise
+    # so a threshold filter has a clear effect.
+    mq = np.linspace(20.0, 60.0, n_var, dtype=np.float32)
+    mq += rng.normal(0.0, 5.0, size=n_var).astype(np.float32)
+    gq = rng.integers(0, 99, size=(n_var, n_sam), dtype=np.int16)
+    dp = rng.integers(1, 40, size=(n_var, n_sam), dtype=np.int16)
+    store.create_array("variant_MQ", data=mq)
+    store.create_array("call_GQ", data=gq)
+    store.create_array("call_DP", data=dp)
+
+
+def _summarize_field(name: str, arr: np.ndarray):
+    """Print median + IQR for a field. Flat for INFO, flattened for FORMAT."""
+    values = arr.ravel()
+    q = np.percentile(values, [5, 25, 50, 75, 95])
+    print(f"  {name:>4}: shape={arr.shape}, "
+          f"5/25/50/75/95% = {q[0]:.2f} / {q[1]:.2f} / "
+          f"{q[2]:.2f} / {q[3]:.2f} / {q[4]:.2f}")
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--n-samples", type=int, default=30,
+                   help="Number of diploid individuals (default: 30)")
+    p.add_argument("--seq-len", type=int, default=1_000_000,
+                   help="Simulated chromosome length in bp (default: 1 Mb)")
+    p.add_argument("--min-mq", type=float, default=35.0,
+                   help="Variant-level MQ threshold (default: 35.0)")
+    p.add_argument("--min-gq", type=int, default=20,
+                   help="Per-genotype GQ threshold (default: 20)")
+    p.add_argument("--min-dp", type=int, default=10,
+                   help="Per-genotype DP threshold (default: 10)")
+    p.add_argument("--src", type=str, default="/tmp/vcf_qc_filter.src.vcz",
+                   help="Where to write the source (pre-filter) VCZ.")
+    p.add_argument("--out", type=str, default="/tmp/vcf_qc_filter.clean.vcz",
+                   help="Where to write the filtered (clean) VCZ.")
+    args = p.parse_args()
+
+    print(f"Simulating ({args.n_samples} diploids, {args.seq_len:,} bp) ...")
+    hm_src = _simulate(args.n_samples, args.seq_len, args.seed)
+    n_var = int(hm_src.haplotypes.shape[1])
+    print(f"  {n_var:,} segregating sites")
+
+    print(f"Writing VCZ with synthetic MQ / GQ / DP to {args.src} ...")
+    _write_vcz_with_synthetic_qc(hm_src, args.src, args.seed)
+
+    print("Reopening with fields=['MQ', 'GQ', 'DP'] ...")
+    hm = HaplotypeMatrix.from_zarr(
+        args.src, fields=["MQ", "GQ", "DP"], streaming="never",
+    )
+    print(f"  hm.fields keys: {sorted(hm.fields)}")
+    print("Field summaries (5 / 25 / 50 / 75 / 95 percentiles):")
+    for name in ("MQ", "GQ", "DP"):
+        _summarize_field(name, hm.fields[name])
+
+    print("Building masks ...")
+    variants = hm.fields["MQ"] >= args.min_mq
+    genotypes = (hm.fields["GQ"] >= args.min_gq) & (hm.fields["DP"] >= args.min_dp)
+    n_var_keep = int(variants.sum())
+    n_gt_drop = int((~genotypes).sum())
+    n_gt_total = genotypes.size
+    print(f"  variants kept (MQ >= {args.min_mq}): "
+          f"{n_var_keep:,} / {n_var:,} "
+          f"({100.0 * n_var_keep / n_var:.1f} %)")
+    print(f"  genotypes masked (GQ >= {args.min_gq} & DP >= {args.min_dp}): "
+          f"{n_gt_drop:,} / {n_gt_total:,} "
+          f"({100.0 * n_gt_drop / n_gt_total:.1f} %)")
+
+    print("Filtering ...")
+    hm_clean = hm.filter(
+        variants=variants,
+        genotypes=genotypes,
+        drop_all_missing=True,
+    )
+    n_clean = int(hm_clean.haplotypes.shape[1])
+    print(f"  {n_clean:,} variants survive both filters "
+          f"(drop_all_missing rolled in)")
+
+    print(f"Writing clean VCZ to {args.out} ...")
+    if Path(args.out).exists():
+        shutil.rmtree(args.out)
+    hm_clean.to_zarr(args.out, format="vcz", contig_name="chr1")
+
+    # Reload to confirm the round-trip; the surviving QC arrays
+    # are present on the new matrix, byte-equal to the in-memory
+    # filtered version.
+    rt = HaplotypeMatrix.from_zarr(
+        args.out, fields=["MQ", "GQ", "DP"], streaming="never",
+    )
+    np.testing.assert_array_equal(rt.fields["MQ"], hm_clean.fields["MQ"])
+    np.testing.assert_array_equal(rt.fields["GQ"], hm_clean.fields["GQ"])
+    np.testing.assert_array_equal(rt.fields["DP"], hm_clean.fields["DP"])
+    print("Round-trip OK -- reloaded fields match the filtered matrix.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -698,8 +698,13 @@ class GenotypeMatrix:
 
         if format == 'vcz':
             write_vcz(zarr_path, gt, pos, self.samples,
-                      contig_name=contig_name)
+                      contig_name=contig_name, fields=self.fields)
         elif format == 'scikit-allel':
+            if self.fields:
+                raise NotImplementedError(
+                    "Writing fields= round-trip is only supported for "
+                    "format='vcz'; the scikit-allel writer has not been "
+                    "extended yet.")
             write_allel(zarr_path, gt, pos, self.samples)
         else:
             raise ValueError(

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -568,6 +568,106 @@ class GenotypeMatrix:
             chunk_bp=chunk_bp, prefetch=prefetch,
         )
 
+    def filter(self, variants=None, genotypes=None,
+               drop_all_missing: bool = True) -> "GenotypeMatrix":
+        """Return a new GenotypeMatrix with quality filters applied.
+
+        Parameters
+        ----------
+        variants : array-like of bool, shape (n_variants,), optional
+            Per-variant keep mask; variants where ``False`` are dropped
+            from every array on the returned matrix.
+        genotypes : array-like of bool, shape (n_variants, n_samples), optional
+            Per-genotype keep mask; genotypes where ``False`` are set to
+            ``-1`` (missing). ``fields`` entries keep their original
+            per-genotype QC values.
+        drop_all_missing : bool, default True
+            After applying both masks, drop variants where every
+            individual's call is ``-1``.
+
+        Returns
+        -------
+        GenotypeMatrix
+            Fresh matrix; underlying arrays are new allocations.
+            ``samples``, ``sample_sets``, ``chrom_start`` / ``chrom_end``
+            are preserved. See ``HaplotypeMatrix.filter`` for the
+            accessibility-mask interaction (this method behaves the
+            same way).
+        """
+        xp = cp if self._device == 'GPU' else np
+        geno_src = self._genotypes
+        pos_src = self._positions
+        n_indiv, n_var = geno_src.shape
+
+        if variants is not None:
+            variants_arr = xp.asarray(variants).astype(bool, copy=False)
+            if variants_arr.shape != (n_var,):
+                raise ValueError(
+                    f"variants mask shape mismatch: expected ({n_var},), "
+                    f"got {tuple(variants_arr.shape)}")
+        else:
+            variants_arr = None
+
+        if genotypes is not None:
+            genotypes_arr = xp.asarray(genotypes).astype(bool, copy=False)
+            if genotypes_arr.shape != (n_var, n_indiv):
+                raise ValueError(
+                    f"genotypes mask shape mismatch: expected "
+                    f"({n_var}, {n_indiv}), got "
+                    f"{tuple(genotypes_arr.shape)}")
+        else:
+            genotypes_arr = None
+
+        if genotypes_arr is not None:
+            # User mask is (n_var, n_samples); genotype matrix lays
+            # samples along axis 0, so transpose to broadcast.
+            geno = xp.where(genotypes_arr.T, geno_src, np.int8(-1))
+        else:
+            geno = geno_src
+
+        keep_v = xp.ones(n_var, dtype=bool)
+        if variants_arr is not None:
+            keep_v &= variants_arr
+        if drop_all_missing:
+            keep_v &= ~(geno == -1).all(axis=0)
+        keep_idx = xp.where(keep_v)[0]
+
+        if int(keep_idx.size) == 0:
+            if self._device == 'GPU':
+                empty_geno = cp.empty((n_indiv, 0), dtype=geno_src.dtype)
+                empty_pos = cp.array([], dtype=pos_src.dtype)
+            else:
+                empty_geno = np.empty((n_indiv, 0), dtype=geno_src.dtype)
+                empty_pos = np.array([], dtype=pos_src.dtype)
+            result = object.__new__(GenotypeMatrix)
+            result._genotypes = empty_geno
+            result._positions = empty_pos
+            result._accessible_idx = None
+            result._geno_filtered = None
+            result._pos_filtered = None
+            result._accessible_mask = None
+            result.chrom_start = self.chrom_start
+            result.chrom_end = self.chrom_end
+            result._sample_sets = self._sample_sets
+            result._device = self._device
+            result.n_total_sites = None
+            result.samples = self.samples
+            result.fields = {tag: arr[:0] for tag, arr in self.fields.items()}
+            return result
+
+        new_geno = geno[:, keep_idx]
+        new_pos = pos_src[keep_idx]
+        keep_idx_np = keep_idx.get() if hasattr(keep_idx, 'get') else keep_idx
+        new_fields = {tag: arr[keep_idx_np] for tag, arr in self.fields.items()}
+
+        return GenotypeMatrix(
+            new_geno, new_pos,
+            chrom_start=self.chrom_start, chrom_end=self.chrom_end,
+            sample_sets=self._sample_sets,
+            samples=self.samples,
+            fields=new_fields,
+        )
+
     def to_zarr(self, zarr_path, format='vcz', contig_name=None):
         """Save genotype data to Zarr format.
 

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -31,7 +31,7 @@ class GenotypeMatrix:
 
     def __init__(self, genotypes, positions, chrom_start=None, chrom_end=None,
                  sample_sets=None, n_total_sites=None, samples=None,
-                 accessible_mask=None):
+                 accessible_mask=None, fields=None):
         if genotypes.size == 0:
             raise ValueError("genotypes cannot be empty")
         if positions.size == 0:
@@ -57,6 +57,8 @@ class GenotypeMatrix:
         self._sample_sets = sample_sets
         self.n_total_sites = n_total_sites
         self.samples = samples
+        # See HaplotypeMatrix.fields for the shape contract.
+        self.fields = dict(fields) if fields else {}
 
         if accessible_mask is not None and not isinstance(accessible_mask, AccessibleMask):
             accessible_mask = resolve_accessible_mask(
@@ -340,7 +342,8 @@ class GenotypeMatrix:
                                accessible_mask=self.accessible_mask)
 
     @classmethod
-    def from_vcf(cls, path, include_invariant=False, accessible_bed=None):
+    def from_vcf(cls, path, include_invariant=False, accessible_bed=None,
+                 fields=None):
         """Construct from a VCF file.
 
         Parameters
@@ -351,15 +354,31 @@ class GenotypeMatrix:
             If True, include invariant sites and set n_total_sites.
         accessible_bed : str, optional
             Path to a BED file defining accessible/callable regions.
+        fields : list of str, optional
+            VCF FORMAT/INFO tags to load (e.g. ``['GQ', 'DP', 'MQ']``); see
+            ``HaplotypeMatrix.from_vcf`` for the shape contract. Arrays are
+            sliced down to the biallelic-only variant set this constructor
+            keeps, so per-variant fields end up shape ``(n_kept,)`` and
+            per-genotype fields ``(n_kept, n_samples)``.
 
         Returns
         -------
         GenotypeMatrix
         """
         import allel
+        from .haplotype_matrix import (
+            _build_read_vcf_fields, _classify_vcf_qc_tags,
+            _resolve_qc_fields_vcf,
+        )
         from ._memory_warning import _maybe_memory_warn
         _maybe_memory_warn(path)
-        callset = allel.read_vcf(path)
+        if fields:
+            tag_to_path, unknown_tags = _classify_vcf_qc_tags(path, fields)
+            read_fields = _build_read_vcf_fields(tag_to_path.values())
+        else:
+            tag_to_path, unknown_tags = {}, []
+            read_fields = None
+        callset = allel.read_vcf(path, fields=read_fields)
         gt = callset['calldata/GT']  # (n_variants, n_samples, 2)
         pos = callset['variants/POS']
         samples = list(callset['samples'])
@@ -372,6 +391,14 @@ class GenotypeMatrix:
         gt = gt[is_biallelic]
         pos = pos[is_biallelic]
 
+        qc_fields = (_resolve_qc_fields_vcf(callset, tag_to_path, unknown_tags)
+                     if fields else {})
+        # The biallelic filter trims the variant axis; QC arrays must be
+        # sliced consistently or they'd no longer align with the genotype
+        # matrix.
+        for tag, arr in qc_fields.items():
+            qc_fields[tag] = arr[is_biallelic]
+
         # sum alleles to get alt count (0/1/2)
         geno = np.sum(gt, axis=2).astype(np.int8)  # (n_variants, n_samples)
         # handle missing (-1 in either allele)
@@ -383,7 +410,8 @@ class GenotypeMatrix:
 
         n_total_sites = geno.shape[1] if include_invariant else None
         gm = cls(geno, pos, chrom_start=pos[0], chrom_end=pos[-1],
-                 n_total_sites=n_total_sites, samples=samples)
+                 n_total_sites=n_total_sites, samples=samples,
+                 fields=qc_fields)
         if accessible_bed is not None:
             chrom = None
             if 'variants/CHROM' in callset:
@@ -398,13 +426,14 @@ class GenotypeMatrix:
                   streaming: str = "auto",
                   chunk_bp: int = 1_500_000,
                   prefetch: int = 1,
-                  backend: str = "auto"):
+                  backend: str = "auto",
+                  fields: list = None):
         """Construct a GenotypeMatrix from a Zarr store.
 
         Identical interface to ``HaplotypeMatrix.from_zarr``;
         see that method's docstring for the meaning of every kwarg
         (``streaming``, ``pop_assignment`` flexibility, ``chunk_bp``,
-        ``prefetch``, ``backend``). The only difference is the
+        ``prefetch``, ``backend``, ``fields``). The only difference is the
         returned type: this returns ``GenotypeMatrix`` (or
         ``StreamingGenotypeMatrix`` on the streaming path) where
         each row is a (n_indiv, ploidy) genotype call, versus
@@ -417,7 +446,7 @@ class GenotypeMatrix:
             If True, set ``n_total_sites`` from the loaded variant
             count. Unique to this entry point (the haplotype matrix
             does not need it).
-        path, region, accessible_bed, pop_assignment, streaming, chunk_bp, prefetch, backend
+        path, region, accessible_bed, pop_assignment, streaming, chunk_bp, prefetch, backend, fields
             See ``HaplotypeMatrix.from_zarr``.
 
         Returns
@@ -436,6 +465,11 @@ class GenotypeMatrix:
             )
 
         if streaming == "always":
+            if fields:
+                raise NotImplementedError(
+                    "fields= is not supported on the streaming "
+                    "(streaming='always') path yet. Load eagerly to "
+                    "access VCF FORMAT/INFO arrays.")
             return cls._build_streaming(
                 path, region=region, pop_assignment=pop_assignment,
                 chunk_bp=chunk_bp, prefetch=prefetch,
@@ -452,6 +486,12 @@ class GenotypeMatrix:
                                                 streaming=streaming,
                                                 pop_assignment=pop_assignment)
         if choice == "streaming":
+            if fields:
+                raise NotImplementedError(
+                    "fields= is not supported on the streaming path; "
+                    "matrix would not fit at streaming='auto'. Pass "
+                    "streaming='never' to force eager (and fit-check), "
+                    "or load without fields=.")
             return cls._build_streaming(
                 path, region=region, pop_assignment=pop_assignment,
                 chunk_bp=chunk_bp, prefetch=prefetch,
@@ -460,12 +500,13 @@ class GenotypeMatrix:
         return cls._build_eager(path, region=region,
                                 accessible_bed=accessible_bed,
                                 include_invariant=include_invariant,
-                                pop_assignment=pop_assignment)
+                                pop_assignment=pop_assignment,
+                                fields=fields)
 
     @classmethod
     def _build_eager(cls, path, *, region, accessible_bed,
-                     include_invariant, pop_assignment):
-        from .zarr_io import read_genotypes, normalize_pop_input
+                     include_invariant, pop_assignment, fields=None):
+        from .zarr_io import read_genotypes, normalize_pop_input, read_qc_fields
         from ._gpu_genotype_prep import build_genotype_matrix
 
         data = read_genotypes(path, region)
@@ -483,6 +524,12 @@ class GenotypeMatrix:
             n_total_sites=n_total_sites,
             samples=list(samples) if samples else None,
         )
+        if fields:
+            gm.fields = read_qc_fields(
+                path, fields,
+                variant_indices=data.get('variant_indices'),
+                region=region,
+            )
         if accessible_bed is not None:
             gm.set_accessible_mask(accessible_bed, chrom=chrom)
 

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -761,8 +761,13 @@ class HaplotypeMatrix:
 
         if format == 'vcz':
             write_vcz(zarr_path, gt, pos, self.samples,
-                      contig_name=contig_name)
+                      contig_name=contig_name, fields=self.fields)
         elif format == 'scikit-allel':
+            if self.fields:
+                raise NotImplementedError(
+                    "Writing fields= round-trip is only supported for "
+                    "format='vcz'; the scikit-allel writer has not been "
+                    "extended yet.")
             write_allel(zarr_path, gt, pos, self.samples)
         else:
             raise ValueError(

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -2,9 +2,82 @@ import cupy as cp
 import numpy as np
 import allel
 import tskit
+import warnings
 from collections import Counter, OrderedDict
 
 from .accessible import AccessibleMask, bed_to_mask, resolve_accessible_mask
+
+
+def _classify_vcf_qc_tags(path, tags):
+    """Decide INFO vs FORMAT for each bare tag using the VCF header.
+
+    ``allel.read_vcf`` will happily materialize a ``variants/<tag>``
+    placeholder of object dtype when no INFO declaration exists, which
+    silently shadows the real FORMAT array. Inspecting the header up
+    front lets us request the right path the first time.
+
+    Returns ``(known, unknown)`` where ``known`` maps tag ->
+    ``'variants/<tag>'`` or ``'calldata/<tag>'`` for tags declared in
+    the header, and ``unknown`` is the list of tags absent from both
+    INFO and FORMAT sections.
+    """
+    headers = allel.read_vcf_headers(path)
+    info_keys = set(getattr(headers, 'infos', {}) or {})
+    format_keys = set(getattr(headers, 'formats', {}) or {})
+    known = {}
+    unknown = []
+    for tag in tags:
+        if tag in info_keys:
+            known[tag] = f'variants/{tag}'
+        elif tag in format_keys:
+            known[tag] = f'calldata/{tag}'
+        else:
+            unknown.append(tag)
+    return known, unknown
+
+
+def _build_read_vcf_fields(known_paths):
+    """Build the explicit field list for ``allel.read_vcf``.
+
+    ``known_paths`` is the iterable of ``variants/<tag>`` /
+    ``calldata/<tag>`` strings returned by ``_classify_vcf_qc_tags``;
+    only paths actually declared in the VCF header are passed through
+    so we don't end up with ghost object-dtype arrays.
+    """
+    out = ['samples', 'variants/POS', 'variants/CHROM', 'calldata/GT']
+    out.extend(known_paths)
+    return out
+
+
+def _resolve_qc_fields_vcf(callset, tag_to_path, unknown):
+    """Pull QC fields out of a scikit-allel callset using known paths.
+
+    ``tag_to_path`` is the mapping from ``_classify_vcf_qc_tags``;
+    ``unknown`` is its sibling list of tags missing from both INFO and
+    FORMAT sections. Tags whose value array is empty (e.g. the read
+    skipped the FORMAT due to an unsupported dtype) are demoted to
+    ``unknown`` so the warning is honest about what was lost.
+    """
+    out = {}
+    missing = list(unknown)
+    for tag, path in tag_to_path.items():
+        if path not in callset:
+            missing.append(tag)
+            continue
+        arr = np.asarray(callset[path])
+        if arr.size == 0:
+            # scikit-allel sometimes emits an empty array when it
+            # decides the declared type isn't decodable; treat that
+            # the same as "field missing".
+            missing.append(tag)
+            continue
+        out[tag] = arr
+    if missing:
+        warnings.warn(
+            f"VCF quality fields not found and dropped: {missing}",
+            stacklevel=3,
+        )
+    return out
 
 
 #: Fraction of free GPU memory the eager matrix is allowed to consume
@@ -104,6 +177,7 @@ class HaplotypeMatrix:
                  n_total_sites: int = None,
                  samples: list = None,
                  accessible_mask=None,
+                 fields: dict = None,
                 ):
         if genotypes.size == 0:
             raise ValueError("genotypes cannot be empty")
@@ -134,6 +208,11 @@ class HaplotypeMatrix:
         self._sample_sets = sample_sets
         self.n_total_sites = n_total_sites
         self.samples = samples  # diploid sample names from VCF
+        # Optional per-variant (n_var,) and per-genotype (n_var, n_samples)
+        # VCF FORMAT/INFO arrays. Empty dict when no quality fields were
+        # requested at load time. Shape disambiguates per-variant vs
+        # per-genotype.
+        self.fields = dict(fields) if fields else {}
 
         if accessible_mask is not None and not isinstance(accessible_mask, AccessibleMask):
             accessible_mask = resolve_accessible_mask(
@@ -356,7 +435,7 @@ class HaplotypeMatrix:
     @classmethod
     def from_vcf(cls, path: str, region: str = None,
                  samples: list = None, include_invariant: bool = False,
-                 accessible_bed: str = None):
+                 accessible_bed: str = None, fields: list = None):
         """Construct a HaplotypeMatrix from a VCF file.
 
         Parameters
@@ -372,6 +451,12 @@ class HaplotypeMatrix:
             If True, set n_total_sites from the loaded variant count.
         accessible_bed : str, optional
             Path to a BED file defining accessible/callable regions.
+        fields : list of str, optional
+            VCF FORMAT/INFO tags to load alongside GT (e.g. ``['GQ', 'DP', 'MQ']``).
+            Each tag is auto-resolved: INFO matches land in
+            ``hm.fields[tag]`` as a ``(n_var,)`` array, FORMAT matches as a
+            ``(n_var, n_samples)`` array. Tags missing from the VCF are
+            warned and dropped silently.
 
         Returns
         -------
@@ -380,7 +465,14 @@ class HaplotypeMatrix:
         """
         from ._memory_warning import _maybe_memory_warn
         _maybe_memory_warn(path, region=region)
-        vcf = allel.read_vcf(path, region=region, samples=samples)
+        if fields:
+            tag_to_path, unknown_tags = _classify_vcf_qc_tags(path, fields)
+            read_fields = _build_read_vcf_fields(tag_to_path.values())
+        else:
+            tag_to_path, unknown_tags = {}, []
+            read_fields = None
+        vcf = allel.read_vcf(path, region=region, samples=samples,
+                             fields=read_fields)
         if vcf is None:
             raise ValueError(f"No variants found in {path}"
                              + (f" for region {region}" if region else ""))
@@ -417,9 +509,13 @@ class HaplotypeMatrix:
         elif 'variants/CHROM' in vcf:
             chrom = vcf['variants/CHROM'][0]
 
+        qc_fields = (_resolve_qc_fields_vcf(vcf, tag_to_path, unknown_tags)
+                     if fields else {})
+
         n_total_sites = num_variants if include_invariant else None
         hm = cls(haplotypes, positions, chrom_start, chrom_end,
-                 n_total_sites=n_total_sites, samples=sample_names)
+                 n_total_sites=n_total_sites, samples=sample_names,
+                 fields=qc_fields)
         if accessible_bed is not None:
             hm.set_accessible_mask(accessible_bed, chrom=chrom)
         return hm
@@ -431,7 +527,8 @@ class HaplotypeMatrix:
                   streaming: str = "auto",
                   chunk_bp: int = 1_500_000,
                   prefetch: int = 1,
-                  backend: str = "auto"):
+                  backend: str = "auto",
+                  fields: list = None):
         """Construct a HaplotypeMatrix from a Zarr store.
 
         Supports both VCZ (bio2zarr) and scikit-allel zarr layouts.
@@ -495,6 +592,13 @@ class HaplotypeMatrix:
             ``'kvikio'`` when both conditions hold and warns +
             ``'host'`` when chunks are whole-sample-axis (the kvikio
             path gives no speedup at that chunking).
+        fields : list of str, optional
+            VCF FORMAT/INFO tags to load alongside genotypes (e.g.
+            ``['GQ', 'DP', 'MQ']``). Each tag is auto-resolved from the
+            store: ``variant_<tag>`` lands in ``hm.fields[tag]`` as a
+            ``(n_var,)`` array, ``call_<tag>`` as ``(n_var, n_samples)``.
+            Tags missing from the store are warned and dropped silently.
+            Not supported on the streaming path.
 
         Returns
         -------
@@ -512,6 +616,11 @@ class HaplotypeMatrix:
             )
 
         if streaming == "always":
+            if fields:
+                raise NotImplementedError(
+                    "fields= is not supported on the streaming "
+                    "(streaming='always') path yet. Load eagerly to "
+                    "access VCF FORMAT/INFO arrays.")
             return cls._build_streaming(
                 path, region=region, pop_assignment=pop_assignment,
                 chunk_bp=chunk_bp, prefetch=prefetch,
@@ -528,6 +637,13 @@ class HaplotypeMatrix:
                                                 streaming=streaming,
                                                 pop_assignment=pop_assignment)
         if choice == "streaming":
+            if fields:
+                raise NotImplementedError(
+                    "fields= is not supported on the streaming path; "
+                    "matrix would not fit at streaming='auto'. Pass "
+                    "streaming='never' to force eager (and fit-check), "
+                    "or load without fields= and apply filters via "
+                    "the streaming kernels directly.")
             return cls._build_streaming(
                 path, region=region, pop_assignment=pop_assignment,
                 chunk_bp=chunk_bp, prefetch=prefetch,
@@ -535,11 +651,13 @@ class HaplotypeMatrix:
             )
         return cls._build_eager(path, region=region,
                                 accessible_bed=accessible_bed,
-                                pop_assignment=pop_assignment)
+                                pop_assignment=pop_assignment,
+                                fields=fields)
 
     @classmethod
-    def _build_eager(cls, path, *, region, accessible_bed, pop_assignment):
-        from .zarr_io import read_genotypes
+    def _build_eager(cls, path, *, region, accessible_bed, pop_assignment,
+                     fields=None):
+        from .zarr_io import read_genotypes, read_qc_fields
         from ._gpu_genotype_prep import build_haplotype_matrix
 
         data = read_genotypes(path, region)
@@ -562,6 +680,17 @@ class HaplotypeMatrix:
             chrom_end=int(positions[-1]),
             samples=list(sample_names) if sample_names is not None else None,
         )
+
+        if fields:
+            # ``data['variant_indices']`` is the int index array each
+            # genotype reader used to slice its region; reusing it keeps
+            # QC arrays aligned with the haplotype matrix one-to-one.
+            # ``None`` means the read covered the whole store.
+            hm.fields = read_qc_fields(
+                path, fields,
+                variant_indices=data.get('variant_indices'),
+                region=region,
+            )
 
         chrom = region.split(':')[0] if region else None
         if accessible_bed is not None:

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -1361,6 +1361,133 @@ class HaplotypeMatrix:
             valid_indices = np.where(valid_mask)[0]
             return self.get_subset(valid_indices)
 
+    def filter(self, variants=None, genotypes=None,
+               drop_all_missing: bool = True) -> "HaplotypeMatrix":
+        """Return a new HaplotypeMatrix with quality filters applied.
+
+        Parameters
+        ----------
+        variants : array-like of bool, shape (n_variants,), optional
+            Per-variant keep mask. Variants where ``False`` are dropped
+            from every array on the returned matrix (haplotypes,
+            positions, all per-variant and per-genotype ``fields``).
+        genotypes : array-like of bool, shape (n_variants, n_samples), optional
+            Per-genotype keep mask. Genotypes where ``False`` are set to
+            ``-1`` (missing) on both haplotype rows of the affected
+            sample. ``fields`` arrays are not zeroed out -- the
+            per-genotype QC values remain available for downstream
+            inspection.
+        drop_all_missing : bool, default True
+            After applying both masks, drop variants whose every
+            haplotype call is ``-1``. Default keeps the output free of
+            rows where the genotype mask blanked every call.
+
+        Returns
+        -------
+        HaplotypeMatrix
+            Fresh matrix; the underlying haplotype + position arrays
+            are new allocations (not views of ``self``). Sample names,
+            ``sample_sets``, and ``chrom_start`` / ``chrom_end`` are
+            propagated. ``n_total_sites`` is dropped because the
+            variant axis has changed; if the caller wants span
+            normalization on the result they should re-attach an
+            accessibility mask explicitly. Any accessibility mask
+            previously attached to ``self`` is not inherited for the
+            same reason.
+
+        Notes
+        -----
+        ``filter`` operates on the underlying haplotype matrix
+        (``self._haplotypes``), not the view exposed when an
+        accessibility mask is attached. The QC ``fields`` arrays this
+        method reads from were loaded against the underlying axis, so
+        masks built from them stay aligned automatically.
+        """
+        xp = cp if self._device == 'GPU' else np
+        haps_src = self._haplotypes
+        pos_src = self._positions
+        n_haps, n_var = haps_src.shape
+        n_samples = n_haps // 2
+
+        if variants is not None:
+            variants_arr = xp.asarray(variants).astype(bool, copy=False)
+            if variants_arr.shape != (n_var,):
+                raise ValueError(
+                    f"variants mask shape mismatch: expected ({n_var},), "
+                    f"got {tuple(variants_arr.shape)}")
+        else:
+            variants_arr = None
+
+        if genotypes is not None:
+            genotypes_arr = xp.asarray(genotypes).astype(bool, copy=False)
+            if genotypes_arr.shape != (n_var, n_samples):
+                raise ValueError(
+                    f"genotypes mask shape mismatch: expected "
+                    f"({n_var}, {n_samples}), got "
+                    f"{tuple(genotypes_arr.shape)}")
+        else:
+            genotypes_arr = None
+
+        # Stamp genotype-level rejections into a working copy of the
+        # haplotype matrix so the original is untouched.
+        if genotypes_arr is not None:
+            # (n_var, n_samples) -> (2 * n_samples, n_var): both
+            # haplotype rows for a sample share its genotype mask.
+            per_sample_keep = genotypes_arr.T  # (n_samples, n_var)
+            hap_keep = xp.concatenate([per_sample_keep, per_sample_keep],
+                                      axis=0)
+            haps = xp.where(hap_keep, haps_src, np.int8(-1))
+        else:
+            haps = haps_src
+
+        keep_v = xp.ones(n_var, dtype=bool)
+        if variants_arr is not None:
+            keep_v &= variants_arr
+        if drop_all_missing:
+            keep_v &= ~(haps == -1).all(axis=0)
+        keep_idx = xp.where(keep_v)[0]
+
+        if int(keep_idx.size) == 0:
+            # Constructor rejects empty matrices; mirror the empty-subset
+            # workaround in ``get_subset`` so a too-aggressive filter
+            # returns a structured empty matrix rather than raising.
+            if self._device == 'GPU':
+                empty_haps = cp.empty((n_haps, 0), dtype=haps_src.dtype)
+                empty_pos = cp.array([], dtype=pos_src.dtype)
+            else:
+                empty_haps = np.empty((n_haps, 0), dtype=haps_src.dtype)
+                empty_pos = np.array([], dtype=pos_src.dtype)
+            result = object.__new__(HaplotypeMatrix)
+            result._haplotypes = empty_haps
+            result._positions = empty_pos
+            result._accessible_idx = None
+            result._hap_filtered = None
+            result._pos_filtered = None
+            result._accessible_mask = None
+            result.chrom_start = self.chrom_start
+            result.chrom_end = self.chrom_end
+            result._sample_sets = self._sample_sets
+            result._device = self._device
+            result.n_total_sites = None
+            result.samples = self.samples
+            result.fields = {tag: arr[:0] for tag, arr in self.fields.items()}
+            return result
+
+        new_haps = haps[:, keep_idx]
+        new_pos = pos_src[keep_idx]
+        # Fields are numpy arrays; slice with a host-side index regardless
+        # of where the haplotype matrix lives.
+        keep_idx_np = keep_idx.get() if hasattr(keep_idx, 'get') else keep_idx
+        new_fields = {tag: arr[keep_idx_np] for tag, arr in self.fields.items()}
+
+        return HaplotypeMatrix(
+            new_haps, new_pos,
+            chrom_start=self.chrom_start, chrom_end=self.chrom_end,
+            sample_sets=self._sample_sets,
+            samples=self.samples,
+            fields=new_fields,
+        )
+
     def summarize_missing_data(self):
         """
         Get summary statistics about missing data patterns.

--- a/pg_gpu/zarr_io.py
+++ b/pg_gpu/zarr_io.py
@@ -353,7 +353,7 @@ def read_genotypes_allel_grouped(store, region):
 
 
 def write_vcz(zarr_path, gt, positions, samples=None, contig_name=None,
-              chunks=None):
+              chunks=None, fields=None):
     """Write genotype data in VCZ format.
 
     Parameters
@@ -373,10 +373,22 @@ def write_vcz(zarr_path, gt, positions, samples=None, contig_name=None,
         e.g. ``(10000, 1000, 2)`` to mirror bio2zarr's defaults. When
         ``None`` (default) zarr picks the chunking, which on a small
         array is the whole array as a single chunk.
+    fields : dict, optional
+        Optional VCF FORMAT/INFO arrays to round-trip alongside the
+        genotype matrix. Keys are bare VCF tags (``'GQ'``, ``'DP'``,
+        ``'MQ'``, ...); values are arrays whose first axis is the
+        variant axis. Shape disambiguates INFO vs FORMAT:
+
+        * ``(n_variants,)`` writes to ``variant_<tag>`` (INFO).
+        * ``(n_variants, n_samples)`` writes to ``call_<tag>`` (FORMAT).
+
+        Anything else raises ``ValueError``. The dtype written matches
+        the input array so the round-trip is byte-exact.
     """
     import zarr
+    n_var = len(positions)
+    n_samples = gt.shape[1]
     store = zarr.open(zarr_path, mode='w')
-    cg_kwargs = {} if chunks is None else {"chunks": chunks}
     if chunks is None:
         store.create_array('call_genotype', data=gt.astype(np.int8))
         store.create_array('call_genotype_mask', data=(gt < 0))
@@ -400,6 +412,25 @@ def write_vcz(zarr_path, gt, positions, samples=None, contig_name=None,
                            data=np.array([contig_name], dtype='U'))
         store.create_array('variant_contig',
                            data=np.zeros(len(positions), dtype=np.int8))
+    if fields:
+        for tag, arr in fields.items():
+            arr = np.asarray(arr)
+            if arr.ndim == 1:
+                if arr.shape != (n_var,):
+                    raise ValueError(
+                        f"INFO-shaped field {tag!r} must be ({n_var},); "
+                        f"got {tuple(arr.shape)}")
+                store.create_array(f'variant_{tag}', data=arr)
+            elif arr.ndim == 2:
+                if arr.shape != (n_var, n_samples):
+                    raise ValueError(
+                        f"FORMAT-shaped field {tag!r} must be "
+                        f"({n_var}, {n_samples}); got {tuple(arr.shape)}")
+                store.create_array(f'call_{tag}', data=arr)
+            else:
+                raise ValueError(
+                    f"field {tag!r} must be 1-D (INFO) or 2-D (FORMAT); "
+                    f"got ndim={arr.ndim}")
 
 
 def allel_zarr_to_vcz(allel_path, vcz_path, *, contig=None, region=None,

--- a/pg_gpu/zarr_io.py
+++ b/pg_gpu/zarr_io.py
@@ -149,7 +149,12 @@ def read_genotypes_vcz(store, region=None):
     Returns
     -------
     dict
-        Keys: 'gt' (n_var, n_samples, ploidy), 'positions', 'samples'.
+        Keys: 'gt' (n_var, n_samples, ploidy), 'positions', 'samples',
+        and 'variant_indices' -- the index array used to slice the
+        store when ``region`` is given (``None`` for a whole-store
+        read). Auxiliary callers (e.g. QC field readers) can reuse the
+        same indices to keep their slices aligned with the genotype
+        matrix.
     """
     if region is not None:
         chrom, start, end = _parse_region(region)
@@ -167,6 +172,7 @@ def read_genotypes_vcz(store, region=None):
             raise ValueError(f"No variants in region {region}")
         gt = np.array(store['call_genotype'][indices])
         positions = pos_arr[indices]
+        variant_indices = indices
     else:
         contig_arr = np.array(store['variant_contig'])
         unique_contigs = np.unique(contig_arr)
@@ -179,9 +185,91 @@ def read_genotypes_vcz(store, region=None):
             )
         gt = np.array(store['call_genotype'])
         positions = np.array(store['variant_position'])
+        variant_indices = None
 
     samples = list(np.array(store['sample_id'])) if 'sample_id' in store else None
-    return {'gt': gt, 'positions': positions, 'samples': samples}
+    return {'gt': gt, 'positions': positions, 'samples': samples,
+            'variant_indices': variant_indices}
+
+
+def read_qc_fields(zarr_path, fields, variant_indices=None, region=None):
+    """Pull requested VCF FORMAT/INFO arrays from any supported zarr layout.
+
+    Dispatches on the store layout (VCZ vs scikit-allel flat vs scikit-allel
+    grouped). For each bare tag, look up the per-variant key first and fall
+    back to the per-genotype key; the lookup names depend on the layout:
+
+    * **VCZ** (``bio2zarr`` output): ``variant_<tag>`` (INFO) then
+      ``call_<tag>`` (FORMAT).
+    * **scikit-allel** (flat or grouped): ``variants/<tag>`` (INFO) then
+      ``calldata/<tag>`` (FORMAT). For a grouped layout (chromosome-keyed
+      subgroups), the chrom in ``region`` selects which subgroup to read
+      from.
+
+    Tags matching neither are warned and dropped silently. ``variant_indices``,
+    when provided, slices the variant axis to keep the returned arrays
+    aligned with a windowed genotype matrix.
+    """
+    import zarr
+    store = zarr.open_group(zarr_path, mode='r')
+    layout = detect_zarr_layout(store)
+    if layout == 'vcz':
+        return _read_qc_fields_vcz(store, fields, variant_indices)
+    if layout == 'scikit-allel-grouped':
+        if region is None:
+            # The genotype reader for this layout requires region= and would
+            # have already raised; return empty rather than introducing a
+            # second error message.
+            return {}
+        chrom = region.split(':')[0]
+        return _read_qc_fields_allel(store[chrom], fields, variant_indices)
+    return _read_qc_fields_allel(store, fields, variant_indices)
+
+
+def _read_qc_fields_vcz(store, fields, variant_indices):
+    """VCZ-style lookup: ``variant_<tag>`` / ``call_<tag>``."""
+    return _pull_qc_fields(
+        store, fields, variant_indices,
+        var_key=lambda tag: f'variant_{tag}',
+        call_key=lambda tag: f'call_{tag}',
+        layout_label='VCZ',
+    )
+
+
+def _read_qc_fields_allel(group, fields, variant_indices):
+    """scikit-allel-style lookup: ``variants/<tag>`` / ``calldata/<tag>``."""
+    return _pull_qc_fields(
+        group, fields, variant_indices,
+        var_key=lambda tag: f'variants/{tag}',
+        call_key=lambda tag: f'calldata/{tag}',
+        layout_label='scikit-allel',
+    )
+
+
+def _pull_qc_fields(group, fields, variant_indices, *, var_key, call_key,
+                     layout_label):
+    """Layout-agnostic core: probe ``var_key(tag)`` then ``call_key(tag)``."""
+    import warnings
+    out = {}
+    missing = []
+    for tag in fields:
+        vk = var_key(tag)
+        ck = call_key(tag)
+        if vk in group:
+            arr = group[vk]
+        elif ck in group:
+            arr = group[ck]
+        else:
+            missing.append(tag)
+            continue
+        out[tag] = (np.array(arr[variant_indices])
+                    if variant_indices is not None else np.array(arr))
+    if missing:
+        warnings.warn(
+            f"{layout_label} quality fields not found and dropped: {missing}",
+            stacklevel=4,
+        )
+    return out
 
 
 def read_genotypes_allel(store, region=None):
@@ -197,21 +285,28 @@ def read_genotypes_allel(store, region=None):
     Returns
     -------
     dict
-        Keys: 'gt' (n_var, n_samples, ploidy), 'positions', 'samples'.
+        Keys: 'gt' (n_var, n_samples, ploidy), 'positions', 'samples',
+        and 'variant_indices' -- the int index array used to slice the
+        store when ``region`` is given (``None`` for a whole-store
+        read). Auxiliary callers (e.g. QC field readers) reuse the same
+        indices to stay aligned with the genotype matrix.
     """
     positions = np.array(store['variants/POS'])
     gt = np.array(store['calldata/GT'])
     samples = list(np.array(store['samples'])) if 'samples' in store else None
+    variant_indices = None
 
     if region is not None:
         _, start, end = _parse_region(region)
         mask = (positions >= start) & (positions < end)
+        variant_indices = np.where(mask)[0]
         positions = positions[mask]
         gt = gt[mask]
         if len(positions) == 0:
             raise ValueError(f"No variants in region {region}")
 
-    return {'gt': gt, 'positions': positions, 'samples': samples}
+    return {'gt': gt, 'positions': positions, 'samples': samples,
+            'variant_indices': variant_indices}
 
 
 def read_genotypes_allel_grouped(store, region):
@@ -247,12 +342,14 @@ def read_genotypes_allel_grouped(store, region):
     samples = list(np.array(grp['samples'])) if 'samples' in grp else None
 
     mask = (positions >= start) & (positions < end)
+    variant_indices = np.where(mask)[0]
     positions = positions[mask]
     gt = gt[mask]
     if len(positions) == 0:
         raise ValueError(f"No variants in region {region}")
 
-    return {'gt': gt, 'positions': positions, 'samples': samples}
+    return {'gt': gt, 'positions': positions, 'samples': samples,
+            'variant_indices': variant_indices}
 
 
 def write_vcz(zarr_path, gt, positions, samples=None, contig_name=None,

--- a/pg_gpu/zarr_io.py
+++ b/pg_gpu/zarr_io.py
@@ -415,22 +415,20 @@ def write_vcz(zarr_path, gt, positions, samples=None, contig_name=None,
     if fields:
         for tag, arr in fields.items():
             arr = np.asarray(arr)
-            if arr.ndim == 1:
-                if arr.shape != (n_var,):
-                    raise ValueError(
-                        f"INFO-shaped field {tag!r} must be ({n_var},); "
-                        f"got {tuple(arr.shape)}")
-                store.create_array(f'variant_{tag}', data=arr)
-            elif arr.ndim == 2:
-                if arr.shape != (n_var, n_samples):
-                    raise ValueError(
-                        f"FORMAT-shaped field {tag!r} must be "
-                        f"({n_var}, {n_samples}); got {tuple(arr.shape)}")
+            if arr.ndim == 0 or arr.shape[0] != n_var:
+                raise ValueError(
+                    f"field {tag!r} must have a leading axis of length "
+                    f"{n_var} (the variant axis); got shape "
+                    f"{tuple(arr.shape)}")
+            # FORMAT is exactly (n_var, n_samples); anything else with
+            # the right leading axis is treated as INFO. Multi-dim INFO
+            # (e.g. ``variant_AF`` arrives as ``(n_var, n_alt)`` from
+            # bio2zarr) round-trips into ``variant_<tag>`` with its
+            # full shape preserved.
+            if arr.ndim == 2 and arr.shape == (n_var, n_samples):
                 store.create_array(f'call_{tag}', data=arr)
             else:
-                raise ValueError(
-                    f"field {tag!r} must be 1-D (INFO) or 2-D (FORMAT); "
-                    f"got ndim={arr.ndim}")
+                store.create_array(f'variant_{tag}', data=arr)
 
 
 def allel_zarr_to_vcz(allel_path, vcz_path, *, contig=None, region=None,

--- a/tests/test_qc_fields.py
+++ b/tests/test_qc_fields.py
@@ -282,3 +282,138 @@ class TestFromVcfFields:
         with pytest.warns(UserWarning, match="NONEXISTENT"):
             hm = HaplotypeMatrix.from_vcf(vcf, fields=["MQ", "NONEXISTENT"])
         assert set(hm.fields) == {"MQ"}
+
+
+# ── HaplotypeMatrix.filter ────────────────────────────────────────────────
+
+
+class TestHaplotypeMatrixFilter:
+
+    def test_variants_only_drops_rows(self, tmp_path):
+        hm = _simulate_hm()
+        path, mq, gq, _ = _write_vcz_with_qc(tmp_path, hm)
+        loaded = HaplotypeMatrix.from_zarr(path, fields=["MQ", "GQ"],
+                                           streaming="never")
+        keep = loaded.fields["MQ"] >= 40.0
+        n_keep = int(keep.sum())
+        filtered = loaded.filter(variants=keep)
+        assert filtered.haplotypes.shape[1] == n_keep
+        assert filtered.fields["MQ"].shape == (n_keep,)
+        assert filtered.fields["GQ"].shape == (n_keep, gq.shape[1])
+        np.testing.assert_array_equal(filtered.fields["MQ"], mq[keep])
+        np.testing.assert_array_equal(filtered.fields["GQ"], gq[keep])
+
+    def test_genotypes_only_sets_missing(self, tmp_path):
+        hm = _simulate_hm()
+        path, _, gq, _ = _write_vcz_with_qc(tmp_path, hm)
+        loaded = HaplotypeMatrix.from_zarr(path, fields=["GQ"],
+                                           streaming="never")
+        gt_keep = loaded.fields["GQ"] >= 50
+        # Force at least one variant to keep all-missing so drop_all_missing
+        # can be tested in isolation; here disable the drop and assert.
+        filtered = loaded.filter(genotypes=gt_keep, drop_all_missing=False)
+        # The variant axis stays put when only genotypes= is applied
+        # without drop_all_missing.
+        assert filtered.haplotypes.shape == loaded.haplotypes.shape
+        # Sample s rejected at variant v means both haplotype rows (s, v)
+        # and (s + n_samples, v) are -1.
+        n_samples = loaded.haplotypes.shape[0] // 2
+        haps_host = _host(filtered._haplotypes)
+        gt_keep_host = np.asarray(gt_keep)
+        for v in range(haps_host.shape[1]):
+            for s in range(n_samples):
+                if not gt_keep_host[v, s]:
+                    assert haps_host[s, v] == -1
+                    assert haps_host[s + n_samples, v] == -1
+
+    def test_drop_all_missing_kicks_in(self, tmp_path):
+        hm = _simulate_hm()
+        path, _, gq, _ = _write_vcz_with_qc(tmp_path, hm)
+        loaded = HaplotypeMatrix.from_zarr(path, fields=["GQ"],
+                                           streaming="never")
+        # Reject every genotype at variant 0 so the whole row goes
+        # missing; with drop_all_missing=True it should disappear.
+        gt_keep = np.ones(loaded.fields["GQ"].shape, dtype=bool)
+        gt_keep[0, :] = False
+        filtered_drop = loaded.filter(genotypes=gt_keep,
+                                      drop_all_missing=True)
+        filtered_keep = loaded.filter(genotypes=gt_keep,
+                                      drop_all_missing=False)
+        assert filtered_drop.haplotypes.shape[1] == \
+            filtered_keep.haplotypes.shape[1] - 1
+
+    def test_combined_filters(self, tmp_path):
+        hm = _simulate_hm()
+        path, mq, gq, dp = _write_vcz_with_qc(tmp_path, hm)
+        loaded = HaplotypeMatrix.from_zarr(
+            path, fields=["MQ", "GQ", "DP"], streaming="never")
+        v_keep = loaded.fields["MQ"] >= 30.0
+        gt_keep = (loaded.fields["GQ"] >= 30) & (loaded.fields["DP"] >= 10)
+        filtered = loaded.filter(variants=v_keep, genotypes=gt_keep)
+        # Sanity: surviving variants are a subset of v_keep AND have at
+        # least one surviving genotype.
+        assert filtered.haplotypes.shape[1] <= int(v_keep.sum())
+        haps_host = _host(filtered._haplotypes)
+        assert not (haps_host == -1).all(axis=0).any()
+
+    def test_no_kwargs_is_a_copy(self, tmp_path):
+        hm = _simulate_hm()
+        path, _, _, _ = _write_vcz_with_qc(tmp_path, hm)
+        loaded = HaplotypeMatrix.from_zarr(path, fields=["MQ"],
+                                           streaming="never")
+        copied = loaded.filter()
+        # New allocation, same content.
+        assert copied._haplotypes is not loaded._haplotypes
+        np.testing.assert_array_equal(_host(copied._haplotypes),
+                                       _host(loaded._haplotypes))
+        np.testing.assert_array_equal(_host(copied._positions),
+                                       _host(loaded._positions))
+        np.testing.assert_array_equal(copied.fields["MQ"],
+                                       loaded.fields["MQ"])
+
+    def test_filter_drops_everything_returns_empty_matrix(self, tmp_path):
+        hm = _simulate_hm()
+        path, _, _, _ = _write_vcz_with_qc(tmp_path, hm)
+        loaded = HaplotypeMatrix.from_zarr(path, fields=["MQ"],
+                                           streaming="never")
+        # Impossible threshold drops every variant.
+        keep_none = loaded.fields["MQ"] > loaded.fields["MQ"].max()
+        empty = loaded.filter(variants=keep_none)
+        assert empty._haplotypes.shape[1] == 0
+        assert empty.fields["MQ"].shape == (0,)
+
+    def test_shape_mismatch_raises(self, tmp_path):
+        hm = _simulate_hm()
+        path, _, _, _ = _write_vcz_with_qc(tmp_path, hm)
+        loaded = HaplotypeMatrix.from_zarr(path, fields=["MQ"],
+                                           streaming="never")
+        bad = np.ones(loaded.fields["MQ"].shape[0] + 1, dtype=bool)
+        with pytest.raises(ValueError, match="variants mask"):
+            loaded.filter(variants=bad)
+
+
+# ── GenotypeMatrix.filter ─────────────────────────────────────────────────
+
+
+class TestGenotypeMatrixFilter:
+
+    def test_variants_and_genotypes(self, tmp_path):
+        hm = _simulate_hm()
+        path, mq, gq, _ = _write_vcz_with_qc(tmp_path, hm)
+        gm = GenotypeMatrix.from_zarr(path, fields=["MQ", "GQ"],
+                                       streaming="never")
+        v_keep = gm.fields["MQ"] >= 40.0
+        gt_keep = gm.fields["GQ"] >= 30
+        filtered = gm.filter(variants=v_keep, genotypes=gt_keep,
+                              drop_all_missing=False)
+        # The variant axis matches the v_keep mask exactly when
+        # drop_all_missing is off.
+        n_v_keep = int(v_keep.sum())
+        assert filtered._genotypes.shape[1] == n_v_keep
+        # Per-sample rejections lay down -1s in the genotype matrix.
+        geno_host = _host(filtered._genotypes)
+        gt_keep_kept = gt_keep[v_keep]
+        for s in range(filtered._genotypes.shape[0]):
+            for v in range(filtered._genotypes.shape[1]):
+                if not gt_keep_kept[v, s]:
+                    assert geno_host[s, v] == -1

--- a/tests/test_qc_fields.py
+++ b/tests/test_qc_fields.py
@@ -1,0 +1,284 @@
+"""Tests for the VCF/VCZ FORMAT/INFO ``fields=`` kwarg on
+``HaplotypeMatrix.from_vcf`` / ``from_zarr`` and
+``GenotypeMatrix.from_vcf`` / ``from_zarr``.
+
+Covers the read path for all three zarr layouts (VCZ, scikit-allel
+flat, scikit-allel grouped) plus a small hand-written VCF for the
+allel.read_vcf path.
+"""
+
+import textwrap
+
+import cupy as cp
+import msprime
+import numpy as np
+import pytest
+import zarr
+
+from pg_gpu import GenotypeMatrix, HaplotypeMatrix
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _simulate_hm(n_samples=8, seq_length=10_000, seed=42):
+    """Small msprime fixture matching the helper in test_zarr_io."""
+    ts = msprime.sim_ancestry(
+        samples=n_samples, sequence_length=seq_length,
+        recombination_rate=1e-4, random_seed=seed, ploidy=2,
+    )
+    ts = msprime.sim_mutations(ts, rate=1e-3, random_seed=seed)
+    return HaplotypeMatrix.from_ts(ts)
+
+
+def _host(arr):
+    return cp.asnumpy(arr) if isinstance(arr, cp.ndarray) else arr
+
+
+def _write_vcz_with_qc(tmp_path, hm, *, mq_values=None, gq_values=None,
+                       dp_values=None, name="qc.vcz"):
+    """Write a VCZ store and inject synthetic QC arrays in place.
+
+    bio2zarr would produce these alongside ``call_genotype`` from a real
+    VCF; for the read tests we forge them directly so the fixture stays
+    msprime-only.
+    """
+    path = str(tmp_path / name)
+    hm.to_zarr(path, format="vcz", contig_name="chr1")
+    store = zarr.open_group(path, mode="r+")
+    n_var = int(hm.haplotypes.shape[1])
+    n_samples = int(hm.haplotypes.shape[0] // 2)
+    if mq_values is None:
+        mq_values = np.linspace(20.0, 60.0, n_var, dtype=np.float32)
+    if gq_values is None:
+        rng = np.random.default_rng(0)
+        gq_values = rng.integers(0, 99, size=(n_var, n_samples),
+                                 dtype=np.int16)
+    if dp_values is None:
+        rng = np.random.default_rng(1)
+        dp_values = rng.integers(1, 50, size=(n_var, n_samples),
+                                 dtype=np.int16)
+    store.create_array("variant_MQ", data=mq_values)
+    store.create_array("call_GQ", data=gq_values)
+    store.create_array("call_DP", data=dp_values)
+    return path, mq_values, gq_values, dp_values
+
+
+def _write_allel_with_qc(tmp_path, hm, name="qc_allel.zarr"):
+    """Write a scikit-allel layout store and add INFO/FORMAT arrays."""
+    path = str(tmp_path / name)
+    hm.to_zarr(path, format="scikit-allel")
+    store = zarr.open_group(path, mode="r+")
+    n_var = int(hm.haplotypes.shape[1])
+    n_samples = int(hm.haplotypes.shape[0] // 2)
+    mq = np.linspace(10.0, 80.0, n_var, dtype=np.float32)
+    rng = np.random.default_rng(7)
+    gq = rng.integers(0, 99, size=(n_var, n_samples), dtype=np.int16)
+    store.create_array("variants/MQ", data=mq)
+    store.create_array("calldata/GQ", data=gq)
+    return path, mq, gq
+
+
+def _write_grouped_with_qc(tmp_path, hm, name="qc_grouped.zarr"):
+    """Write a chromosome-grouped scikit-allel store with QC arrays.
+
+    Mirrors the ``grouped_store`` fixture in test_zarr_io but reuses one
+    chromosome so the QC fields can be asserted against a single
+    msprime-derived matrix.
+    """
+    path = str(tmp_path / name)
+    store = zarr.open(path, mode="w")
+    chrom = "chr1"
+    hap = hm.haplotypes
+    pos = hm.positions
+    gt = HaplotypeMatrix._haplotypes_to_gt(hap)
+    grp = store.create_group(chrom)
+    grp.create_array("calldata/GT", data=gt)
+    grp.create_array("variants/POS", data=pos)
+    if hm.samples is not None:
+        grp.create_array("samples",
+                          data=np.array(hm.samples, dtype="U"))
+    n_var = int(hap.shape[1])
+    n_samples = int(hap.shape[0] // 2)
+    mq = np.linspace(5.0, 50.0, n_var, dtype=np.float32)
+    rng = np.random.default_rng(11)
+    gq = rng.integers(0, 99, size=(n_var, n_samples), dtype=np.int16)
+    grp.create_array("variants/MQ", data=mq)
+    grp.create_array("calldata/GQ", data=gq)
+    region = f"{chrom}:{int(pos[0])}-{int(pos[-1]) + 1}"
+    return path, region, mq, gq
+
+
+def _write_small_vcf(tmp_path, name="small.vcf"):
+    """Write a 4-variant, 3-sample VCF with GT, GQ, DP, and INFO/MQ.
+
+    Hand-written so the test doesn't depend on bcftools, pysam, etc.
+    """
+    body = textwrap.dedent(
+        """\
+        ##fileformat=VCFv4.2
+        ##contig=<ID=chr1,length=10000>
+        ##INFO=<ID=MQ,Number=1,Type=Float,Description="Mapping quality">
+        ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+        ##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">
+        ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read depth">
+        #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS1\tS2\tS3
+        chr1\t100\t.\tA\tG\t30\tPASS\tMQ=50\tGT:GQ:DP\t0|0:20:10\t0|1:30:12\t1|1:40:15
+        chr1\t200\t.\tC\tT\t30\tPASS\tMQ=35\tGT:GQ:DP\t0|1:25:8\t1|1:15:5\t0|0:35:14
+        chr1\t300\t.\tG\tA\t30\tPASS\tMQ=55\tGT:GQ:DP\t1|1:45:20\t0|0:50:18\t0|1:55:22
+        chr1\t400\t.\tT\tC\t30\tPASS\tMQ=42\tGT:GQ:DP\t0|0:33:11\t1|1:28:9\t0|1:40:13
+        """
+    )
+    path = tmp_path / name
+    path.write_text(body)
+    return str(path)
+
+
+# ── HaplotypeMatrix.from_zarr ─────────────────────────────────────────────
+
+
+class TestHaplotypeMatrixFromZarrFields:
+
+    def test_vcz_info_field_shape(self, tmp_path):
+        hm = _simulate_hm()
+        path, mq, _, _ = _write_vcz_with_qc(tmp_path, hm)
+        loaded = HaplotypeMatrix.from_zarr(path, fields=["MQ"],
+                                           streaming="never")
+        assert "MQ" in loaded.fields
+        assert loaded.fields["MQ"].shape == (mq.shape[0],)
+        np.testing.assert_array_equal(loaded.fields["MQ"], mq)
+
+    def test_vcz_format_field_shape(self, tmp_path):
+        hm = _simulate_hm()
+        path, _, gq, _ = _write_vcz_with_qc(tmp_path, hm)
+        loaded = HaplotypeMatrix.from_zarr(path, fields=["GQ"],
+                                           streaming="never")
+        assert "GQ" in loaded.fields
+        assert loaded.fields["GQ"].shape == gq.shape
+        np.testing.assert_array_equal(loaded.fields["GQ"], gq)
+
+    def test_vcz_both_kinds_together(self, tmp_path):
+        hm = _simulate_hm()
+        path, mq, gq, dp = _write_vcz_with_qc(tmp_path, hm)
+        loaded = HaplotypeMatrix.from_zarr(
+            path, fields=["MQ", "GQ", "DP"], streaming="never")
+        assert set(loaded.fields) == {"MQ", "GQ", "DP"}
+        np.testing.assert_array_equal(loaded.fields["MQ"], mq)
+        np.testing.assert_array_equal(loaded.fields["GQ"], gq)
+        np.testing.assert_array_equal(loaded.fields["DP"], dp)
+
+    def test_missing_field_warns_and_drops(self, tmp_path):
+        hm = _simulate_hm()
+        path, mq, _, _ = _write_vcz_with_qc(tmp_path, hm)
+        with pytest.warns(UserWarning, match="NONEXISTENT"):
+            loaded = HaplotypeMatrix.from_zarr(
+                path, fields=["MQ", "NONEXISTENT"], streaming="never")
+        assert set(loaded.fields) == {"MQ"}
+        np.testing.assert_array_equal(loaded.fields["MQ"], mq)
+
+    def test_no_fields_kwarg_leaves_fields_empty(self, tmp_path):
+        hm = _simulate_hm()
+        path, _, _, _ = _write_vcz_with_qc(tmp_path, hm)
+        loaded = HaplotypeMatrix.from_zarr(path, streaming="never")
+        assert loaded.fields == {}
+
+    def test_allel_flat_layout_loads_fields(self, tmp_path):
+        hm = _simulate_hm()
+        path, mq, gq = _write_allel_with_qc(tmp_path, hm)
+        loaded = HaplotypeMatrix.from_zarr(path, fields=["MQ", "GQ"],
+                                           streaming="never")
+        assert set(loaded.fields) == {"MQ", "GQ"}
+        np.testing.assert_array_equal(loaded.fields["MQ"], mq)
+        np.testing.assert_array_equal(loaded.fields["GQ"], gq)
+
+    def test_allel_grouped_layout_loads_fields(self, tmp_path):
+        hm = _simulate_hm()
+        path, region, mq, gq = _write_grouped_with_qc(tmp_path, hm)
+        loaded = HaplotypeMatrix.from_zarr(
+            path, region=region, fields=["MQ", "GQ"], streaming="never")
+        assert set(loaded.fields) == {"MQ", "GQ"}
+        np.testing.assert_array_equal(loaded.fields["MQ"], mq)
+        np.testing.assert_array_equal(loaded.fields["GQ"], gq)
+
+    def test_region_subsets_keep_qc_aligned(self, tmp_path):
+        hm = _simulate_hm()
+        path, mq, gq, _ = _write_vcz_with_qc(tmp_path, hm)
+        # Take the middle ~half of positions.
+        pos = _host(hm.positions)
+        lo = int(pos[len(pos) // 4])
+        hi = int(pos[3 * len(pos) // 4])
+        region = f"chr1:{lo}-{hi + 1}"
+        loaded = HaplotypeMatrix.from_zarr(
+            path, region=region, fields=["MQ", "GQ"], streaming="never")
+        n_loaded = loaded.haplotypes.shape[1]
+        # The QC arrays must have been sliced down to match the loaded
+        # variant axis, not still hold the full-store length.
+        assert loaded.fields["MQ"].shape == (n_loaded,)
+        assert loaded.fields["GQ"].shape[0] == n_loaded
+
+    def test_streaming_with_fields_raises(self, tmp_path):
+        hm = _simulate_hm()
+        path, _, _, _ = _write_vcz_with_qc(tmp_path, hm)
+        with pytest.raises(NotImplementedError, match="streaming"):
+            HaplotypeMatrix.from_zarr(path, fields=["MQ"], streaming="always")
+
+
+# ── GenotypeMatrix.from_zarr ──────────────────────────────────────────────
+
+
+class TestGenotypeMatrixFromZarrFields:
+
+    def test_vcz_loads_fields(self, tmp_path):
+        hm = _simulate_hm()
+        path, mq, gq, _ = _write_vcz_with_qc(tmp_path, hm)
+        gm = GenotypeMatrix.from_zarr(path, fields=["MQ", "GQ"],
+                                       streaming="never")
+        assert set(gm.fields) == {"MQ", "GQ"}
+        np.testing.assert_array_equal(gm.fields["MQ"], mq)
+        np.testing.assert_array_equal(gm.fields["GQ"], gq)
+
+    def test_streaming_with_fields_raises(self, tmp_path):
+        hm = _simulate_hm()
+        path, _, _, _ = _write_vcz_with_qc(tmp_path, hm)
+        with pytest.raises(NotImplementedError, match="streaming"):
+            GenotypeMatrix.from_zarr(path, fields=["MQ"], streaming="always")
+
+
+# ── *.from_vcf ────────────────────────────────────────────────────────────
+
+
+class TestFromVcfFields:
+
+    def test_haplotype_matrix_loads_info_and_format(self, tmp_path):
+        vcf = _write_small_vcf(tmp_path)
+        hm = HaplotypeMatrix.from_vcf(vcf, fields=["MQ", "GQ", "DP"])
+        assert set(hm.fields) == {"MQ", "GQ", "DP"}
+        # 4 variants, 3 samples
+        np.testing.assert_array_equal(
+            hm.fields["MQ"], np.array([50.0, 35.0, 55.0, 42.0]))
+        np.testing.assert_array_equal(
+            hm.fields["GQ"],
+            np.array([[20, 30, 40], [25, 15, 35],
+                      [45, 50, 55], [33, 28, 40]]))
+        np.testing.assert_array_equal(
+            hm.fields["DP"],
+            np.array([[10, 12, 15], [8, 5, 14],
+                      [20, 18, 22], [11, 9, 13]]))
+
+    def test_genotype_matrix_loads_info_and_format(self, tmp_path):
+        vcf = _write_small_vcf(tmp_path)
+        gm = GenotypeMatrix.from_vcf(vcf, fields=["MQ", "GQ"])
+        # All four variants are biallelic so nothing is dropped by the
+        # biallelic filter; the QC arrays match the input row-for-row.
+        np.testing.assert_array_equal(
+            gm.fields["MQ"], np.array([50.0, 35.0, 55.0, 42.0]))
+        np.testing.assert_array_equal(
+            gm.fields["GQ"],
+            np.array([[20, 30, 40], [25, 15, 35],
+                      [45, 50, 55], [33, 28, 40]]))
+
+    def test_missing_field_warns_and_drops(self, tmp_path):
+        vcf = _write_small_vcf(tmp_path)
+        with pytest.warns(UserWarning, match="NONEXISTENT"):
+            hm = HaplotypeMatrix.from_vcf(vcf, fields=["MQ", "NONEXISTENT"])
+        assert set(hm.fields) == {"MQ"}

--- a/tests/test_qc_fields.py
+++ b/tests/test_qc_fields.py
@@ -417,3 +417,73 @@ class TestGenotypeMatrixFilter:
             for v in range(filtered._genotypes.shape[1]):
                 if not gt_keep_kept[v, s]:
                     assert geno_host[s, v] == -1
+
+
+# ── round-trip (filter -> to_zarr -> from_zarr) ───────────────────────────
+
+
+class TestFilteredVczRoundTrip:
+
+    def test_roundtrip_keeps_fields(self, tmp_path):
+        hm = _simulate_hm()
+        src, mq, gq, dp = _write_vcz_with_qc(tmp_path, hm)
+        loaded = HaplotypeMatrix.from_zarr(
+            src, fields=["MQ", "GQ", "DP"], streaming="never")
+
+        # Apply a real filter so the output is not a pass-through.
+        v_keep = loaded.fields["MQ"] >= 30.0
+        filtered = loaded.filter(variants=v_keep)
+        out = str(tmp_path / "clean.vcz")
+        filtered.to_zarr(out, format="vcz", contig_name="chr1")
+
+        reloaded = HaplotypeMatrix.from_zarr(
+            out, fields=["MQ", "GQ", "DP"], streaming="never")
+        assert set(reloaded.fields) == {"MQ", "GQ", "DP"}
+        np.testing.assert_array_equal(reloaded.fields["MQ"],
+                                       filtered.fields["MQ"])
+        np.testing.assert_array_equal(reloaded.fields["GQ"],
+                                       filtered.fields["GQ"])
+        np.testing.assert_array_equal(reloaded.fields["DP"],
+                                       filtered.fields["DP"])
+
+    def test_roundtrip_preserves_dtypes(self, tmp_path):
+        hm = _simulate_hm()
+        src, mq, gq, dp = _write_vcz_with_qc(tmp_path, hm)
+        loaded = HaplotypeMatrix.from_zarr(
+            src, fields=["MQ", "GQ", "DP"], streaming="never")
+        out = str(tmp_path / "rt_dtype.vcz")
+        loaded.to_zarr(out, format="vcz", contig_name="chr1")
+        reloaded = HaplotypeMatrix.from_zarr(
+            out, fields=["MQ", "GQ", "DP"], streaming="never")
+        # MQ float32 INFO, GQ + DP int16 FORMAT.
+        assert reloaded.fields["MQ"].dtype == np.float32
+        assert reloaded.fields["GQ"].dtype == np.int16
+        assert reloaded.fields["DP"].dtype == np.int16
+        # And shape-disambiguation survives the round-trip too.
+        assert reloaded.fields["MQ"].ndim == 1
+        assert reloaded.fields["GQ"].ndim == 2
+
+    def test_roundtrip_shape_mismatch_raises(self, tmp_path):
+        """``write_vcz`` should refuse a fields dict whose array sizes
+        don't match the genotype matrix; otherwise round-trip is silently
+        corrupt."""
+        from pg_gpu.zarr_io import write_vcz
+        n_var, n_sam = 5, 3
+        gt = np.zeros((n_var, n_sam, 2), dtype=np.int8)
+        pos = np.arange(1, n_var + 1, dtype=np.int32)
+        bad = np.zeros(n_var + 1, dtype=np.float32)
+        with pytest.raises(ValueError, match="INFO-shaped"):
+            write_vcz(str(tmp_path / "bad.vcz"), gt, pos,
+                       contig_name="chr1", fields={"MQ": bad})
+
+    def test_to_zarr_allel_with_fields_raises(self, tmp_path):
+        """The scikit-allel writer hasn't been extended; combining the
+        two should fail loudly rather than silently dropping the
+        fields."""
+        hm = _simulate_hm()
+        src, _, _, _ = _write_vcz_with_qc(tmp_path, hm)
+        loaded = HaplotypeMatrix.from_zarr(src, fields=["MQ"],
+                                            streaming="never")
+        with pytest.raises(NotImplementedError, match="scikit-allel"):
+            loaded.to_zarr(str(tmp_path / "rt.allel.zarr"),
+                            format="scikit-allel")

--- a/tests/test_qc_fields.py
+++ b/tests/test_qc_fields.py
@@ -464,17 +464,35 @@ class TestFilteredVczRoundTrip:
         assert reloaded.fields["GQ"].ndim == 2
 
     def test_roundtrip_shape_mismatch_raises(self, tmp_path):
-        """``write_vcz`` should refuse a fields dict whose array sizes
-        don't match the genotype matrix; otherwise round-trip is silently
+        """``write_vcz`` should refuse a fields dict whose leading axis
+        doesn't match the variant axis; otherwise round-trip is silently
         corrupt."""
         from pg_gpu.zarr_io import write_vcz
         n_var, n_sam = 5, 3
         gt = np.zeros((n_var, n_sam, 2), dtype=np.int8)
         pos = np.arange(1, n_var + 1, dtype=np.int32)
         bad = np.zeros(n_var + 1, dtype=np.float32)
-        with pytest.raises(ValueError, match="INFO-shaped"):
+        with pytest.raises(ValueError, match="variant axis"):
             write_vcz(str(tmp_path / "bad.vcz"), gt, pos,
                        contig_name="chr1", fields={"MQ": bad})
+
+    def test_multidim_info_roundtrip(self, tmp_path):
+        """bio2zarr writes some INFO fields with shape (n_var, n_alt) --
+        e.g. ``variant_AF`` for biallelic sites lands as (n_var, 1).
+        Round-trip must preserve that extra trailing axis."""
+        from pg_gpu.zarr_io import write_vcz
+        n_var, n_sam = 6, 4
+        gt = np.zeros((n_var, n_sam, 2), dtype=np.int8)
+        pos = np.arange(1, n_var + 1, dtype=np.int32)
+        af = np.linspace(0.05, 0.5, n_var, dtype=np.float32).reshape(n_var, 1)
+        path = str(tmp_path / "multidim.vcz")
+        write_vcz(path, gt, pos, contig_name="chr1",
+                   fields={"AF": af, "AC": np.arange(n_var, dtype=np.int16)})
+        loaded = HaplotypeMatrix.from_zarr(path, fields=["AF", "AC"],
+                                            streaming="never")
+        assert loaded.fields["AF"].shape == (n_var, 1)
+        assert loaded.fields["AC"].shape == (n_var,)
+        np.testing.assert_array_equal(loaded.fields["AF"], af)
 
     def test_to_zarr_allel_with_fields_raises(self, tmp_path):
         """The scikit-allel writer hasn't been extended; combining the


### PR DESCRIPTION
Closes #108.

Adds a minimal four-surface addition for VCF FORMAT/INFO quality metrics. 
## API

```python
from pg_gpu import HaplotypeMatrix

# 1. Load with quality fields (auto-detected as INFO or FORMAT by shape)
hm = HaplotypeMatrix.from_vcf("foo.vcf.gz", fields=["MQ", "GQ", "DP"])
hm = HaplotypeMatrix.from_zarr("foo.vcz", fields=["MQ", "GQ", "DP"])

# 2. Inspect: one dict, shape tells you per-variant vs per-genotype
hm.fields["MQ"]   # (n_var,)             -- INFO
hm.fields["GQ"]   # (n_var, n_samples)   -- FORMAT
# plt.hist(hm.fields["GQ"].ravel(), bins=50)  # raw arrays, user plots

# 3. Filter (returns a new matrix)
hm_clean = hm.filter(
    variants=hm.fields["MQ"] >= 40.0,
    genotypes=(hm.fields["GQ"] >= 20) & (hm.fields["DP"] >= 10),
    drop_all_missing=True,
)

# 4. Write clean VCZ -- round-trips surviving fields
hm_clean.to_zarr("clean.vcz", format="vcz")
```

Same surface on `GenotypeMatrix`. One new kwarg (`fields=`), one new attribute (`hm.fields`), one new method (`hm.filter`), one extended writer kwarg. Bare VCF tags throughout (`'MQ'`, `'GQ'`) -- internal layout names (`variants/MQ`, `calldata/GQ`, `variant_MQ`, `call_MQ`) stay in the I/O layer.

## Commits

1. **`4c725a2` feat: read VCF FORMAT/INFO quality fields via `fields=` kwarg.** Read path for all four layouts: VCF (via `allel.read_vcf` with header probing through `allel.read_vcf_headers`), VCZ (`variant_<tag>` / `call_<tag>`), scikit-allel flat (`variants/<tag>` / `calldata/<tag>`), scikit-allel grouped (same under the chrom subgroup). Region-restricted reads slice the QC arrays consistently with the genotype matrix via the `variant_indices` each genotype reader now returns. Missing tags warn and drop.
2. **`25ed8b6` feat: `filter()` method for variant + genotype QC masks.** Eager, copy semantics. `variants=` drops rows, `genotypes=` sets cells to `-1` (both haplotype rows on the haplotype-matrix side). `drop_all_missing=True` by default. Empty results route through the same `object.__new__` workaround `get_subset` uses so a too-aggressive filter returns a structured empty matrix instead of raising from the constructor.
3. **`2ffb68b` feat: round-trip fields through `write_vcz` / `to_zarr`.** `write_vcz(..., fields=...)` creates `variant_<tag>` (ndim=1) or `call_<tag>` (ndim=2) arrays in the VCZ output using the input dtype, so `load -> filter -> save -> reload` is byte-exact on every surviving QC array. Mismatched shapes raise before write so the output never disagrees with `call_genotype`. `format='scikit-allel'` with non-empty `fields` raises `NotImplementedError` to avoid silent drops.

## Tests

`tests/test_qc_fields.py` covers 26 cases: read paths (all four layouts), region alignment, missing-field warnings, the streaming guard, all combinations of `filter()` masks plus `drop_all_missing`, no-args copy, empty result, shape-mismatch guards, and three round-trip cases (filter-then-save preserves values, dtype is preserved, write_vcz rejects mismatched shapes).

Full repo `pytest tests/` (excluding the docs-example runners): **946 passed, 55 skipped, 0 failures**.

## Out of scope (deferred follow-ups)

* **Streaming filter on `StreamingHaplotypeMatrix` / `StreamingGenotypeMatrix`.** Combining `streaming=` with `fields=` raises `NotImplementedError`. Streaming filter is a separate piece of work that needs `ZarrGenotypeSource.slice_region` to pull extra arrays per chunk.
* **Filtering at VCZ-build time** inside `vcf_to_zarr` (bio2zarr-side per-genotype masking / FORMAT pruning during encode). Read-time path covers the common case -- encode once, iterate on thresholds.
* **Predicate sugar** (`hm.filter(min_gq=20, min_dp=10)`). Convenience kwargs are mechanical to add on top of the mask-based path.
* **`pg_gpu.moments_ld.compute_ld_statistics`** keeps reading VCFs through its own parser; no change in this branch.