### PR TITLE
Multiallelic handling for scalar statistics and SFS

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -111,7 +111,6 @@ Core Functions
 .. autofunction:: pg_gpu.diversity.theta_w
 .. autofunction:: pg_gpu.diversity.tajimas_d
 .. autofunction:: pg_gpu.diversity.haplotype_diversity
-.. autofunction:: pg_gpu.diversity.allele_frequency_spectrum
 .. autofunction:: pg_gpu.diversity.segregating_sites
 .. autofunction:: pg_gpu.diversity.singleton_count
 .. autofunction:: pg_gpu.diversity.fay_wus_h

--- a/pg_gpu/_memutil.py
+++ b/pg_gpu/_memutil.py
@@ -2,6 +2,9 @@
 
 import cupy as cp
 
+# Threads per block for the one-thread-per-variant fused kernels.
+_THREADS_PER_BLOCK = 256
+
 
 def estimate_variant_chunk_size(n_hap, bytes_per_element=4, n_intermediates=3,
                                  memory_fraction=0.4):
@@ -149,7 +152,7 @@ def dac_and_n(hap):
     out_dac = cp.empty(n_var, dtype=cp.int64)
     out_n = cp.empty(n_var, dtype=cp.int64)
     s0, s1 = hap.strides
-    threads = 256
+    threads = _THREADS_PER_BLOCK
     blocks = (n_var + threads - 1) // threads
     _dac_and_n_kernel((blocks,), (threads,),
                       (hap, n_hap, n_var, s0, s1, out_dac, out_n))
@@ -158,6 +161,76 @@ def dac_and_n(hap):
 
 # Backward-compatible alias
 chunked_dac_and_n = dac_and_n
+
+
+_allele_counts_kernel = cp.RawKernel(r'''
+extern "C" __global__
+void allele_counts(const signed char* hap, int n_hap, int n_var,
+                   long long stride0, long long stride1, int K,
+                   long long* out_ac, long long* out_n) {
+    int j = blockIdx.x * blockDim.x + threadIdx.x;
+    if (j >= n_var) return;
+    // One thread owns variant j's output row, so no atomics are needed:
+    // the row doubles as this thread's histogram. Zero it, then tally.
+    long long base = (long long)j * K;
+    for (int a = 0; a < K; a++) out_ac[base + a] = 0;
+    int nv = 0;
+    for (int i = 0; i < n_hap; i++) {
+        signed char v = hap[i * stride0 + j * stride1];
+        if (v >= 0) {
+            nv++;
+            if (v < K) out_ac[base + v]++;  // v < K guaranteed when K == max+1
+        }
+    }
+    out_n[j] = nv;
+}
+''', 'allele_counts')
+
+
+def allele_counts(hap, n_alleles=None):
+    """Compute per-allele sample counts and valid counts via fused CUDA kernel.
+
+    Single-pass kernel: one thread per variant reads each element once and
+    tallies a per-allele histogram directly into its own output row (no
+    intermediate array, no atomics). This is the per-allele analogue of
+    ``dac_and_n`` and the multiallelic-correct primitive: allele ``a`` at a
+    site gets its own count, rather than all non-reference alleles being
+    collapsed into one derived class.
+
+    Parameters
+    ----------
+    hap : cupy.ndarray, int8, shape (n_hap, n_var)
+        Allele indices (0 = reference/ancestral, 1.. = alternate), -1 missing.
+    n_alleles : int, optional
+        Output width ``K`` (number of allele columns). If None, derived as
+        ``max(hap) + 1`` via a one-shot reduction. Pass a global value when
+        several calls (e.g. per population) must produce aligned matrices;
+        it must be at least ``max(hap) + 1`` (counts for larger indices are
+        dropped from ``ac`` but still counted in ``n_valid``).
+
+    Returns
+    -------
+    ac : cupy.ndarray, int64, shape (n_var, K)
+        Per-allele sample count; column ``a`` is the count of allele ``a``.
+    n_valid : cupy.ndarray, int64, shape (n_var,)
+        Number of non-missing haplotypes per site (== ac.sum(axis=1) when
+        n_alleles covers the true allele range).
+    """
+    n_hap, n_var = hap.shape
+    if n_alleles is None:
+        K = (max(int(hap.max()), 0) + 1) if hap.size else 1
+    else:
+        K = int(n_alleles)
+    if n_var == 0:
+        return cp.empty((0, K), dtype=cp.int64), cp.empty(0, dtype=cp.int64)
+    out_ac = cp.empty((n_var, K), dtype=cp.int64)
+    out_n = cp.empty(n_var, dtype=cp.int64)
+    s0, s1 = hap.strides
+    threads = _THREADS_PER_BLOCK
+    blocks = (n_var + threads - 1) // threads
+    _allele_counts_kernel((blocks,), (threads,),
+                          (hap, n_hap, n_var, s0, s1, K, out_ac, out_n))
+    return out_ac, out_n
 
 
 def chunked_matmul_accumulate(X, chunk_size=None):

--- a/pg_gpu/diversity.py
+++ b/pg_gpu/diversity.py
@@ -642,16 +642,25 @@ class FrequencySpectrum:
         if n_total_sites is None:
             n_total_sites = matrix.n_total_sites
 
-        from ._memutil import dac_and_n as _dac_n
-        dac, n_valid = _dac_n(matrix.haplotypes)
+        from ._memutil import allele_counts
+        ac, n_valid = allele_counts(matrix.haplotypes)
 
         if missing_data == 'exclude':
             complete = n_valid == n_hap
-            dac = dac[complete]
+            ac = ac[complete]
             n_valid = n_valid[complete]
 
+        # NOTE (issue #100): per-allele polarised SFS -- each derived allele
+        # contributes at its own frequency for 0 < count < n (both fixed classes,
+        # bin 0 and bin n, excluded, matching tskit). The SFS is marginal (it
+        # forgets which derived alleles co-occur at a site), so on MULTIALLELIC
+        # data the estimators that depend on co-occurrence diverge from the
+        # authoritative scalar functions (diversity.pi etc.): pi -- and hence
+        # Tajima's D and Fay-Wu H -- overcount, and Watterson (sum of xi) differs
+        # from the scalar distinct-alleles-1 at reference-absent sites.
+        # theta_h/theta_l and the eta-family are exact.
         self.sfs_by_n = {}
-        if len(dac) == 0:
+        if len(n_valid) == 0:
             self.n_max = 0
             self.n_segregating = 0
         else:
@@ -662,7 +671,12 @@ class FrequencySpectrum:
                 if ni < 2:
                     continue
                 mask = n_valid == ni
-                xi = cp.bincount(dac[mask], minlength=ni + 1)[:ni + 1]
+                vals = ac[mask][:, 1:]
+                vals = vals[(vals > 0) & (vals < ni)]
+                if vals.size:
+                    xi = cp.bincount(vals, minlength=ni + 1)[:ni + 1]
+                else:  # no segregating derived alleles (cupy bincount rejects empty)
+                    xi = cp.zeros(ni + 1, dtype=cp.int64)
                 self.sfs_by_n[ni] = xi.astype(cp.float64).get()
             self.n_segregating = sum(
                 int(np.sum(xi[1:n])) for n, xi in self.sfs_by_n.items())
@@ -1000,7 +1014,9 @@ def allele_frequency_spectrum(haplotype_matrix: HaplotypeMatrix,
     Returns
     -------
     ndarray
-        Array where element i contains the number of sites with i derived alleles
+        Per-allele (unfolded) SFS: element i is the number of derived alleles
+        carried by i samples. A multiallelic site contributes one entry per
+        derived allele.
     """
 
     # Get population subset if specified
@@ -1013,50 +1029,27 @@ def allele_frequency_spectrum(haplotype_matrix: HaplotypeMatrix,
     if matrix.device == 'CPU':
         matrix.transfer_to_gpu()
 
+    from ._memutil import allele_counts
+    max_n = matrix.num_haplotypes
+
     if missing_data == 'exclude':
         matrix = matrix.exclude_missing_sites()
         if matrix.num_variants == 0:
-            return np.zeros(matrix.num_haplotypes + 1, dtype=np.int64)
-        n_haplotypes = matrix.num_haplotypes
-        freqs = cp.sum(matrix.haplotypes, axis=0)
-
-    else:  # missing_data == 'include'
-        max_n = matrix.num_haplotypes
-        derived_counts, n_valid_per_site = _dac_and_n(matrix.haplotypes)
-
-        sites_with_data = n_valid_per_site > 0
-        if not cp.any(sites_with_data):
             return np.zeros(max_n + 1, dtype=np.int64)
 
-        # Filter to sites with valid data and check they're biallelic
-        valid_sites = cp.where(sites_with_data)[0]
-        derived_at_valid = derived_counts[valid_sites]
-        n_valid_at_valid = n_valid_per_site[valid_sites]
-
-        # Check biallelic assumption: derived count should be <= n_valid
-        biallelic_mask = derived_at_valid <= n_valid_at_valid
-        final_derived = derived_at_valid[biallelic_mask]
-
-        # Create AFS histogram
-        # Use bincount which is more efficient than a loop
-        if len(final_derived) > 0:
-            # Ensure derived counts don't exceed max_n
-            final_derived = cp.minimum(final_derived, max_n)
-            afs = cp.bincount(final_derived, minlength=max_n + 1)
-            # Ensure correct size and type
-            if len(afs) < max_n + 1:
-                afs_full = cp.zeros(max_n + 1, dtype=cp.int64)
-                afs_full[:len(afs)] = afs
-                afs = afs_full
-            else:
-                afs = afs[:max_n + 1].astype(cp.int64)
-        else:
-            return np.zeros(max_n + 1, dtype=np.int64)
-
-        return afs.get()
-
-    # For exclude mode, create standard histogram
-    return cp.histogram(freqs, bins=cp.arange(n_haplotypes + 2))[0].get()
+    ac, n_valid = allele_counts(matrix.haplotypes)
+    # Per-allele polarised SFS: each derived allele contributes one count at its
+    # sample frequency, for 0 < count < n. Both fixed classes are excluded --
+    # bin 0 (invariant-ancestral: no derived allele) and bin n (monomorphic-
+    # derived) -- so this matches tskit's polarised allele_frequency_spectrum
+    # exactly. Invariant-site counting is a separate concern (see
+    # FrequencySpectrum's n_total_sites).
+    derived = ac[:, 1:]
+    vals = derived[(derived > 0) & (derived < n_valid[:, None])]
+    if vals.size == 0:  # no segregating derived alleles (cupy bincount rejects empty)
+        return np.zeros(max_n + 1, dtype=np.int64)
+    afs = cp.bincount(vals, minlength=max_n + 1)[:max_n + 1]
+    return afs.astype(cp.int64).get()
 
 
 def segregating_sites(haplotype_matrix: HaplotypeMatrix,

--- a/pg_gpu/diversity.py
+++ b/pg_gpu/diversity.py
@@ -872,24 +872,6 @@ def pi_components(haplotypes, n_total_sites=None, n_haplotypes_full=None):
     return total_diffs, total_comps, total_missing, n_sites
 
 
-def _dac_and_n(haplotypes):
-    """Shared helper: derived allele counts and valid sample counts per site.
-
-    Uses adaptive chunking from _memutil for memory safety on large matrices.
-
-    Parameters
-    ----------
-    haplotypes : cupy.ndarray, int8, shape (n_hap, n_var)
-
-    Returns
-    -------
-    dac : cupy.ndarray, int64, shape (n_var,)
-    n_valid : cupy.ndarray, int64, shape (n_var,)
-    """
-    from ._memutil import dac_and_n
-    return dac_and_n(haplotypes)
-
-
 
 def pi(haplotype_matrix: HaplotypeMatrix,
        population: Optional[Union[str, list]] = None,
@@ -1137,24 +1119,18 @@ def singleton_count(haplotype_matrix: HaplotypeMatrix,
     if matrix.device == 'CPU':
         matrix.transfer_to_gpu()
 
+    from ._memutil import allele_counts
     if missing_data == 'exclude':
         matrix = matrix.exclude_missing_sites()
         if matrix.num_variants == 0:
             return 0
-        allele_counts = cp.sum(matrix.haplotypes, axis=0)
 
-    else:  # missing_data == 'include'
-        derived_counts, n_valid_per_site = _dac_and_n(matrix.haplotypes)
-        sites_with_data = n_valid_per_site >= 1
-
-        if not cp.any(sites_with_data):
-            return 0
-
-        valid_sites = cp.where(sites_with_data)[0]
-        return int(cp.sum(derived_counts[valid_sites] == 1).get())
-
-    # For exclude mode
-    return int(cp.sum(allele_counts == 1).get())
+    ac, n_valid = allele_counts(matrix.haplotypes)
+    # A singleton is a derived allele carried by exactly one sample at a
+    # segregating site (count == 1, which is < n whenever n >= 2). A
+    # multiallelic site can contribute more than one singleton.
+    derived = ac[:, 1:]
+    return int(cp.sum((derived == 1) & (derived < n_valid[:, None])).get())
 
 
 def diversity_stats(haplotype_matrix: HaplotypeMatrix,
@@ -1620,18 +1596,22 @@ def max_daf(haplotype_matrix: HaplotypeMatrix,
     if matrix.device == 'CPU':
         matrix.transfer_to_gpu()
 
-    dac_i, n_valid_i = _dac_and_n(matrix.haplotypes)
-    dac = dac_i.astype(cp.float64)
+    from ._memutil import allele_counts
+    ac, n_valid_i = allele_counts(matrix.haplotypes)
+    if ac.shape[1] < 2:  # no derived alleles present anywhere
+        return 0.0
     n_valid = n_valid_i.astype(cp.float64)
-
+    # Per-allele DAF: the frequency of each individual derived allele. NOTE
+    # (issue #100): "max DAF" is the frequency of the single most common derived
+    # allele, not the total non-ancestral fraction of the sample.
+    freq = ac[:, 1:].astype(cp.float64) / cp.maximum(n_valid[:, None], 1.0)
+    present = ac[:, 1:] > 0
     if missing_data == 'exclude':
-        complete = n_valid_i == matrix.haplotypes.shape[0]
-        freqs = cp.where(complete, dac / n_valid, -1.0)
+        keep = present & (n_valid_i[:, None] == matrix.haplotypes.shape[0])
+        freq = cp.where(keep, freq, -1.0)
     else:
-        usable = n_valid > 0
-        freqs = cp.where(usable, dac / n_valid, 0.0)
-
-    return float(cp.max(freqs).get())
+        freq = cp.where(present & (n_valid_i[:, None] > 0), freq, 0.0)
+    return float(cp.max(freq).get())
 
 
 def haplotype_count(haplotype_matrix: HaplotypeMatrix,
@@ -1718,18 +1698,20 @@ def daf_histogram(matrix, n_bins: int = 20,
     if matrix.device == 'CPU':
         matrix.transfer_to_gpu()
 
-    dac_i, n_valid_i = _dac_and_n(matrix.haplotypes)
-    dac = dac_i.astype(cp.float64)
+    from ._memutil import allele_counts
+    ac, n_valid_i = allele_counts(matrix.haplotypes)
     n_valid = n_valid_i.astype(cp.float64)
-
+    # Per-allele DAF: each derived allele contributes its own frequency. NOTE
+    # (issue #100): this histograms individual derived-allele frequencies (was
+    # the per-site total non-ancestral fraction), and only present derived
+    # alleles are binned (no 0-frequency spike from monomorphic sites).
+    freq = ac[:, 1:].astype(cp.float64) / cp.maximum(n_valid[:, None], 1.0)
+    present = ac[:, 1:] > 0
     if missing_data == 'exclude':
-        complete = n_valid_i == matrix.haplotypes.shape[0]
-        dafs = (dac / n_valid)[complete]
+        keep = present & (n_valid_i[:, None] == matrix.haplotypes.shape[0])
     else:
-        usable = n_valid > 0
-        dafs = cp.where(usable, dac / n_valid, 0.0)
-
-    return _histogram_from_dafs(dafs, n_bins)
+        keep = present & (n_valid_i[:, None] > 0)
+    return _histogram_from_dafs(freq[keep], n_bins)
 
 
 def diplotype_frequency_spectrum(genotype_matrix,
@@ -1874,22 +1856,23 @@ def heterozygosity_expected(haplotype_matrix: HaplotypeMatrix,
     if matrix.device == 'CPU':
         matrix.transfer_to_gpu()
 
-    dac_i, n_valid_i = _dac_and_n(matrix.haplotypes)
-    dac = dac_i.astype(cp.float64)
+    from ._memutil import allele_counts
+    ac, n_valid_i = allele_counts(matrix.haplotypes)
     n_valid = n_valid_i.astype(cp.float64)
     n = matrix.haplotypes.shape[0]
+    ac_f = ac.astype(cp.float64)
 
+    # He = 1 - sum_a p_a^2 over ALL alleles (per-allele; reduces to 2p(1-p) for
+    # biallelic). The old 2p(1-p) with p = total-derived collapsed multiallelic
+    # alleles into one class (issue #100).
     if missing_data == 'include':
-        p = cp.where(n_valid > 0, dac / n_valid, 0.0)
-        he = 2.0 * p * (1.0 - p)
-        he = cp.where(n_valid >= 2, he, cp.nan)
+        p_sq = (ac_f ** 2).sum(axis=1) / cp.maximum(n_valid, 1.0) ** 2
+        he = cp.where(n_valid >= 2, 1.0 - p_sq, cp.nan)
     else:
-        p = dac / n
-        he = 2.0 * p * (1.0 - p)
-
+        p_sq = (ac_f ** 2).sum(axis=1) / (n ** 2)
+        he = 1.0 - p_sq
         if missing_data == 'exclude':
-            incomplete = n_valid_i < n
-            he[incomplete] = cp.nan
+            he = cp.where(n_valid_i < n, cp.nan, he)
 
     return he.get()
 
@@ -2070,21 +2053,19 @@ def mu_sfs(haplotype_matrix: HaplotypeMatrix,
     if matrix.device == 'CPU':
         matrix.transfer_to_gpu()
 
-    dac, n_valid = _dac_and_n(matrix.haplotypes)
-
+    from ._memutil import allele_counts
+    ac, n_valid = allele_counts(matrix.haplotypes)
+    derived = ac[:, 1:]
+    nn = n_valid[:, None]
+    # per-derived-allele edge/segregating classification (mutation-count basis)
+    is_seg = (derived > 0) & (derived < nn)
+    is_edge = is_seg & ((derived == 1) | (derived == nn - 1))
     if missing_data == 'exclude':
-        n = matrix.haplotypes.shape[0]
-        complete = n_valid == n
-        is_seg = complete & (dac > 0) & (dac < n)
-        is_edge = complete & ((dac == 1) | (dac == n - 1))
-    else:
-        usable = n_valid >= 2
-        is_seg = usable & (dac > 0) & (dac < n_valid)
-        is_edge = usable & ((dac == 1) | (dac == n_valid - 1))
+        complete = (n_valid == matrix.haplotypes.shape[0])[:, None]
+        is_seg = is_seg & complete
+        is_edge = is_edge & complete
 
-    n_seg = cp.sum(is_seg)
-    if int(n_seg.get()) == 0:
+    n_seg = int(cp.sum(is_seg).get())
+    if n_seg == 0:
         return 0.0
-
-    n_edge = cp.sum(is_edge)
-    return float((n_edge.astype(cp.float64) / n_seg.astype(cp.float64)).get())
+    return float(cp.sum(is_edge).get() / n_seg)

--- a/pg_gpu/diversity.py
+++ b/pg_gpu/diversity.py
@@ -190,9 +190,11 @@ def _achaz_variance(w1_name, w2_name, n, S):
 def _site_contribution(name, d, n_safe, seg, n_valid, n_hap, dac=None):
     """Compute per-site contribution for a theta estimator on GPU.
 
-    This is the single source of truth for what each estimator computes.
-    Both scalar (_compute_thetas) and windowed (_windowed_thetas_scatter)
-    paths call this function.
+    LEGACY (collapsed, biallelic) path: derived alleles are lumped into a single
+    ``dac`` count, so this is not multiallelic-correct. The scalar diversity path
+    now uses the per-allele ``_ac_contribution``; this function is retained only
+    for ``windowed_analysis``, which still imports it and is migrated to the
+    per-allele primitive in a later subproject.
 
     Parameters
     ----------
@@ -266,6 +268,81 @@ def _prepare_dac(matrix):
     return dac, n_valid, d, n_safe, seg, matrix.num_haplotypes
 
 
+def _prepare_allele_counts(matrix):
+    """Compute per-allele counts and valid counts on GPU.
+
+    Returns (ac, n_valid, n_hap): the per-allele count matrix (n_var, K),
+    per-site non-missing counts, and total haplotype count. Shared per-allele
+    intermediate for the scalar diversity path (multiallelic-correct).
+    """
+    if matrix.device == 'CPU':
+        matrix.transfer_to_gpu()
+    from ._memutil import allele_counts
+    ac, n_valid = allele_counts(matrix.haplotypes)
+    return ac, n_valid, matrix.num_haplotypes
+
+
+def _ac_contribution(name, ac, n_valid, n_hap):
+    """Per-site contribution for a theta estimator from per-allele counts.
+
+    Per-allele single source of truth for the scalar theta path. ``ac`` is the
+    (n_var, K) per-allele count matrix (column 0 is the ancestral/reference
+    allele); ``n_valid`` the per-site non-missing count. Each estimator is a
+    closed-form reduction over the allele axis. pi and watterson use
+    self-correcting closed forms; the SFS-weighted estimators (theta_h, theta_l,
+    eta*) count only polymorphic derived alleles (0 < count < n), which excludes
+    fixed-derived alleles to match the per-allele SFS.
+
+    Returns a float64 (n_var,) array (zero for non-contributing sites).
+    """
+    n = n_valid.astype(cp.float64)
+    n_safe = cp.maximum(n, 2.0)
+    has_data = n_valid >= 2
+    dcols = ac[:, 1:]                     # per-derived-allele counts
+    nn = n_valid[:, None]
+    poly = (dcols > 0) & (dcols < nn)     # segregating (non-fixed) derived alleles
+
+    if name in ('pi', 'theta_pi'):
+        pairs = n_safe * (n_safe - 1.0)
+        same = (ac * (ac - 1)).sum(axis=1).astype(cp.float64)
+        return cp.where(n >= 2.0, (pairs - same) / pairs, 0.0)
+    elif name in ('watterson', 'theta_s'):
+        a1_inv = _get_a1_inv(n_hap)
+        alleles_present = (ac > 0).sum(axis=1)
+        return cp.where(
+            has_data, (alleles_present - 1).astype(cp.float64) * a1_inv[n_valid], 0.0)
+    elif name == 'theta_h':
+        num = 2.0 * (dcols.astype(cp.float64) ** 2 * poly).sum(axis=1)
+        return cp.where(has_data, num / (n_safe * (n_safe - 1.0)), 0.0)
+    elif name == 'theta_l':
+        num = (dcols.astype(cp.float64) * poly).sum(axis=1)
+        return cp.where(has_data, num / (n_safe - 1.0), 0.0)
+    elif name == 'eta1':
+        # Singleton derived alleles (count == 1).
+        a1_inv = _get_a1_inv(n_hap)
+        cnt = (dcols == 1).sum(axis=1).astype(cp.float64)
+        return cp.where(has_data, cnt * a1_inv[n_valid], 0.0)
+    elif name == 'eta1_star':
+        # Singletons + (n-1)-tons.
+        a1_inv = _get_a1_inv(n_hap)
+        is_edge = (dcols == 1) | (dcols == (n_valid - 1)[:, None])
+        cnt = is_edge.sum(axis=1).astype(cp.float64)
+        return cp.where(has_data, cnt * a1_inv[n_valid], 0.0)
+    elif name == 'minus_eta1':
+        # Non-singleton segregating derived alleles (2 <= count < n).
+        norm = _get_minus_eta1_norm(n_hap)
+        cnt = ((dcols >= 2) & (dcols < nn)).sum(axis=1).astype(cp.float64)
+        return cp.where(has_data, cnt * norm[n_valid], 0.0)
+    elif name == 'minus_eta1_star':
+        # Interior derived alleles (2 <= count <= n-2).
+        norm = _get_minus_eta1_star_norm(n_hap)
+        cnt = ((dcols >= 2) & (dcols <= (n_valid - 2)[:, None])).sum(axis=1).astype(cp.float64)
+        return cp.where(has_data, cnt * norm[n_valid], 0.0)
+    else:
+        raise ValueError(f"Unknown estimator: {name}. Use FrequencySpectrum "
+                         f"for custom weight functions.")
+
+
 def _compute_thetas(matrix, estimators=('pi', 'watterson', 'theta_h', 'theta_l')):
     """Compute multiple theta estimators via direct vectorized GPU arithmetic.
 
@@ -283,16 +360,18 @@ def _compute_thetas(matrix, estimators=('pi', 'watterson', 'theta_h', 'theta_l')
         'S': int, number of segregating sites
         'n_harmonic_mean': int, harmonic mean of per-site sample sizes
     """
-    dac, n_valid, d, n_safe, seg, n_hap = _prepare_dac(matrix)
+    ac, n_valid, n_hap = _prepare_allele_counts(matrix)
 
     thetas = {}
     for name in estimators:
-        val = cp.sum(_site_contribution(name, d, n_safe, seg, n_valid, n_hap, dac=dac))
+        val = cp.sum(_ac_contribution(name, ac, n_valid, n_hap))
         thetas[name] = float(val.get())
 
-    S = int(cp.sum(seg).get())
-
+    # Segregating sites = number of mutations = sum over sites of (alleles - 1)
+    # (tskit convention: triallelic counts as 2; reference-absent sites count).
     has_data = n_valid >= 2
+    S = int(cp.sum(cp.where(has_data, (ac > 0).sum(axis=1) - 1, 0)).get())
+
     if cp.any(has_data):
         valid_n = n_valid[has_data].astype(cp.float64)
         n_harm = round(float(len(valid_n) / cp.sum(1.0 / valid_n).get()))
@@ -751,13 +830,14 @@ def pi_components(haplotypes, n_total_sites=None, n_haplotypes_full=None):
     total_missing : float
     n_sites : int
     """
-    dac, n_valid_i = _dac_and_n(haplotypes)
+    from ._memutil import allele_counts
+    ac, n_valid_i = allele_counts(haplotypes)
     n_valid = n_valid_i.astype(cp.float64)
-    derived = dac.astype(cp.float64)
-    ancestral = n_valid - derived
 
-    site_diffs = derived * ancestral
+    # Per-allele differing pairs at a site: C(n,2) - sum_a C(ac_a, 2).
+    same_pairs = (ac * (ac - 1)).sum(axis=1).astype(cp.float64) / 2.0
     site_comps = n_valid * (n_valid - 1) / 2.0
+    site_diffs = site_comps - same_pairs
 
     usable = n_valid >= 2
     total_diffs = float(cp.sum(site_diffs[usable]).get())
@@ -1013,26 +1093,21 @@ def segregating_sites(haplotype_matrix: HaplotypeMatrix,
     if matrix.device == 'CPU':
         matrix.transfer_to_gpu()
 
+    from ._memutil import allele_counts
     if missing_data == 'exclude':
         matrix = matrix.exclude_missing_sites()
         if matrix.num_variants == 0:
             return 0
-        allele_counts = cp.sum(matrix.haplotypes, axis=0)
-        n_haplotypes = matrix.num_haplotypes
-        segregating = (allele_counts > 0) & (allele_counts < n_haplotypes)
 
-    else:  # missing_data == 'include'
-        derived_counts, n_valid_per_site = _dac_and_n(matrix.haplotypes)
-        sites_with_data = n_valid_per_site >= 2
+    ac, n_valid_per_site = allele_counts(matrix.haplotypes)
+    sites_with_data = n_valid_per_site >= 2
+    if not cp.any(sites_with_data):
+        return 0
 
-        if not cp.any(sites_with_data):
-            return 0
-
-        valid_sites = cp.where(sites_with_data)[0]
-        segregating_mask = (derived_counts[valid_sites] > 0) & (derived_counts[valid_sites] < n_valid_per_site[valid_sites])
-        return int(cp.sum(segregating_mask).get())
-
-    return int(cp.sum(segregating).get())
+    # tskit convention: segregating count = number of mutations = sum(alleles - 1);
+    # a triallelic site contributes 2, and reference-absent sites are counted.
+    alleles_present = (ac > 0).sum(axis=1)
+    return int(cp.sum(cp.where(sites_with_data, alleles_present - 1, 0)).get())
 
 
 def singleton_count(haplotype_matrix: HaplotypeMatrix,

--- a/pg_gpu/diversity.py
+++ b/pg_gpu/diversity.py
@@ -975,65 +975,6 @@ def tajimas_d(haplotype_matrix: HaplotypeMatrix,
     return _compute_neutrality_test(matrix, 'pi', 'watterson')
 
 
-def allele_frequency_spectrum(haplotype_matrix: HaplotypeMatrix,
-                            population: Optional[Union[str, list]] = None,
-                            missing_data: str = 'include') -> cp.ndarray:
-    """
-    Calculate the allele frequency spectrum (AFS).
-
-    The AFS is a histogram of allele frequencies across all sites.
-
-    Parameters
-    ----------
-    haplotype_matrix : HaplotypeMatrix
-        The haplotype data
-    population : str or list, optional
-        Population name or list of sample indices. If None, uses all samples
-    missing_data : str
-        'include' - Calculate AFS using available data per site.
-        'exclude' - Only use sites with no missing data.
-
-    Returns
-    -------
-    ndarray
-        Per-allele (unfolded) SFS: element i is the number of derived alleles
-        carried by i samples. A multiallelic site contributes one entry per
-        derived allele.
-    """
-
-    # Get population subset if specified
-    if population is not None:
-        matrix = _get_population_matrix(haplotype_matrix, population)
-    else:
-        matrix = haplotype_matrix
-
-    # Ensure on GPU
-    if matrix.device == 'CPU':
-        matrix.transfer_to_gpu()
-
-    from ._memutil import allele_counts
-    max_n = matrix.num_haplotypes
-
-    if missing_data == 'exclude':
-        matrix = matrix.exclude_missing_sites()
-        if matrix.num_variants == 0:
-            return np.zeros(max_n + 1, dtype=np.int64)
-
-    ac, n_valid = allele_counts(matrix.haplotypes)
-    # Per-allele polarised SFS: each derived allele contributes one count at its
-    # sample frequency, for 0 < count < n. Both fixed classes are excluded --
-    # bin 0 (invariant-ancestral: no derived allele) and bin n (monomorphic-
-    # derived) -- so this matches tskit's polarised allele_frequency_spectrum
-    # exactly. Invariant-site counting is a separate concern (see
-    # FrequencySpectrum's n_total_sites).
-    derived = ac[:, 1:]
-    vals = derived[(derived > 0) & (derived < n_valid[:, None])]
-    if vals.size == 0:  # no segregating derived alleles (cupy bincount rejects empty)
-        return np.zeros(max_n + 1, dtype=np.int64)
-    afs = cp.bincount(vals, minlength=max_n + 1)[:max_n + 1]
-    return afs.astype(cp.int64).get()
-
-
 def segregating_sites(haplotype_matrix: HaplotypeMatrix,
                      population: Optional[Union[str, list]] = None,
                      missing_data: str = 'include') -> int:

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -1530,15 +1530,6 @@ class HaplotypeMatrix:
             }
 
     ####### some polymorphism statistics #######
-    def allele_frequency_spectrum(self) -> cp.ndarray:
-        """
-        Calculate the allele frequency spectrum for a haplotype matrix.
-
-        Note: This method is deprecated. Use diversity.allele_frequency_spectrum() instead.
-        """
-        from . import diversity
-        return diversity.allele_frequency_spectrum(self)
-
     def diversity(self, span_normalize=True) -> float:
         """
         Calculate the nucleotide diversity (π) for the haplotype matrix.

--- a/pg_gpu/sfs.py
+++ b/pg_gpu/sfs.py
@@ -72,6 +72,20 @@ def _allele_counts(haplotype_matrix, missing_data='include'):
     return ac, n
 
 
+def _per_allele_counts(matrix, n_alleles=None):
+    """Per-allele counts (n_var, K) and per-site n_valid via the fused kernel.
+
+    K defaults to the site-local maximum allele index + 1; pass ``n_alleles``
+    for a fixed/global width (e.g. to align populations for the joint SFS).
+    Multiallelic-correct (each allele counted separately), unlike the collapsed
+    ``_derived_allele_counts``.
+    """
+    if matrix.device == 'CPU':
+        matrix.transfer_to_gpu()
+    from ._memutil import allele_counts
+    return allele_counts(matrix.haplotypes, n_alleles=n_alleles)
+
+
 # ---------------------------------------------------------------------------
 # Public API: Single-population SFS
 # ---------------------------------------------------------------------------
@@ -108,26 +122,41 @@ def sfs(haplotype_matrix: HaplotypeMatrix,
     else:
         matrix = haplotype_matrix
 
-    dac, n = _derived_allele_counts(matrix, missing_data)
+    if matrix.device == 'CPU':
+        matrix.transfer_to_gpu()
+    max_n = matrix.num_haplotypes
 
     if missing_data == 'exclude':
-        # filter out incomplete sites (marked as -1)
-        valid = dac >= 0
-        dac = dac[valid]
+        matrix = matrix.exclude_missing_sites()
+        if matrix.num_variants == 0:
+            return np.zeros(max_n + 1, dtype=np.int64)
 
-    if isinstance(n, cp.ndarray):
-        max_n = int(cp.max(n).get()) if n.size > 0 else 0
-    else:
-        max_n = int(n)
-
-    s = cp.bincount(dac.astype(cp.int32), minlength=max_n + 1)
-    return s[:max_n + 1].get()
+    ac, n_valid = _per_allele_counts(matrix)
+    # Per-allele polarised SFS: each derived allele contributes one count at its
+    # own sample frequency, for 0 < count < n (both fixed classes excluded),
+    # matching tskit's polarised allele_frequency_spectrum.
+    derived = ac[:, 1:]
+    vals = derived[(derived > 0) & (derived < n_valid[:, None])]
+    if vals.size == 0:
+        return np.zeros(max_n + 1, dtype=np.int64)
+    s = cp.bincount(vals, minlength=max_n + 1)[:max_n + 1]
+    return s.astype(cp.int64).get()
 
 
 def sfs_folded(haplotype_matrix: HaplotypeMatrix,
                population: Optional[Union[str, list]] = None,
                missing_data: str = 'include'):
     """Compute the folded site frequency spectrum (minor allele counts).
+
+    Per-allele and conforming to tskit's ``allele_frequency_spectrum(
+    polarised=False)``: **every** allele (the reference/ancestral column
+    included) contributes weight 1/2 to bin ``min(count, n - count)``, and the
+    fixed class (bin 0) is dropped. A k-allelic site therefore contributes k
+    half-weight entries, so bin values are half-integers on multiallelic data;
+    on biallelic data the reference and derived alleles land in the same
+    ``min`` bin, summing to the usual integer count. This cannot be built from
+    the unfolded ``sfs()`` (which discards the reference column), but it is a
+    single pass over the per-allele counts.
 
     Parameters
     ----------
@@ -139,31 +168,41 @@ def sfs_folded(haplotype_matrix: HaplotypeMatrix,
 
     Returns
     -------
-    ndarray, int64, shape (n_chromosomes // 2 + 1,)
-        Element k = number of variants with minor allele count k.
+    ndarray, float64, shape (n_chromosomes // 2 + 1,)
+        Element k = folded weight of alleles with minor allele count k.
     """
+    if isinstance(haplotype_matrix, StreamingHaplotypeMatrix):
+        return _stream_sum(
+            haplotype_matrix,
+            lambda chunk: sfs_folded(chunk, population=population,
+                                     missing_data=missing_data),
+        )
 
     if population is not None:
         matrix = _get_population_matrix(haplotype_matrix, population)
     else:
         matrix = haplotype_matrix
 
-    ac, n = _allele_counts(matrix, missing_data)
+    if matrix.device == 'CPU':
+        matrix.transfer_to_gpu()
+    max_n = matrix.num_haplotypes
+    length = max_n // 2 + 1
 
     if missing_data == 'exclude':
-        valid = ac[:, 1] >= 0  # dac >= 0
-        ac = ac[valid]
+        matrix = matrix.exclude_missing_sites()
+        if matrix.num_variants == 0:
+            return np.zeros(length, dtype=np.float64)
 
-    mac = cp.amin(ac, axis=1).astype(cp.int32)
-
-    if isinstance(n, cp.ndarray):
-        max_n = int(cp.max(n).get()) if n.size > 0 else 0
-    else:
-        max_n = int(n)
-
-    x = max_n // 2 + 1
-    s = cp.bincount(mac, minlength=x)[:x]
-    return s.get()
+    ac, n_valid = _per_allele_counts(matrix)
+    # Fold every allele (reference column 0 included) to bin min(count, n-count),
+    # weight 1/2; drop the fixed class (foldbin == 0, i.e. count in {0, n}).
+    foldbin = cp.minimum(ac, n_valid[:, None] - ac)
+    mask = (ac > 0) & (foldbin > 0)
+    vals = foldbin[mask].astype(cp.int32)
+    if vals.size == 0:
+        return np.zeros(length, dtype=np.float64)
+    s = 0.5 * cp.bincount(vals, minlength=length)[:length]
+    return s.astype(cp.float64).get()
 
 
 def sfs_scaled(haplotype_matrix: HaplotypeMatrix,
@@ -205,14 +244,12 @@ def sfs_folded_scaled(haplotype_matrix: HaplotypeMatrix,
     -------
     ndarray, float64, shape (n_chromosomes // 2 + 1,)
     """
+    # sfs_folded already handles streaming / population subsetting and is pinned
+    # to tskit; scaling is a fixed transform on top of it (no tskit analogue).
     if population is not None:
-        matrix = _get_population_matrix(haplotype_matrix, population)
+        n = _get_population_matrix(haplotype_matrix, population).num_haplotypes
     else:
-        matrix = haplotype_matrix
-
-    _, n = _derived_allele_counts(matrix, missing_data)
-    if isinstance(n, cp.ndarray):
-        n = int(cp.max(n).get()) if n.size > 0 else 0
+        n = haplotype_matrix.num_haplotypes
     s = sfs_folded(haplotype_matrix, population, missing_data=missing_data)
     return scale_sfs_folded(s, n)
 

--- a/pg_gpu/sfs.py
+++ b/pg_gpu/sfs.py
@@ -258,11 +258,108 @@ def sfs_folded_scaled(haplotype_matrix: HaplotypeMatrix,
 # Public API: Joint SFS (two populations)
 # ---------------------------------------------------------------------------
 
+def _joint_global_k(m1, m2):
+    """Global allele-index width K spanning both population matrices.
+
+    The joint SFS counts each population on a *shared* K so that allele
+    column ``a`` denotes the same allele in both per-allele count matrices
+    (the alignment discipline from 0001). ``K = max allele index over both
+    pops + 1``.
+    """
+    k1 = int(m1.haplotypes.max()) if m1.num_variants > 0 else 0
+    k2 = int(m2.haplotypes.max()) if m2.num_variants > 0 else 0
+    return max(k1, k2, 0) + 1
+
+
+def _joint_aligned_counts(haplotype_matrix, pop1, pop2):
+    """Per-allele counts for both pops on a shared global K.
+
+    Returns ``(ac1, ac2, nv1, nv2, n1, n2)`` where ``ac1``/``ac2`` are
+    ``(n_var, K)`` on the same K (so allele column ``a`` is the same allele in
+    both), ``nv1``/``nv2`` are per-site valid counts, and ``n1``/``n2`` the
+    population sizes.
+    """
+    m1 = _get_population_matrix(haplotype_matrix, pop1)
+    m2 = _get_population_matrix(haplotype_matrix, pop2)
+    if m1.device == 'CPU':
+        m1.transfer_to_gpu()
+    if m2.device == 'CPU':
+        m2.transfer_to_gpu()
+    K = _joint_global_k(m1, m2)
+    ac1, nv1 = _per_allele_counts(m1, n_alleles=K)
+    ac2, nv2 = _per_allele_counts(m2, n_alleles=K)
+    return ac1, ac2, nv1, nv2, m1.num_haplotypes, m2.num_haplotypes
+
+
+def _joint_per_allele_counts(haplotype_matrix, pop1, pop2, missing_data):
+    """Per-allele (count_A, count_B) for every derived allele passing the
+    tskit cohort-polymorphic filter.
+
+    Keeps derived columns only (ancestral column 0 excluded) and retains
+    alleles with ``0 < count_A + count_B < n_valid_A + n_valid_B``
+    (segregating in the A+B cohort). This is exactly tskit's sample-set AFS
+    rule: all edge cells populated, only the two global-monomorphic corners
+    ``(0,0)`` and ``(nA,nB)`` dropped. Returns ``(cA, cB, n1, n2)`` with
+    ``cA``/``cB`` flat GPU int64 arrays.
+    """
+    ac1, ac2, nv1, nv2, n1, n2 = _joint_aligned_counts(haplotype_matrix,
+                                                       pop1, pop2)
+    dA = ac1[:, 1:]                       # derived alleles only
+    dB = ac2[:, 1:]
+    cohort = dA + dB
+    n_cohort = (nv1 + nv2)[:, None]
+    keep = (cohort > 0) & (cohort < n_cohort)
+    if missing_data == 'exclude':
+        complete = ((nv1 == n1) & (nv2 == n2))[:, None]
+        keep = keep & complete
+
+    cA = dA[keep].astype(cp.int64)
+    cB = dB[keep].astype(cp.int64)
+    return cA, cB, n1, n2
+
+
+def _joint_folded_cells(haplotype_matrix, pop1, pop2, missing_data):
+    """Folded joint cells ``(fA, fB)`` for tskit's ``polarised=False`` 2D AFS.
+
+    Every allele (ancestral column 0 **included**) is folded as a unit by the
+    global minor: cell ``(cA, cB)`` is paired with ``(nA-cA, nB-cB)`` and the
+    smaller-total orientation is kept (ties broken by the first axis). Each
+    surviving allele carries weight 1/2; global-monomorphic corners are
+    dropped. Returns ``(fA, fB, n1, n2)`` (flat GPU int64), to be binned with
+    weight 1/2. Unlike the unfolded rule, this folds *the whole site by one
+    global minor allele* rather than each axis independently -- which is where
+    tskit departs from scikit-allel's per-axis fold (see the ledger).
+    """
+    ac1, ac2, nv1, nv2, n1, n2 = _joint_aligned_counts(haplotype_matrix,
+                                                       pop1, pop2)
+    cohort = ac1 + ac2                    # all alleles incl. ancestral
+    ncoh = (nv1 + nv2)[:, None]
+    keep = (cohort > 0) & (cohort < ncoh)
+    if missing_data == 'exclude':
+        complete = ((nv1 == n1) & (nv2 == n2))[:, None]
+        keep = keep & complete
+
+    nv1b = nv1[:, None]
+    nv2b = nv2[:, None]
+    comp = ncoh - cohort
+    flip = (cohort > comp) | ((cohort == comp) & (ac1 > nv1b - ac1))
+    fA = cp.where(flip, nv1b - ac1, ac1)
+    fB = cp.where(flip, nv2b - ac2, ac2)
+    return fA[keep].astype(cp.int64), fB[keep].astype(cp.int64), n1, n2
+
+
 def joint_sfs(haplotype_matrix: HaplotypeMatrix,
               pop1: Union[str, list],
               pop2: Union[str, list],
               missing_data: str = 'include'):
     """Compute the joint site frequency spectrum between two populations.
+
+    Per-allele and conforming to tskit's ``allele_frequency_spectrum([popA,
+    popB], polarised=True)``: each derived allele contributes to cell
+    ``(count_A, count_B)``, retaining alleles segregating in the A+B cohort
+    (``0 < count_A + count_B < nA + nB``). All edge cells are populated
+    (alleles private to / fixed within one population); only the two
+    global-monomorphic corners ``(0,0)`` and ``(nA,nB)`` are excluded.
 
     Parameters
     ----------
@@ -274,8 +371,8 @@ def joint_sfs(haplotype_matrix: HaplotypeMatrix,
     Returns
     -------
     ndarray, int64, shape (n1 + 1, n2 + 1)
-        Element [i, j] = number of variants with i derived alleles in pop1
-        and j derived alleles in pop2.
+        Element [i, j] = number of derived alleles with i copies in pop1
+        and j copies in pop2.
     """
     if isinstance(haplotype_matrix, StreamingHaplotypeMatrix):
         return _stream_sum(
@@ -284,27 +381,15 @@ def joint_sfs(haplotype_matrix: HaplotypeMatrix,
                                     missing_data=missing_data),
         )
 
-    m1 = _get_population_matrix(haplotype_matrix, pop1)
-    m2 = _get_population_matrix(haplotype_matrix, pop2)
-
-    dac1, n1 = _derived_allele_counts(m1, missing_data)
-    dac2, n2 = _derived_allele_counts(m2, missing_data)
-
-    if missing_data == 'exclude':
-        valid = (dac1 >= 0) & (dac2 >= 0)
-        dac1 = dac1[valid]
-        dac2 = dac2[valid]
-
-    if isinstance(n1, cp.ndarray):
-        n1 = int(cp.max(n1).get()) if n1.size > 0 else 0
-    if isinstance(n2, cp.ndarray):
-        n2 = int(cp.max(n2).get()) if n2.size > 0 else 0
-
+    cA, cB, n1, n2 = _joint_per_allele_counts(haplotype_matrix, pop1, pop2,
+                                              missing_data)
     x = n1 + 1
     y = n2 + 1
-    tmp = (dac1 * y + dac2).astype(cp.int32)
-    s = cp.bincount(tmp, minlength=x * y)
-    return s[:x * y].reshape(x, y).get()
+    if cA.size == 0:
+        return np.zeros((x, y), dtype=np.int64)
+    flat = cA * y + cB
+    s = cp.bincount(flat, minlength=x * y)
+    return s[:x * y].reshape(x, y).astype(cp.int64).get()
 
 
 @lru_cache(maxsize=16)
@@ -400,27 +485,22 @@ def project_joint_sfs(haplotype_matrix: HaplotypeMatrix,
                                                  P1, P2, missing_data)
         return acc.get()
 
-    # Eager path: compute (dac1, dac2) once then apply the same gather.
-    m1 = _get_population_matrix(haplotype_matrix, pop1)
-    m2 = _get_population_matrix(haplotype_matrix, pop2)
-    dac1, n1 = _derived_allele_counts(m1, missing_data)
-    dac2, n2 = _derived_allele_counts(m2, missing_data)
-    if missing_data == 'exclude':
-        valid = (dac1 >= 0) & (dac2 >= 0)
-        dac1 = dac1[valid]
-        dac2 = dac2[valid]
-    if isinstance(n1, cp.ndarray):
-        n1 = int(cp.max(n1).get()) if n1.size > 0 else 0
-    if isinstance(n2, cp.ndarray):
-        n2 = int(cp.max(n2).get()) if n2.size > 0 else 0
+    # Eager path: per-allele (count_A, count_B) then gather + matmul. This is
+    # exactly P1 @ joint_sfs(...) @ P2.T -- each surviving derived allele
+    # contributes P1[:, cA] outer P2[:, cB] -- so the same cohort filter as
+    # joint_sfs keeps the sandwich identity.
+    cA, cB, n1, n2 = _joint_per_allele_counts(haplotype_matrix, pop1, pop2,
+                                              missing_data)
     if target_n1 > n1 or target_n2 > n2:
         raise ValueError(
             f"Cannot project up: target_n1={target_n1} > n1={n1} "
             f"or target_n2={target_n2} > n2={n2}")
     P1 = cp.asarray(_projection_matrix_vec(n1, target_n1))
     P2 = cp.asarray(_projection_matrix_vec(n2, target_n2))
-    A = P1[:, dac1.astype(cp.int64)]
-    B = P2[:, dac2.astype(cp.int64)]
+    if cA.size == 0:
+        return np.zeros((target_n1 + 1, target_n2 + 1), dtype=np.float64)
+    A = P1[:, cA]
+    B = P2[:, cB]
     return (A @ B.T).get()
 
 
@@ -430,18 +510,13 @@ def _project_joint_sfs_chunk_gpu(chunk_hm, pop1, pop2, P1, P2,
 
     Factored out so the streaming dispatch can accumulate on-device
     without round-tripping each chunk's contribution through host
-    memory.
+    memory. Per-allele, using the same cohort filter as ``joint_sfs``.
     """
-    m1 = _get_population_matrix(chunk_hm, pop1)
-    m2 = _get_population_matrix(chunk_hm, pop2)
-    dac1, _ = _derived_allele_counts(m1, missing_data)
-    dac2, _ = _derived_allele_counts(m2, missing_data)
-    if missing_data == 'exclude':
-        valid = (dac1 >= 0) & (dac2 >= 0)
-        dac1 = dac1[valid]
-        dac2 = dac2[valid]
-    A = P1[:, dac1.astype(cp.int64)]
-    B = P2[:, dac2.astype(cp.int64)]
+    cA, cB, _, _ = _joint_per_allele_counts(chunk_hm, pop1, pop2, missing_data)
+    if cA.size == 0:
+        return cp.zeros((P1.shape[0], P2.shape[0]), dtype=cp.float64)
+    A = P1[:, cA]
+    B = P2[:, cB]
     return A @ B.T
 
 
@@ -457,35 +532,34 @@ def joint_sfs_folded(haplotype_matrix: HaplotypeMatrix,
     pop1, pop2 : str or list
     missing_data : str
 
+    Per-allele and conforming to tskit's ``allele_frequency_spectrum([popA,
+    popB], polarised=False)``: each allele (ancestral included) is folded as a
+    unit by the global minor and contributes weight 1/2 to the kept cell. The
+    output is the full ``(n1+1, n2+1)`` array (the kept region is the
+    lower-total triangle; the rest is zero), with half-integer weights on
+    multiallelic data. **This departs from scikit-allel's per-axis fold even on
+    biallelic data** (see the ledger) -- we pin to tskit here.
+
     Returns
     -------
-    ndarray, int64, shape (n1 // 2 + 1, n2 // 2 + 1)
+    ndarray, float64, shape (n1 + 1, n2 + 1)
     """
+    if isinstance(haplotype_matrix, StreamingHaplotypeMatrix):
+        return _stream_sum(
+            haplotype_matrix,
+            lambda chunk: joint_sfs_folded(chunk, pop1=pop1, pop2=pop2,
+                                           missing_data=missing_data),
+        )
 
-    m1 = _get_population_matrix(haplotype_matrix, pop1)
-    m2 = _get_population_matrix(haplotype_matrix, pop2)
-
-    ac1, n1 = _allele_counts(m1, missing_data)
-    ac2, n2 = _allele_counts(m2, missing_data)
-
-    if missing_data == 'exclude':
-        valid = (ac1[:, 1] >= 0) & (ac2[:, 1] >= 0)
-        ac1 = ac1[valid]
-        ac2 = ac2[valid]
-
-    mac1 = cp.amin(ac1, axis=1).astype(cp.int32)
-    mac2 = cp.amin(ac2, axis=1).astype(cp.int32)
-
-    if isinstance(n1, cp.ndarray):
-        n1 = int(cp.max(n1).get()) if n1.size > 0 else 0
-    if isinstance(n2, cp.ndarray):
-        n2 = int(cp.max(n2).get()) if n2.size > 0 else 0
-
-    x = n1 // 2 + 1
-    y = n2 // 2 + 1
-    tmp = (mac1 * y + mac2).astype(cp.int32)
-    s = cp.bincount(tmp, minlength=x * y)
-    return s[:x * y].reshape(x, y).get()
+    fA, fB, n1, n2 = _joint_folded_cells(haplotype_matrix, pop1, pop2,
+                                         missing_data)
+    x = n1 + 1
+    y = n2 + 1
+    if fA.size == 0:
+        return np.zeros((x, y), dtype=np.float64)
+    flat = fA * y + fB
+    s = 0.5 * cp.bincount(flat, minlength=x * y)[:x * y]
+    return s.reshape(x, y).astype(cp.float64).get()
 
 
 def joint_sfs_scaled(haplotype_matrix: HaplotypeMatrix,
@@ -526,22 +600,13 @@ def joint_sfs_folded_scaled(haplotype_matrix: HaplotypeMatrix,
 
     Returns
     -------
-    ndarray, float64, shape (n1 // 2 + 1, n2 // 2 + 1)
+    ndarray, float64, shape (n1 + 1, n2 + 1)
     """
-
-    m1 = _get_population_matrix(haplotype_matrix, pop1)
-    m2 = _get_population_matrix(haplotype_matrix, pop2)
-
-    _, n1 = _derived_allele_counts(m1, missing_data)
-    _, n2 = _derived_allele_counts(m2, missing_data)
-
-    if isinstance(n1, cp.ndarray):
-        n1 = int(cp.max(n1).get()) if n1.size > 0 else 0
-    if isinstance(n2, cp.ndarray):
-        n2 = int(cp.max(n2).get()) if n2.size > 0 else 0
-
+    # joint_sfs_folded handles streaming / subsetting and is pinned to tskit;
+    # scaling is a fixed transform on top of it. n1/n2 read off the shape.
     s = joint_sfs_folded(haplotype_matrix, pop1, pop2,
                           missing_data=missing_data)
+    n1, n2 = s.shape[0] - 1, s.shape[1] - 1
     return scale_joint_sfs_folded(s, n1, n2)
 
 

--- a/pg_gpu/sfs.py
+++ b/pg_gpu/sfs.py
@@ -15,70 +15,14 @@ from ._utils import get_population_matrix as _get_population_matrix
 from .streaming_matrix import StreamingHaplotypeMatrix, _stream_sum
 
 
-def _derived_allele_counts(haplotype_matrix, missing_data='include'):
-    """Compute derived allele counts per variant on GPU.
-
-    Parameters
-    ----------
-    haplotype_matrix : HaplotypeMatrix
-    missing_data : str
-        'include' - return per-site n_valid
-        'exclude' - filter to complete sites
-
-    Returns
-    -------
-    dac : cupy.ndarray, int64, shape (n_variants,)
-        Derived allele counts.
-    n : int or cupy.ndarray
-        Total haplotypes (int) or per-site valid counts (array).
-    """
-    if haplotype_matrix.device == 'CPU':
-        haplotype_matrix.transfer_to_gpu()
-
-    hap = haplotype_matrix.haplotypes  # (n_haplotypes, n_variants)
-
-    if missing_data == 'include':
-        from ._memutil import dac_and_n
-        dac, n_valid = dac_and_n(hap)
-        return dac, n_valid
-    elif missing_data == 'exclude':
-        from ._memutil import dac_and_n
-        dac, n_valid = dac_and_n(hap)
-        incomplete = n_valid < hap.shape[0]
-        dac[incomplete] = -1
-        n = hap.shape[0]
-        return dac, n
-    else:
-        from ._memutil import chunked_sum_int32
-        n = hap.shape[0]
-        dac = chunked_sum_int32(cp.maximum(hap, 0))
-        return dac, n
-
-
-def _allele_counts(haplotype_matrix, missing_data='include'):
-    """Compute biallelic allele counts [ref, alt] per variant.
-
-    Returns
-    -------
-    ac : cupy.ndarray, int64, shape (n_variants, 2)
-    n : int or cupy.ndarray
-    """
-    dac, n = _derived_allele_counts(haplotype_matrix, missing_data)
-    if isinstance(n, cp.ndarray):
-        ref_counts = n - dac
-    else:
-        ref_counts = n - dac
-    ac = cp.stack([ref_counts, dac], axis=1)
-    return ac, n
-
-
 def _per_allele_counts(matrix, n_alleles=None):
     """Per-allele counts (n_var, K) and per-site n_valid via the fused kernel.
 
     K defaults to the site-local maximum allele index + 1; pass ``n_alleles``
     for a fixed/global width (e.g. to align populations for the joint SFS).
-    Multiallelic-correct (each allele counted separately), unlike the collapsed
-    ``_derived_allele_counts``.
+    Multiallelic-correct: each allele is counted separately. This is the sole
+    counting primitive for every SFS in this module (the old collapsed
+    ``dac_and_n`` wrappers were removed once all variants went per-allele).
     """
     if matrix.device == 'CPU':
         matrix.transfer_to_gpu()

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -55,7 +55,10 @@ def _stream_sum(streaming_hm, kernel_fn):
     """
     total = None
     for _, _, chunk in streaming_hm.iter_gpu_chunks():
-        s = np.asarray(kernel_fn(chunk), dtype=np.int64)
+        # Preserve the kernel's own dtype: integer bincounts (sfs, joint_sfs)
+        # stay int64; the folded SFS carries half-integer weights, so it must
+        # accumulate in float (a forced int64 cast would truncate per chunk).
+        s = np.asarray(kernel_fn(chunk))
         if total is None:
             total = s.copy()
             continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,3 +129,31 @@ def simulate_hm(n_samples=20, seq_length=100_000, seed=42,
         kw["model"] = mutation_model
     ts = msprime.sim_mutations(ts, rate=1e-3, random_seed=seed, **kw)
     return HaplotypeMatrix.from_ts(ts)
+
+
+@pytest.fixture(scope="session")
+def multiallelic_ts():
+    """JC69 tree sequence with genuine multiallelic sites (issue #100).
+
+    Recurrent Jukes-Cantor mutation produces tri/tetra-allelic and
+    reference-absent sites, which is what the tskit-oracle multiallelic tests
+    need. Deterministic (fixed seeds). No missing data, so per-site n_valid
+    equals the full sample size.
+    """
+    import msprime
+    ts = msprime.sim_ancestry(
+        samples=25, population_size=2e4, sequence_length=1e5,
+        recombination_rate=1e-8, random_seed=42, ploidy=2,
+    )
+    ts = msprime.sim_mutations(
+        ts, rate=1e-6, model=msprime.JC69(state_independent=True),
+        random_seed=43,
+    )
+    return ts
+
+
+@pytest.fixture
+def multiallelic_hm(multiallelic_ts):
+    """(ts, hm) pair for the multiallelic tree sequence; hm on GPU."""
+    from pg_gpu import HaplotypeMatrix
+    return multiallelic_ts, HaplotypeMatrix.from_ts(multiallelic_ts, device="GPU")

--- a/tests/test_achaz.py
+++ b/tests/test_achaz.py
@@ -18,7 +18,18 @@ def simple_ts():
         samples=50, sequence_length=100_000,
         recombination_rate=1e-8, population_size=10_000,
         random_seed=42, ploidy=2)
-    return msprime.sim_mutations(ts, rate=1e-8, random_seed=42)
+    ts = msprime.sim_mutations(ts, rate=1e-8, random_seed=42)
+    # These tests assert scalar diversity == FrequencySpectrum (SFS) values.
+    # That equivalence only holds on biallelic data: at multiallelic sites the
+    # scalar mutation-count Watterson and the per-allele SFS diverge
+    # (kr-colab/pg_gpu#100). Nothing above forces biallelic (the default JC
+    # mutation model can produce triallelic sites), so guard it explicitly --
+    # if a future rate/seed change adds a >2-allele site this fails loudly
+    # rather than letting the equivalence break silently.
+    G = ts.genotype_matrix()
+    assert all(np.unique(G[i]).size <= 2 for i in range(ts.num_sites)), \
+        "test_achaz fixture must stay biallelic (see kr-colab/pg_gpu#100)"
+    return ts
 
 
 @pytest.fixture

--- a/tests/test_allele_counts.py
+++ b/tests/test_allele_counts.py
@@ -1,0 +1,106 @@
+"""
+Tests for the per-allele allele-count primitive (_memutil.allele_counts).
+
+This is the multiallelic-correct counting primitive behind the diversity
+family (issue #100). Oracles: a cupy per-column bincount reference and
+scikit-allel's count_alleles.
+"""
+
+import numpy as np
+import cupy as cp
+import allel
+import pytest
+
+from pg_gpu._memutil import allele_counts
+
+
+def _ref_counts(hap, K):
+    """Ground-truth per-allele counts via per-value reduction (n_hap, n_var)."""
+    ac = np.zeros((hap.shape[1], K), dtype=np.int64)
+    for a in range(K):
+        ac[:, a] = (hap == a).sum(axis=0)
+    return ac
+
+
+class TestAlleleCounts:
+
+    def test_biallelic(self):
+        # site0: 3x ref, 1x alt ; site1: all alt
+        hap = np.array([[0, 1],
+                        [0, 1],
+                        [0, 1],
+                        [1, 1]], dtype=np.int8)
+        ac, n = allele_counts(cp.asarray(hap))
+        assert ac.shape == (2, 2)
+        np.testing.assert_array_equal(ac.get(), [[3, 1], [0, 4]])
+        np.testing.assert_array_equal(n.get(), [4, 4])
+
+    def test_triallelic(self):
+        # one site: 2x allele0, 1x allele1, 1x allele2
+        hap = np.array([[0], [0], [1], [2]], dtype=np.int8)
+        ac, n = allele_counts(cp.asarray(hap))
+        assert ac.shape == (1, 3)
+        np.testing.assert_array_equal(ac.get(), [[2, 1, 1]])
+        np.testing.assert_array_equal(n.get(), [4])
+
+    def test_tetraallelic(self):
+        hap = np.array([[0], [1], [2], [3]], dtype=np.int8)
+        ac, n = allele_counts(cp.asarray(hap))
+        np.testing.assert_array_equal(ac.get(), [[1, 1, 1, 1]])
+        np.testing.assert_array_equal(n.get(), [4])
+
+    def test_reference_absent(self):
+        # site with only alleles 1 and 2 (ancestral index 0 absent)
+        hap = np.array([[1], [1], [2], [2]], dtype=np.int8)
+        ac, n = allele_counts(cp.asarray(hap))
+        np.testing.assert_array_equal(ac.get(), [[0, 2, 2]])
+        np.testing.assert_array_equal(n.get(), [4])
+
+    def test_missing_data(self):
+        # -1 excluded from n_valid and from all allele columns
+        hap = np.array([[0], [1], [-1], [2]], dtype=np.int8)
+        ac, n = allele_counts(cp.asarray(hap))
+        np.testing.assert_array_equal(ac.get(), [[1, 1, 1]])
+        np.testing.assert_array_equal(n.get(), [3])
+        # counts sum to n_valid (K covers the range)
+        assert int(ac.get().sum()) == int(n.get().sum())
+
+    def test_sum_equals_n_valid(self):
+        rng = np.random.default_rng(0)
+        hap = rng.integers(-1, 4, size=(30, 200)).astype(np.int8)
+        ac, n = allele_counts(cp.asarray(hap))
+        np.testing.assert_array_equal(ac.get().sum(axis=1), n.get())
+
+    def test_matches_bincount_reference(self):
+        rng = np.random.default_rng(1)
+        hap = rng.integers(-1, 4, size=(40, 500)).astype(np.int8)
+        ac, _ = allele_counts(cp.asarray(hap))
+        K = ac.shape[1]
+        np.testing.assert_array_equal(ac.get(), _ref_counts(hap, K))
+
+    def test_matches_scikit_allel(self):
+        rng = np.random.default_rng(2)
+        hap = rng.integers(0, 4, size=(24, 300)).astype(np.int8)
+        ac, _ = allele_counts(cp.asarray(hap))
+        # allel expects (n_var, n_hap); count_alleles gives (n_var, n_alleles)
+        allel_ac = np.asarray(allel.HaplotypeArray(hap.T).count_alleles())
+        assert ac.shape == allel_ac.shape
+        np.testing.assert_array_equal(ac.get(), allel_ac)
+
+    def test_n_alleles_override_pads(self):
+        hap = np.array([[0], [1], [0], [1]], dtype=np.int8)  # biallelic
+        ac, n = allele_counts(cp.asarray(hap), n_alleles=4)
+        assert ac.shape == (1, 4)
+        np.testing.assert_array_equal(ac.get(), [[2, 2, 0, 0]])
+
+    def test_all_missing(self):
+        hap = np.full((5, 3), -1, dtype=np.int8)
+        ac, n = allele_counts(cp.asarray(hap))
+        assert ac.shape == (3, 1)  # K floored to 1
+        np.testing.assert_array_equal(ac.get(), np.zeros((3, 1)))
+        np.testing.assert_array_equal(n.get(), [0, 0, 0])
+
+    def test_empty(self):
+        hap = np.empty((5, 0), dtype=np.int8)
+        ac, n = allele_counts(cp.asarray(hap))
+        assert ac.shape[0] == 0 and n.shape[0] == 0

--- a/tests/test_backward_compatibility.py
+++ b/tests/test_backward_compatibility.py
@@ -108,32 +108,10 @@ class TestHaplotypeMatrixCompatibility:
 
         assert abs(tajd_old - tajd_allel) < 1e-8
 
-    def test_allele_frequency_spectrum_compatibility(self, test_matrix):
-        """Test that HaplotypeMatrix.allele_frequency_spectrum() matches diversity module."""
-        # Old method
-        afs_old = test_matrix.allele_frequency_spectrum()
-
-        # New module method
-        afs_new = diversity.allele_frequency_spectrum(test_matrix)
-
-        # Convert to numpy if needed
-        if hasattr(afs_old, 'get'):
-            afs_old = np.asarray(afs_old)
-        if hasattr(afs_new, 'get'):
-            afs_new = np.asarray(afs_new)
-
-        # Should be identical
-        np.testing.assert_array_equal(afs_old, afs_new)
-
-        # Should also match scikit-allel SFS
-        h = allel.HaplotypeArray(test_matrix.haplotypes.T if isinstance(test_matrix.haplotypes, np.ndarray)
-                                 else test_matrix.haplotypes.get().T)
-        ac = h.count_alleles()
-        sfs_allel = allel.sfs(ac[:, 1])
-
-        # pg_gpu AFS has n+1 bins, scikit-allel SFS has variable length
-        sfs_length = len(sfs_allel) - 1  # Exclude sfs_allel[0] since we start from index 1
-        np.testing.assert_array_equal(afs_old[1:1+sfs_length], sfs_allel[1:])
+    # NOTE: HaplotypeMatrix.allele_frequency_spectrum() and
+    # diversity.allele_frequency_spectrum() were removed (issue #100 consolidation);
+    # the SFS now lives only in the sfs module. See
+    # tests/test_sfs_allel_comparison.py::TestSFSComparison::test_sfs.
 
     @pytest.mark.skipif(not cp.cuda.is_available(), reason="GPU not available")
     def test_gpu_compatibility(self):
@@ -150,18 +128,15 @@ class TestHaplotypeMatrixCompatibility:
         pi_gpu_old = matrix.diversity(span_normalize=True)
         theta_gpu_old = matrix.watersons_theta(span_normalize=True)
         tajd_gpu_old = matrix.Tajimas_D()
-        afs_gpu_old = matrix.allele_frequency_spectrum()
 
         # New methods should give identical results
         pi_gpu_new = diversity.pi(matrix, span_normalize=True)
         theta_gpu_new = diversity.theta_w(matrix, span_normalize=True)
         tajd_gpu_new = diversity.tajimas_d(matrix)
-        afs_gpu_new = diversity.allele_frequency_spectrum(matrix)
 
         assert abs(pi_gpu_old - pi_gpu_new) < 1e-15
         assert abs(theta_gpu_old - theta_gpu_new) < 1e-15
         assert abs(tajd_gpu_old - tajd_gpu_new) < 1e-15
-        np.testing.assert_array_equal(np.asarray(afs_gpu_old), np.asarray(afs_gpu_new))
 
         # CPU version should match
         matrix_cpu = HaplotypeMatrix(haplotypes, positions, positions[0], positions[-1])
@@ -191,7 +166,6 @@ class TestDeprecationWarnings:
             pi_val = matrix.diversity()
             theta_val = matrix.watersons_theta()
             tajd_val = matrix.Tajimas_D()
-            afs_val = matrix.allele_frequency_spectrum()
 
         # Filter out any unrelated warnings
         relevant_warnings = [w for w in warning_list if 'deprecated' in str(w.message).lower()]
@@ -247,10 +221,6 @@ class TestAPIConsistency:
         tajd_new = diversity.tajimas_d(matrix)
         assert type(tajd_old) == type(tajd_new) == float
 
-        afs_old = matrix.allele_frequency_spectrum()
-        afs_new = diversity.allele_frequency_spectrum(matrix)
-        assert type(afs_old) == type(afs_new)  # Both should be same array type
-
 
 class TestDocumentationExamples:
     """Test examples that might be in documentation to ensure they still work."""
@@ -297,7 +267,6 @@ class TestDocumentationExamples:
             'pi': matrix.diversity(span_normalize=True),
             'theta': matrix.watersons_theta(span_normalize=True),
             'tajimas_d': matrix.Tajimas_D(),
-            'afs': matrix.allele_frequency_spectrum()
         }
 
         # New workflow
@@ -305,23 +274,9 @@ class TestDocumentationExamples:
             'pi': diversity.pi(matrix, span_normalize=True),
             'theta': diversity.theta_w(matrix, span_normalize=True),
             'tajimas_d': diversity.tajimas_d(matrix),
-            'afs': diversity.allele_frequency_spectrum(matrix)
         }
 
         # Should be identical
         assert abs(old_results['pi'] - new_results['pi']) < 1e-15
         assert abs(old_results['theta'] - new_results['theta']) < 1e-15
         assert abs(old_results['tajimas_d'] - new_results['tajimas_d']) < 1e-15
-
-        # AFS arrays should be identical
-        if hasattr(old_results['afs'], 'get'):
-            old_afs = np.asarray(old_results['afs'])
-        else:
-            old_afs = old_results['afs']
-
-        if hasattr(new_results['afs'], 'get'):
-            new_afs = np.asarray(new_results['afs'])
-        else:
-            new_afs = new_results['afs']
-
-        np.testing.assert_array_equal(old_afs, new_afs)

--- a/tests/test_diversity.py
+++ b/tests/test_diversity.py
@@ -7,6 +7,7 @@ import numpy as np
 import cupy as cp
 from pg_gpu import HaplotypeMatrix
 from pg_gpu import diversity
+from pg_gpu import sfs
 
 
 class TestNucleotideDiversity:
@@ -216,7 +217,7 @@ class TestAlleleFrequencySpectrum:
         positions = np.arange(n_variants) * 1000
         matrix = HaplotypeMatrix(haplotypes, positions)
 
-        afs = diversity.allele_frequency_spectrum(matrix)
+        afs = sfs.sfs(matrix)
 
         if isinstance(afs, np.ndarray):
             afs = np.asarray(afs)
@@ -243,7 +244,7 @@ class TestAlleleFrequencySpectrum:
         positions = np.arange(n_variants) * 1000
         matrix = HaplotypeMatrix(haplotypes, positions)
 
-        afs = diversity.allele_frequency_spectrum(matrix)
+        afs = sfs.sfs(matrix)
 
         if isinstance(afs, np.ndarray):
             afs = np.asarray(afs)
@@ -454,7 +455,7 @@ class TestGPUCalculations:
         assert isinstance(seg_sites, int)
 
         # AFS should return GPU array
-        afs = diversity.allele_frequency_spectrum(matrix)
+        afs = sfs.sfs(matrix)
         assert isinstance(afs, np.ndarray)
 
 

--- a/tests/test_diversity.py
+++ b/tests/test_diversity.py
@@ -221,11 +221,14 @@ class TestAlleleFrequencySpectrum:
         if isinstance(afs, np.ndarray):
             afs = np.asarray(afs)
 
-        # Should have 25 sites with 0 copies and 25 with n_samples copies
-        assert afs[0] == 25  # Sites with 0 derived alleles
-        assert afs[n_samples] == 25  # Sites with all derived alleles
-        # All other frequencies should be 0
-        assert np.sum(afs[1:n_samples]) == 0
+        # Per-allele polarised SFS (issue #100): both fixed classes are excluded,
+        # matching tskit. A monomorphic-ancestral site has no derived allele
+        # (bin 0), and a fully-derived site is monomorphic-derived (bin n) -- so
+        # neither contributes and the whole spectrum is empty here. (Invariant
+        # counting is a separate concern: FrequencySpectrum's n_total_sites.)
+        assert afs[0] == 0
+        assert afs[n_samples] == 0
+        assert np.sum(afs) == 0
 
     def test_afs_singletons(self):
         """Test AFS with singleton sites."""

--- a/tests/test_haplotype_matrix.py
+++ b/tests/test_haplotype_matrix.py
@@ -290,12 +290,14 @@ def test_transfer_to_cpu():
 
 
 def test_allele_frequency_spectrum(sample_vcf):
-    """Test calculation of allele frequency spectrum."""
+    """Test calculation of the SFS (formerly HaplotypeMatrix.allele_frequency_spectrum,
+    removed in the issue #100 consolidation; the SFS now lives in the sfs module)."""
+    from pg_gpu import sfs as sfs_mod
     hap_matrix = HaplotypeMatrix.from_vcf(sample_vcf)
-    afs = hap_matrix.allele_frequency_spectrum()
+    afs = sfs_mod.sfs(hap_matrix)
     assert isinstance(afs, np.ndarray)
     assert afs.ndim == 1
-    # AFS has n+1 bins for frequencies 0 to n
+    # SFS has n+1 bins for frequencies 0 to n
     assert afs.size == hap_matrix.num_haplotypes + 1
 
 def test_diversity(sample_vcf):

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -1,0 +1,221 @@
+"""
+Multiallelic-site correctness for the diversity family (issue #100).
+
+Oracle: tskit (per-allele pi/SFS; mutation-count segregating/Watterson). Also
+scikit-allel where it coincides (pi). The biallelic control confirms parity on
+biallelic data. Fixtures live in conftest.py (multiallelic_ts / multiallelic_hm).
+"""
+
+import numpy as np
+import allel
+import pytest
+
+from pg_gpu import HaplotypeMatrix
+from pg_gpu import diversity
+
+
+def _a1(n):
+    return float(np.sum(1.0 / np.arange(1, n)))
+
+
+def _strict_biallelic_mask(G):
+    """Sites whose sample alleles are exactly {0, 1}."""
+    return (G.max(axis=1) == 1) & (G == 0).any(axis=1) & (G == 1).any(axis=1)
+
+
+def _expected_segregating(hap, exclude=False):
+    """Independent numpy reference: mutation-count segregating sites.
+
+    hap is (n_hap, n_var) with -1 for missing. ``exclude`` drops any variant
+    with a missing genotype first (the missing_data='exclude' semantics).
+    """
+    hap = np.asarray(hap)
+    total = 0
+    for j in range(hap.shape[1]):
+        col = hap[:, j]
+        if exclude and np.any(col < 0):
+            continue
+        valid = col[col >= 0]
+        if valid.size < 2:
+            continue
+        total += np.unique(valid).size - 1
+    return total
+
+
+def _expected_pi(hap):
+    """Independent numpy reference: per-site per-allele mean pairwise difference."""
+    hap = np.asarray(hap)
+    total = 0.0
+    for j in range(hap.shape[1]):
+        valid = hap[:, j][hap[:, j] >= 0]
+        n = valid.size
+        if n < 2:
+            continue
+        _, counts = np.unique(valid, return_counts=True)
+        total += 1.0 - float(np.sum(counts * (counts - 1))) / (n * (n - 1))
+    return total
+
+
+class TestDiversityCoreVsTskit:
+    """pi / segregating / Watterson / Tajima numerator against tskit."""
+
+    def test_fixture_is_multiallelic(self, multiallelic_hm):
+        ts, _ = multiallelic_hm
+        G = ts.genotype_matrix()
+        n_alleles = np.array([np.unique(G[i]).size for i in range(ts.num_sites)])
+        assert (n_alleles >= 3).sum() > 0, "fixture has no multiallelic sites"
+
+    def test_pi_matches_tskit(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        pi_pg = diversity.pi(hm, span_normalize=False)
+        pi_ts = float(ts.diversity(mode="site", span_normalise=False))
+        np.testing.assert_allclose(pi_pg, pi_ts, rtol=1e-9)
+
+    def test_pi_matches_allel(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        ac = allel.HaplotypeArray(ts.genotype_matrix()).count_alleles()
+        pi_allel = float(np.nansum(allel.mean_pairwise_difference(ac)))
+        np.testing.assert_allclose(diversity.pi(hm, span_normalize=False),
+                                   pi_allel, rtol=1e-9)
+
+    def test_segregating_matches_tskit_mutation_count(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        s_pg = diversity.segregating_sites(hm)
+        s_ts = ts.segregating_sites(mode="site", span_normalise=False)
+        assert s_pg == int(round(float(s_ts)))
+
+    def test_watterson_is_mutation_count_over_a1(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        # no missing data -> n_valid == n everywhere, so theta_w = S / a1(n)
+        s_ts = float(ts.segregating_sites(mode="site", span_normalise=False))
+        expected = s_ts / _a1(ts.num_samples)
+        np.testing.assert_allclose(diversity.theta_w(hm, span_normalize=False),
+                                   expected, rtol=1e-9)
+
+    def test_tajimas_d_matches_tskit(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        ct = diversity._compute_thetas(hm, ("pi", "watterson"))
+        num_pg = ct["thetas"]["pi"] - ct["thetas"]["watterson"]
+        pi_ts = float(ts.diversity(mode="site", span_normalise=False))
+        s_ts = float(ts.segregating_sites(mode="site", span_normalise=False))
+        num_ts = pi_ts - s_ts / _a1(ts.num_samples)
+        np.testing.assert_allclose(num_pg, num_ts, rtol=1e-9)
+        # Full D matches tskit exactly on complete data: tskit plugs the
+        # mutation-count S straight into the classic Tajima variance
+        # sqrt(a*S + (b/c)*S(S-1)), which is what pg_gpu's Achaz framework
+        # reduces to for the (pi, watterson) pair with the same S.
+        np.testing.assert_allclose(diversity.tajimas_d(hm),
+                                   float(ts.Tajimas_D(mode="site")), rtol=1e-9)
+
+    def test_theta_h_matches_tskit_sfs(self, multiallelic_hm):
+        # oracle: tskit per-allele SFS through the theta_H weight 2*i^2/(n(n-1))
+        ts, hm = multiallelic_hm
+        xi = ts.allele_frequency_spectrum(polarised=True, span_normalise=False)
+        n = ts.num_samples
+        i = np.arange(len(xi), dtype=float)
+        ref = float(np.sum(xi * 2.0 * i ** 2 / (n * (n - 1))))
+        np.testing.assert_allclose(diversity.theta_h(hm, span_normalize=False),
+                                   ref, rtol=1e-9)
+
+    def test_theta_l_matches_tskit_sfs(self, multiallelic_hm):
+        # oracle: tskit per-allele SFS through the theta_L weight i/(n-1)
+        ts, hm = multiallelic_hm
+        xi = ts.allele_frequency_spectrum(polarised=True, span_normalise=False)
+        n = ts.num_samples
+        i = np.arange(len(xi), dtype=float)
+        ref = float(np.sum(xi * i / (n - 1)))
+        np.testing.assert_allclose(diversity.theta_l(hm, span_normalize=False),
+                                   ref, rtol=1e-9)
+
+
+class TestBiallelicControl:
+    """On strict-biallelic sites, pg_gpu matches both tskit and scikit-allel."""
+
+    def test_biallelic_pi_and_segregating(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        G = ts.genotype_matrix()
+        nonbi = np.where(~_strict_biallelic_mask(G))[0].astype(np.int32)
+        ts_bi = ts.delete_sites(nonbi)
+        hm_bi = hm.apply_biallelic_filter()
+
+        # tskit oracle
+        np.testing.assert_allclose(
+            diversity.pi(hm_bi, span_normalize=False),
+            float(ts_bi.diversity(mode="site", span_normalise=False)), rtol=1e-9)
+        assert diversity.segregating_sites(hm_bi) == int(round(
+            float(ts_bi.segregating_sites(mode="site", span_normalise=False))))
+
+        # scikit-allel oracle
+        ac_bi = allel.HaplotypeArray(G[_strict_biallelic_mask(G)]).count_alleles()
+        np.testing.assert_allclose(
+            diversity.pi(hm_bi, span_normalize=False),
+            float(np.nansum(allel.mean_pairwise_difference(ac_bi))), rtol=1e-9)
+
+
+class TestMissingData:
+    """Missing genotypes (-1): the include per-site path and the exclude filter."""
+
+    # cols: biallelic+missing / triallelic+missing / biallelic+missing /
+    #       mostly-missing (n_valid<2) / complete triallelic / complete monomorphic
+    HAP = np.array([
+        [0, 0, 1, 1, -1, -1],
+        [0, 1, 2, -1, -1, -1],
+        [0, 0, 0, 1, -1, -1],
+        [-1, -1, -1, -1, -1, 0],
+        [0, 1, 0, 1, 2, 2],
+        [0, 0, 0, 0, 0, 0],
+    ], dtype=np.int8).T  # -> (6 haplotypes, 6 variants)
+
+    def _hm(self):
+        return HaplotypeMatrix(self.HAP.copy(), np.arange(6) * 100, 0, 600)
+
+    def test_segregating_include(self):
+        # per-site: n_valid>=2 sites counted by mutation count; the n_valid=1
+        # site is dropped. Reference: 1 + 2 + 1 + 0 + 2 + 0 = 6.
+        got = diversity.segregating_sites(self._hm(), missing_data="include")
+        assert got == _expected_segregating(self.HAP, exclude=False) == 6
+
+    def test_segregating_exclude(self):
+        # exclude drops any variant with missing -> only the 2 complete sites
+        # remain (triallelic -> 2, monomorphic -> 0). Reference: 2.
+        got = diversity.segregating_sites(self._hm(), missing_data="exclude")
+        assert got == _expected_segregating(self.HAP, exclude=True) == 2
+
+    def test_pi_include_with_missing(self):
+        # include mode uses per-site n_valid. Oracle 1: a numpy per-site
+        # per-allele reference. Oracle 2: allel (note HAP is n_hap x n_var, so
+        # transpose for allel's n_var x n_hap layout).
+        pi_pg = diversity.pi(self._hm(), span_normalize=False, missing_data="include")
+        np.testing.assert_allclose(pi_pg, _expected_pi(self.HAP), rtol=1e-9)
+        ac = allel.HaplotypeArray(self.HAP.T).count_alleles()
+        pi_allel = float(np.nansum(allel.mean_pairwise_difference(ac, fill=0)))
+        np.testing.assert_allclose(pi_pg, pi_allel, rtol=1e-9)
+
+
+class TestMultiallelicEdgeCases:
+    """Hand-built sites: per-allele pi and mutation-count segregating."""
+
+    def _hm(self, col):
+        hap = np.array(col, dtype=np.int8)
+        return HaplotypeMatrix(hap, np.array([100]), 0, 200)
+
+    def test_reference_absent_site(self):
+        # alleles {1, 2}, ancestral 0 absent: pi = 1 - (C(2,2)+C(2,2))/C(4,2)
+        hm = self._hm([[1], [1], [2], [2]])
+        np.testing.assert_allclose(diversity.pi(hm, span_normalize=False),
+                                   1.0 - 2.0 / 6.0, rtol=1e-12)
+        assert diversity.segregating_sites(hm) == 1  # 2 alleles -> 1 mutation
+
+    def test_triallelic_site(self):
+        # counts 2,1,1: pi = 1 - C(2,2)/C(4,2) = 1 - 1/6
+        hm = self._hm([[0], [0], [1], [2]])
+        np.testing.assert_allclose(diversity.pi(hm, span_normalize=False),
+                                   1.0 - 1.0 / 6.0, rtol=1e-12)
+        assert diversity.segregating_sites(hm) == 2  # 3 alleles -> 2 mutations
+
+    def test_tetraallelic_site(self):
+        # all four distinct: every pair differs -> pi = 1.0
+        hm = self._hm([[0], [1], [2], [3]])
+        np.testing.assert_allclose(diversity.pi(hm, span_normalize=False),
+                                   1.0, rtol=1e-12)
+        assert diversity.segregating_sites(hm) == 3

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -12,6 +12,7 @@ import pytest
 
 from pg_gpu import HaplotypeMatrix
 from pg_gpu import diversity
+from pg_gpu.diversity import FrequencySpectrum
 
 
 def _a1(n):
@@ -190,6 +191,68 @@ class TestMissingData:
         ac = allel.HaplotypeArray(self.HAP.T).count_alleles()
         pi_allel = float(np.nansum(allel.mean_pairwise_difference(ac, fill=0)))
         np.testing.assert_allclose(pi_pg, pi_allel, rtol=1e-9)
+
+
+class TestPerAlleleSFS:
+    """allele_frequency_spectrum + FrequencySpectrum on the per-allele SFS."""
+
+    def test_afs_matches_tskit(self, multiallelic_hm):
+        # Full array matches tskit's polarised AFS exactly: per-allele interior,
+        # both fixed classes (bins 0 and n) excluded.
+        ts, hm = multiallelic_hm
+        afs_pg = np.asarray(diversity.allele_frequency_spectrum(hm))
+        afs_ts = ts.allele_frequency_spectrum(polarised=True, span_normalise=False)
+        np.testing.assert_array_equal(afs_pg, afs_ts.astype(int))
+
+    def test_afs_interior_matches_allel(self, multiallelic_hm):
+        # Independent-library check on the segregating interior (1..n-1).
+        ts, hm = multiallelic_hm
+        n = ts.num_samples
+        ac = allel.HaplotypeArray(ts.genotype_matrix()).count_alleles()
+        per_allele = ac[:, 1:].flatten()
+        per_allele = per_allele[(per_allele > 0) & (per_allele < n)].astype(np.int64)
+        ref = np.bincount(per_allele, minlength=n + 1)[:n + 1]
+        afs_pg = np.asarray(diversity.allele_frequency_spectrum(hm))
+        np.testing.assert_array_equal(afs_pg[1:n], ref[1:n])
+
+    def test_afs_excludes_fixed_classes(self):
+        # Both fixed classes are excluded (matches tskit): a fully-derived site
+        # (bin n) and a monomorphic-ancestral site (bin 0) contribute nothing.
+        derived = HaplotypeMatrix(np.array([[1], [1], [1], [1]], dtype=np.int8),
+                                  np.array([100]), 0, 200)
+        ancestral = HaplotypeMatrix(np.array([[0], [0], [0], [0]], dtype=np.int8),
+                                    np.array([100]), 0, 200)
+        assert np.asarray(diversity.allele_frequency_spectrum(derived)).sum() == 0
+        assert np.asarray(diversity.allele_frequency_spectrum(ancestral)).sum() == 0
+
+    def test_freqspec_theta_h_l_match_scalar(self, multiallelic_hm):
+        # theta_h / theta_l are additive per allele, so the SFS path equals the
+        # scalar path even on multiallelic data.
+        _, hm = multiallelic_hm
+        fs = FrequencySpectrum(hm)
+        np.testing.assert_allclose(fs.theta('theta_h'),
+                                   diversity.theta_h(hm, span_normalize=False), rtol=1e-9)
+        np.testing.assert_allclose(fs.theta('theta_l'),
+                                   diversity.theta_l(hm, span_normalize=False), rtol=1e-9)
+
+    def test_freqspec_matches_scalar_biallelic(self, multiallelic_hm):
+        # On biallelic data every estimator agrees between the two paths.
+        _, hm = multiallelic_hm
+        hm_bi = hm.apply_biallelic_filter()
+        fs = FrequencySpectrum(hm_bi)
+        for name, fn in [('pi', diversity.pi), ('watterson', diversity.theta_w),
+                         ('theta_h', diversity.theta_h), ('theta_l', diversity.theta_l)]:
+            np.testing.assert_allclose(fs.theta(name),
+                                       fn(hm_bi, span_normalize=False), rtol=1e-9)
+
+    def test_freqspec_pi_diverges_from_scalar_on_multiallelic(self, multiallelic_hm):
+        # Documented divergence (issue #100): the marginal SFS overcounts pi on
+        # multiallelic data; the scalar diversity.pi is authoritative.
+        _, hm = multiallelic_hm
+        pi_sfs = FrequencySpectrum(hm).theta('pi')
+        pi_scalar = diversity.pi(hm, span_normalize=False)
+        assert pi_sfs > pi_scalar
+        assert not np.isclose(pi_sfs, pi_scalar, rtol=1e-6)
 
 
 class TestMultiallelicEdgeCases:

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -289,6 +289,73 @@ class TestPerAlleleSFS:
         assert not np.isclose(pi_sfs, pi_scalar, rtol=1e-6)
 
 
+class TestJointSFS:
+    """Joint / projected SFS per-allele vs tskit (two sample sets)."""
+
+    @staticmethod
+    def _pops(ts):
+        s = ts.samples()
+        h = len(s) // 2
+        return list(s[:h]), list(s[h:])
+
+    def test_joint_sfs_matches_tskit(self, multiallelic_hm):
+        from pg_gpu import sfs as sfs_mod
+        ts, hm = multiallelic_hm
+        A, B = self._pops(ts)
+        j_pg = np.asarray(sfs_mod.joint_sfs(hm, A, B))
+        j_ts = ts.allele_frequency_spectrum([A, B], polarised=True,
+                                            span_normalise=False)
+        np.testing.assert_array_equal(j_pg, j_ts.astype(int))
+
+    def test_joint_sfs_excludes_only_global_mono_corners(self, multiallelic_hm):
+        # Edge cells (alleles private to / fixed within one pop) are populated;
+        # only the two global-monomorphic corners are dropped.
+        from pg_gpu import sfs as sfs_mod
+        ts, hm = multiallelic_hm
+        A, B = self._pops(ts)
+        j = np.asarray(sfs_mod.joint_sfs(hm, A, B))
+        assert j[0, 0] == 0 and j[-1, -1] == 0
+        assert j[0, 1:].sum() > 0 and j[1:, 0].sum() > 0  # private-allele edges
+
+    def test_joint_sfs_folded_matches_tskit(self, multiallelic_hm):
+        # Folded joint = tskit polarised=False: fold each site as a unit by the
+        # global minor (NOT allel's per-axis fold), weight 1/2, corners dropped.
+        from pg_gpu import sfs as sfs_mod
+        ts, hm = multiallelic_hm
+        A, B = self._pops(ts)
+        jf_pg = np.asarray(sfs_mod.joint_sfs_folded(hm, A, B))
+        jf_ts = ts.allele_frequency_spectrum([A, B], polarised=False,
+                                             span_normalise=False)
+        np.testing.assert_allclose(jf_pg, jf_ts)
+        assert np.any(jf_pg != np.round(jf_pg))  # half-integers on multiallelic
+
+    def test_joint_sfs_folded_scaled_matches_base(self, multiallelic_hm):
+        from pg_gpu import sfs as sfs_mod
+        ts, hm = multiallelic_hm
+        A, B = self._pops(ts)
+        n1, n2 = len(A), len(B)
+        base = np.asarray(sfs_mod.joint_sfs_folded(hm, A, B))
+        scaled = np.asarray(sfs_mod.joint_sfs_folded_scaled(hm, A, B))
+        i = np.arange(base.shape[0])[:, None]
+        j = np.arange(base.shape[1])[None, :]
+        np.testing.assert_allclose(scaled, base * i * j * (n1 - i) * (n2 - j))
+
+    def test_projection_matches_per_allele_sandwich(self, multiallelic_hm):
+        # project_joint_sfs == P1 @ joint_sfs @ P2.T on the per-allele joint.
+        from pg_gpu import sfs as sfs_mod
+        from pg_gpu.diversity import _projection_matrix
+        ts, hm = multiallelic_hm
+        A, B = self._pops(ts)
+        n1, n2 = len(A), len(B)
+        t1, t2 = 8, 9
+        full = np.asarray(sfs_mod.joint_sfs(hm, A, B)).astype(np.float64)
+        P1 = _projection_matrix(n1, t1)
+        P2 = _projection_matrix(n2, t2)
+        expected = P1 @ full @ P2.T
+        result = sfs_mod.project_joint_sfs(hm, A, B, target_n1=t1, target_n2=t2)
+        np.testing.assert_allclose(result, expected, rtol=1e-9, atol=1e-9)
+
+
 class TestMultiallelicConsumers:
     """singleton_count / heterozygosity_expected / max_daf / mu_sfs / daf_histogram."""
 

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -255,6 +255,47 @@ class TestPerAlleleSFS:
         assert not np.isclose(pi_sfs, pi_scalar, rtol=1e-6)
 
 
+class TestMultiallelicConsumers:
+    """singleton_count / heterozygosity_expected / max_daf / mu_sfs / daf_histogram."""
+
+    def test_singleton_count_per_allele(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        ac = allel.HaplotypeArray(ts.genotype_matrix()).count_alleles()
+        # per-allele singletons: derived alleles carried by exactly one sample
+        ref = int(np.sum(ac[:, 1:] == 1))
+        assert diversity.singleton_count(hm) == ref
+
+    def test_heterozygosity_expected_per_allele(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        n = ts.num_samples
+        ac = np.asarray(allel.HaplotypeArray(ts.genotype_matrix()).count_alleles(),
+                        dtype=float)
+        # He = 1 - sum_a p_a^2 over all alleles (no missing so n_valid = n)
+        ref = 1.0 - (ac ** 2).sum(axis=1) / (n ** 2)
+        np.testing.assert_allclose(diversity.heterozygosity_expected(hm), ref, rtol=1e-9)
+
+    def test_heterozygosity_expected_triallelic(self):
+        # {0:2, 1:1, 2:1}, n=4: He = 1 - (2^2 + 1 + 1)/16 = 1 - 6/16 = 0.625
+        hm = HaplotypeMatrix(np.array([[0], [0], [1], [2]], dtype=np.int8),
+                             np.array([100]), 0, 200)
+        np.testing.assert_allclose(diversity.heterozygosity_expected(hm)[0],
+                                   0.625, rtol=1e-12)
+
+    def test_max_daf_is_single_derived_allele(self):
+        # {0:1, 1:5, 2:4}, n=10: per-allele max DAF = 0.5 (allele 1), NOT the
+        # total non-ancestral fraction 0.9.
+        col = [[0]] + [[1]] * 5 + [[2]] * 4
+        hm = HaplotypeMatrix(np.array(col, dtype=np.int8), np.array([100]), 0, 200)
+        np.testing.assert_allclose(diversity.max_daf(hm), 0.5, rtol=1e-12)
+
+    def test_mu_sfs_and_daf_histogram_run(self, multiallelic_hm):
+        _, hm = multiallelic_hm
+        assert 0.0 <= diversity.mu_sfs(hm) <= 1.0
+        hist, edges = diversity.daf_histogram(hm)
+        assert np.isclose(hist.sum(), 1.0)
+        assert len(edges) == len(hist) + 1
+
+
 class TestMultiallelicEdgeCases:
     """Hand-built sites: per-allele pi and mutation-count segregating."""
 

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -12,6 +12,7 @@ import pytest
 
 from pg_gpu import HaplotypeMatrix
 from pg_gpu import diversity
+from pg_gpu import sfs
 from pg_gpu.diversity import FrequencySpectrum
 
 
@@ -194,15 +195,7 @@ class TestMissingData:
 
 
 class TestPerAlleleSFS:
-    """allele_frequency_spectrum + FrequencySpectrum on the per-allele SFS."""
-
-    def test_afs_matches_tskit(self, multiallelic_hm):
-        # Full array matches tskit's polarised AFS exactly: per-allele interior,
-        # both fixed classes (bins 0 and n) excluded.
-        ts, hm = multiallelic_hm
-        afs_pg = np.asarray(diversity.allele_frequency_spectrum(hm))
-        afs_ts = ts.allele_frequency_spectrum(polarised=True, span_normalise=False)
-        np.testing.assert_array_equal(afs_pg, afs_ts.astype(int))
+    """sfs.sfs + FrequencySpectrum on the per-allele SFS."""
 
     def test_sfs_module_matches_tskit(self, multiallelic_hm):
         # The sfs module's unfolded SFS is per-allele and matches tskit too.
@@ -246,7 +239,7 @@ class TestPerAlleleSFS:
         per_allele = ac[:, 1:].flatten()
         per_allele = per_allele[(per_allele > 0) & (per_allele < n)].astype(np.int64)
         ref = np.bincount(per_allele, minlength=n + 1)[:n + 1]
-        afs_pg = np.asarray(diversity.allele_frequency_spectrum(hm))
+        afs_pg = np.asarray(sfs.sfs(hm))
         np.testing.assert_array_equal(afs_pg[1:n], ref[1:n])
 
     def test_afs_excludes_fixed_classes(self):
@@ -256,8 +249,8 @@ class TestPerAlleleSFS:
                                   np.array([100]), 0, 200)
         ancestral = HaplotypeMatrix(np.array([[0], [0], [0], [0]], dtype=np.int8),
                                     np.array([100]), 0, 200)
-        assert np.asarray(diversity.allele_frequency_spectrum(derived)).sum() == 0
-        assert np.asarray(diversity.allele_frequency_spectrum(ancestral)).sum() == 0
+        assert np.asarray(sfs.sfs(derived)).sum() == 0
+        assert np.asarray(sfs.sfs(ancestral)).sum() == 0
 
     def test_freqspec_theta_h_l_match_scalar(self, multiallelic_hm):
         # theta_h / theta_l are additive per allele, so the SFS path equals the

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -204,6 +204,40 @@ class TestPerAlleleSFS:
         afs_ts = ts.allele_frequency_spectrum(polarised=True, span_normalise=False)
         np.testing.assert_array_equal(afs_pg, afs_ts.astype(int))
 
+    def test_sfs_module_matches_tskit(self, multiallelic_hm):
+        # The sfs module's unfolded SFS is per-allele and matches tskit too.
+        from pg_gpu import sfs as sfs_mod
+        ts, hm = multiallelic_hm
+        afs_pg = np.asarray(sfs_mod.sfs(hm))
+        afs_ts = ts.allele_frequency_spectrum(polarised=True, span_normalise=False)
+        np.testing.assert_array_equal(afs_pg, afs_ts.astype(int))
+
+    def test_sfs_folded_matches_tskit(self, multiallelic_hm):
+        # Folded SFS is per-allele = tskit polarised=False: every allele (ref
+        # included) weight 1/2 at min(count, n-count), fixed class dropped.
+        # Half-integer bins appear on multiallelic data.
+        from pg_gpu import sfs as sfs_mod
+        ts, hm = multiallelic_hm
+        n = ts.num_samples
+        folded_pg = np.asarray(sfs_mod.sfs_folded(hm))
+        folded_ts = ts.allele_frequency_spectrum(polarised=False,
+                                                 span_normalise=False)
+        # pg_gpu returns the compact folded domain [0, n//2]; tskit pads to n+1
+        # with zeros above n//2.
+        np.testing.assert_allclose(folded_pg, folded_ts[:n // 2 + 1])
+        # multiallelic input really does produce half-integer weights
+        assert np.any(folded_pg != np.round(folded_pg))
+
+    def test_sfs_folded_scaled_matches_tskit_base(self, multiallelic_hm):
+        # Scaled folded = tskit-pinned folded base * the k*(n-k)/n transform.
+        from pg_gpu import sfs as sfs_mod
+        ts, hm = multiallelic_hm
+        n = ts.num_samples
+        base = np.asarray(sfs_mod.sfs_folded(hm))
+        scaled = np.asarray(sfs_mod.sfs_folded_scaled(hm))
+        k = np.arange(base.shape[0])
+        np.testing.assert_allclose(scaled, base * k * (n - k) / n)
+
     def test_afs_interior_matches_allel(self, multiallelic_hm):
         # Independent-library check on the segregating interior (1..n-1).
         ts, hm = multiallelic_hm

--- a/tests/test_scikit_allel_comparison.py
+++ b/tests/test_scikit_allel_comparison.py
@@ -10,7 +10,7 @@ import numpy as np
 import cupy as cp
 import allel
 from pg_gpu import HaplotypeMatrix
-from pg_gpu import diversity, divergence
+from pg_gpu import diversity, divergence, sfs as sfs_mod
 
 
 class TestDiversityComparison:
@@ -130,7 +130,7 @@ class TestDiversityComparison:
 
         # pg_gpu
         matrix = HaplotypeMatrix(haplotypes, positions, test_data['start'], test_data['end'])
-        afs_pg = diversity.allele_frequency_spectrum(matrix)
+        afs_pg = sfs_mod.sfs(matrix)
         if hasattr(afs_pg, 'get'):
             afs_pg = np.asarray(afs_pg)
 

--- a/tests/test_sfs_allel_comparison.py
+++ b/tests/test_sfs_allel_comparison.py
@@ -92,15 +92,11 @@ class TestJointSFSComparison:
         expected = allel.joint_sfs(dac1, dac2, n1=n1, n2=n2)
         np.testing.assert_array_equal(result, expected)
 
-    def test_joint_sfs_folded(self, two_pop_data):
-        matrix, hap, n1, n2 = two_pop_data
-        result = sfs.joint_sfs_folded(matrix, 'pop1', 'pop2')
-        dac1 = np.sum(hap[:n1], axis=0)
-        dac2 = np.sum(hap[n1:], axis=0)
-        ac1 = np.column_stack([n1 - dac1, dac1])
-        ac2 = np.column_stack([n2 - dac2, dac2])
-        expected = allel.joint_sfs_folded(ac1, ac2)
-        np.testing.assert_array_equal(result, expected)
+    # NOTE: joint_sfs_folded / joint_sfs_folded_scaled deliberately do NOT match
+    # scikit-allel. The 2D fold is the one place tskit and allel disagree even on
+    # biallelic data -- allel folds each axis independently, tskit folds the site
+    # as a unit by the global minor. We pin to tskit (see the ledger). Parity is
+    # tested in test_multiallelic.py::TestJointSFS::test_joint_sfs_folded_matches_tskit.
 
     def test_joint_sfs_scaled(self, two_pop_data):
         matrix, hap, n1, n2 = two_pop_data
@@ -108,16 +104,6 @@ class TestJointSFSComparison:
         dac1 = np.sum(hap[:n1], axis=0)
         dac2 = np.sum(hap[n1:], axis=0)
         expected = allel.joint_sfs_scaled(dac1, dac2, n1=n1, n2=n2)
-        np.testing.assert_array_almost_equal(result, expected)
-
-    def test_joint_sfs_folded_scaled(self, two_pop_data):
-        matrix, hap, n1, n2 = two_pop_data
-        result = sfs.joint_sfs_folded_scaled(matrix, 'pop1', 'pop2')
-        dac1 = np.sum(hap[:n1], axis=0)
-        dac2 = np.sum(hap[n1:], axis=0)
-        ac1 = np.column_stack([n1 - dac1, dac1])
-        ac2 = np.column_stack([n2 - dac2, dac2])
-        expected = allel.joint_sfs_folded_scaled(ac1, ac2)
         np.testing.assert_array_almost_equal(result, expected)
 
 

--- a/tests/test_sfs_allel_comparison.py
+++ b/tests/test_sfs_allel_comparison.py
@@ -47,7 +47,11 @@ class TestSFSComparison:
         # allel: pass n explicitly to match full-size output
         dac = np.sum(hap, axis=0)
         expected = allel.sfs(dac, n=n)
-        np.testing.assert_array_equal(result, expected)
+        # sfs.sfs is now the per-allele polarised SFS (tskit convention): both
+        # fixed classes (bins 0 and n) are excluded, whereas allel.sfs includes
+        # them. Compare the segregating interior; assert the endpoints are dropped.
+        np.testing.assert_array_equal(result[1:n], expected[1:n])
+        assert result[0] == 0 and result[n] == 0
 
     def test_sfs_folded(self, single_pop_data):
         matrix, hap = single_pop_data

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -302,6 +302,13 @@ class TestSFSDispatch:
         s_s = sfs_module.sfs(stream)
         np.testing.assert_array_equal(s_e, s_s)
 
+    def test_sfs_folded_equivalent(self, vcz_store):
+        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                            chunk_bp=10_000)
+        np.testing.assert_allclose(sfs_module.sfs_folded(eager),
+                                   sfs_module.sfs_folded(stream))
+
     def test_joint_sfs_equivalent(self, vcz_store, tmp_path):
         n_dip = HaplotypeMatrix.from_zarr(vcz_store).num_haplotypes // 2
         half = n_dip // 2

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -799,6 +799,11 @@ class TestOverlappingWindowsScatter:
             assert df['fst'].notna().any()
             assert (df['fst'].dropna() >= -0.5).all()
 
+    @pytest.mark.xfail(strict=True, reason=(
+        "windowed_analysis pi still uses the legacy collapsed multiallelic "
+        "convention (pre-existing bug); it now detectably diverges from the "
+        "per-allele scalar diversity.pi on multiallelic data. Fixed in the "
+        "windowed subproject (kr-colab/pg_gpu#100) -- remove this marker then."))
     def test_non_overlapping_unchanged(self, sim_hm):
         """Guard: step==window path (n_per_var=1) matches per-window reference."""
         window_size, step_size = 50_000, 50_000


### PR DESCRIPTION
First of several staggered PRs onto `nsp-multiallelic-trunk`. This still needs some cleanup, but is ready for feedback (esp on behavior changes and arbitrary decisions).

**Background:** pg_gpu collapsed multiallelic sites so pi, theta estimators, Tajima's D, and the whole SFS family were wrong whenever a site had >2 alleles. This PR adds a per-allele allele-count primitive (`_memutil.allele_counts`) and routes the `diversity` and `sfs` modules through it, matching tskit. The goal is that statistics on biallelic data should be identical, only multiallelic behaviour should change, and that our target for parity is tskit.

**Scope:** `diversity.py` + `sfs.py` (every SFS variant: unfolded / folded / scaled, joint/2D, and hypergeometric projection), plus removal of the duplicate `diversity.allele_frequency_spectrum`. I didn't touch `divergence`, `admixture`, `windowed_analysis`, and `decomposition`; these still collapse multiallelic sites and fixes will follow in later PRs. Also, I've only touched the library itself, auxiliary scripts and documentation still need to be updated.

**Verification:** `tests/test_allele_counts.py` + `tests/test_multiallelic.py` check pi / S / Watterson / Tajima's D / theta_H / theta_L / He / singletons and the full SFS family against tskit and scikit-allel (preference to the former); with a biallelic control and reference-absent, tri-/tetra-allelic, and missing-data edge cases.

## Behaviour changes

Multiallelic stats match tskit: pi, theta_W, theta_H, theta_L, Tajima's D, Fay-Wu H, Zeng E, segregating sites, singletons, He, and every SFS (`sfs`, `sfs_folded`, `*_scaled`, `joint_sfs`, `joint_sfs_folded`, `project_joint_sfs`) are now per-allele, matching tskit. Mutation-count for segregating / theta_W / Tajima's D uses tskit's `(alleles−1)` weighting, which diverges from scikit-allel's polymorphic-site count on multiallelic sites

But there are some conventions that also touch biallelic data (causing a behavior change to earlier pg_gpu):
- SFS fixed classes excluded to match tskit, which changes the SFS / `daf_histogram` on biallelic data only when
  monomorphic/fixed sites are present. All theta values are unchanged.
- Folded SFS dtype to float64 because of tskit's 0.5-weighting for folding
- `joint_sfs_folded` now uses tskit's total-fold, which diverges from scikit-allel even on biallelic data. allel folds each axis independently (which can mix two different alleles into one cell); tskit folds the site by the global minor allele. Output shape also changes `(n1//2+1, n2//2+1)` to `(n1+1, n2+1)`. This is the one place we knowingly change biallelic output beyond the endpoint convention.

## Arbitrary decisions 

These had no tskit-parity guide:
- `FrequencySpectrum` pi / Tajima's D / Fay-Wu H are SFS-based approximations for multiallelic data (because a marginal SFS can't reproduce per-allele pi); the scalar functions (outside FrequencySpectrum) are authoritative and match tskit.
- `max_daf` / `daf_histogram` = per-derived-allele; `mu_sfs` = per-derived-allele edge/segregating fraction. The alternative is to collapse all non-ref alleles into one count, but that'd be inconsistent with the tskit-style handling.
- `joint_sfs_folded` total-fold discussed above: tskit keeps one physical allele per site, allel's per-axis fold can mix alleles).

## Misc

- Removed API for `diversity.allele_frequency_spectrum` and `HaplotypeMatrix.allele_frequency_spectrum`, as these are superceded by the `sfs` module
- `_stream_sum` now preserves the kernel dtype.
- hypergeometric projection works with tskit's multiallelic SFS, even with folding: that is, we'd get the same thing if we did hypergeometric sampling on the "multiallelic spectrum", and then collapsed down to "non-reference".
