### PR TITLE
Add pg_gpu.windowed_pca — winpca-style per-window PCA

### DIFF
--- a/pg_gpu/__init__.py
+++ b/pg_gpu/__init__.py
@@ -63,8 +63,9 @@ from .decomposition import (
     corners,
 )
 from .resampling import block_jackknife, block_bootstrap
+from .windowed_pca import windowed_pca, WindowedPCAResult
 from ._memory_warning import MemoryLimitedWarning
 
-__all__ = ['ld_statistics', 'diversity', 'divergence', 'windowed_analysis', 'selection', 'sfs', 'admixture', 'decomposition', 'plotting', 'distance_stats', 'resampling', 'HaplotypeMatrix', 'GenotypeMatrix', 'WindowedAnalyzer', 'windowed_analysis', 'AccessibleMask', 'bed_to_mask', 'parse_bed', 'LocalPCAResult', 'LostructResult', 'local_pca', 'local_pca_jackknife', 'lostruct', 'pc_dist', 'corners', 'block_jackknife', 'block_bootstrap', 'MemoryLimitedWarning']
+__all__ = ['ld_statistics', 'diversity', 'divergence', 'windowed_analysis', 'selection', 'sfs', 'admixture', 'decomposition', 'plotting', 'distance_stats', 'resampling', 'HaplotypeMatrix', 'GenotypeMatrix', 'WindowedAnalyzer', 'windowed_analysis', 'AccessibleMask', 'bed_to_mask', 'parse_bed', 'LocalPCAResult', 'LostructResult', 'local_pca', 'local_pca_jackknife', 'lostruct', 'pc_dist', 'corners', 'block_jackknife', 'block_bootstrap', 'windowed_pca', 'WindowedPCAResult', 'MemoryLimitedWarning']
 
 __version__ = '0.1.0'

--- a/pg_gpu/windowed_pca.py
+++ b/pg_gpu/windowed_pca.py
@@ -1,0 +1,247 @@
+"""Windowed PCA: per-window PCA coordinates across a chromosome.
+
+A winpca-style API (https://github.com/MoritzBlumer/winpca) layered on
+top of :func:`pg_gpu.local_pca` (lostruct, Li & Ralph 2019). Both functions
+compute per-window PCA; they differ in defaults and in how the output is
+typically plotted:
+
+* :func:`local_pca` is tuned for the lostruct workflow — find genomic regions
+  where population structure *changes*, usually via MDS on inter-window
+  PC distances (``pc_dist`` / ``lostruct``).
+* :func:`windowed_pca` (this module) is tuned for the winpca workflow —
+  plot per-window PC1/PC2 *trajectories* per sample across the chromosome,
+  with biallelic + MAF filtering and the Patterson scaler that
+  ``scikit-allel`` uses by default.
+
+The two share an SVD-per-window kernel. The shapes of the outputs are
+related by a transpose:
+
+* :class:`local_pca`'s :class:`LocalPCAResult.eigvecs` has shape
+  ``(n_windows, k, n_samples)``.
+* :func:`windowed_pca` returns :class:`WindowedPCAResult.coords` with shape
+  ``(n_windows, n_samples, n_components)`` — the conventional "rows are
+  samples, columns are PCs" orientation winpca plots from.
+"""
+from __future__ import annotations
+
+import dataclasses
+import warnings
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+from pg_gpu.haplotype_matrix import HaplotypeMatrix
+from pg_gpu.decomposition import local_pca
+
+
+@dataclasses.dataclass
+class WindowedPCAResult:
+    """Output of :func:`windowed_pca`.
+
+    Attributes
+    ----------
+    windows : pandas.DataFrame
+        One row per window. Columns:
+
+        * ``chrom``, ``start``, ``end``, ``center`` -- window genomic coords
+        * ``n_variants`` -- variants used in the window
+        * ``ev_1`` .. ``ev_{n_components}`` -- per-PC eigenvalues
+    coords : numpy.ndarray
+        Per-sample PCA coordinates, shape
+        ``(n_windows, n_samples, n_components)``. NaN for windows that had
+        fewer variants than ``n_components``.
+    sample_ids : list of str
+        Length ``n_samples``. Labels for ``coords`` axis 1.
+    component_labels : list of str
+        Length ``n_components``. Labels for ``coords`` axis 2.
+    """
+
+    windows: pd.DataFrame
+    coords: np.ndarray
+    sample_ids: list
+    component_labels: list
+
+
+def _maf_keep_indices(haps, maf_threshold: float) -> np.ndarray:
+    """Numpy indices of sites where minor allele frequency exceeds threshold.
+
+    Handles both numpy and cupy arrays. ``haps`` shape is
+    ``(n_haplotypes, n_variants)`` with ``-1`` marking missing.
+    """
+    if type(haps).__module__.startswith("cupy"):
+        import cupy as xp
+    else:
+        xp = np
+    valid    = haps >= 0
+    n_valid  = valid.sum(axis=0)
+    alt      = (haps == 1).sum(axis=0)
+    af       = xp.where(n_valid > 0, alt / xp.maximum(n_valid, 1), 0.0)
+    maf      = xp.minimum(af, 1.0 - af)
+    keep     = xp.where(maf > maf_threshold)[0]
+    return keep.get() if hasattr(keep, "get") else np.asarray(keep)
+
+
+def windowed_pca(
+    haplotype_matrix: HaplotypeMatrix,
+    window_size: int,
+    step_size: Optional[int] = None,
+    *,
+    n_components: int = 10,
+    window_type: str = "bp",
+    maf_threshold: float = 0.05,
+    ld_prune: bool = True,
+    ld_size: int = 100,
+    ld_step: int = 20,
+    ld_threshold: float = 0.1,
+    biallelic_only: bool = True,
+    scaler: str = "patterson",
+    population: Optional[str] = None,
+    random_state: Optional[int] = None,
+) -> WindowedPCAResult:
+    """Per-window PCA across the genome with winpca-style defaults.
+
+    Thin wrapper over :func:`pg_gpu.local_pca` that:
+
+    1. Optionally pre-filters the matrix to biallelic / MAF > threshold /
+       LD-pruned sites (applied **once globally** — see Notes below).
+    2. Runs ``local_pca`` with ``scaler='patterson'`` and ``k=n_components``.
+    3. Repackages the result with shape ``(n_windows, n_samples,
+       n_components)`` (transpose of ``LocalPCAResult.eigvecs``) so it's
+       ready for the winpca-style plotting idiom — one PC1 line per
+       sample, x-axis = window center.
+
+    Parameters
+    ----------
+    haplotype_matrix : HaplotypeMatrix
+        Eager (non-streaming) matrix. ``local_pca`` requires the matrix in
+        memory.
+    window_size : int
+        Window size in bp (when ``window_type='bp'``) or number of SNPs
+        (when ``window_type='snp'``).
+    step_size : int, optional
+        Sliding step. Defaults to ``window_size`` (non-overlapping windows).
+    n_components : int, default 10
+        Number of PCs to retain per window.
+    window_type : {'bp', 'snp'}, default 'bp'
+        Forwarded to ``local_pca``.
+    maf_threshold : float, default 0.05
+        Drop sites with MAF below this. Set to 0 to skip.
+    ld_prune : bool, default True
+        Apply ``locate_unlinked`` LD pruning before the per-window PCA.
+    ld_size, ld_step, ld_threshold : int, int, float
+        Args to ``locate_unlinked``.
+    biallelic_only : bool, default True
+        Apply ``apply_biallelic_filter()`` first.
+    scaler : str, default 'patterson'
+        Forwarded to ``local_pca`` (matches scikit-allel / winpca default).
+    population : str, optional
+        Restrict to a single population from ``hm.sample_sets``.
+    random_state : int, optional
+        Reproducible randomized-SVD seed.
+
+    Returns
+    -------
+    WindowedPCAResult
+
+    Notes
+    -----
+    Per-window MAF and LD-prune adaptivity (winpca's stricter mode) is NOT
+    supported here — the filters apply once to the whole matrix before
+    windowing. The alternative — iterating windows and re-filtering each —
+    duplicates ``local_pca``'s iteration logic; if you need it, file an
+    issue or compose the loop yourself with
+    :func:`pg_gpu.decomposition.randomized_pca`.
+
+    Examples
+    --------
+    >>> from pg_gpu import HaplotypeMatrix, windowed_pca
+    >>> hm = HaplotypeMatrix.from_zarr(VCZ, region='X:1-10000000',
+    ...                                streaming='never')
+    >>> result = windowed_pca(hm, window_size=200_000)
+    >>> result.coords.shape          # (n_windows, n_samples, n_components)
+    >>> result.windows.head()        # window metadata
+    """
+    if type(haplotype_matrix).__name__ == "StreamingHaplotypeMatrix":
+        raise ValueError(
+            "windowed_pca requires an eager HaplotypeMatrix; "
+            "streaming matrices are not supported. Reload the region with "
+            "streaming='never' (and a smaller region if it won't fit on GPU)."
+        )
+
+    if step_size is None:
+        step_size = window_size
+
+    hm = haplotype_matrix
+    if biallelic_only:
+        hm = hm.apply_biallelic_filter()
+    if maf_threshold > 0 and hm.num_variants > 0:
+        keep = _maf_keep_indices(hm.haplotypes, maf_threshold)
+        if len(keep) == 0:
+            warnings.warn(
+                "No sites passed the MAF > %g filter; returning empty result."
+                % maf_threshold
+            )
+            return _empty_result(haplotype_matrix, n_components)
+        hm = hm.get_subset(keep)
+    if ld_prune and hm.num_variants > 0:
+        unlinked = hm.locate_unlinked(
+            size=ld_size, step=ld_step, threshold=ld_threshold,
+        )
+        if hasattr(unlinked, "get"):
+            unlinked = unlinked.get()
+        keep = np.where(unlinked)[0]
+        if len(keep) == 0:
+            warnings.warn(
+                "No sites surviving LD prune; returning empty result."
+            )
+            return _empty_result(haplotype_matrix, n_components)
+        hm = hm.get_subset(keep)
+
+    lpca = local_pca(
+        hm,
+        window_size=window_size,
+        step_size=step_size,
+        window_type=window_type,
+        k=n_components,
+        scaler=scaler,
+        population=population,
+        random_state=random_state,
+    )
+
+    eigvecs = lpca.eigvecs
+    n_rows = eigvecs.shape[-1]
+    n_samples = haplotype_matrix.num_haplotypes // 2
+    # Fold haplotype-pair rows to per-sample under pg_gpu's
+    # [hap0_of_all, hap1_of_all] layout (sample i at rows i, i+n_samples).
+    if isinstance(haplotype_matrix, HaplotypeMatrix) and n_rows == 2 * n_samples:
+        eigvecs = (eigvecs[..., :n_samples] + eigvecs[..., n_samples:]) / 2.0
+
+    coords = np.transpose(eigvecs, (0, 2, 1))
+
+    windows = lpca.windows.copy()
+    eigvals = lpca.eigvals
+    for i in range(n_components):
+        windows[f"ev_{i + 1}"] = eigvals[:, i] if i < eigvals.shape[1] else np.nan
+
+    sample_ids = list(getattr(haplotype_matrix, "samples", []))
+    if not sample_ids:
+        n_samples = coords.shape[1] if coords.size else 0
+        sample_ids = [f"sample_{i}" for i in range(n_samples)]
+
+    return WindowedPCAResult(
+        windows=windows,
+        coords=coords,
+        sample_ids=sample_ids,
+        component_labels=[f"PC{i + 1}" for i in range(n_components)],
+    )
+
+
+def _empty_result(hm, n_components):
+    n_samples = hm.num_haplotypes // 2
+    return WindowedPCAResult(
+        windows=pd.DataFrame(),
+        coords=np.empty((0, n_samples, n_components), dtype=np.float64),
+        sample_ids=list(getattr(hm, "samples", [])) or [f"sample_{i}" for i in range(n_samples)],
+        component_labels=[f"PC{i + 1}" for i in range(n_components)],
+    )

--- a/tests/test_windowed_pca.py
+++ b/tests/test_windowed_pca.py
@@ -1,0 +1,129 @@
+"""Tests for pg_gpu.windowed_pca (winpca-style API over local_pca).
+
+Uses the shipped Ag1000G X-chromosome 8-12 Mb / 100-diploid VCZ fixture
+under examples/data/.
+"""
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from pg_gpu import HaplotypeMatrix, windowed_pca, WindowedPCAResult, local_pca
+
+
+REPO_ROOT = Path(__file__).parent.parent
+GAMB_ZARR = REPO_ROOT / "examples/data/gamb.X.8-12Mb.n100.derived.zarr"
+
+
+@pytest.fixture(scope="module")
+def gamb_region_hm():
+    if not GAMB_ZARR.exists():
+        pytest.skip(f"fixture not present: {GAMB_ZARR}")
+    return HaplotypeMatrix.from_zarr(
+        str(GAMB_ZARR), region="X:8000000-10000000", streaming="never",
+    )
+
+
+def test_returns_windowed_pca_result(gamb_region_hm):
+    result = windowed_pca(
+        gamb_region_hm, window_size=500_000, step_size=500_000,
+        n_components=3,
+    )
+    assert isinstance(result, WindowedPCAResult)
+    assert result.coords.ndim == 3
+    n_windows, n_samples, n_components = result.coords.shape
+    assert n_components == 3
+    assert n_samples == gamb_region_hm.num_haplotypes // 2
+    assert n_windows == len(result.windows)
+    assert n_windows > 0
+
+
+def test_window_metadata_columns(gamb_region_hm):
+    result = windowed_pca(
+        gamb_region_hm, window_size=500_000, n_components=2,
+    )
+    cols = set(result.windows.columns)
+    for c in ("chrom", "start", "end", "center", "n_variants",
+              "ev_1", "ev_2"):
+        assert c in cols, f"missing column: {c}"
+
+
+def test_eigenvalues_non_increasing(gamb_region_hm):
+    """Per-window eigenvalues must be sorted descending (top-k PCs)."""
+    result = windowed_pca(
+        gamb_region_hm, window_size=500_000, n_components=5,
+    )
+    ev_cols = [f"ev_{i+1}" for i in range(5)]
+    ev = result.windows[ev_cols].to_numpy()
+    finite = ev[~np.isnan(ev).all(axis=1)]
+    for row in finite:
+        valid = row[~np.isnan(row)]
+        assert np.all(np.diff(valid) <= 1e-9), \
+            f"eigenvalues not descending: {row}"
+
+
+def test_sample_ids_count(gamb_region_hm):
+    result = windowed_pca(
+        gamb_region_hm, window_size=500_000, n_components=2,
+    )
+    assert len(result.sample_ids) == gamb_region_hm.num_haplotypes // 2
+
+
+def test_component_labels(gamb_region_hm):
+    result = windowed_pca(
+        gamb_region_hm, window_size=500_000, n_components=4,
+    )
+    assert result.component_labels == ["PC1", "PC2", "PC3", "PC4"]
+
+
+def test_overlapping_windows_more_than_non_overlapping(gamb_region_hm):
+    r_step  = windowed_pca(gamb_region_hm, window_size=500_000, step_size=500_000, n_components=2)
+    r_slide = windowed_pca(gamb_region_hm, window_size=500_000, step_size=250_000, n_components=2)
+    assert len(r_slide.windows) > len(r_step.windows)
+
+
+def test_coords_match_local_pca_eigvecs_transpose(gamb_region_hm):
+    """With pre-filters disabled, windowed_pca output is local_pca output
+    folded across the haplotype-pair axis and transposed (w, k, n) -> (w, n, k).
+    """
+    kwargs = dict(window_size=500_000, step_size=500_000, window_type="bp")
+    wp = windowed_pca(gamb_region_hm,
+                      n_components=3, scaler="patterson",
+                      maf_threshold=0.0, ld_prune=False,
+                      biallelic_only=False,
+                      **kwargs)
+    lp = local_pca(gamb_region_hm,
+                   k=3, scaler="patterson",
+                   **kwargs)
+    assert wp.coords.shape[0] == lp.eigvecs.shape[0]
+
+    n_samples = gamb_region_hm.num_haplotypes // 2
+    eigvecs_folded = (
+        lp.eigvecs[..., :n_samples] + lp.eigvecs[..., n_samples:]
+    ) / 2.0
+    np.testing.assert_allclose(
+        wp.coords,
+        np.transpose(eigvecs_folded, (0, 2, 1)),
+        equal_nan=True,
+    )
+
+
+def test_maf_filter_reduces_variant_count(gamb_region_hm):
+    no_maf  = windowed_pca(gamb_region_hm, window_size=500_000,
+                           maf_threshold=0.0, ld_prune=False, n_components=2)
+    with_maf = windowed_pca(gamb_region_hm, window_size=500_000,
+                            maf_threshold=0.05, ld_prune=False, n_components=2)
+    merged = no_maf.windows.merge(
+        with_maf.windows, on="start", suffixes=("_raw", "_maf"),
+    )
+    assert (merged["n_variants_maf"] <= merged["n_variants_raw"]).all()
+
+
+def test_streaming_matrix_rejected():
+    class FakeStreaming:
+        __class__ = type("StreamingHaplotypeMatrix", (), {})
+    fake = FakeStreaming()
+    # __class__.__name__ is what the guard checks
+    type(fake).__name__ = "StreamingHaplotypeMatrix"
+    with pytest.raises(ValueError, match="streaming"):
+        windowed_pca(fake, window_size=10_000)


### PR DESCRIPTION
## Summary

A new `windowed_pca` function (and `WindowedPCAResult` dataclass) modeled on [winpca](https://github.com/MoritzBlumer/winpca). It's a thin wrapper over the existing `local_pca` (lostruct) machinery that re-frames the output for the winpca workflow — plot PC1/PC2 trajectories per sample across the chromosome.

```python
from pg_gpu import HaplotypeMatrix, windowed_pca

hm = HaplotypeMatrix.from_zarr(VCZ, region='X:1-10000000', streaming='never')
result = windowed_pca(
    hm, window_size=100_000, step_size=50_000,
    n_components=10,
    maf_threshold=0.05, ld_prune=True, biallelic_only=True,
    scaler='patterson',
)
# result.windows           — pandas DataFrame, one row per window (chrom/start/end/center/n_variants/ev_1..k)
# result.coords            — ndarray (n_windows, n_samples, n_components), per-sample
# result.sample_ids        — list of n_samples labels
# result.component_labels  — ['PC1', 'PC2', ...]
```

## How it relates to `local_pca`

| | `local_pca` (lostruct) | `windowed_pca` (winpca) |
|---|---|---|
| Purpose | Find regions where structure *changes* (MDS on inter-window PC distances) | Plot per-window PC trajectories per sample |
| Pre-filter pipeline | none built in | biallelic + MAF + LD-prune (defaults match scikit-allel) |
| Default `scaler` | `None` (lostruct convention) | `'patterson'` (scikit-allel / winpca convention) |
| Output shape | `eigvecs (n_windows, k, n_haplotypes)` | `coords (n_windows, n_samples, n_components)` (folded across haplotype-pair axis under pg_gpu's `[hap0_of_all, hap1_of_all]` layout) |

`windowed_pca` calls `local_pca` under the hood and transposes/folds the eigenvectors. Equivalence is asserted by a test (see `test_coords_match_local_pca_eigvecs_transpose`).

## Filtering caveat

Per-window adaptive MAF / LD-prune is not supported — the filters apply once globally before windowing. This is documented in the function docstring. A per-window implementation would duplicate `local_pca`'s iteration loop; happy to add if there's demand.

## Tests

9 pytest cases (`tests/test_windowed_pca.py`) using the shipped `examples/data/gamb.X.8-12Mb.n100.derived.zarr` fixture:

- Shape / metadata / sample id checks
- Per-window eigenvalues are non-increasing
- Overlapping windows produce more rows than non-overlapping
- Pre-filter-off equivalence with `local_pca` up to transpose+fold
- MAF filter monotonically reduces per-window variant count
- Streaming input is rejected with `ValueError`

All 9 pass in ~14s.

## Test plan
- [ ] `pixi run -e default pytest tests/test_windowed_pca.py -v`
- [ ] Spot-check the trajectory plot on a real dataset (e.g. Ag1000G Ag3.0 X)
- [ ] Confirm `from pg_gpu import windowed_pca, WindowedPCAResult` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)