### PR TITLE
Add PyPI trusted-publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # hatch-vcs derives the version from git tags, so the tag and history
+          # must be present; the default shallow checkout omits them.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: Publish
+
+# Publish to PyPI on version tags (e.g. v0.1.0). Authentication uses PyPI
+# Trusted Publishing (OIDC) -- no API token or stored secret is involved; PyPI
+# verifies this repository and workflow directly. The repo must first be
+# registered as a trusted publisher for the pg_gpu project on pypi.org.
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependencies
+        run: python -m pip install --upgrade pip build
+
+      # pg_gpu is pure Python (CUDA kernels are compiled at runtime), so the
+      # wheel and sdist build on a plain runner with no GPU or CUDA toolchain.
+      - name: Build package
+        run: python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      id-token: write  # required for trusted publishing
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pg_gpu/__init__.py
+++ b/pg_gpu/__init__.py
@@ -67,4 +67,12 @@ from ._memory_warning import MemoryLimitedWarning
 
 __all__ = ['ld_statistics', 'diversity', 'divergence', 'windowed_analysis', 'selection', 'sfs', 'admixture', 'decomposition', 'plotting', 'distance_stats', 'resampling', 'HaplotypeMatrix', 'GenotypeMatrix', 'WindowedAnalyzer', 'windowed_analysis', 'AccessibleMask', 'bed_to_mask', 'parse_bed', 'LocalPCAResult', 'LostructResult', 'local_pca', 'local_pca_jackknife', 'lostruct', 'pc_dist', 'corners', 'block_jackknife', 'block_bootstrap', 'MemoryLimitedWarning']
 
-__version__ = '0.1.0'
+# Version is derived from the git tag at build time (hatch-vcs) and read here
+# from the installed package metadata, so there is no hardcoded string to keep
+# in sync. The fallback covers running from an unbuilt source tree.
+from importlib.metadata import version as _pkg_version, PackageNotFoundError as _PackageNotFoundError
+
+try:
+    __version__ = _pkg_version('pg_gpu')
+except _PackageNotFoundError:
+    __version__ = '0.0.0+unknown'

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,7 @@
 [workspace]
 name = "pg_gpu"
-version = "0.1.0"
+# No version here on purpose: the package version is derived from git tags by
+# hatch-vcs (see pyproject.toml), so duplicating it would only drift.
 description = "GPU-accelerated population genetics statistics"
 channels = ["conda-forge", "bioconda"]
 platforms = ["linux-64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,12 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+# The package version is derived from the latest git tag (e.g. tag v0.1.0 ->
+# version 0.1.0), so a release is cut by tagging -- there is no version string
+# to bump by hand. Untagged builds get a setuptools-scm dev version.
+[tool.hatch.version]
+source = "vcs"
 
 # Restrict the source distribution to the package and its tests. Without an
 # explicit allowlist hatchling sweeps in everything not git-ignored -- stray
@@ -15,7 +21,7 @@ include = [
 
 [project]
 name = "pg_gpu"
-version = "0.1.0"
+dynamic = ["version"]
 description = "GPU-accelerated population genetics statistics"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Adds a tokenless PyPI publish workflow (Trusted Publishing / OIDC), mirroring the approach used in diploSHIC.

## What it does
- Triggers on `v*` tags.
- `build` job: `python -m build` produces the pure-Python wheel + sdist (no GPU/CUDA toolchain needed to build) and uploads them as an artifact.
- `publish` job: requests `id-token: write` and hands the dists to `pypa/gh-action-pypi-publish` -- PyPI authenticates this repo directly, so there is no API token or stored secret.

## Required one-time setup (maintainer, on pypi.org)
Register `kr-colab/pg_gpu` as a Trusted Publisher for the `pg_gpu` project (or create a pending publisher before the first release), specifying:
- Owner/repo: `kr-colab/pg_gpu`
- Workflow filename: `publish.yml`

## Releasing
After setup, publishing is: `git tag v0.1.0 && git push origin v0.1.0`.

The package already builds clean wheel + sdist that pass `twine check`.