### PR TITLE
docs: install from PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ pixi shell
 ### Into an existing conda / venv environment
 
 To use pg_gpu from your own workflow (Snakemake, Jupyter, an existing conda
-env), install it with pip:
+env), install it from PyPI with pip:
 
 ```bash
-pip install "git+https://github.com/kr-colab/pg_gpu"
+pip install pg_gpu
 ```
 
 This pulls the full runtime stack (cupy-cuda12x with toolkit headers, bio2zarr,

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -84,12 +84,12 @@ Installation into an Existing Environment
 
 If you already manage dependencies with conda, a virtualenv, or another
 tool -- for example to call pg_gpu from a Snakemake rule or an existing
-Jupyter kernel -- you can install it directly with ``pip`` instead of
+Jupyter kernel -- you can install it from PyPI with ``pip`` instead of
 adopting pixi:
 
 .. code-block:: bash
 
-   pip install "git+https://github.com/kr-colab/pg_gpu.git"
+   pip install pg_gpu
 
 This pulls the full runtime stack declared in ``pyproject.toml``:
 ``cupy-cuda12x[ctk]``, ``kvikio`` / ``nvcomp``,


### PR DESCRIPTION
Now that `pg_gpu 0.1.0` is published on PyPI, update the pip install instructions in the README and installation docs to use `pip install pg_gpu` instead of the git URL.

Scope: pip install line only; the editable/dev install and pixi sections are unchanged.