### PR TITLE
Multiallelic handling in count-based divergence stats

### DIFF
--- a/pg_gpu/divergence.py
+++ b/pg_gpu/divergence.py
@@ -243,6 +243,40 @@ def fst_tskit(haplotype_matrix: HaplotypeMatrix,
     return 0.0
 
 
+def _pop_wc_stats(pop_haps, k):
+    """Per-allele diploid stats for Weir & Cockerham from one population.
+
+    Consecutive haplotypes are one diploid individual (a trailing unpaired
+    haplotype is dropped). For each allele ``a`` in ``0..k-1`` returns the
+    number of copies and the number of individuals heterozygous FOR THAT ALLELE
+    (exactly one copy) -- the per-allele observed het that WC's c component
+    needs (see the NOTE in ``fst_weir_cockerham``).
+
+    Returns
+    -------
+    ac : cupy.ndarray, float64, shape (n_variants, k)
+        Allele copies from complete diploid pairs.
+    het : cupy.ndarray, float64, shape (n_variants, k)
+        Per-allele heterozygote counts.
+    n : cupy.ndarray, float64, shape (n_variants,)
+        Complete diploid individuals per site.
+    """
+    n_pairs = pop_haps.shape[0] // 2
+    ha = pop_haps[0:2 * n_pairs:2, :]
+    hb = pop_haps[1:2 * n_pairs:2, :]
+    both = (ha >= 0) & (hb >= 0)
+    n = cp.sum(both, axis=0).astype(cp.float64)     # complete individuals/site
+    n_var = pop_haps.shape[1]
+    ac = cp.zeros((n_var, k), dtype=cp.float64)      # allele copies (from pairs)
+    het = cp.zeros((n_var, k), dtype=cp.float64)     # per-allele heterozygotes
+    for allele in range(k):
+        a_ha = (ha == allele) & both
+        a_hb = (hb == allele) & both
+        ac[:, allele] = cp.sum(a_ha, axis=0) + cp.sum(a_hb, axis=0)
+        het[:, allele] = cp.sum(a_ha != a_hb, axis=0)  # exactly one copy
+    return ac, het, n
+
+
 def fst_weir_cockerham(haplotype_matrix,
                        pop1: Union[str, list],
                        pop2: Union[str, list],
@@ -287,90 +321,73 @@ def fst_weir_cockerham(haplotype_matrix,
     pop1_haps = haplotype_matrix.haplotypes[pop1_idx, :]
     pop2_haps = haplotype_matrix.haplotypes[pop2_idx, :]
 
-    # Compute per-site observed heterozygosity and allele counts from
-    # complete diploid pairs only. WC FST requires that frequencies and
-    # het are computed from the same set of individuals — using all valid
-    # haplotypes for counts but only complete pairs for n inflates
-    # frequencies by 1/(1-miss_rate) under MCAR.
-    def _pop_diploid_stats(pop_haps):
-        ha = pop_haps[0::2, :]  # first haplotype of each diploid
-        hb = pop_haps[1::2, :]  # second haplotype
-        both_valid = (ha >= 0) & (hb >= 0)
-        het = (ha != hb) & both_valid
-        n_called = cp.sum(both_valid, axis=0).astype(cp.float64)
-        h_bar = cp.where(n_called > 0,
-                         cp.sum(het, axis=0).astype(cp.float64) / n_called, 0.0)
-        # Derived allele count from complete pairs only
-        derived = cp.sum(
-            cp.where(both_valid, ha, 0) + cp.where(both_valid, hb, 0),
-            axis=0).astype(cp.float64)
-        return h_bar, n_called, derived
+    # NOTE: WC is a per-allele one-vs-rest ANOVA. For each allele it splits the
+    # variance of the "carries this allele" gamete indicator into between-pop
+    # (a), between-individual-within-pop (b), and between-gamete-within-
+    # individual (c) components, and FST = sum_alleles a / sum_alleles (a+b+c).
+    # The c component IS the per-allele observed heterozygosity -- individuals
+    # with exactly ONE copy of the allele -- so het is counted PER ALLELE, not
+    # the site-level "any difference" H_obs in diversity.heterozygosity_observed.
+    # The two coincide only for biallelic sites; for 3+ alleles a 1/2 individual
+    # is het for alleles 1 and 2 but homozygous for allele 0. Multiallelic form
+    # matches scikit-allel's weir_cockerham_fst (a/b/c are (n_var, K); sum over
+    # alleles and sites).
+    k = max(int(pop1_haps.max()) if pop1_haps.size else 0,
+            int(pop2_haps.max()) if pop2_haps.size else 0, 0) + 1
 
-    if len(pop1_idx) >= 2 and len(pop2_idx) >= 2:
-        h_bar1, n1, pop1_counts = _pop_diploid_stats(pop1_haps)
-        h_bar2, n2, pop2_counts = _pop_diploid_stats(pop2_haps)
-    else:
-        pop1_counts, pop1_n = _pop_dac_and_n(pop1_haps)
-        pop2_counts, pop2_n = _pop_dac_and_n(pop2_haps)
-        pop1_counts = pop1_counts.astype(cp.float64)
-        pop2_counts = pop2_counts.astype(cp.float64)
-        n1 = pop1_n.astype(cp.float64)
-        n2 = pop2_n.astype(cp.float64)
-        h_bar1 = cp.zeros_like(n1)
-        h_bar2 = cp.zeros_like(n2)
-
-    # Allele frequencies from complete diploid pairs
-    pop1_freqs = cp.where(n1 > 0, pop1_counts / (2.0 * n1), 0.0)
-    pop2_freqs = cp.where(n2 > 0, pop2_counts / (2.0 * n2), 0.0)
+    ac1, het1, n1 = _pop_wc_stats(pop1_haps, k)
+    ac2, het2, n2 = _pop_wc_stats(pop2_haps, k)
 
     r = 2.0
     n_total = n1 + n2
     n_bar = n_total / r
 
-    # n_C: sample size correction factor
+    # Per-allele frequencies within each pop (diploid: 2 gametes per individual);
+    # only where the pop has complete individuals (freq 0 elsewhere, unused).
+    p1 = cp.zeros_like(ac1)
+    p2 = cp.zeros_like(ac2)
+    v1 = n1 > 0
+    v2 = n2 > 0
+    p1[v1] = ac1[v1] / (2.0 * n1[v1])[:, None]
+    p2[v2] = ac2[v2] / (2.0 * n2[v2])[:, None]
+
+    # Sample-size correction, pooled freq, allele-freq variance, per-allele het,
+    # computed only at sites with data (subset on the mask, as the biallelic
+    # code did -- avoids the div-by-zero guards).
     nc = cp.zeros_like(n_total)
-    valid = n_total > 0
-    nc[valid] = (n_total[valid] - (n1[valid]**2 + n2[valid]**2) / n_total[valid]) / (r - 1)
+    p_bar = cp.zeros_like(ac1)
+    s_squared = cp.zeros_like(ac1)
+    h_bar = cp.zeros_like(ac1)
+    vt = n_total > 0
+    nt = n_total[vt]
+    n1t = n1[vt][:, None]
+    n2t = n2[vt][:, None]
+    nc[vt] = (nt - (n1[vt]**2 + n2[vt]**2) / nt) / (r - 1)
+    p_bar[vt] = (n1t * p1[vt] + n2t * p2[vt]) / nt[:, None]
+    s_squared[vt] = (n1t * (p1[vt] - p_bar[vt])**2
+                     + n2t * (p2[vt] - p_bar[vt])**2) / ((r - 1) * (nt / r)[:, None])
+    h_bar[vt] = (het1[vt] + het2[vt]) / nt[:, None]       # per-allele obs het
 
-    # Weighted average allele frequency
-    p_bar = cp.zeros_like(pop1_freqs)
-    valid = n_total > 0
-    p_bar[valid] = (n1[valid] * pop1_freqs[valid] + n2[valid] * pop2_freqs[valid]) / n_total[valid]
-
-    # Sample variance of allele frequencies
-    s_squared = cp.zeros_like(p_bar)
-    valid = n_bar > 0
-    s_squared[valid] = (n1[valid] * (pop1_freqs[valid] - p_bar[valid])**2 +
-                       n2[valid] * (pop2_freqs[valid] - p_bar[valid])**2) / ((r - 1) * n_bar[valid])
-
-    # Average observed heterozygosity weighted by sample size
-    h_bar = cp.zeros_like(p_bar)
-    valid = n_total > 0
-    h_bar[valid] = (n1[valid] * h_bar1[valid] + n2[valid] * h_bar2[valid]) / n_total[valid]
-
-    # W-C variance components (Eqs 2, 3, 4 from Weir & Cockerham 1984)
-    a = cp.zeros_like(p_bar)
-    b = cp.zeros_like(p_bar)
-    c = cp.zeros_like(p_bar)
-
+    # W-C variance components (Eqs 2, 3, 4 from Weir & Cockerham 1984), per
+    # allele, only where estimable (n_bar > 1). Sum over alleles AND sites.
+    a = cp.zeros_like(ac1)
+    b = cp.zeros_like(ac1)
+    c = cp.zeros_like(ac1)
     valid = (n_bar > 1) & (nc > 0)
+    nb = n_bar[valid][:, None]
+    ncc = nc[valid][:, None]
     pq = p_bar[valid] * (1 - p_bar[valid])
     s2 = s_squared[valid]
-    nb = n_bar[valid]
-    ncc = nc[valid]
     hb = h_bar[valid]
-
     a[valid] = (nb / ncc) * (s2 - (1.0 / (nb - 1)) * (pq - (r - 1) * s2 / r - hb / 4.0))
     b[valid] = (nb / (nb - 1)) * (pq - (r - 1) * s2 / r - (2 * nb - 1) * hb / (4.0 * nb))
     c[valid] = hb / 2.0
 
-    # Global FST = sum(a) / sum(a + b + c)
-    valid_mask = (n1 > 0) & (n2 > 0)
-    if cp.any(valid_mask):
-        sum_a = float(cp.sum(a[valid_mask]).get())
-        sum_abc = float(cp.sum((a + b + c)[valid_mask]).get())
-        if sum_abc > 0:
-            return sum_a / sum_abc
+    # Global FST = sum(a) / sum(a + b + c), summed over alleles AND sites.
+    sum_a = float(cp.sum(a).get())
+    sum_abc = float(cp.sum(a + b + c).get())
+    if sum_abc > 0:
+        return sum_a / sum_abc
     return 0.0
 
 

--- a/pg_gpu/divergence.py
+++ b/pg_gpu/divergence.py
@@ -15,10 +15,46 @@ from ._memutil import dac_and_n as _pop_dac_and_n
 from .diversity import _apply_span_normalize, pi as _diversity_pi
 
 
+def _aligned_pop_counts(pop1_haps, pop2_haps):
+    """Per-allele counts for two populations on a shared global K.
+
+    Both populations are counted with the same allele-index width
+    K = max allele index over both pops + 1, so column ``a`` denotes the same
+    allele in each (the alignment discipline from the joint SFS). This is what
+    makes ``sum_a ac1[:, a] * ac2[:, a]`` a valid per-allele cross term.
+
+    Parameters
+    ----------
+    pop1_haps, pop2_haps : cupy.ndarray, shape (n_haplotypes, n_variants)
+        Haplotype data for each population, with -1 for missing.
+
+    Returns
+    -------
+    ac1, ac2 : cupy.ndarray, int64, shape (n_variants, K)
+        Per-allele counts on the shared K.
+    nv1, nv2 : cupy.ndarray, int64, shape (n_variants,)
+        Per-site valid (non-missing) haplotype counts.
+    """
+    from ._memutil import allele_counts
+    k1 = int(pop1_haps.max()) if pop1_haps.size else 0
+    k2 = int(pop2_haps.max()) if pop2_haps.size else 0
+    k = max(k1, k2, 0) + 1
+    ac1, nv1 = allele_counts(pop1_haps, n_alleles=k)
+    ac2, nv2 = allele_counts(pop2_haps, n_alleles=k)
+    return ac1, ac2, nv1, nv2
+
+
 def dxy_components(pop1_haps, pop2_haps):
     """Compute between-population pairwise differences and comparisons.
 
     Returns raw counts for custom aggregation (e.g., windowed analysis).
+    Per-allele (multiallelic-correct): at a site the number of differing
+    cross-population pairs is
+
+        diffs = nv1 * nv2 - sum_a ac1_a * ac2_a
+
+    (comparisons minus same-allele pairs, summed over every allele a), which
+    reduces to the biallelic ancestral/derived form when there are two alleles.
 
     Parameters
     ----------
@@ -34,19 +70,14 @@ def dxy_components(pop1_haps, pop2_haps):
     n_sites : int
         Number of sites with data in both populations.
     """
-    pop1_derived, pop1_n = _pop_dac_and_n(pop1_haps)
-    pop2_derived, pop2_n = _pop_dac_and_n(pop2_haps)
-    pop1_n = pop1_n.astype(cp.float64)
-    pop2_n = pop2_n.astype(cp.float64)
-    pop1_derived = pop1_derived.astype(cp.float64)
-    pop2_derived = pop2_derived.astype(cp.float64)
-    pop1_ancestral = pop1_n - pop1_derived
-    pop2_ancestral = pop2_n - pop2_derived
+    ac1, ac2, nv1, nv2 = _aligned_pop_counts(pop1_haps, pop2_haps)
+    nv1 = nv1.astype(cp.float64)
+    nv2 = nv2.astype(cp.float64)
+    same = cp.sum(ac1.astype(cp.float64) * ac2.astype(cp.float64), axis=1)
+    site_comps = nv1 * nv2
+    site_diffs = site_comps - same
 
-    site_diffs = pop1_derived * pop2_ancestral + pop1_ancestral * pop2_derived
-    site_comps = pop1_n * pop2_n
-
-    usable = (pop1_n > 0) & (pop2_n > 0)
+    usable = (nv1 > 0) & (nv2 > 0)
     total_diffs = float(cp.sum(site_diffs[usable]).get())
     total_comps = float(cp.sum(site_comps[usable]).get())
     n_sites = int(cp.sum(usable).get())
@@ -434,22 +465,18 @@ def dxy(haplotype_matrix: HaplotypeMatrix,
 
     n_filtered = pop1_haps.shape[1]
 
-    # Get allele frequencies from non-missing data per site
-    pop1_counts, pop1_n = _pop_dac_and_n(pop1_haps)
-    pop2_counts, pop2_n = _pop_dac_and_n(pop2_haps)
-    pop1_counts = pop1_counts.astype(cp.float64)
-    pop2_counts = pop2_counts.astype(cp.float64)
-    pop1_n = pop1_n.astype(cp.float64)
-    pop2_n = pop2_n.astype(cp.float64)
+    # Per-allele Dxy: dxy = 1 - sum_a p1_a * p2_a, from non-missing data per
+    # site. Reduces to the biallelic p1 + p2 - 2*p1*p2 when there are two
+    # alleles; multiallelic-correct (matches tskit divergence).
+    ac1, ac2, nv1, nv2 = _aligned_pop_counts(pop1_haps, pop2_haps)
+    nv1 = nv1.astype(cp.float64)
+    nv2 = nv2.astype(cp.float64)
 
-    pop1_freqs = cp.where(pop1_n > 0, pop1_counts / pop1_n, 0.0)
-    pop2_freqs = cp.where(pop2_n > 0, pop2_counts / pop2_n, 0.0)
-
-    # Calculate Dxy only for sites with data
-    valid_mask = (pop1_n > 0) & (pop2_n > 0)
+    valid_mask = (nv1 > 0) & (nv2 > 0)
+    p1 = cp.where(valid_mask[:, None], ac1.astype(cp.float64) / nv1[:, None], 0.0)
+    p2 = cp.where(valid_mask[:, None], ac2.astype(cp.float64) / nv2[:, None], 0.0)
     dxy_per_site = cp.zeros(n_filtered)
-    dxy_per_site[valid_mask] = (pop1_freqs[valid_mask] + pop2_freqs[valid_mask] -
-                               2 * pop1_freqs[valid_mask] * pop2_freqs[valid_mask])
+    dxy_per_site[valid_mask] = 1.0 - cp.sum(p1 * p2, axis=1)[valid_mask]
 
     if per_site:
         return dxy_per_site.get()

--- a/pg_gpu/divergence.py
+++ b/pg_gpu/divergence.py
@@ -165,43 +165,16 @@ def fst_hudson(haplotype_matrix: HaplotypeMatrix,
     pop1_haps = haplotype_matrix.haplotypes[pop1_idx, :]
     pop2_haps = haplotype_matrix.haplotypes[pop2_idx, :]
 
-    pop1_counts, pop1_n = _pop_dac_and_n(pop1_haps)
-    pop2_counts, pop2_n = _pop_dac_and_n(pop2_haps)
-    pop1_counts = pop1_counts.astype(cp.float64)
-    pop2_counts = pop2_counts.astype(cp.float64)
-    n1 = pop1_n.astype(cp.float64)
-    n2 = pop2_n.astype(cp.float64)
+    # Per-allele Hudson: within = mean within-pop pairwise diff, between = dxy,
+    # FST = 1 - sum(within)/sum(between) (ratio-of-averages). den > 0 already
+    # implies both pops have data and the site is polymorphic between them.
+    ac1, ac2, nv1, nv2 = _aligned_pop_counts(pop1_haps, pop2_haps)
+    num, den = _hudson_fst_from_counts(ac1, nv1, ac2, nv2)
 
-    pop1_freqs = cp.where(n1 > 0, pop1_counts / n1, 0.0)
-    pop2_freqs = cp.where(n2 > 0, pop2_counts / n2, 0.0)
-
-    # Per-site within-population mean pairwise difference
-    # mpd(p, n) = p*(1-p)*n/(n-1)  (unbiased heterozygosity)
-    within1 = cp.zeros_like(pop1_freqs)
-    within2 = cp.zeros_like(pop2_freqs)
-    valid1 = n1 > 1
-    valid2 = n2 > 1
-    within1[valid1] = (pop1_freqs[valid1] * (1 - pop1_freqs[valid1])
-                       * n1[valid1] / (n1[valid1] - 1))
-    within2[valid2] = (pop2_freqs[valid2] * (1 - pop2_freqs[valid2])
-                       * n2[valid2] / (n2[valid2] - 1))
-    within = (within1 + within2) / 2.0
-
-    # Per-site between-population mean pairwise difference
-    between = (pop1_freqs * (1 - pop2_freqs)
-               + pop2_freqs * (1 - pop1_freqs)) / 2.0
-
-    # Numerator and denominator per SNP (ratio-of-averages)
-    num = between - within
-    den = between
-
-    valid_mask = (den > 0) & (n1 > 0) & (n2 > 0)
-
+    valid_mask = den > 0
     if cp.any(valid_mask):
-        fst_val = float((cp.sum(num[valid_mask]) / cp.sum(den[valid_mask])).get())
-        return fst_val
-    else:
-        return 0.0
+        return float((cp.sum(num[valid_mask]) / cp.sum(den[valid_mask])).get())
+    return 0.0
 
 
 def fst_weir_cockerham(haplotype_matrix,
@@ -693,43 +666,44 @@ def _get_population_indices(haplotype_matrix: HaplotypeMatrix,
         return list(pop)
 
 
-def _pop_allele_counts(haplotype_matrix, pop, missing_data='include'):
-    """Compute per-variant allele counts for a population on GPU.
+def _hudson_fst_from_counts(ac1, nv1, ac2, nv2):
+    """Per-variant Hudson FST num/den from per-allele counts on a shared K.
 
-    Returns (ac_0, ac_1, n) as CuPy arrays. n is per-site (array)
-    for 'include' mode, and also per-site after filtering
-    for 'exclude' mode.
+    Classic Hudson estimator (== scikit-allel): FST = sum(num) / sum(den) with
+    per-site num = Hb - Hw, den = Hb, where Hw is the mean within-population
+    pairwise difference and Hb the between-population divergence. The
+    same-allele pair counts sum over every allele column, so this is
+    multiallelic-correct and reduces to the biallelic ancestral/derived form
+    (ac columns [ref, alt]) exactly.
+
+    Parameters
+    ----------
+    ac1, ac2 : cupy.ndarray, shape (n_variants, K)
+        Per-allele counts on the SAME K (see _aligned_pop_counts).
+    nv1, nv2 : cupy.ndarray, shape (n_variants,)
+        Per-site valid haplotype counts.
+
+    Returns
+    -------
+    num, den : cupy.ndarray, float64, shape (n_variants,)
     """
-    if missing_data == 'exclude':
-        haplotype_matrix = haplotype_matrix.exclude_missing_sites(
-            populations=[pop])
+    nv1 = nv1.astype(cp.float64)
+    nv2 = nv2.astype(cp.float64)
+    ac1 = ac1.astype(cp.float64)
+    ac2 = ac2.astype(cp.float64)
 
-    pop_idx = _get_population_indices(haplotype_matrix, pop)
-    h = haplotype_matrix.haplotypes[pop_idx, :]
-    ac_1, n = _pop_dac_and_n(h)
-    n = n.astype(cp.float64)
-    ac_1 = ac_1.astype(cp.float64)
-    ac_0 = n - ac_1
-    return ac_0, ac_1, n
-
-
-def _hudson_fst_from_counts(ac1_0, ac1_1, n1, ac2_0, ac2_1, n2):
-    """Compute per-variant Hudson FST num/den from precomputed allele counts.
-
-    Returns (num, den) as CuPy arrays on GPU.
-    """
-    n1_pairs = n1 * (n1 - 1) / 2
-    n1_same = (ac1_0 * (ac1_0 - 1) + ac1_1 * (ac1_1 - 1)) / 2
+    n1_pairs = nv1 * (nv1 - 1) / 2
+    n1_same = cp.sum(ac1 * (ac1 - 1), axis=1) / 2
     mpd1 = cp.where(n1_pairs > 0, (n1_pairs - n1_same) / n1_pairs, 0.0)
 
-    n2_pairs = n2 * (n2 - 1) / 2
-    n2_same = (ac2_0 * (ac2_0 - 1) + ac2_1 * (ac2_1 - 1)) / 2
+    n2_pairs = nv2 * (nv2 - 1) / 2
+    n2_same = cp.sum(ac2 * (ac2 - 1), axis=1) / 2
     mpd2 = cp.where(n2_pairs > 0, (n2_pairs - n2_same) / n2_pairs, 0.0)
 
     within = (mpd1 + mpd2) / 2.0
 
-    n_between = n1 * n2
-    n_between_same = ac1_0 * ac2_0 + ac1_1 * ac2_1
+    n_between = nv1 * nv2
+    n_between_same = cp.sum(ac1 * ac2, axis=1)
     between = cp.where(n_between > 0,
                        (n_between - n_between_same) / n_between, 0.0)
 
@@ -800,15 +774,27 @@ def pbs(haplotype_matrix: HaplotypeMatrix,
     if haplotype_matrix.device == 'CPU':
         haplotype_matrix.transfer_to_gpu()
 
-    # precompute allele counts once per population
-    ac1_0, ac1_1, n1 = _pop_allele_counts(haplotype_matrix, pop1, missing_data)
-    ac2_0, ac2_1, n2 = _pop_allele_counts(haplotype_matrix, pop2, missing_data)
-    ac3_0, ac3_1, n3 = _pop_allele_counts(haplotype_matrix, pop3, missing_data)
+    if missing_data == 'exclude':
+        haplotype_matrix = haplotype_matrix.exclude_missing_sites(
+            populations=[pop1, pop2, pop3])
+
+    # Per-allele counts for all three pops on a shared global K, so each pair's
+    # cross term sum_a ac_i,a * ac_j,a is over aligned alleles.
+    from ._memutil import allele_counts
+    h1 = haplotype_matrix.haplotypes[_get_population_indices(haplotype_matrix, pop1), :]
+    h2 = haplotype_matrix.haplotypes[_get_population_indices(haplotype_matrix, pop2), :]
+    h3 = haplotype_matrix.haplotypes[_get_population_indices(haplotype_matrix, pop3), :]
+    k = max(int(h1.max()) if h1.size else 0,
+            int(h2.max()) if h2.size else 0,
+            int(h3.max()) if h3.size else 0, 0) + 1
+    ac1, nv1 = allele_counts(h1, n_alleles=k)
+    ac2, nv2 = allele_counts(h2, n_alleles=k)
+    ac3, nv3 = allele_counts(h3, n_alleles=k)
 
     # compute all three pairwise FST num/den from shared counts
-    num12, den12 = _hudson_fst_from_counts(ac1_0, ac1_1, n1, ac2_0, ac2_1, n2)
-    num13, den13 = _hudson_fst_from_counts(ac1_0, ac1_1, n1, ac3_0, ac3_1, n3)
-    num23, den23 = _hudson_fst_from_counts(ac2_0, ac2_1, n2, ac3_0, ac3_1, n3)
+    num12, den12 = _hudson_fst_from_counts(ac1, nv1, ac2, nv2)
+    num13, den13 = _hudson_fst_from_counts(ac1, nv1, ac3, nv3)
+    num23, den23 = _hudson_fst_from_counts(ac2, nv2, ac3, nv3)
 
     fst12 = _windowed_fst(num12, den12, window_size, window_start,
                           window_stop, window_step)

--- a/pg_gpu/divergence.py
+++ b/pg_gpu/divergence.py
@@ -416,27 +416,28 @@ def fst_nei(haplotype_matrix: HaplotypeMatrix,
     pop1_haps = haplotype_matrix.haplotypes[pop1_idx, :]
     pop2_haps = haplotype_matrix.haplotypes[pop2_idx, :]
 
-    pop1_counts, pop1_n = _pop_dac_and_n(pop1_haps)
-    pop2_counts, pop2_n = _pop_dac_and_n(pop2_haps)
-    pop1_counts = pop1_counts.astype(cp.float64)
-    pop2_counts = pop2_counts.astype(cp.float64)
-    n1 = pop1_n.astype(cp.float64)
-    n2 = pop2_n.astype(cp.float64)
+    # Per-allele Nei GST: within het HS = 1 - sum_a p_a^2 (per pop, sample-size
+    # weighted), total het HT = 1 - sum_a pbar_a^2 with the pooled allele freq
+    # pbar_a = (n1*p1_a + n2*p2_a)/(n1+n2). Reduces to the biallelic 2p(1-p)
+    # forms; multiallelic-correct.
+    ac1, ac2, nv1, nv2 = _aligned_pop_counts(pop1_haps, pop2_haps)
+    n1 = nv1.astype(cp.float64)
+    n2 = nv2.astype(cp.float64)
+    tot = n1 + n2
+    both = tot > 0
 
-    pop1_freqs = cp.where(n1 > 0, pop1_counts / n1, 0.0)
-    pop2_freqs = cp.where(n2 > 0, pop2_counts / n2, 0.0)
+    p1 = cp.where((n1 > 0)[:, None], ac1.astype(cp.float64) / n1[:, None], 0.0)
+    p2 = cp.where((n2 > 0)[:, None], ac2.astype(cp.float64) / n2[:, None], 0.0)
 
-    # Within-population heterozygosity
-    hs1 = 2.0 * pop1_freqs * (1 - pop1_freqs)
-    hs2 = 2.0 * pop2_freqs * (1 - pop2_freqs)
+    h1 = 1.0 - cp.sum(p1 * p1, axis=1)
+    h2 = 1.0 - cp.sum(p2 * p2, axis=1)
 
-    hs = cp.zeros_like(hs1)
-    p_total = cp.zeros_like(pop1_freqs)
-    valid = (n1 + n2) > 0
-    hs[valid] = (hs1[valid] * n1[valid] + hs2[valid] * n2[valid]) / (n1[valid] + n2[valid])
-    p_total[valid] = (pop1_freqs[valid] * n1[valid] + pop2_freqs[valid] * n2[valid]) / (n1[valid] + n2[valid])
+    hs = cp.zeros_like(h1)
+    hs[both] = (h1[both] * n1[both] + h2[both] * n2[both]) / tot[both]
 
-    ht = 2.0 * p_total * (1 - p_total)
+    pbar = cp.zeros_like(p1)
+    pbar[both] = (n1[both, None] * p1[both] + n2[both, None] * p2[both]) / tot[both, None]
+    ht = 1.0 - cp.sum(pbar * pbar, axis=1)
 
     # Calculate GST - only for sites with sufficient data
     valid_mask = (ht > 0) & (n1 > 0) & (n2 > 0)

--- a/pg_gpu/divergence.py
+++ b/pg_gpu/divergence.py
@@ -11,7 +11,6 @@ import numpy as np
 import cupy as cp
 from typing import Union, Tuple, Optional, Dict
 from .haplotype_matrix import HaplotypeMatrix
-from ._memutil import dac_and_n as _pop_dac_and_n
 from .diversity import _apply_span_normalize, pi as _diversity_pi
 
 
@@ -658,6 +657,8 @@ def divergence_stats(haplotype_matrix: HaplotypeMatrix,
             results['fst'] = fst(haplotype_matrix, pop1, pop2, missing_data=missing_data)
         elif stat == 'fst_hudson':
             results['fst_hudson'] = fst_hudson(haplotype_matrix, pop1, pop2, missing_data=missing_data)
+        elif stat == 'fst_tskit':
+            results['fst_tskit'] = fst_tskit(haplotype_matrix, pop1, pop2, missing_data=missing_data)
         elif stat == 'fst_wc':
             results['fst_wc'] = fst_weir_cockerham(haplotype_matrix, pop1, pop2, missing_data=missing_data)
         elif stat == 'fst_nei':

--- a/pg_gpu/divergence.py
+++ b/pg_gpu/divergence.py
@@ -102,7 +102,9 @@ def fst(haplotype_matrix: HaplotypeMatrix,
     pop2 : str or list
         Second population (name from sample_sets or list of indices)
     method : str
-        FST estimation method ('hudson', 'weir_cockerham', 'nei')
+        FST estimation method ('hudson', 'tskit', 'weir_cockerham', 'nei').
+        'hudson' is the classic 1 - Hw/Hb estimator (== scikit-allel); 'tskit'
+        is tskit's (Hb - Hw)/(Hb + Hw) combination. See fst_tskit.
     missing_data : str
         'include' - Use all sites, calculate from available data per site
         'exclude' - Only use sites with no missing data
@@ -114,6 +116,8 @@ def fst(haplotype_matrix: HaplotypeMatrix,
     """
     if method == 'hudson':
         return fst_hudson(haplotype_matrix, pop1, pop2, missing_data)
+    elif method == 'tskit':
+        return fst_tskit(haplotype_matrix, pop1, pop2, missing_data)
     elif method == 'weir_cockerham':
         return fst_weir_cockerham(haplotype_matrix, pop1, pop2, missing_data)
     elif method == 'nei':
@@ -174,6 +178,68 @@ def fst_hudson(haplotype_matrix: HaplotypeMatrix,
     valid_mask = den > 0
     if cp.any(valid_mask):
         return float((cp.sum(num[valid_mask]) / cp.sum(den[valid_mask])).get())
+    return 0.0
+
+
+def fst_tskit(haplotype_matrix: HaplotypeMatrix,
+              pop1: Union[str, list],
+              pop2: Union[str, list],
+              missing_data: str = 'include') -> float:
+    """
+    Compute tskit's FST estimator between two populations.
+
+    tskit assembles the same within/between pieces as Hudson but with a
+    different combination (added here for tskit parity; NOT the classic Hudson
+    ``1 - Hw/Hb`` returned by ``fst_hudson``):
+
+        FST = (sum(Hb) - sum(Hw)) / (sum(Hb) + sum(Hw))
+
+    where, per site, Hw = (pi_1 + pi_2) / 2 is the mean within-population
+    pairwise difference (unbiased) and Hb = dxy is the between-population
+    divergence. Both are per-allele, so this matches
+    ``ts.Fst([pop1, pop2], mode='site')`` on multiallelic data. See
+    ``plans/NOTES_fst_estimators.md`` (untracked) for the estimator comparison.
+
+    Parameters
+    ----------
+    haplotype_matrix : HaplotypeMatrix
+        The haplotype data
+    pop1 : str or list
+        First population
+    pop2 : str or list
+        Second population
+    missing_data : str
+        'include' - Use all sites, calculate from available data per site
+        'exclude' - Only use sites with no missing data
+
+    Returns
+    -------
+    float
+        tskit's FST estimate
+    """
+    if haplotype_matrix.device == 'CPU':
+        haplotype_matrix.transfer_to_gpu()
+
+    if missing_data == 'exclude':
+        haplotype_matrix = haplotype_matrix.exclude_missing_sites(
+            populations=[pop1, pop2])
+        if haplotype_matrix.num_variants == 0:
+            return 0.0
+
+    pop1_idx = _get_population_indices(haplotype_matrix, pop1)
+    pop2_idx = _get_population_indices(haplotype_matrix, pop2)
+    pop1_haps = haplotype_matrix.haplotypes[pop1_idx, :]
+    pop2_haps = haplotype_matrix.haplotypes[pop2_idx, :]
+
+    # Reuse the per-allele Hudson pieces: den = Hb (between), den - num = Hw
+    # (within). tskit combines them as (Hb - Hw) / (Hb + Hw), summed over sites.
+    ac1, ac2, nv1, nv2 = _aligned_pop_counts(pop1_haps, pop2_haps)
+    num, den = _hudson_fst_from_counts(ac1, nv1, ac2, nv2)
+    between_sum = float(cp.sum(den).get())
+    within_sum = float(cp.sum(den - num).get())
+    total = between_sum + within_sum
+    if total > 0:
+        return (between_sum - within_sum) / total
     return 0.0
 
 

--- a/pg_gpu/divergence.py
+++ b/pg_gpu/divergence.py
@@ -196,8 +196,7 @@ def fst_tskit(haplotype_matrix: HaplotypeMatrix,
     where, per site, Hw = (pi_1 + pi_2) / 2 is the mean within-population
     pairwise difference (unbiased) and Hb = dxy is the between-population
     divergence. Both are per-allele, so this matches
-    ``ts.Fst([pop1, pop2], mode='site')`` on multiallelic data. See
-    ``plans/NOTES_fst_estimators.md`` (untracked) for the estimator comparison.
+    ``ts.Fst([pop1, pop2], mode='site')`` on multiallelic data.
 
     Parameters
     ----------

--- a/pg_gpu/diversity.py
+++ b/pg_gpu/diversity.py
@@ -193,8 +193,7 @@ def _site_contribution(name, d, n_safe, seg, n_valid, n_hap, dac=None):
     LEGACY (collapsed, biallelic) path: derived alleles are lumped into a single
     ``dac`` count, so this is not multiallelic-correct. The scalar diversity path
     now uses the per-allele ``_ac_contribution``; this function is retained only
-    for ``windowed_analysis``, which still imports it and is migrated to the
-    per-allele primitive in a later subproject.
+    for ``windowed_analysis``, which still imports it.
 
     Parameters
     ----------

--- a/pg_gpu/sfs.py
+++ b/pg_gpu/sfs.py
@@ -272,7 +272,7 @@ def _joint_folded_cells(haplotype_matrix, pop1, pop2, missing_data):
     dropped. Returns ``(fA, fB, n1, n2)`` (flat GPU int64), to be binned with
     weight 1/2. Unlike the unfolded rule, this folds *the whole site by one
     global minor allele* rather than each axis independently -- which is where
-    tskit departs from scikit-allel's per-axis fold (see the ledger).
+    tskit departs from scikit-allel's per-axis fold.
     """
     ac1, ac2, nv1, nv2, n1, n2 = _joint_aligned_counts(haplotype_matrix,
                                                        pop1, pop2)
@@ -482,7 +482,7 @@ def joint_sfs_folded(haplotype_matrix: HaplotypeMatrix,
     output is the full ``(n1+1, n2+1)`` array (the kept region is the
     lower-total triangle; the rest is zero), with half-integer weights on
     multiallelic data. **This departs from scikit-allel's per-axis fold even on
-    biallelic data** (see the ledger) -- we pin to tskit here.
+    biallelic data** -- we pin to tskit here.
 
     Returns
     -------

--- a/tests/test_divergence.py
+++ b/tests/test_divergence.py
@@ -239,12 +239,14 @@ class TestDivergenceStats:
         # Compute all statistics
         stats = divergence.divergence_stats(
             matrix, 'popA', 'popB',
-            statistics=['fst', 'fst_hudson', 'fst_wc', 'fst_nei', 'dxy', 'da', 'pi1', 'pi2']
+            statistics=['fst', 'fst_hudson', 'fst_tskit', 'fst_wc', 'fst_nei',
+                        'dxy', 'da', 'pi1', 'pi2']
         )
 
         # Check all statistics are present
         assert 'fst' in stats
         assert 'fst_hudson' in stats
+        assert 'fst_tskit' in stats
         assert 'fst_wc' in stats
         assert 'fst_nei' in stats
         assert 'dxy' in stats

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -390,6 +390,30 @@ class TestDivergenceVsTskit:
         assert divergence.fst(hm, 'A', 'B', method='tskit') == fst_pg
         assert not np.isclose(fst_pg, divergence.fst_hudson(hm, 'A', 'B'))
 
+    def test_fst_nei_matches_hand_formula(self, multiallelic_ts):
+        # Nei GST per-allele: HS = 1 - sum_a p_a^2 (weighted), HT from pooled
+        # pbar_a. allel has no Nei GST, so pin to the numpy hand formula.
+        from pg_gpu import divergence
+        ts = multiallelic_ts
+        hm, A, B = self._hm_with_pops(ts)
+        gst_pg = divergence.fst_nei(hm, 'A', 'B')
+
+        G = ts.genotype_matrix()
+        K = int(G.max()) + 1
+        Ai, Bi = hm.sample_sets['A'], hm.sample_sets['B']
+        ac1 = np.stack([(G[:, Ai] == a).sum(1) for a in range(K)], axis=1).astype(float)
+        ac2 = np.stack([(G[:, Bi] == a).sum(1) for a in range(K)], axis=1).astype(float)
+        n1, n2 = ac1.sum(1), ac2.sum(1)
+        p1, p2 = ac1 / n1[:, None], ac2 / n2[:, None]
+        h1, h2 = 1 - (p1**2).sum(1), 1 - (p2**2).sum(1)
+        tot = n1 + n2
+        hs = (h1 * n1 + h2 * n2) / tot
+        pbar = (n1[:, None] * p1 + n2[:, None] * p2) / tot[:, None]
+        ht = 1 - (pbar**2).sum(1)
+        v = ht > 0
+        gst_ref = (ht[v] - hs[v]).sum() / ht[v].sum()
+        np.testing.assert_allclose(gst_pg, gst_ref, rtol=1e-12)
+
     def test_pbs_matches_allel(self, multiallelic_ts):
         # PBS composes three per-allele Hudson FSTs; matches allel.pbs.
         from pg_gpu import divergence

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -349,6 +349,58 @@ class TestJointSFS:
         np.testing.assert_allclose(result, expected, rtol=1e-9, atol=1e-9)
 
 
+class TestDivergenceVsTskit:
+    """Count-based divergence per-allele vs tskit (two sample sets)."""
+
+    @staticmethod
+    def _pops(ts):
+        s = ts.samples()
+        h = len(s) // 2
+        return list(s[:h]), list(s[h:])
+
+    def _hm_with_pops(self, ts):
+        # HaplotypeMatrix carrying sample_sets so divergence funcs can name pops.
+        A, B = self._pops(ts)
+        hm = HaplotypeMatrix.from_ts(ts, device="GPU")
+        hm.sample_sets = {'A': list(range(len(A))),
+                          'B': list(range(len(A), len(A) + len(B)))}
+        return hm, A, B
+
+    def test_dxy_matches_tskit(self, multiallelic_ts):
+        # dxy = 1 - sum_a p1_a*p2_a per site; mean over sites == tskit divergence.
+        from pg_gpu import divergence
+        ts = multiallelic_ts
+        hm, A, B = self._hm_with_pops(ts)
+        dxy_pg = divergence.dxy(hm, 'A', 'B', span_normalize=False)
+        dxy_ts = ts.divergence([A, B], mode='site', span_normalise=False) / ts.num_sites
+        np.testing.assert_allclose(dxy_pg, dxy_ts, rtol=1e-12)
+
+    def test_dxy_components_consistent_with_dxy(self, multiallelic_ts):
+        # Raw-count path (used by windowed analysis) agrees with dxy's mean.
+        from pg_gpu import divergence
+        ts = multiallelic_ts
+        hm, A, B = self._hm_with_pops(ts)
+        pop1 = hm.haplotypes[hm.sample_sets['A'], :]
+        pop2 = hm.haplotypes[hm.sample_sets['B'], :]
+        diffs, comps, nsites = divergence.dxy_components(pop1, pop2)
+        dxy_pg = divergence.dxy(hm, 'A', 'B', span_normalize=False)
+        # No missing data => n1*n2 constant across sites, so the pooled ratio
+        # diffs/comps equals dxy's mean-of-per-site-ratios.
+        assert nsites == ts.num_sites
+        np.testing.assert_allclose(diffs / comps, dxy_pg, rtol=1e-12)
+
+    def test_da_uses_per_allele_pieces(self, multiallelic_ts):
+        # da = dxy - (pi1+pi2)/2, both per-allele now (internally consistent).
+        from pg_gpu import divergence
+        ts = multiallelic_ts
+        hm, A, B = self._hm_with_pops(ts)
+        da = divergence.da(hm, 'A', 'B', span_normalize=False)
+        dxy_pg = divergence.dxy(hm, 'A', 'B', span_normalize=False)
+        pi1 = diversity.pi(hm, 'A', span_normalize=False)
+        pi2 = diversity.pi(hm, 'B', span_normalize=False)
+        np.testing.assert_allclose(da, dxy_pg - (pi1 + pi2) / 2.0, rtol=1e-12)
+
+
 class TestMultiallelicConsumers:
     """singleton_count / heterozygosity_expected / max_daf / mu_sfs / daf_histogram."""
 

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -350,7 +350,8 @@ class TestJointSFS:
 
 
 class TestDivergenceVsTskit:
-    """Count-based divergence per-allele vs tskit (two sample sets)."""
+    """Count-based divergence per-allele vs tskit (dxy/da) and scikit-allel
+    (Hudson FST / PBS), on multiallelic two/three sample sets."""
 
     @staticmethod
     def _pops(ts):
@@ -365,6 +366,36 @@ class TestDivergenceVsTskit:
         hm.sample_sets = {'A': list(range(len(A))),
                           'B': list(range(len(A), len(A) + len(B)))}
         return hm, A, B
+
+    def test_fst_hudson_matches_allel(self, multiallelic_ts):
+        # Classic Hudson FST = sum(num)/sum(den); per-allele == allel.hudson_fst.
+        from pg_gpu import divergence
+        ts = multiallelic_ts
+        hm, A, B = self._hm_with_pops(ts)
+        fst_pg = divergence.fst_hudson(hm, 'A', 'B')
+        ha = allel.HaplotypeArray(ts.genotype_matrix())
+        ac1 = ha.count_alleles(subpop=hm.sample_sets['A'])
+        ac2 = ha.count_alleles(subpop=hm.sample_sets['B'])
+        num, den = allel.hudson_fst(ac1, ac2)
+        np.testing.assert_allclose(fst_pg, np.sum(num) / np.sum(den), rtol=1e-9)
+
+    def test_pbs_matches_allel(self, multiallelic_ts):
+        # PBS composes three per-allele Hudson FSTs; matches allel.pbs.
+        from pg_gpu import divergence
+        ts = multiallelic_ts
+        n = ts.num_samples
+        t = n // 3
+        sets = {'A': list(range(t)), 'B': list(range(t, 2 * t)),
+                'C': list(range(2 * t, n))}
+        hm = HaplotypeMatrix.from_ts(ts, device="GPU")
+        hm.sample_sets = sets
+        w = 50
+        pbs_pg = divergence.pbs(hm, 'A', 'B', 'C', window_size=w)
+        ha = allel.HaplotypeArray(ts.genotype_matrix())
+        ac = {k: ha.count_alleles(subpop=v) for k, v in sets.items()}
+        pbs_allel = allel.pbs(ac['A'], ac['B'], ac['C'], window_size=w, normed=True)
+        valid = ~np.isnan(pbs_pg) & ~np.isnan(pbs_allel)
+        np.testing.assert_allclose(pbs_pg[valid], pbs_allel[valid], rtol=1e-6, atol=1e-9)
 
     def test_dxy_matches_tskit(self, multiallelic_ts):
         # dxy = 1 - sum_a p1_a*p2_a per site; mean over sites == tskit divergence.

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -379,6 +379,17 @@ class TestDivergenceVsTskit:
         num, den = allel.hudson_fst(ac1, ac2)
         np.testing.assert_allclose(fst_pg, np.sum(num) / np.sum(den), rtol=1e-9)
 
+    def test_fst_tskit_matches_tskit(self, multiallelic_ts):
+        # tskit's FST = (Hb - Hw)/(Hb + Hw); a distinct assembly from Hudson.
+        from pg_gpu import divergence
+        ts = multiallelic_ts
+        hm, A, B = self._hm_with_pops(ts)
+        fst_pg = divergence.fst_tskit(hm, 'A', 'B')
+        np.testing.assert_allclose(fst_pg, ts.Fst([A, B], mode='site'), rtol=1e-9)
+        # dispatcher routes method='tskit' here; and it differs from Hudson
+        assert divergence.fst(hm, 'A', 'B', method='tskit') == fst_pg
+        assert not np.isclose(fst_pg, divergence.fst_hudson(hm, 'A', 'B'))
+
     def test_pbs_matches_allel(self, multiallelic_ts):
         # PBS composes three per-allele Hudson FSTs; matches allel.pbs.
         from pg_gpu import divergence

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -414,6 +414,27 @@ class TestDivergenceVsTskit:
         gst_ref = (ht[v] - hs[v]).sum() / ht[v].sum()
         np.testing.assert_allclose(gst_pg, gst_ref, rtol=1e-12)
 
+    def test_fst_weir_cockerham_matches_allel(self, multiallelic_ts):
+        # WC per-allele one-vs-rest a/b/c summed over alleles (incl. per-allele
+        # observed het) == allel.weir_cockerham_fst on multiallelic diploid data.
+        from pg_gpu import divergence
+        ts = multiallelic_ts
+        G = ts.genotype_matrix()
+        nsites, n_nodes = G.shape
+        n_ind = n_nodes // 2
+        half = n_ind // 2
+        gd = G.reshape(nsites, n_ind, 2)
+        subpops = [list(range(half)), list(range(half, n_ind))]
+        a, b, c = allel.weir_cockerham_fst(allel.GenotypeArray(gd), subpops)
+        fst_allel = np.sum(a) / np.sum(a + b + c)
+
+        hm = HaplotypeMatrix.from_ts(ts, device="GPU")
+        # individual i == haplotype rows 2i, 2i+1
+        hm.sample_sets = {'A': list(range(2 * half)),
+                          'B': list(range(2 * half, n_nodes))}
+        fst_pg = divergence.fst_weir_cockerham(hm, 'A', 'B')
+        np.testing.assert_allclose(fst_pg, fst_allel, rtol=1e-9)
+
     def test_pbs_matches_allel(self, multiallelic_ts):
         # PBS composes three per-allele Hudson FSTs; matches allel.pbs.
         from pg_gpu import divergence

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -819,6 +819,29 @@ class TestOverlappingWindowsScatter:
                       if sub.num_variants > 0 else 0.0)
             assert np.isclose(pi_scatter, pi_ref, rtol=1e-10, atol=1e-12)
 
+    @pytest.mark.xfail(strict=True, reason=(
+        "windowed_analysis dxy/fst still collapse multiallelic sites: "
+        "_allele_sum_and_n uses cp.sum(hap) (mechanism A, sums allele indices), "
+        "so windowed dxy detectably diverges from the per-allele scalar "
+        "divergence.dxy made correct in subproject 0003. Pre-existing; fixed in "
+        "the windowed subproject (kr-colab/pg_gpu#100) -- remove this marker then."))
+    def test_twopop_non_overlapping_dxy_matches_scalar(self, sim_hm):
+        """Per-window windowed dxy should equal scalar divergence.dxy on the
+        window subset; currently fails on multiallelic sites (collapsed path)."""
+        window_size, step_size = 50_000, 50_000
+        df = windowed_analysis(sim_hm, window_size=window_size,
+                               step_size=step_size, statistics=['dxy'],
+                               populations=['pop1', 'pop2'], span_normalize=False)
+        for start, dxy_scatter in zip(df['start'], df['dxy']):
+            stop = start + window_size
+            if stop > sim_hm.chrom_end:
+                continue
+            sub = self._window_subset(sim_hm, start, stop)
+            sub.sample_sets = sim_hm.sample_sets
+            dxy_ref = (divergence.dxy(sub, 'pop1', 'pop2', span_normalize=False)
+                       if sub.num_variants > 0 else 0.0)
+            assert np.isclose(dxy_scatter, dxy_ref, rtol=1e-10, atol=1e-12)
+
     def test_max_daf_overlapping_windows(self):
         """max_daf per window reflects max DAF among contained variants,
         including variants shared between overlapping windows."""


### PR DESCRIPTION

**Background:** The count-based two-population statistics in `divergence.py` collapsed multiallelic sites, so dxy, the Fst estimators, and PBS were wrong at any site with more than two alleles. This PR routes them through the per-allele `_memutil.allele_counts` primitive and adds `fst_tskit` for tskit parity. Biallelic values are unchanged; only multiallelic behaviour changes, plus the one Weir-Cockerham divergence noted below.

**Scope:** `dxy`, `dxy_components`, `da`, `fst_hudson`, `fst_tskit` (new), `fst_nei`, `fst_weir_cockerham`, `pbs`, and the aggregators (`fst`, `divergence_stats`, `pairwise_fst`). Out of scope (to be dealt with later): the distance-based stats (`snn`, `dxy_min`, `gmin`, `dd`, `dd_rank`, `zx`) and `distance_stats._pairwise_diffs_matrix_gpu`, which is separately multiallelic-broken (its `sum_i + sum_j - 2*X@X.T` assumes binary genotypes and returns negative distances on multiallelic pairs). Also, doc/auxiliary script updates are deferred. The `windowed_analysis` analogue is left uncorrected, and will be addressed later.

**Behaviour changes:** Stats corrected for multiallelic data (these were collapsed before):

- `dxy` / `dxy_components` / `da` are now per-allele `1 - sum_a p1_a*p2_a`, matching tskit `divergence`.
- `fst_hudson` / `pbs` use per-allele within/between diversity with the classic assembly `1 - Hw/Hb`, matching `allel.hudson_fst` / `allel.pbs`.
- `fst_nei` uses per-allele `HS/HT` with within-heterozygosity `het = 1 - sum_a p_a^2`.
- `fst_weir_cockerham` uses per-allele one-vs-rest `a/b/c` components summed over alleles, matching `allel.weir_cockerham_fst`.

New function: `fst_tskit` computes `(sum(Hb) - sum(Hw)) / (sum(Hb) + sum(Hw))`, tskit's combination, which is a distinct assembly from classic Hudson (`fst_hudson` is unchanged and still the classic `1 - Hw/Hb`). It is wired into `fst(method='tskit')` and `divergence_stats`.

The one genuine divergence: `fst_weir_cockerham`'s c component now uses per-allele observed heterozygosity (individuals carrying exactly one copy of allele a), not the site-level "any difference" heterozygosity the old biallelic code used. This is required because WC is a per-allele ANOVA and c is the between-gamete-within-individual variance of that specific allele; the two coincide for biallelic sites, so biallelic output is unchanged. The public `diversity.heterozygosity_observed` is deliberately left as the standard site-level H_obs (it already matches `allel.heterozygosity_observed`, is bounded in [0,1], and is perfectly correct for multiallelic data).

**Verification:** New `tests/test_multiallelic.py::TestDivergenceVsTskit` covers: dxy and da vs tskit `divergence`; `fst_hudson`, `pbs`, and `fst_weir_cockerham` vs scikit-allel; `fst_tskit` vs `ts.Fst`; and `fst_nei` vs the per-allele hand formula (scikit-allel has no Nei GST).