### PR TITLE
Multiallelic admixture statistics

### DIFF
--- a/pg_gpu/admixture.py
+++ b/pg_gpu/admixture.py
@@ -13,49 +13,76 @@ from ._utils import get_population_matrix as _get_population_matrix
 from .resampling import block_jackknife, _moving_nansum, _moving_nanmean
 
 
-def _allele_freq(haplotype_matrix):
-    """Compute alternate allele frequency from per-site valid data."""
-    if haplotype_matrix.device == 'CPU':
-        haplotype_matrix.transfer_to_gpu()
+def _aligned_allele_counts(haplotype_matrix, pops):
+    """Per-allele counts for a list of populations on a shared global K.
 
-    hap = haplotype_matrix.haplotypes
-    valid_mask = hap >= 0
-    n_valid = cp.sum(valid_mask, axis=0).astype(cp.float64)
-    n1 = cp.sum(cp.where(valid_mask, hap, 0), axis=0).astype(cp.float64)
-    return cp.where(n_valid > 0, n1 / n_valid, 0.0)
-
-
-def _allele_freq_and_het(haplotype_matrix):
-    """Compute alternate allele frequency and unbiased heterozygosity.
-
-    Parameters
-    ----------
-    haplotype_matrix : HaplotypeMatrix
-
-    Returns
-    -------
-    freq : cupy.ndarray, float64, shape (n_variants,)
-        Alternate allele frequency.
-    h : cupy.ndarray, float64, shape (n_variants,)
-        Unbiased heterozygosity estimator: n0*n1 / (n*(n-1)).
-    n : cupy.ndarray, float64, shape (n_variants,)
-        Allele number per site (n_valid).
+    Returns a list of ``(x, n)`` per pop, where ``x`` is ``(n_var, K)`` allele
+    counts (float64) and ``n`` is ``(n_var,)`` valid haplotype counts. K is the
+    max allele index over ALL listed pops + 1, so column ``a`` denotes the same
+    allele in every pop (the alignment discipline from the joint SFS /
+    divergence). This is the counting substrate for the tskit f-statistics.
     """
-    if haplotype_matrix.device == 'CPU':
-        haplotype_matrix.transfer_to_gpu()
+    from ._memutil import allele_counts
+    mats = [_get_population_matrix(haplotype_matrix, p) for p in pops]
+    for m in mats:
+        if m.device == 'CPU':
+            m.transfer_to_gpu()
+    k = max((int(m.haplotypes.max()) for m in mats if m.haplotypes.size),
+            default=0)
+    n_alleles = max(k, 0) + 1
+    out = []
+    for m in mats:
+        x, n = allele_counts(m.haplotypes, n_alleles=n_alleles)
+        out.append((x.astype(cp.float64), n.astype(cp.float64)))
+    return out
 
-    hap = haplotype_matrix.haplotypes
 
-    valid_mask = hap >= 0
-    an = cp.sum(valid_mask, axis=0).astype(cp.float64)
-    n1 = cp.sum(cp.where(valid_mask, hap, 0), axis=0).astype(cp.float64)
-    n0 = an - n1
+def _f2_terms(xa, na, xb, nb):
+    """Per-variant f2(A,B), the tskit unbiased U-statistic summed over alleles.
 
-    freq = cp.where(an > 0, n1 / an, 0.0)
-    h = cp.where(an > 1, (n0 * n1) / (an * (an - 1)), 0.0)
+    x* are (n_var, K) per-allele counts on a shared K; n* are (n_var,) valid
+    counts. Matches tskit's ``ts.f2``. Non-estimable sites (n < 2 in either pop)
+    contribute 0.
+    """
+    na_, nb_ = na[:, None], nb[:, None]
+    num = (xa * (xa - 1) * (nb_ - xb) * (nb_ - xb - 1)
+           - xa * (na_ - xa) * (nb_ - xb) * xb)
+    den = na_ * (na_ - 1) * nb_ * (nb_ - 1)
+    return cp.where(den > 0, num / den, 0.0).sum(axis=1)
 
-    return freq, h, an
 
+def _f3_terms(xi, ni, xj, nj, xk, nk):
+    """Per-variant f3(I; J, K), the tskit unbiased U-statistic over alleles.
+
+    I is the target population (tskit's first sample set). Matches ``ts.f3``.
+    """
+    ni_, nj_, nk_ = ni[:, None], nj[:, None], nk[:, None]
+    num = (xi * (xi - 1) * (nj_ - xj) * (nk_ - xk)
+           - xi * (ni_ - xi) * (nj_ - xj) * xk)
+    den = ni_ * (ni_ - 1) * nj_ * nk_
+    return cp.where(den > 0, num / den, 0.0).sum(axis=1)
+
+
+def _het_unbiased(x, n):
+    """Per-variant unbiased heterozygosity: (n^2 - sum_a x_a^2) / (n(n-1)).
+
+    Per-allele; reduces to the biallelic 2*n0*n1/(n(n-1)) form. Used as the f3
+    normalization (B = heterozygosity of the target population).
+    """
+    sumsq = (x * x).sum(axis=1)
+    return cp.where(n > 1, (n * n - sumsq) / (n * (n - 1)), 0.0)
+
+
+def _f4_terms(xa, na, xb, nb, xc, nc, xd, nd):
+    """Per-variant f4(A,B,C,D), the tskit unbiased U-statistic over alleles.
+
+    Matches tskit's ``ts.f4``.
+    """
+    na_, nb_, nc_, nd_ = na[:, None], nb[:, None], nc[:, None], nd[:, None]
+    num = (xa * xc * (nb_ - xb) * (nd_ - xd)
+           - xa * xd * (nb_ - xb) * (nc_ - xc))
+    den = na_ * nb_ * nc_ * nd_
+    return cp.where(den > 0, num / den, 0.0).sum(axis=1)
 
 
 # ---------------------------------------------------------------------------
@@ -88,14 +115,9 @@ def patterson_f2(haplotype_matrix: HaplotypeMatrix,
         if haplotype_matrix.num_variants == 0:
             return np.array([])
 
-    ma = _get_population_matrix(haplotype_matrix, pop_a)
-    mb = _get_population_matrix(haplotype_matrix, pop_b)
-
-    a, ha, sa = _allele_freq_and_het(ma)
-    b, hb, sb = _allele_freq_and_het(mb)
-
-    f2 = ((a - b) ** 2) - (ha / sa) - (hb / sb)
-    return f2.get()
+    (xa, na), (xb, nb) = _aligned_allele_counts(haplotype_matrix,
+                                                [pop_a, pop_b])
+    return _f2_terms(xa, na, xb, nb).get()
 
 
 def patterson_f3(haplotype_matrix: HaplotypeMatrix,
@@ -122,50 +144,69 @@ def patterson_f3(haplotype_matrix: HaplotypeMatrix,
     Returns
     -------
     T : ndarray, float64, shape (n_variants,)
-        Un-normalized F3 estimates per variant.
+        Un-normalized F3 estimates per variant (matches tskit f3(C; A, B)).
     B : ndarray, float64, shape (n_variants,)
-        Heterozygosity estimates (2 * h_hat) for population C.
+        Unbiased heterozygosity of the target population C (f3 normalization).
     """
-    if missing_data == 'exclude':
-        haplotype_matrix = haplotype_matrix.exclude_missing_sites(
-            populations=[pop_c, pop_a, pop_b])
-        if haplotype_matrix.num_variants == 0:
-            return np.array([]), np.array([])
-
-    mc = _get_population_matrix(haplotype_matrix, pop_c)
-    ma = _get_population_matrix(haplotype_matrix, pop_a)
-    mb = _get_population_matrix(haplotype_matrix, pop_b)
-
-    c, hc, sc = _allele_freq_and_het(mc)
-    a, _, _ = _allele_freq_and_het(ma)
-    b, _, _ = _allele_freq_and_het(mb)
-
-    T = ((c - a) * (c - b)) - (hc / sc)
-    B = 2 * hc
-
-    return T.get(), B.get()
+    return tuple(v.get() for v in
+                 _patterson_f3_gpu(haplotype_matrix, pop_c, pop_a, pop_b,
+                                   missing_data))
 
 
 def _patterson_f3_gpu(haplotype_matrix, pop_c, pop_a, pop_b,
                       missing_data='include'):
-    """Like patterson_f3 but returns CuPy arrays (no D2H transfer)."""
+    """Like patterson_f3 but returns CuPy arrays (no D2H transfer).
+
+    T = tskit f3(C; A, B) per variant (unbiased U-statistic); B = unbiased
+    heterozygosity of the target population C (the f3 normalization).
+    """
     if missing_data == 'exclude':
         haplotype_matrix = haplotype_matrix.exclude_missing_sites(
             populations=[pop_c, pop_a, pop_b])
         if haplotype_matrix.num_variants == 0:
             return cp.array([]), cp.array([])
 
-    mc = _get_population_matrix(haplotype_matrix, pop_c)
-    ma = _get_population_matrix(haplotype_matrix, pop_a)
-    mb = _get_population_matrix(haplotype_matrix, pop_b)
+    (xc, nc), (xa, na), (xb, nb) = _aligned_allele_counts(
+        haplotype_matrix, [pop_c, pop_a, pop_b])
 
-    c, hc, sc = _allele_freq_and_het(mc)
-    a, _, _ = _allele_freq_and_het(ma)
-    b, _, _ = _allele_freq_and_het(mb)
-
-    T = ((c - a) * (c - b)) - (hc / sc)
-    B = 2 * hc
+    T = _f3_terms(xc, nc, xa, na, xb, nb)   # target C is tskit's first set
+    B = _het_unbiased(xc, nc)
     return T, B
+
+
+def patterson_f4(haplotype_matrix: HaplotypeMatrix,
+                 pop_a: Union[str, list],
+                 pop_b: Union[str, list],
+                 pop_c: Union[str, list],
+                 pop_d: Union[str, list],
+                 missing_data: str = 'include'):
+    """Patterson's f4(A, B; C, D) statistic (per variant).
+
+    The unbiased per-allele U-statistic, matching tskit's ``f4`` (site mode).
+    A tree-of-populations under (A,B),(C,D) has f4 == 0; a nonzero value
+    indicates gene flow.
+
+    Parameters
+    ----------
+    haplotype_matrix : HaplotypeMatrix
+    pop_a, pop_b, pop_c, pop_d : str or list
+        Population names or sample indices.
+    missing_data : str
+        'include' - per-site n_valid; 'exclude' - filter complete sites.
+
+    Returns
+    -------
+    f4 : ndarray, float64, shape (n_variants,)
+        Per-variant f4 estimates (sum over variants gives the statistic).
+    """
+    if missing_data == 'exclude':
+        haplotype_matrix = haplotype_matrix.exclude_missing_sites(
+            populations=[pop_a, pop_b, pop_c, pop_d])
+        if haplotype_matrix.num_variants == 0:
+            return np.array([])
+    (xa, na), (xb, nb), (xc, nc), (xd, nd) = _aligned_allele_counts(
+        haplotype_matrix, [pop_a, pop_b, pop_c, pop_d])
+    return _f4_terms(xa, na, xb, nb, xc, nc, xd, nd).get()
 
 
 def patterson_d(haplotype_matrix: HaplotypeMatrix,
@@ -193,50 +234,59 @@ def patterson_d(haplotype_matrix: HaplotypeMatrix,
         Numerator (un-normalized F4 estimates).
     den : ndarray, float64, shape (n_variants,)
         Denominator.
+
+    Notes
+    -----
+    D is a biallelic-SNP statistic: sites with more than two alleles across the
+    four populations are excluded (num = den = 0), silently, as biallelic
+    filtering is handled elsewhere in the package. A multiallelic generalization
+    is a possible future extension.
     """
-    if missing_data == 'exclude':
-        haplotype_matrix = haplotype_matrix.exclude_missing_sites(
-            populations=[pop_a, pop_b, pop_c, pop_d])
-        if haplotype_matrix.num_variants == 0:
-            return np.array([]), np.array([])
-
-    ma = _get_population_matrix(haplotype_matrix, pop_a)
-    mb = _get_population_matrix(haplotype_matrix, pop_b)
-    mc = _get_population_matrix(haplotype_matrix, pop_c)
-    md = _get_population_matrix(haplotype_matrix, pop_d)
-
-    a = _allele_freq(ma)
-    b = _allele_freq(mb)
-    c = _allele_freq(mc)
-    d = _allele_freq(md)
-
-    num = (a - b) * (c - d)
-    den = (a + b - 2 * a * b) * (c + d - 2 * c * d)
-
-    return num.get(), den.get()
+    return tuple(v.get() for v in
+                 _patterson_d_gpu(haplotype_matrix, pop_a, pop_b, pop_c, pop_d,
+                                  missing_data))
 
 
 def _patterson_d_gpu(haplotype_matrix, pop_a, pop_b, pop_c, pop_d,
                      missing_data='include'):
-    """Like patterson_d but returns CuPy arrays (no D2H transfer)."""
+    """Like patterson_d but returns CuPy arrays (no D2H transfer).
+
+    BIALLELIC-RESTRICTED: D (ABBA-BABA) is defined on biallelic SNPs; sites with
+    >2 alleles across the four pops are excluded (num=den=0). On the retained
+    sites the allele frequency is a proper per-allele frequency (count of the
+    single alt allele / n), NOT cp.sum(hap)/n -- so a biallelic {0,2}-type site
+    is handled correctly, not index-inflated. The multiallelic generalization is
+    deferred (needs validation; no reference implementation to pin to).
+    """
     if missing_data == 'exclude':
         haplotype_matrix = haplotype_matrix.exclude_missing_sites(
             populations=[pop_a, pop_b, pop_c, pop_d])
         if haplotype_matrix.num_variants == 0:
             return cp.array([]), cp.array([])
 
-    ma = _get_population_matrix(haplotype_matrix, pop_a)
-    mb = _get_population_matrix(haplotype_matrix, pop_b)
-    mc = _get_population_matrix(haplotype_matrix, pop_c)
-    md = _get_population_matrix(haplotype_matrix, pop_d)
+    (xa, na), (xb, nb), (xc, nc), (xd, nd) = _aligned_allele_counts(
+        haplotype_matrix, [pop_a, pop_b, pop_c, pop_d])
 
-    a = _allele_freq(ma)
-    b = _allele_freq(mb)
-    c = _allele_freq(mc)
-    d = _allele_freq(md)
+    # Sites with >2 alleles across the four pops are dropped (num=den=0),
+    # silently -- consistent with the package's biallelic filtering elsewhere
+    # (e.g. GenotypeMatrix.from_vcf); the biallelic-only contract is documented.
+    present = (xa + xb + xc + xd) > 0
+    biallelic = present.sum(axis=1) <= 2
 
-    num = (a - b) * (c - d)
-    den = (a + b - 2 * a * b) * (c + d - 2 * c * d)
+    # Alt allele = highest-index present allele (== allele 1 for a {0,1} site,
+    # so this reduces to the previous behaviour on standard biallelic data);
+    # D is invariant to which of the two alleles is chosen.
+    k = xa.shape[1]
+    alt = cp.where(present, cp.arange(k)[None, :], -1).argmax(axis=1)[:, None]
+
+    def freq(x, n):
+        alt_count = cp.take_along_axis(x, alt, axis=1)[:, 0]
+        return cp.where(n > 0, alt_count / n, 0.0)
+
+    a, b, c, d = freq(xa, na), freq(xb, nb), freq(xc, nc), freq(xd, nd)
+    num = cp.where(biallelic, (a - b) * (c - d), 0.0)
+    den = cp.where(biallelic,
+                   (a + b - 2 * a * b) * (c + d - 2 * c * d), 0.0)
     return num, den
 
 

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -593,6 +593,115 @@ class TestDivergenceVsTskit:
         np.testing.assert_allclose(da, dxy_pg - (pi1 + pi2) / 2.0, rtol=1e-12)
 
 
+class TestFStatisticsVsTskit:
+    """Patterson f2 / f3 per-allele vs tskit (unbiased U-statistics)."""
+
+    @staticmethod
+    def _pops(ts):
+        s = ts.samples()
+        q = len(s) // 4
+        return (list(s[:q]), list(s[q:2 * q]), list(s[2 * q:3 * q]),
+                list(s[3 * q:]))
+
+    def _hm(self, ts):
+        s = ts.samples()
+        q = len(s) // 4
+        hm = HaplotypeMatrix.from_ts(ts, device="GPU")
+        hm.sample_sets = {'A': list(range(q)), 'B': list(range(q, 2 * q)),
+                          'C': list(range(2 * q, 3 * q)),
+                          'D': list(range(3 * q, len(s)))}
+        return hm
+
+    def test_f2_matches_tskit(self, multiallelic_ts):
+        from pg_gpu import admixture
+        ts = multiallelic_ts
+        A, B, _, _ = self._pops(ts)
+        hm = self._hm(ts)
+        f2_pg = float(np.nansum(admixture.patterson_f2(hm, 'A', 'B')))
+        f2_ts = float(ts.f2([A, B], mode='site', span_normalise=False))
+        np.testing.assert_allclose(f2_pg, f2_ts, rtol=1e-9)
+        assert f2_pg < 0  # unbiased estimator can be negative (and is here)
+
+    def test_f3_matches_tskit(self, multiallelic_ts):
+        # pg_gpu patterson_f3(C, A, B) == f3(C; A, B); tskit target set is first.
+        from pg_gpu import admixture
+        ts = multiallelic_ts
+        A, B, C, _ = self._pops(ts)
+        hm = self._hm(ts)
+        T, _ = admixture.patterson_f3(hm, 'C', 'A', 'B')
+        f3_pg = float(np.nansum(T))
+        f3_ts = float(ts.f3([C, A, B], mode='site', span_normalise=False))
+        np.testing.assert_allclose(f3_pg, f3_ts, rtol=1e-9)
+
+    def test_f4_matches_tskit(self, multiallelic_ts):
+        from pg_gpu import admixture
+        ts = multiallelic_ts
+        A, B, C, D = self._pops(ts)
+        hm = self._hm(ts)
+        f4_pg = float(np.nansum(admixture.patterson_f4(hm, 'A', 'B', 'C', 'D')))
+        f4_ts = float(ts.f4([A, B, C, D], mode='site', span_normalise=False))
+        np.testing.assert_allclose(f4_pg, f4_ts, rtol=1e-9)
+
+    def test_patterson_d_is_biallelic_restricted(self, multiallelic_ts):
+        # D silently excludes >2-allele sites (num=den=0) and stays in [-1, 1];
+        # exclusion is silent, matching the package's biallelic filtering.
+        from pg_gpu import admixture
+        ts = multiallelic_ts
+        hm = self._hm(ts)
+        num, den = admixture.patterson_d(hm, 'A', 'B', 'C', 'D')
+        d_val = np.nansum(num) / np.nansum(den)
+        assert -1.0 <= d_val <= 1.0
+        # reference: strictly-biallelic subset ({0,1} across all four pops) gives
+        # the same D (non-biallelic sites contribute 0 to both sums).
+        G = ts.genotype_matrix()
+        cols = (list(hm.sample_sets['A']) + list(hm.sample_sets['B'])
+                + list(hm.sample_sets['C']) + list(hm.sample_sets['D']))
+        n_alleles = np.array([np.unique(G[i, cols]).size
+                              for i in range(ts.num_sites)])
+        assert (n_alleles > 2).any()          # fixture really has multiallelic sites
+        d_all = num[n_alleles <= 2]
+        assert np.allclose(num[n_alleles > 2], 0.0)   # multiallelic sites zeroed
+
+    def test_moving_and_jackknife_inherit_per_allele_fix(self, multiallelic_ts):
+        # moving_* / average_* build on the corrected _patterson_*_gpu helpers,
+        # so they inherit the per-allele fix. A single all-variant window
+        # reproduces the global estimate; jackknife runs and is finite.
+        from pg_gpu import admixture
+        ts = multiallelic_ts
+        hm = self._hm(ts)
+        nv = hm.num_variants
+
+        T, B = admixture.patterson_f3(hm, 'C', 'A', 'B')
+        f3_global = float(np.nansum(T) / np.nansum(B))
+        f3_win = admixture.moving_patterson_f3(hm, 'C', 'A', 'B', size=nv,
+                                               normed=True)
+        assert len(f3_win) == 1
+        np.testing.assert_allclose(f3_win[0], f3_global, rtol=1e-9)
+
+        num, den = admixture.patterson_d(hm, 'A', 'B', 'C', 'D')
+        d_global = float(np.nansum(num) / np.nansum(den))
+        d_win = admixture.moving_patterson_d(hm, 'A', 'B', 'C', 'D', size=nv)
+        assert len(d_win) == 1
+        np.testing.assert_allclose(d_win[0], d_global, rtol=1e-9)
+
+        blen = max(nv // 5, 1)
+        f3_est = admixture.average_patterson_f3(hm, 'C', 'A', 'B', blen=blen)[0]
+        d_est = admixture.average_patterson_d(hm, 'A', 'B', 'C', 'D', blen=blen)[0]
+        assert np.isfinite(f3_est) and np.isfinite(d_est)
+
+    def test_f3_normalizer_is_unbiased_het_of_target(self, multiallelic_ts):
+        # B == unbiased heterozygosity of C == tskit diversity(C) per site.
+        from pg_gpu import admixture
+        ts = multiallelic_ts
+        _, _, C, _ = self._pops(ts)
+        hm = self._hm(ts)
+        _, B = admixture.patterson_f3(hm, 'C', 'A', 'B')
+        het_c = float(np.nansum(B))
+        div_c = float(np.atleast_1d(
+            ts.diversity([C], mode='site', span_normalise=False))[0])
+        np.testing.assert_allclose(het_c, div_c, rtol=1e-9)
+
+
 class TestMultiallelicConsumers:
     """singleton_count / heterozygosity_expected / max_daf / mu_sfs / daf_histogram."""
 


### PR DESCRIPTION
**Background:** `admixture.py`'s f-statistics built a single "alt frequency" via `_allele_freq = cp.sum(hap)/n`, which for allele-index haplotypes sums allele INDICES (so a frequency can exceed 1). So f2/f3/f4/D were wrong on multiallelic sites. 

**Scope:** This PR routes f2/f3/f4 through per-allele counts matching tskit, adds a public `patterson_f4`, and makes `patterson_d` biallelic-restricted. Biallelic data is unchanged. The moving admixture statistics inherit the fix as they utilize the same underlying machinery. Docs/auxiliary scripts are not updated, that's deferred til later.

### What changed

f2 and f3 (`patterson_f2`, `patterson_f3`) now use tskit's unbiased per-allele U-statistic (the exact `f2_summary_func` / `f3_summary_func` from the tskit C source), summed over alleles. They match `TreeSequence.f2` / `TreeSequence.f3` on multiallelic data and are unchanged on biallelic data (the ADMIXTOOLS `(a-b)^2 - het` form already equals tskit's all-alleles sum there). f3 still returns `(T, B)`, now with `T` = tskit f3(C;A,B) and `B` = the unbiased heterozygosity of the target C (which equals `ts.diversity(C)`).

New `patterson_f4(A,B,C,D)` -- the per-allele unbiased f4, matching `TreeSequence.f4`. tskit exposes f4 and pg_gpu previously had no public f4 (it only existed implicitly inside D), so this is a parity addition.

`patterson_d` (ABBA-BABA) is now biallelic-restricted (it silently filters to biallelic). D is a biallelic-SNP statistic and no library (tskit or scikit-allel) computes a multiallelic D as far as I know, although f4 is proportional to the numerator of D so a generalization is certainly possible (but deferred here). The retained sites use proper per-allele counts (the frequency of the single alt allele, alt = highest-index present allele), so even a biallelic `{0,2}`-type site is correct rather than index-inflated; standard `{0,1}` data is unchanged. Exclusion is silent, consistent with the package's other biallelic filtering (e.g. `GenotypeMatrix.from_vcf` drops multiallelic sites without warning).

Removed the dead `_allele_freq` / `_allele_freq_and_het` helpers (the index-inflation source; unreferenced after the rewrite).