### PR TITLE
docs: mock kvikio for the Read the Docs build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,6 +4,16 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('../..'))
 
+# Read the Docs and other CPU-only build environments can't install
+# kvikio (which needs CUDA at build time), so ``import kvikio`` in
+# ``pg_gpu.streaming_matrix`` fails before autodoc gets a chance to
+# walk the module. Pre-inject a Mock under the same env-var gate that
+# pg_gpu.__init__ already uses for its CuPy availability check.
+if os.environ.get('READTHEDOCS') or os.environ.get('PG_GPU_SKIP_CUDA_CHECK'):
+    from unittest.mock import MagicMock
+    for _name in ('kvikio', 'kvikio.defaults', 'kvikio.zarr'):
+        sys.modules.setdefault(_name, MagicMock())
+
 import pg_gpu
 release = pg_gpu.__version__
 
@@ -27,6 +37,11 @@ html_theme = 'sphinx_rtd_theme'
 # Autodoc settings
 autodoc_member_order = 'bysource'
 autodoc_typehints = 'description'
+# Stand-ins for GPU-only deps that aren't installable on a CPU-only
+# build host. The sys.modules pre-injection above covers the top-level
+# ``import pg_gpu`` chain; this list covers any module autodoc imports
+# afresh as it walks the API reference.
+autodoc_mock_imports = ['kvikio', 'kvikio.defaults', 'kvikio.zarr']
 
 # Napoleon settings
 napoleon_google_docstring = True


### PR DESCRIPTION
RTD has been red since the streaming machinery landed (3 consecutive failing builds — `8a5dcd36`, `9446e459`, `6675a79c`).

## Failure

```
File ".../docs/source/conf.py", line 7, in <module>
    import pg_gpu
File ".../pg_gpu/__init__.py", line 44, in <module>
    from . import sfs
File ".../pg_gpu/sfs.py", line 15, in <module>
    from .streaming_matrix import StreamingHaplotypeMatrix, _stream_sum
File ".../pg_gpu/streaming_matrix.py", line 28, in <module>
    import kvikio
ModuleNotFoundError: No module named 'kvikio'
```

kvikio (a CUDA library) isn't installable on RTD's CPU-only build host, and `streaming_matrix` does an unconditional `import kvikio` at module load.

## Fix

Two layers, both gated on the `READTHEDOCS` env var that `pg_gpu/__init__.py` already special-cases for its CuPy-availability check:

1. **Pre-inject MagicMock entries** for `kvikio`, `kvikio.defaults`, and `kvikio.zarr` into `sys.modules` in `conf.py` itself, BEFORE `import pg_gpu`. `autodoc_mock_imports` alone doesn't help here because `conf.py` reads `pg_gpu.__version__` via a direct `import` (not through autodoc).
2. **Add `autodoc_mock_imports`** for the same three names so autodoc's own per-module imports later in the build also see mocks.

Plus a trailing newline on `conf.py` (W292 ruff lint that was already there pre-PR).

## Verification

Reproduced locally by hiding kvikio via a `sys.meta_path` block hook and setting `READTHEDOCS=True`:

```
sphinx-build -W -b html docs/source /tmp/sphinx_rtd_sim
build succeeded.
sphinx exit: 0
```

Lint: `pixi run -e lint ruff check pg_gpu/ tests/ examples/` — All checks passed.