### PR TITLE
moments_ld: default use_genotypes=True to match moments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: latest
+          # Pinned: floating `latest` pulled a pixi release that panics while
+          # solving the unrelated `moments` env's pypi source build, failing
+          # the lint job before ruff runs.
+          pixi-version: v0.66.0
           environments: lint
       - run: pixi run -e lint ruff check pg_gpu/ tests/ examples/
 

--- a/docs/source/tutorials/moments_integration.rst
+++ b/docs/source/tutorials/moments_integration.rst
@@ -33,6 +33,18 @@ unchanged. The validation tests run pg_gpu's parser against
 ``moments``'s on the same VCFs and confirm machine precision agreement
 (max relative error :math:`< 10^{-11}`).
 
+.. important::
+
+   Both functions take a ``use_genotypes`` flag that selects the
+   *estimator*: ``True`` (the default on both sides) uses unphased 9-way
+   genotype counts, ``False`` uses phased 4-way haplotype counts. The two
+   agree in expectation but give different values on finite data. pg_gpu
+   defaults to ``True`` specifically to match ``moments.LD`` so a bare
+   import swap reproduces it. If you override the flag, set it the **same**
+   on both the pg_gpu and moments sides -- mixing them (e.g. phased
+   haplotype counts on one side, genotype counts on the other) silently
+   compares two different estimators and looks like a bug that is not one.
+
 The packaged script is an end-to-end demonstration: it simulates 200
 replicate 1 Mb regions under a three-population model with recent
 admixture using ``msprime``, parses each replicate with pg_gpu, fits

--- a/pg_gpu/moments_ld.py
+++ b/pg_gpu/moments_ld.py
@@ -39,7 +39,7 @@ from . import ld_statistics
 
 def compute_ld_statistics(
     vcf_file=None, rec_map_file=None, pop_file=None, pops=None,
-    r_bins=None, bp_bins=None, use_genotypes=False,
+    r_bins=None, bp_bins=None, use_genotypes=True,
     report=True, ac_filter=True, haplotype_matrix=None,
     genotype_matrix=None, accessible_bed=None,
     pop_assignment=None,
@@ -72,6 +72,19 @@ def compute_ld_statistics(
     The returned dict has the same structure (keys 'bins', 'sums', 'stats',
     'pops') and can be passed directly to moments inference functions.
 
+    .. important::
+       ``use_genotypes`` defaults to ``True``, matching
+       ``moments.LD.Parsing.compute_ld_statistics``. This is deliberate:
+       the two functions compute *different estimators*
+       (``True`` = unphased 9-way genotype counts, ``False`` = phased
+       4-way haplotype counts), which agree in expectation but give
+       different values on finite data. Matching the moments default means
+       a bare import swap reproduces moments exactly. If your data are
+       phased and you want the haplotype estimator, you must pass
+       ``use_genotypes=False`` here **and** to moments -- setting it on
+       only one side silently compares two different estimators (a
+       discrepancy that looks like a bug but is not).
+
     Parameters
     ----------
     vcf_file : str, optional
@@ -92,9 +105,13 @@ def compute_ld_statistics(
         Recombination rate bin edges (Morgans).
     bp_bins : array-like, optional
         Base-pair distance bin edges (alternative to r_bins).
-    use_genotypes : bool
-        If True, use diploid genotype counts (9-way) instead of haplotype
-        counts (4-way). Requires unphased diploid data.
+    use_genotypes : bool, default True
+        Selects the estimator, and defaults to ``True`` to match
+        ``moments.LD.Parsing.compute_ld_statistics``. If True, use diploid
+        genotype counts (9-way), the correct estimator for unphased data.
+        If False, use haplotype counts (4-way), which requires phased data.
+        The two estimators differ on finite data; keep this flag identical
+        on both the pg_gpu and moments sides of any comparison.
     report : bool
         Print progress.
     ac_filter : bool

--- a/tests/test_moments_ld.py
+++ b/tests/test_moments_ld.py
@@ -46,9 +46,13 @@ def moments_stats():
 @pytest.fixture(scope="module")
 def gpu_stats():
     """Compute pg_gpu stats once for the module."""
+    # The moments fixtures use the haplotype estimator (use_genotypes=False),
+    # so pin pg_gpu to the same estimator. The default is use_genotypes=True
+    # (to match moments' own default), which would compute the genotype
+    # estimator and not be comparable to the moments-haplotype reference.
     return compute_ld_statistics(
         VCF, pop_file=POP_FILE, pops=POPS,
-        bp_bins=BP_BINS, report=False,
+        bp_bins=BP_BINS, use_genotypes=False, report=False,
     )
 
 
@@ -127,9 +131,10 @@ class TestPopAssignmentAlias:
     them through the same code path."""
 
     def test_pop_assignment_matches_pop_file(self, gpu_stats):
+        # Match the gpu_stats fixture's estimator so the two are comparable.
         alias = compute_ld_statistics(
             VCF, pop_assignment=POP_FILE, pops=POPS,
-            bp_bins=BP_BINS, report=False,
+            bp_bins=BP_BINS, use_genotypes=False, report=False,
         )
         # Same VCF + same pop file -> identical structure (bins,
         # stats, pops) and per-bin sums equal to machine precision.
@@ -239,7 +244,7 @@ def three_pop_data():
             bp_bins=bp_bins, use_genotypes=False, report=False)
         g_stats = compute_ld_statistics(
             vcf, pop_file=pop_file, pops=pops,
-            bp_bins=bp_bins, report=False)
+            bp_bins=bp_bins, use_genotypes=False, report=False)
         yield m_stats, g_stats, pops
     finally:
         os.unlink(vcf)
@@ -257,7 +262,7 @@ def four_pop_data():
             bp_bins=bp_bins, use_genotypes=False, report=False)
         g_stats = compute_ld_statistics(
             vcf, pop_file=pop_file, pops=pops,
-            bp_bins=bp_bins, report=False)
+            bp_bins=bp_bins, use_genotypes=False, report=False)
         yield m_stats, g_stats, pops
     finally:
         os.unlink(vcf)


### PR DESCRIPTION
Fixes #125.

## Problem

`pg_gpu.moments_ld.compute_ld_statistics` bills itself as a drop-in replacement for `moments.LD.Parsing.compute_ld_statistics`, but the two had opposite defaults for the single most behavior-defining argument:

- pg_gpu: `use_genotypes=False`
- moments: `use_genotypes=True`

A user following our own docstring advice ("switch by changing only the import") silently changed which estimator was computed -- phased 4-way haplotype counts vs. unphased 9-way genotype counts. The two estimators agree in expectation but give different values on finite data, so the result is a large, unexplained mismatch that looks like a pg_gpu bug. This already cost a downstream user real debugging time.

On a real phased window, leaving each library on its own default produced up to ~119% disagreement (worst in the Dz family); aligning the flag brought them to floating-point agreement (max relative diff 3.3e-11).

## Change

- Flip pg_gpu's default to `use_genotypes=True` so a bare import swap reproduces moments out of the box.
- Make the function docstring and the moments-integration tutorial state loudly that this flag selects the *estimator*, defaults to `True` to match moments, and must be set identically on both sides of any comparison.
- The moments parity tests compare pg_gpu against moments' haplotype path, so pin their pg_gpu calls to `use_genotypes=False`. This keeps the haplotype-path parity valid and independent of the moments version (the moments 1.5.0 genotype path has a separate, unrelated pi2 sign bug fixed upstream in v1.5.3).

## Compatibility note

This changes the default behavior for any existing pg_gpu-native caller of the integration layer that relied on the implicit haplotype path. That is the intended, correct-but-breaking part of the fix: the default now matches the function it claims to replace.

## Verification

- `pixi run ruff check pg_gpu/ tests/ examples/` -> all checks passed.
- `CUDA_VISIBLE_DEVICES=1 pixi run -e moments pytest tests/test_moments_ld.py` -> 25 passed.