### PR TITLE
Correct pairwise distances for multiallelic data

### DIFF
--- a/pg_gpu/distance_stats.py
+++ b/pg_gpu/distance_stats.py
@@ -32,6 +32,15 @@ def _pairwise_diffs_matrix_gpu(hap, missing_data='include'):
     chunks to GPU on-the-fly so the full matrix never needs to reside
     on GPU at once.
 
+    Multiallelic-correct Hamming: the number of DIFFERING jointly-valid sites is
+    ``joint_valid - same``, where ``same`` counts sites at which the two
+    haplotypes carry the same allele, summed over allele values via one-hot
+    indicators (``same = sum_v I_v @ I_v.T``, ``I_v[h,s] = 1 if hap[h,s] == v``).
+    This generalizes the biallelic ``sum_i + sum_j - 2*X@X.T`` gram identity
+    (which silently assumes ``v^2 = v``) to any number of alleles, and reduces
+    to it exactly on ``{0, 1}`` data. Missing entries (``-1``) match no allele
+    value and are excluded from ``joint_valid``, so they never contribute.
+
     Parameters
     ----------
     hap : numpy.ndarray or cupy.ndarray, shape (n_haplotypes, n_variants)
@@ -50,28 +59,31 @@ def _pairwise_diffs_matrix_gpu(hap, missing_data='include'):
     n_hap, n_var = hap.shape
     is_numpy = isinstance(hap, np.ndarray)
     chunk_size = estimate_variant_chunk_size(n_hap, bytes_per_element=8,
-                                             n_intermediates=2)
+                                             n_intermediates=3)
 
-    gram = cp.zeros((n_hap, n_hap), dtype=cp.float64)
-    row_sums = cp.zeros(n_hap, dtype=cp.float64)
-    need_valid = missing_data == 'normalize'
-    joint_valid = cp.zeros((n_hap, n_hap), dtype=cp.float64) if need_valid else None
+    # One-hot Hamming over K allele values. K matmuls/chunk (vs 1 for the old
+    # binary-only gram trick); K is the number of allele values, typically small.
+    max_allele = int(hap.max()) if hap.size else -1
+    n_alleles = max(max_allele + 1, 0)
+
+    matches = cp.zeros((n_hap, n_hap), dtype=cp.float64)
+    joint_valid = cp.zeros((n_hap, n_hap), dtype=cp.float64)
 
     for start in range(0, n_var, chunk_size):
         end = min(start + chunk_size, n_var)
         h_chunk = cp.asarray(hap[:, start:end]) if is_numpy else hap[:, start:end]
-        x_chunk = cp.where(h_chunk >= 0, h_chunk, 0).astype(cp.float64)
-        row_sums += cp.sum(x_chunk, axis=1)
-        gram += x_chunk @ x_chunk.T
-        if need_valid:
-            v_chunk = (h_chunk >= 0).astype(cp.float64)
-            joint_valid += v_chunk @ v_chunk.T
-            del v_chunk
-        del h_chunk, x_chunk
+        v_chunk = (h_chunk >= 0).astype(cp.float64)
+        joint_valid += v_chunk @ v_chunk.T
+        # sites where both carry allele v (missing is -1, matches no v >= 0)
+        for v in range(n_alleles):
+            iv = (h_chunk == v).astype(cp.float64)
+            matches += iv @ iv.T
+            del iv
+        del h_chunk, v_chunk
 
-    diffs_mat = row_sums[:, None] + row_sums[None, :] - 2.0 * gram
+    diffs_mat = joint_valid - matches
 
-    if joint_valid is not None:
+    if missing_data == 'normalize':
         diffs_mat = cp.where(joint_valid > 0, diffs_mat / joint_valid, 0.0)
 
     return diffs_mat
@@ -81,8 +93,9 @@ def pairwise_diffs_haploid(haplotype_matrix, population=None,
                            missing_data='include'):
     """Compute pairwise Hamming distances between haplotypes on GPU.
 
-    Uses a single matrix multiply: for 0/1 data,
-    diffs_ij = sum_i + sum_j - 2 * (X @ X.T)_ij.
+    Per-site average allele differences over jointly non-missing sites,
+    multiallelic-correct (one-hot indicators per allele value; see
+    ``_pairwise_diffs_matrix_gpu``).
 
     Parameters
     ----------
@@ -123,6 +136,13 @@ def pairwise_diffs_diploid(genotype_matrix, population=None,
 
     For 0/1/2 genotypes, uses indicator matrices: matches = I0.T@I0 +
     I1.T@I1 + I2.T@I2, then diffs = n_var - matches.
+
+    Biallelic only: the input is a ``GenotypeMatrix`` of 0/1/2 alt-allele dosage,
+    which is a biallelic representation by construction (multiallelic sites are
+    filtered/collapsed when the matrix is built). For multiallelic data, use the
+    allele-index haplotype path (``pairwise_diffs_haploid`` /
+    ``divergence.pairwise_distance_matrix`` on a ``HaplotypeMatrix``), which is
+    multiallelic-correct.
 
     Parameters
     ----------

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -17,6 +17,12 @@ class GenotypeMatrix:
 
     Shape: (n_individuals, n_variants). Missing data encoded as -1.
 
+    Biallelic by construction: values are alt-allele dosage (0/1/2), so this
+    structure cannot represent multiallelic genotypes -- ``from_vcf`` filters
+    multiallelic sites out and ``from_haplotype_matrix`` sums paired haplotypes
+    (well-defined only for {0,1} alleles). For multiallelic data use the
+    allele-index ``HaplotypeMatrix``.
+
     Parameters
     ----------
     genotypes : ndarray, int8, shape (n_individuals, n_variants)

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -349,6 +349,111 @@ class TestJointSFS:
         np.testing.assert_allclose(result, expected, rtol=1e-9, atol=1e-9)
 
 
+class TestPairwiseDistanceKernel:
+    """Multiallelic pairwise Hamming distance kernel (0003b) vs numpy direct."""
+
+    @staticmethod
+    def _direct(hap):
+        # raw = # jointly-valid sites that differ; jv = # jointly-valid sites
+        n = hap.shape[0]
+        raw = np.zeros((n, n))
+        jv = np.zeros((n, n))
+        for i in range(n):
+            for j in range(n):
+                both = (hap[i] >= 0) & (hap[j] >= 0)
+                jv[i, j] = both.sum()
+                raw[i, j] = (both & (hap[i] != hap[j])).sum()
+        return raw, jv
+
+    def test_multiallelic_with_missing_matches_numpy(self):
+        import cupy as cp
+        from pg_gpu.distance_stats import _pairwise_diffs_matrix_gpu
+        rng = np.random.RandomState(0)
+        hap = rng.randint(0, 4, size=(8, 200)).astype(np.int8)  # 4 alleles
+        hap[rng.random((8, 200)) < 0.1] = -1                     # 10% missing
+        assert hap.max() > 1                                     # genuinely multiallelic
+        raw_ref, jv_ref = self._direct(hap)
+        norm_ref = np.where(jv_ref > 0, raw_ref / jv_ref, 0.0)
+        raw = cp.asnumpy(_pairwise_diffs_matrix_gpu(hap, 'include'))
+        norm = cp.asnumpy(_pairwise_diffs_matrix_gpu(hap, 'normalize'))
+        np.testing.assert_allclose(raw, raw_ref)
+        np.testing.assert_allclose(norm, norm_ref)
+        assert np.allclose(np.diag(raw), 0)
+        assert not (raw < 0).any()          # the old binary-only identity went negative
+
+    def test_biallelic_bit_identical_to_gram_trick(self):
+        import cupy as cp
+        from pg_gpu.distance_stats import _pairwise_diffs_matrix_gpu
+        rng = np.random.RandomState(1)
+        hb = rng.randint(0, 2, size=(6, 150)).astype(np.int8)   # no missing
+        old = (hb.sum(1)[:, None] + hb.sum(1)[None, :]
+               - 2 * (hb.astype(float) @ hb.astype(float).T))
+        new = cp.asnumpy(_pairwise_diffs_matrix_gpu(hb, 'include'))
+        np.testing.assert_array_equal(new, old)
+
+
+class TestDistanceStatsConsumers:
+    """Distance-based stats inherit the corrected multiallelic Hamming kernel."""
+
+    @staticmethod
+    def _raw_hamming(haps):
+        # raw pairwise Hamming count (fixture has no missing data)
+        n = haps.shape[0]
+        D = np.zeros((n, n))
+        for i in range(n):
+            D[i] = (haps != haps[i]).sum(axis=1)
+        return D
+
+    def _setup(self, ts):
+        n = ts.num_samples
+        h = n // 2
+        hm = HaplotypeMatrix.from_ts(ts, device="GPU")
+        hm.sample_sets = {'A': list(range(h)), 'B': list(range(h, n))}
+        haps = ts.genotype_matrix().T          # (n_samples, n_sites) allele indices
+        # Guard the coverage claim: allele indices must exceed {0,1}, i.e. the
+        # exact regime where the old binary-only kernel broke.
+        assert haps.max() > 1, "fixture is not multiallelic"
+        return hm, h, n, haps
+
+    def test_pairwise_diffs_haploid_matches_numpy(self, multiallelic_ts):
+        from pg_gpu import distance_stats as ds
+        ts = multiallelic_ts
+        hm, h, n, haps = self._setup(ts)
+        got = np.asarray(ds.pairwise_diffs_haploid(hm))     # condensed, per-site avg
+        D = self._raw_hamming(haps) / haps.shape[1]
+        ii, jj = np.triu_indices(n, k=1)
+        np.testing.assert_allclose(got, D[ii, jj], rtol=1e-9)
+
+    def test_pairwise_distance_matrix_blocks_match_numpy(self, multiallelic_ts):
+        import cupy as cp
+        from pg_gpu import divergence
+        ts = multiallelic_ts
+        hm, h, n, haps = self._setup(ts)
+        D = self._raw_hamming(haps)
+        between, within1, within2 = divergence.pairwise_distance_matrix(hm, 'A', 'B')
+        np.testing.assert_allclose(cp.asnumpy(between), D[:h, h:])
+        np.testing.assert_allclose(cp.asnumpy(within1), D[:h, :h])
+        np.testing.assert_allclose(cp.asnumpy(within2), D[h:, h:])
+
+    # NOTE: zx is excluded -- it is an LD/ZnS ratio (ld_statistics.zns), not a
+    # distance-matrix statistic, so it does not consume the Hamming kernel.
+    @pytest.mark.parametrize("statname",
+                             ["snn", "dxy_min", "gmin", "dd", "dd_rank"])
+    def test_distance_stat_consumes_corrected_kernel(self, multiallelic_ts, statname):
+        # stat via the pg_gpu kernel == stat fed numpy-reference distance matrices,
+        # so each stat correctly consumes the corrected multiallelic distances.
+        import cupy as cp
+        from pg_gpu import divergence
+        ts = multiallelic_ts
+        hm, h, n, haps = self._setup(ts)
+        D = self._raw_hamming(haps)
+        ref = (cp.asarray(D[:h, h:]), cp.asarray(D[:h, :h]), cp.asarray(D[h:, h:]))
+        fn = getattr(divergence, statname)
+        got = fn(hm, 'A', 'B')
+        ref_val = fn(hm, 'A', 'B', distance_matrices=ref)
+        np.testing.assert_allclose(got, ref_val, rtol=1e-9, equal_nan=True)
+
+
 class TestDivergenceVsTskit:
     """Count-based divergence per-allele vs tskit (dxy/da) and scikit-allel
     (Hudson FST / PBS), on multiallelic two/three sample sets."""


### PR DESCRIPTION

**Background:** the haploid pairwise-distance kernel `distance_stats._pairwise_diffs_matrix_gpu` computed Hamming distance via the binary-only identity `diffs_ij = sum_i + sum_j - 2*(X@X.T)_ij` on the raw allele-index matrix, which only holds for `{0,1}` data (it silently assumes `v^2 = v`). On multiallelic allele indices it returned garbage (negative "distances"). This PR replaces it with the one-hot form `diffs = joint_valid - sum_v (I_v @ I_v.T)` (count same-allele sites over allele values, subtract from the jointly-valid count), which is multiallelic-correct and reduces to the old values exactly on biallelic no-missing data. Every distance-based two-population statistic inherits the fix through the kernel, so no consumer code changed.

**Scope:** the kernel `_pairwise_diffs_matrix_gpu`, `pairwise_diffs_haploid`, and the divergence distance stats via `pairwise_distance_matrix` (`snn`, `dxy_min`, `gmin`, `dd`, `dd_rank`, `distance_based_stats`). Out of scope by deliberate decision: `pairwise_diffs_diploid` (see the decision below). Also, docs and auxiliary scripts are untouched and will be updated later.

### Behaviour changes

Bugfix: missing data in the kernel's `'include'` mode (also affects biallelic data). The old code set missing genotypes to allele 0 (`x = where(hap>=0, hap, 0)`) and never masked them, so a missing call was treated as a reference homozygote: a (missing, allele-1) pair counted as a difference, a (missing, missing) pair as a match, and missing sites sat in the implicit denominator. The one-hot rewrite excludes missing entries from both the match count and `joint_valid`, so distances are over jointly-non-missing sites only (what the docstring erroneously promised).

Multiallelic correction: pairwise Hamming distances (and every stat built on them) are now correct for allele indices beyond `{0,1}`, where the old kernel produced meaningless (often negative) values.

Out-of-scope: `pairwise_diffs_diploid` is left biallelic-only. We could respec it for multiallelic, but chose not to: its only input, `GenotypeMatrix`, is biallelic by construction (0/1/2 alt dosage; `from_vcf` filters multiallelic sites; `from_haplotype_matrix` sums paired haplotypes, defined only for `{0,1}`), so supporting multiallelic needs a new genotype representation plus a one-hot-over-`K(K+1)/2`-genotypes kernel (quadratic in K). This seems unnecessary, because multiallelic diploid distance is already available through the haploid allele-index path. The biallelic-only contract is now made explicit in the `pairwise_diffs_diploid` and `GenotypeMatrix` docstrings.

Cost: the kernel does K matmuls per variant-chunk (was 1), linear in the number of allele values K.