### PR TITLE
Fix windowed analysis for multiallelic data (with some exceptions)

### DIFF
--- a/pg_gpu/__init__.py
+++ b/pg_gpu/__init__.py
@@ -65,9 +65,10 @@ from .decomposition import (
 from .resampling import block_jackknife, block_bootstrap
 from ._warnings import (
     BadlyChunkedWarning, HaploidDataWarning, MemoryLimitedWarning,
+    MultiallelicCapWarning,
 )
 
-__all__ = ['ld_statistics', 'diversity', 'divergence', 'windowed_analysis', 'selection', 'sfs', 'admixture', 'decomposition', 'plotting', 'distance_stats', 'resampling', 'HaplotypeMatrix', 'GenotypeMatrix', 'WindowedAnalyzer', 'windowed_analysis', 'AccessibleMask', 'bed_to_mask', 'parse_bed', 'LocalPCAResult', 'LostructResult', 'local_pca', 'local_pca_jackknife', 'lostruct', 'pc_dist', 'corners', 'block_jackknife', 'block_bootstrap', 'MemoryLimitedWarning', 'HaploidDataWarning', 'BadlyChunkedWarning']
+__all__ = ['ld_statistics', 'diversity', 'divergence', 'windowed_analysis', 'selection', 'sfs', 'admixture', 'decomposition', 'plotting', 'distance_stats', 'resampling', 'HaplotypeMatrix', 'GenotypeMatrix', 'WindowedAnalyzer', 'windowed_analysis', 'AccessibleMask', 'bed_to_mask', 'parse_bed', 'LocalPCAResult', 'LostructResult', 'local_pca', 'local_pca_jackknife', 'lostruct', 'pc_dist', 'corners', 'block_jackknife', 'block_bootstrap', 'MemoryLimitedWarning', 'HaploidDataWarning', 'BadlyChunkedWarning', 'MultiallelicCapWarning']
 
 # Version is derived from the git tag at build time (hatch-vcs) and read here
 # from the installed package metadata, so there is no hardcoded string to keep

--- a/pg_gpu/_warnings.py
+++ b/pg_gpu/_warnings.py
@@ -67,6 +67,23 @@ class BadlyChunkedWarning(UserWarning):
     unlock the GPU-decode fast path."""
 
 
+class MultiallelicCapWarning(UserWarning):
+    """Emitted when a fused windowed kernel drops sites with more alleles
+    than the kernel's fixed per-allele capacity.
+
+    The fused windowed-statistics CUDA kernels count alleles into a fixed-size
+    per-variant array (``MAX_ALLELES``), so any site with more alleles than that
+    cap is excluded from the windowed scalar statistics and a count is reported.
+    The cap is generous (nucleotide data has at most 4 alleles); this only fires
+    on unusually multiallelic input. The (non-windowed) scalar functions in
+    ``diversity`` / ``divergence`` handle arbitrary allele counts. Silence with::
+
+        import warnings
+        from pg_gpu import MultiallelicCapWarning
+        warnings.filterwarnings("ignore", category=MultiallelicCapWarning)
+    """
+
+
 # ── VCF size heuristic ──────────────────────────────────────────────────────
 #
 # VCF text parsing is single-threaded in htslib and the whole genotype matrix

--- a/pg_gpu/divergence.py
+++ b/pg_gpu/divergence.py
@@ -495,8 +495,9 @@ def dxy(haplotype_matrix: HaplotypeMatrix,
         ``'include'`` (default) uses per-site valid data.
         ``'exclude'`` filters to sites with no missing data.
     span_normalize : bool
-        ``True`` (default): auto-detect best denominator.
-        ``False``: return raw sum / sites-with-data average.
+        ``True`` (default): auto-detect best denominator (per-base rate).
+        ``False``: return the raw sum of per-site Dxy over sites with data
+        (consistent with ``diversity.pi`` and the other raw-sum statistics).
 
     Returns
     -------
@@ -537,9 +538,6 @@ def dxy(haplotype_matrix: HaplotypeMatrix,
         return dxy_per_site.get()
     else:
         dxy_sum = cp.sum(dxy_per_site)
-        if span_normalize is False:
-            n_sites = int(cp.sum(valid_mask).get())
-            return float(dxy_sum.get() / n_sites) if n_sites > 0 else 0.0
         return _apply_span_normalize(dxy_sum, haplotype_matrix, span_normalize)
 
 

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -3064,34 +3064,34 @@ def windowed_statistics(haplotype_matrix: HaplotypeMatrix,
             results['end'], is_accessible)
         window_bases = cp.asarray(window_bases, dtype=cp.float64)
 
-    # Phase 1: compute per-variant values and aggregate
+    # Phase 1: per-variant per-allele contributions (multiallelic-correct),
+    # mirroring diversity._ac_contribution and the scatter engine so all three
+    # single-pop windowed engines agree with the scalar diversity functions.
+    from ._memutil import allele_counts
+    from .diversity import _ac_contribution, _achaz_variance_coefficients
 
-    # check for missing data once, share across all stats
-    _has_missing = bool(int(cp.min(hap)) < 0)
+    ac, n_valid_i = allele_counts(hap)
+    n_v = n_valid_i.astype(cp.float64)
+    has_data = n_valid_i >= 2
+    derived = ac[:, 1:]                        # per-derived-allele counts
+    # per-site mutation count = (#alleles present) - 1  (tskit segregating)
+    alleles_present = (ac > 0).sum(axis=1)
+    mut = cp.where(has_data, cp.maximum(alleles_present - 1, 0),
+                   0).astype(cp.float64)
 
-    # precompute allele counts once (shared across all stats)
-    dac, n_valid = _allele_sum_and_n(hap, has_missing=_has_missing)
-    dac = dac.astype(cp.float64)
-    if isinstance(n_valid, int):
-        n_v = cp.float64(n_valid)
-        usable = cp.ones(dac.shape, dtype=bool)
-    else:
-        n_v = n_valid.astype(cp.float64)
-        usable = n_v > 1
-    p = cp.where(usable, dac / n_v, 0.0)
-    need_mpd = any(s in statistics for s in ('pi', 'tajimas_d'))
+    need_pi = any(s in statistics for s in ('pi', 'tajimas_d'))
+    need_watt = any(s in statistics for s in ('theta_w', 'tajimas_d'))
     need_seg = any(s in statistics for s in
                    ('theta_w', 'tajimas_d', 'segregating_sites'))
 
-    if need_mpd:
-        mpd = cp.zeros_like(dac)
-        mpd[usable] = 2.0 * p[usable] * (1.0 - p[usable]) * n_v[usable] / (n_v[usable] - 1) if not isinstance(n_valid, int) else 2.0 * p[usable] * (1.0 - p[usable]) * n_hap / (n_hap - 1)
-    else:
-        mpd = None
-    is_seg = (dac > 0) & (dac < n_v) if need_seg else None
+    pi_contrib = (_ac_contribution('pi', ac, n_valid_i, n_hap_int)
+                  if need_pi else None)
+    watt_contrib = (_ac_contribution('watterson', ac, n_valid_i, n_hap_int)
+                    if need_watt else None)
+    seg_count = _scatter_sum(mut, bin_idx, n_windows) if need_seg else None
 
     if 'pi' in statistics:
-        pi_sum = _scatter_sum(mpd, bin_idx, n_windows)
+        pi_sum = _scatter_sum(pi_contrib, bin_idx, n_windows)
         if per_base:
             results['pi'] = cp.where(window_bases > 0,
                                      pi_sum / window_bases, cp.nan).get()
@@ -3099,10 +3099,9 @@ def windowed_statistics(haplotype_matrix: HaplotypeMatrix,
             results['pi'] = pi_sum.get()
 
     if 'theta_w' in statistics:
-        seg_counts = _scatter_sum(is_seg.astype(cp.float64), bin_idx, n_windows)
-        n = n_hap_int
-        a1 = np.sum(1.0 / np.arange(1, n))
-        theta_abs = seg_counts / a1
+        # Watterson via per-site a1(n_valid) (missing-data aware), == the
+        # scatter/scalar path; == old seg/a1(n_hap) when data is complete.
+        theta_abs = _scatter_sum(watt_contrib, bin_idx, n_windows)
         if per_base:
             results['theta_w'] = cp.where(window_bases > 0,
                                           theta_abs / window_bases, cp.nan).get()
@@ -3110,49 +3109,45 @@ def windowed_statistics(haplotype_matrix: HaplotypeMatrix,
             results['theta_w'] = theta_abs.get()
 
     if 'segregating_sites' in statistics:
-        seg_vals = is_seg if is_seg is not None else (dac > 0) & (dac < n_v)
-        seg_counts_out = _scatter_sum(seg_vals.astype(cp.float64), bin_idx,
-                                      n_windows)
-        results['segregating_sites'] = seg_counts_out.get().astype(int)
+        # Mutation count (alleles_present - 1) = tskit segregating; == the
+        # biallelic boolean is_seg for two-allele sites.
+        results['segregating_sites'] = seg_count.get().astype(int)
 
     if 'singletons' in statistics:
-        is_sing = (dac == 1) | (dac == n_v - 1)
-        sing_counts = _scatter_sum(is_sing.astype(cp.float64), bin_idx,
-                                   n_windows)
+        # Per-allele: derived alleles observed exactly once (unfolded, ==
+        # scalar singleton_count). The old (dac==1)|(dac==n-1) also counted
+        # ancestral-allele singletons (folded).
+        n_sing = ((derived == 1).sum(axis=1) if derived.shape[1]
+                  else cp.zeros(ac.shape[0], dtype=cp.int64))
+        sing = cp.where(has_data, n_sing, 0).astype(cp.float64)
+        sing_counts = _scatter_sum(sing, bin_idx, n_windows)
         results['singletons'] = sing_counts.get().astype(int)
 
     if 'het_expected' in statistics:
-        he = 2.0 * p * (1.0 - p)
+        # He = 1 - sum_a p_a^2 (per-allele; reduces to 2p(1-p) for biallelic).
+        p_sq = (ac.astype(cp.float64) ** 2).sum(axis=1) / cp.maximum(n_v, 1.0) ** 2
+        he = cp.where(has_data, 1.0 - p_sq, 0.0)
         he_sum = _scatter_sum(he, bin_idx, n_windows)
         results['het_expected'] = cp.where(
             variant_counts > 0,
             he_sum / variant_counts.astype(cp.float64), cp.nan).get()
 
     if 'tajimas_d' in statistics:
-        # aggregate mpd and seg counts into windows, then apply formula
-        pi_sum_td = _scatter_sum(mpd, bin_idx, n_windows) if 'pi' not in statistics else _scatter_sum(mpd, bin_idx, n_windows)
-        seg_counts_td = _scatter_sum(is_seg.astype(cp.float64), bin_idx,
-                                     n_windows)
-
-        n = n_hap_int
-        a1 = np.sum(1.0 / np.arange(1, n))
-        a2 = np.sum(1.0 / np.arange(1, n) ** 2)
-        b1 = (n + 1) / (3 * (n - 1))
-        b2 = 2 * (n ** 2 + n + 3) / (9 * n * (n - 1))
-        c1 = b1 - 1 / a1
-        c2 = b2 - (n + 2) / (a1 * n) + a2 / a1 ** 2
-        e1 = c1 / a1
-        e2 = c2 / (a1 ** 2 + a2)
-
-        S = seg_counts_td.get()
-        pi_w = pi_sum_td.get()
-
-        d_num = pi_w - S / a1
-        d_var = e1 * S + e2 * S * (S - 1)
-        d_std = np.sqrt(np.maximum(d_var, 0))
-
-        tajd = np.where(d_std > 0, d_num / d_std, np.nan)
-        tajd[S < 3] = np.nan
+        # numerator = pi - theta_w (per-allele sums); Achaz (2009) variance from
+        # a single n_hap and mutation-count S, matching the scatter engine. (The
+        # effective-n-under-missing-data question is tracked separately.)
+        pi_sum_td = _scatter_sum(pi_contrib, bin_idx, n_windows)
+        watt_sum_td = _scatter_sum(watt_contrib, bin_idx, n_windows)
+        S = seg_count.get()
+        a1 = sum(1.0 / i for i in range(1, n_hap_int))
+        a2 = sum(1.0 / (i ** 2) for i in range(1, n_hap_int))
+        theta_est = S / a1
+        theta_sq_est = S * (S - 1) / (a1 ** 2 + a2)
+        alpha, beta = _achaz_variance_coefficients('pi', 'watterson', n_hap_int)
+        var = alpha * theta_est + beta * theta_sq_est
+        num = (pi_sum_td - watt_sum_td).get()
+        with np.errstate(invalid='ignore', divide='ignore'):
+            tajd = np.where((var > 0) & (S >= 3), num / np.sqrt(var), np.nan)
         results['tajimas_d'] = tajd
 
     # two-population statistics

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -2905,59 +2905,6 @@ def _bin_counts(bin_idx, n_bins):
     return cp.bincount(bin_idx[valid], minlength=n_bins)
 
 
-def _allele_sum_and_n(hap, has_missing=None):
-    """Sum of alleles and valid count per variant, skipping missing (-1).
-
-    Parameters
-    ----------
-    hap : cupy.ndarray
-    has_missing : bool, optional
-        If known, skip the check. If None, checks for negatives.
-
-    Returns
-    -------
-    dac : cupy.ndarray  — derived allele count per variant
-    n_valid : cupy.ndarray or int — valid haplotypes per variant
-    """
-    if has_missing is None:
-        has_missing = bool(int(cp.min(hap)) < 0)
-    if has_missing:
-        valid_mask = hap >= 0
-        dac = cp.sum(cp.where(valid_mask, hap, 0), axis=0)
-        n_valid = cp.sum(valid_mask, axis=0)
-    else:
-        dac = cp.sum(hap, axis=0)
-        n_valid = hap.shape[0]
-    return dac, n_valid
-
-
-def _per_variant_mpd(hap, n_hap):
-    """Mean pairwise difference per variant (GPU)."""
-    dac, n_valid = _allele_sum_and_n(hap)
-    dac = dac.astype(cp.float64)
-    if isinstance(n_valid, int):
-        n = cp.float64(n_valid)
-    else:
-        n = n_valid.astype(cp.float64)
-    usable = n > 1
-    p = cp.where(usable, dac / n, 0.0)
-    mpd = cp.zeros_like(dac)
-    mpd[usable] = 2.0 * p[usable] * (1.0 - p[usable]) * n[usable] / (n[usable] - 1)
-    return mpd
-
-
-def _per_variant_is_seg(hap, n_hap_int):
-    """Boolean: is variant segregating (GPU)."""
-    dac, n_valid = _allele_sum_and_n(hap)
-    return (dac > 0) & (dac < n_valid)
-
-
-def _per_variant_is_singleton(hap, n_hap_int):
-    """Boolean: is variant a singleton (GPU)."""
-    dac, n_valid = _allele_sum_and_n(hap)
-    return (dac == 1) | (dac == n_valid - 1)
-
-
 def _per_variant_fst_hudson_components(hap1, hap2, n1, n2):
     """Per-variant Hudson FST numerator and denominator (GPU).
 

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -718,8 +718,10 @@ def _windowed_thetas_scatter(haplotype_matrix, window_size, step_size,
                               span_normalize, chrom=None):
     """Compute windowed theta estimators via scatter-add on GPU.
 
-    Uses dac_and_n fused kernel + direct vectorized arithmetic + scatter_add
-    for per-window accumulation. Handles variable sample sizes per site.
+    Uses per-allele counts (``allele_counts``) + per-variant contributions
+    (``_ac_contribution``) + scatter_add for per-window accumulation, so
+    multiallelic sites are handled per-allele. Handles variable sample sizes
+    per site.
     """
     from ._utils import get_population_matrix
     from cupyx import scatter_add
@@ -738,8 +740,14 @@ def _windowed_thetas_scatter(haplotype_matrix, window_size, step_size,
         if matrix.num_variants == 0:
             return pd.DataFrame()
 
-    from .diversity import _prepare_dac, _site_contribution
-    dac, n_valid, d, n_safe, seg, n_hap = _prepare_dac(matrix)
+    from .diversity import _prepare_allele_counts, _ac_contribution
+    ac, n_valid, n_hap = _prepare_allele_counts(matrix)
+    # Per-allele intermediates (multiallelic-correct; match the scalar diversity
+    # path). mut = per-variant mutation count = (#alleles present) - 1.
+    n = n_valid.astype(cp.float64)
+    has_data = n_valid >= 2
+    alleles_present = (ac > 0).sum(axis=1)
+    mut = cp.where(has_data, cp.maximum(alleles_present - 1, 0), 0).astype(cp.float64)
 
     pos = matrix.positions
     if isinstance(pos, cp.ndarray):
@@ -803,20 +811,28 @@ def _windowed_thetas_scatter(haplotype_matrix, window_size, step_size,
         'watterson': stats_set & {'theta_w', 'tajimas_d', 'zeng_e', 'zeng_dh'},
     }
 
-    # Compute per-variant contributions via _site_contribution (single source of truth)
+    # Compute per-variant contributions via _ac_contribution (single source of truth)
     raw = {}
     for est_name, dependents in needs.items():
         if dependents:
             raw[est_name] = scatter_sum(
-                _site_contribution(est_name, d, n_safe, seg, n_valid, n_hap, dac=dac))
+                _ac_contribution(est_name, ac, n_valid, n_hap))
 
     if stats_set & {'segregating_sites', 'tajimas_d', 'normalized_fay_wu_h', 'zeng_e', 'zeng_dh'}:
-        seg_count = scatter_sum(seg.astype(cp.float64))
+        seg_count = scatter_sum(mut)
+    derived = ac[:, 1:]
     if 'singletons' in stats_set:
-        is_sing = seg & ((dac == 1) | (dac == n_valid - 1))
-        sing_count = scatter_sum(is_sing.astype(cp.float64))
+        # Per-allele: derived alleles (columns >= 1) observed exactly once.
+        n_sing = ((derived == 1).sum(axis=1) if derived.shape[1]
+                  else cp.zeros(ac.shape[0], dtype=cp.int64))
+        sing_count = scatter_sum(cp.where(has_data, n_sing, 0).astype(cp.float64))
     if 'max_daf' in stats_set:
-        dafs = cp.where(seg, d / n_safe, 0.0).get()
+        # Per-allele: highest derived-allele frequency at the site.
+        if derived.shape[1]:
+            p_der = derived.astype(cp.float64) / cp.where(n > 0, n, 1.0)[:, None]
+            dafs = cp.where(has_data, p_der.max(axis=1), 0.0).get()
+        else:
+            dafs = np.zeros(ac.shape[0])
         rep_dafs = np.broadcast_to(dafs[:, None], contains.shape) * contains
         max_daf_arr = np.zeros(n_windows)
         np.maximum.at(max_daf_arr, k_safe.ravel(), rep_dafs.ravel())
@@ -1251,7 +1267,7 @@ def windowed_analysis(haplotype_matrix: HaplotypeMatrix,
                 on='window_id', how='left')
         return result
 
-    # Scatter-add path: single-pop theta estimators via dac_and_n + scatter
+    # Scatter-add path: single-pop theta estimators via per-allele counts + scatter
     scatter_single = {'pi', 'theta_w', 'tajimas_d', 'segregating_sites',
                       'theta_h', 'theta_l', 'fay_wu_h', 'singletons',
                       'normalized_fay_wu_h', 'zeng_e', 'zeng_dh', 'max_daf'}
@@ -1408,7 +1424,66 @@ def _compute_mean_r2(matrix: HaplotypeMatrix, max_distance: int,
 # Haplotype data is transposed before kernel launch so variants are the
 # leading dimension (column-major for haplotype access). This ensures
 # coalesced memory reads when threads iterate over haplotypes.
+_FUSED_MAX_ALLELES = 8
+"""Per-variant allele capacity of the fused windowed CUDA kernels.
+
+The kernels count alleles into a fixed cnt[MAX_ALLELES] array per variant, so a
+site with an allele index >= this cap cannot be represented and is filtered out
+(with a MultiallelicCapWarning). Keep in sync with the ``#define MAX_ALLELES`` in
+the kernel sources. Nucleotide data has at most 4 alleles, so the cap is never
+hit in practice.
+"""
+
+
+def _warn_fused_allele_cap(n_over):
+    """Emit a MultiallelicCapWarning for ``n_over`` sites dropped by the cap."""
+    import warnings
+    from ._warnings import MultiallelicCapWarning
+    warnings.warn(
+        f"{n_over} site(s) with an allele index >= {_FUSED_MAX_ALLELES} were "
+        "excluded from the fused windowed statistics (kernel per-allele "
+        "capacity). Nucleotide data has at most 4 alleles; the non-windowed "
+        "diversity/divergence functions handle any number of alleles.",
+        MultiallelicCapWarning, stacklevel=3)
+
+
+def _filter_fused_allele_cap(hap, positions):
+    """Drop variants whose max allele index >= _FUSED_MAX_ALLELES (fused kernels).
+
+    ``hap`` is the transposed (n_var, n_hap) matrix on GPU. Returns ``(hap,
+    positions)`` filtered consistently. Emits a ``MultiallelicCapWarning`` with
+    the dropped-site count when any site exceeds the cap. Missing (-1) never
+    triggers the cap.
+    """
+    overcap = hap.max(axis=1) >= _FUSED_MAX_ALLELES
+    n_over = int(overcap.sum())
+    if n_over:
+        _warn_fused_allele_cap(n_over)
+        keep = ~overcap
+        hap = hap[keep]
+        positions = positions[keep]
+    return hap, positions
+
+
+def _filter_fused_allele_cap_raw(hap_raw, positions):
+    """Cap filter for the chunked path's un-transposed (n_hap, n_var) matrix.
+
+    Reduces over the haplotype axis (axis 0) to get per-variant max allele
+    indices without a full transpose, then slices variants (axis 1) and
+    positions consistently. Same semantics as ``_filter_fused_allele_cap``.
+    """
+    overcap = hap_raw.max(axis=0) >= _FUSED_MAX_ALLELES
+    n_over = int(overcap.sum())
+    if n_over:
+        _warn_fused_allele_cap(n_over)
+        keep = ~overcap
+        hap_raw = hap_raw[:, keep]
+        positions = positions[keep]
+    return hap_raw, positions
+
+
 _fused_windowed_kernel_v2 = cp.RawKernel(r'''
+#define MAX_ALLELES 8   /* keep in sync with _FUSED_MAX_ALLELES (host guard) */
 extern "C" __global__
 void fused_windowed_stats_v2(const signed char* hap_t,
                              const long long* win_start,
@@ -1438,30 +1513,46 @@ void fused_windowed_stats_v2(const signed char* hap_t,
         return;
     }
 
-    double dn = (double)n_hap;
     double t_mpd = 0.0, t_seg = 0.0, t_sing = 0.0;
     double t_count = 0.0, t_theta_h = 0.0, t_max_daf = 0.0;
 
     for (int vi = threadIdx.x; vi < n_vars; vi += blockDim.x) {
         int v = v_start + vi;
-        int dac = 0;
         const signed char* row = hap_t + (long long)v * n_hap;
+        /* Per-allele counts over non-missing calls. Sites with an allele index
+           >= MAX_ALLELES are filtered out on the host before launch, so every
+           allele here fits in cnt[]. */
+        int cnt[MAX_ALLELES];
+        for (int a = 0; a < MAX_ALLELES; a++) cnt[a] = 0;
+        int nv = 0;
         for (int h = 0; h < n_hap; h++) {
-            if (row[h] > 0) dac++;
+            signed char al = row[h];
+            if (al >= 0) { nv++; if (al < MAX_ALLELES) cnt[al]++; }
         }
-
-        double p = (double)dac / dn;
-        t_mpd += 2.0 * p * (1.0 - p) * dn / (dn - 1.0);
-
-        int is_seg = (dac > 0 && dac < n_hap) ? 1 : 0;
-        t_seg += is_seg;
-        t_sing += (dac == 1 || dac == n_hap - 1) ? 1.0 : 0.0;
         t_count += 1.0;
+        if (nv < 2) continue;
+        double dn = (double)nv;
 
-        if (is_seg) {
-            t_theta_h += 2.0 * (double)dac * (double)dac / (dn * (dn - 1.0));
+        double same = 0.0;      /* sum_a cnt_a*(cnt_a-1) : same-allele pairs */
+        double th = 0.0;        /* theta_h numerator: sum_{a>=1,0<c<nv} 2 c^2 */
+        double mdaf = 0.0;      /* max derived-allele frequency */
+        int n_present = 0;
+        for (int a = 0; a < MAX_ALLELES; a++) {
+            int c = cnt[a];
+            if (c > 0) n_present++;
+            same += (double)c * (double)(c - 1);
+            if (a >= 1 && c > 0) {
+                if (c == 1) t_sing += 1.0;            /* per-derived-allele singleton */
+                double freq = (double)c / dn;
+                if (freq > mdaf) mdaf = freq;
+                if (c < nv) th += 2.0 * (double)c * (double)c;
+            }
         }
-        if (p > t_max_daf) t_max_daf = p;
+        /* pi = 1 - sum_a C(c,2)/C(n,2); seg = mutation count (alleles present - 1) */
+        t_mpd += 1.0 - same / (dn * (dn - 1.0));
+        t_seg += (double)(n_present - 1);
+        t_theta_h += th / (dn * (dn - 1.0));
+        if (mdaf > t_max_daf) t_max_daf = mdaf;
     }
 
     // Sum reduction for 5 accumulators
@@ -1828,6 +1919,12 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
     positions = matrix.positions
     if not isinstance(positions, cp.ndarray):
         positions = cp.asarray(positions)
+
+    # Drop sites the fused kernel's per-allele capacity can't represent (rare;
+    # nucleotide data has <= 4 alleles). Must precede window indexing so the
+    # variant-index ranges are computed against the retained sites.
+    hap, positions = _filter_fused_allele_cap(hap, positions)
+    n_total_var = hap.shape[0]
 
     # Support overlapping windows via explicit start/stop arrays
     if _win_starts is not None and _win_stops is not None:
@@ -2196,11 +2293,15 @@ def windowed_statistics_fused_chunked(haplotype_matrix: HaplotypeMatrix,
 
     hap_raw = matrix.haplotypes
     n_hap = hap_raw.shape[0]
-    n_total_var = hap_raw.shape[1]
 
     positions = matrix.positions
     if not isinstance(positions, cp.ndarray):
         positions = cp.asarray(positions)
+
+    # Drop sites the fused kernel's per-allele capacity can't represent. Must
+    # precede window indexing so variant-index ranges match the retained sites.
+    hap_raw, positions = _filter_fused_allele_cap_raw(hap_raw, positions)
+    n_total_var = hap_raw.shape[1]
 
     # Window ranges (same setup as non-chunked)
     if _win_starts is not None and _win_stops is not None:

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -909,44 +909,34 @@ def _twopop_site_components(hap1, hap2):
       mpd2 = within-pop2 mean pairwise difference per site
       between = between-pop mean pairwise difference per site
 
-    All quantities use per-site valid counts (missing-data aware).
-    Reduces along the sample axis in chunks to avoid materializing
-    full (n_hap, n_var) float64 intermediates.
+    Per-allele (multiallelic-correct): the same-allele pair counts sum over
+    every allele column on a shared allele-index width K, so ``between``
+    equals the per-site Dxy (``1 - sum_a p1_a p2_a``) and mpd1/mpd2 the
+    per-site within-pop pi -- identical to the scalar ``divergence`` functions
+    (``_hudson_fst_from_counts`` / ``dxy``). Reduces to the biallelic
+    ancestral/derived form when there are two alleles. All quantities use
+    per-site valid counts (missing-data aware).
     """
-    n_var = hap1.shape[1]
+    from .divergence import _aligned_pop_counts
 
-    # Compute per-site allele counts and valid counts via chunked reduction.
-    # Only allocates (n_hap, chunk) temporaries instead of (n_hap, n_var).
-    ac1 = cp.zeros(n_var, dtype=cp.float64)
-    n1 = cp.zeros(n_var, dtype=cp.float64)
-    ac2 = cp.zeros(n_var, dtype=cp.float64)
-    n2 = cp.zeros(n_var, dtype=cp.float64)
-    chunk = max(1, n_var // 20)
-    for s in range(0, n_var, chunk):
-        e = min(s + chunk, n_var)
-        h1c = hap1[:, s:e]
-        v1 = h1c >= 0
-        n1[s:e] = cp.sum(v1, axis=0)
-        ac1[s:e] = cp.sum(cp.where(v1, h1c, 0), axis=0)
-        del h1c, v1
-        h2c = hap2[:, s:e]
-        v2 = h2c >= 0
-        n2[s:e] = cp.sum(v2, axis=0)
-        ac2[s:e] = cp.sum(cp.where(v2, h2c, 0), axis=0)
-        del h2c, v2
+    ac1, ac2, n1, n2 = _aligned_pop_counts(hap1, hap2)
+    ac1 = ac1.astype(cp.float64)
+    ac2 = ac2.astype(cp.float64)
+    n1 = n1.astype(cp.float64)
+    n2 = n2.astype(cp.float64)
 
-    # Within-pop mean pairwise differences
+    # Within-pop mean pairwise differences (same pairs summed over alleles)
     n1_pairs = n1 * (n1 - 1) / 2
-    n1_same = ((n1 - ac1) * (n1 - ac1 - 1) + ac1 * (ac1 - 1)) / 2
+    n1_same = cp.sum(ac1 * (ac1 - 1), axis=1) / 2
     mpd1 = cp.where(n1_pairs > 0, (n1_pairs - n1_same) / n1_pairs, 0.0)
 
     n2_pairs = n2 * (n2 - 1) / 2
-    n2_same = ((n2 - ac2) * (n2 - ac2 - 1) + ac2 * (ac2 - 1)) / 2
+    n2_same = cp.sum(ac2 * (ac2 - 1), axis=1) / 2
     mpd2 = cp.where(n2_pairs > 0, (n2_pairs - n2_same) / n2_pairs, 0.0)
 
-    # Between-pop mean pairwise differences
+    # Between-pop mean pairwise differences (per-allele cross term)
     n_between = n1 * n2
-    n_between_same = (n1 - ac1) * (n2 - ac2) + ac1 * ac2
+    n_between_same = cp.sum(ac1 * ac2, axis=1)
     between = cp.where(n_between > 0,
                        (n_between - n_between_same) / n_between, 0.0)
 
@@ -1447,30 +1437,15 @@ def _warn_fused_allele_cap(n_over):
         MultiallelicCapWarning, stacklevel=3)
 
 
-def _filter_fused_allele_cap(hap, positions):
-    """Drop variants whose max allele index >= _FUSED_MAX_ALLELES (fused kernels).
-
-    ``hap`` is the transposed (n_var, n_hap) matrix on GPU. Returns ``(hap,
-    positions)`` filtered consistently. Emits a ``MultiallelicCapWarning`` with
-    the dropped-site count when any site exceeds the cap. Missing (-1) never
-    triggers the cap.
-    """
-    overcap = hap.max(axis=1) >= _FUSED_MAX_ALLELES
-    n_over = int(overcap.sum())
-    if n_over:
-        _warn_fused_allele_cap(n_over)
-        keep = ~overcap
-        hap = hap[keep]
-        positions = positions[keep]
-    return hap, positions
-
-
 def _filter_fused_allele_cap_raw(hap_raw, positions):
     """Cap filter for the chunked path's un-transposed (n_hap, n_var) matrix.
 
     Reduces over the haplotype axis (axis 0) to get per-variant max allele
     indices without a full transpose, then slices variants (axis 1) and
-    positions consistently. Same semantics as ``_filter_fused_allele_cap``.
+    positions consistently. Drops variants whose max allele index
+    >= _FUSED_MAX_ALLELES and emits a ``MultiallelicCapWarning``; missing (-1)
+    never triggers the cap. (The non-chunked single-pass path filters inline,
+    capturing the keep mask so the two-pop kernel's hap1/hap2 align.)
     """
     overcap = hap_raw.max(axis=0) >= _FUSED_MAX_ALLELES
     n_over = int(overcap.sum())
@@ -1594,6 +1569,7 @@ void fused_windowed_stats_v2(const signed char* hap_t,
 
 # Two-population fused kernel for FST and Dxy
 _fused_windowed_twopop_kernel = cp.RawKernel(r'''
+#define MAX_ALLELES 8   /* keep in sync with _FUSED_MAX_ALLELES (host guard) */
 extern "C" __global__
 void fused_windowed_twopop(const signed char* hap1_t,
                            const signed char* hap2_t,
@@ -1631,44 +1607,52 @@ void fused_windowed_twopop(const signed char* hap1_t,
     for (int vi = threadIdx.x; vi < n_vars; vi += blockDim.x) {
         int v = v_start + vi;
 
-        // Count valid (non-missing) samples and alt alleles per site
-        int ac1_1 = 0, valid1 = 0;
+        // Per-allele counts over non-missing calls (shared cnt width for both
+        // pops). Sites with an allele index >= MAX_ALLELES are filtered on the
+        // host before launch, so every allele fits in cnt[].
+        int cnt1[MAX_ALLELES];
+        int cnt2[MAX_ALLELES];
+        for (int a = 0; a < MAX_ALLELES; a++) { cnt1[a] = 0; cnt2[a] = 0; }
+        int valid1 = 0;
         const signed char* row1 = hap1_t + (long long)v * n_hap1;
         for (int h = 0; h < n_hap1; h++) {
             signed char a = row1[h];
-            if (a >= 0) { valid1++; if (a > 0) ac1_1++; }
+            if (a >= 0) { valid1++; if (a < MAX_ALLELES) cnt1[a]++; }
         }
-        int ac2_1 = 0, valid2 = 0;
+        int valid2 = 0;
         const signed char* row2 = hap2_t + (long long)v * n_hap2;
         for (int h = 0; h < n_hap2; h++) {
             signed char a = row2[h];
-            if (a >= 0) { valid2++; if (a > 0) ac2_1++; }
+            if (a >= 0) { valid2++; if (a < MAX_ALLELES) cnt2[a]++; }
         }
 
         if (valid1 == 0 || valid2 == 0) continue;
 
         double dn1 = (double)valid1;
         double dn2 = (double)valid2;
-        double ac1_0 = dn1 - ac1_1;
-        double ac2_0 = dn2 - ac2_1;
-        double d_ac1_1 = (double)ac1_1;
-        double d_ac2_1 = (double)ac2_1;
 
-        // Hudson: within-pop mean pairwise difference
-        double n1_pairs = dn1 * (dn1 - 1.0) / 2.0;
-        double n1_same = (ac1_0 * (ac1_0 - 1.0) + d_ac1_1 * (d_ac1_1 - 1.0)) / 2.0;
-        double mpd1 = (n1_pairs > 0) ? (n1_pairs - n1_same) / n1_pairs : 0.0;
-
-        double n2_pairs = dn2 * (dn2 - 1.0) / 2.0;
-        double n2_same = (ac2_0 * (ac2_0 - 1.0) + d_ac2_1 * (d_ac2_1 - 1.0)) / 2.0;
-        double mpd2 = (n2_pairs > 0) ? (n2_pairs - n2_same) / n2_pairs : 0.0;
-
+        // Per-allele within-pop mean pairwise difference (same pairs summed over
+        // alleles) and between-pop difference (per-allele cross term) -- mirrors
+        // divergence._hudson_fst_from_counts / dxy, multiallelic-correct.
+        double same1 = 0.0, same2 = 0.0, between_same = 0.0;
+        for (int a = 0; a < MAX_ALLELES; a++) {
+            double c1 = (double)cnt1[a];
+            double c2 = (double)cnt2[a];
+            same1 += c1 * (c1 - 1.0);
+            same2 += c2 * (c2 - 1.0);
+            between_same += c1 * c2;
+        }
+        double mpd1 = (dn1 > 1.0) ? 1.0 - same1 / (dn1 * (dn1 - 1.0)) : 0.0;
+        double mpd2 = (dn2 > 1.0) ? 1.0 - same2 / (dn2 * (dn2 - 1.0)) : 0.0;
         double within = (mpd1 + mpd2) / 2.0;
+        double between = 1.0 - between_same / (dn1 * dn2);
 
-        // Between-pop mean pairwise difference
-        double n_between = dn1 * dn2;
-        double n_between_same = ac1_0 * ac2_0 + d_ac1_1 * d_ac2_1;
-        double between = (n_between > 0) ? (n_between - n_between_same) / n_between : 0.0;
+        // Total non-reference copy counts (all alt alleles collapsed) retained
+        // for the HAPLOID Weir-Cockerham block below, which is deliberately
+        // unchanged -- the fused fst_wc haploid/diploid mismatch is tracked
+        // separately and is out of scope here.
+        double d_ac1_1 = dn1 - (double)cnt1[0];
+        double d_ac2_1 = dn2 - (double)cnt2[0];
 
         t_fst_num += between - within;
         t_fst_den += between;
@@ -1922,8 +1906,16 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
 
     # Drop sites the fused kernel's per-allele capacity can't represent (rare;
     # nucleotide data has <= 4 alleles). Must precede window indexing so the
-    # variant-index ranges are computed against the retained sites.
-    hap, positions = _filter_fused_allele_cap(hap, positions)
+    # variant-index ranges are computed against the retained sites. Capture the
+    # keep mask so the two-pop path can slice hap1/hap2 to the same variants
+    # (positions/window indices are computed against the filtered set below).
+    cap_keep = hap.max(axis=1) < _FUSED_MAX_ALLELES if hap.shape[0] else None
+    if cap_keep is not None and not bool(cap_keep.all()):
+        _warn_fused_allele_cap(int((~cap_keep).sum()))
+        hap = hap[cap_keep]
+        positions = positions[cap_keep]
+    else:
+        cap_keep = None
     n_total_var = hap.shape[0]
 
     # Support overlapping windows via explicit start/stop arrays
@@ -2057,6 +2049,11 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
         n2 = m2.haplotypes.shape[0]
         hap1 = cp.ascontiguousarray(m1.haplotypes.T.astype(cp.int8))
         hap2 = cp.ascontiguousarray(m2.haplotypes.T.astype(cp.int8))
+        # Align to the variants retained by the allele-cap filter above, so the
+        # variant axis matches positions/win_start/win_stop/n_total_var.
+        if cap_keep is not None:
+            hap1 = hap1[cap_keep]
+            hap2 = hap2[cap_keep]
 
         out_fst_num = cp.zeros(n_windows, dtype=cp.float64)
         out_fst_den = cp.zeros(n_windows, dtype=cp.float64)

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -559,12 +559,13 @@ class TestDivergenceVsTskit:
         np.testing.assert_allclose(pbs_pg[valid], pbs_allel[valid], rtol=1e-6, atol=1e-9)
 
     def test_dxy_matches_tskit(self, multiallelic_ts):
-        # dxy = 1 - sum_a p1_a*p2_a per site; mean over sites == tskit divergence.
+        # dxy = 1 - sum_a p1_a*p2_a per site. span_normalize=False returns the
+        # raw sum over sites, which equals tskit's site divergence sum.
         from pg_gpu import divergence
         ts = multiallelic_ts
         hm, A, B = self._hm_with_pops(ts)
         dxy_pg = divergence.dxy(hm, 'A', 'B', span_normalize=False)
-        dxy_ts = ts.divergence([A, B], mode='site', span_normalise=False) / ts.num_sites
+        dxy_ts = ts.divergence([A, B], mode='site', span_normalise=False)
         np.testing.assert_allclose(dxy_pg, dxy_ts, rtol=1e-12)
 
     def test_dxy_components_consistent_with_dxy(self, multiallelic_ts):
@@ -576,10 +577,11 @@ class TestDivergenceVsTskit:
         pop2 = hm.haplotypes[hm.sample_sets['B'], :]
         diffs, comps, nsites = divergence.dxy_components(pop1, pop2)
         dxy_pg = divergence.dxy(hm, 'A', 'B', span_normalize=False)
-        # No missing data => n1*n2 constant across sites, so the pooled ratio
-        # diffs/comps equals dxy's mean-of-per-site-ratios.
+        # dxy (span_normalize=False) is the raw sum of per-site ratios. With no
+        # missing data n1*n2 is constant, so the pooled ratio diffs/comps equals
+        # the per-site mean == dxy_pg / nsites.
         assert nsites == ts.num_sites
-        np.testing.assert_allclose(diffs / comps, dxy_pg, rtol=1e-12)
+        np.testing.assert_allclose(diffs / comps, dxy_pg / nsites, rtol=1e-12)
 
     def test_da_uses_per_allele_pieces(self, multiallelic_ts):
         # da = dxy - (pi1+pi2)/2, both per-allele now (internally consistent).

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -801,7 +801,7 @@ class TestOverlappingWindowsScatter:
 
     def test_non_overlapping_unchanged(self, sim_hm):
         """Guard: step==window windowed pi equals per-window diversity.pi, now
-        that windowed_analysis uses the per-allele path (issue #100 / 0005a)."""
+        that windowed_analysis uses the per-allele path (issue #100)."""
         window_size, step_size = 50_000, 50_000
         df = windowed_analysis(sim_hm, window_size=window_size,
                                step_size=step_size, statistics=['pi'],
@@ -815,15 +815,9 @@ class TestOverlappingWindowsScatter:
                       if sub.num_variants > 0 else 0.0)
             assert np.isclose(pi_scatter, pi_ref, rtol=1e-10, atol=1e-12)
 
-    @pytest.mark.xfail(strict=True, reason=(
-        "windowed_analysis dxy/fst still collapse multiallelic sites: "
-        "_allele_sum_and_n uses cp.sum(hap) (mechanism A, sums allele indices), "
-        "so windowed dxy detectably diverges from the per-allele scalar "
-        "divergence.dxy made correct in subproject 0003. Pre-existing; fixed in "
-        "the windowed subproject (kr-colab/pg_gpu#100) -- remove this marker then."))
     def test_twopop_non_overlapping_dxy_matches_scalar(self, sim_hm):
-        """Per-window windowed dxy should equal scalar divergence.dxy on the
-        window subset; currently fails on multiallelic sites (collapsed path)."""
+        """Per-window windowed dxy equals scalar divergence.dxy on the window
+        subset, now that the two-pop path is per-allele (issue #100)."""
         window_size, step_size = 50_000, 50_000
         df = windowed_analysis(sim_hm, window_size=window_size,
                                step_size=step_size, statistics=['dxy'],
@@ -870,7 +864,7 @@ class TestOverlappingWindowsScatter:
 
 
 class TestMultiallelicSinglePop:
-    """Issue #100 / subproject 0005a: single-pop windowed scalar stats must
+    """Issue #100: single-pop windowed scalar stats must
     be multiallelic-correct -- each window equals the per-allele scalar
     ``diversity`` function on that window's subset -- on BOTH single-pop
     engines: the host scatter path (``_windowed_thetas_scatter``, reached by a
@@ -947,6 +941,124 @@ class TestMultiallelicSinglePop:
                               rtol=1e-9, atol=1e-12)
             assert np.isclose(seg_w, diversity.segregating_sites(sub),
                               rtol=1e-9, atol=1e-12)
+
+
+class TestMultiallelicTwoPop:
+    """Issue #100: two-pop windowed scalar stats must be
+    multiallelic-correct -- each window equals the per-allele scalar
+    ``divergence`` functions on that window's subset. Exercises the host scatter
+    engine (``_windowed_twopop_scatter``, reached by a pure two-pop request)."""
+
+    @pytest.fixture(scope="class")
+    def sim_hm(self):
+        import msprime
+        ts = msprime.sim_ancestry(
+            samples=30, sequence_length=100_000, recombination_rate=1e-8,
+            population_size=20_000, ploidy=2, random_seed=42)
+        ts = msprime.sim_mutations(
+            ts, rate=1e-6, model=msprime.JC69(state_independent=True),
+            random_seed=43)
+        G = ts.genotype_matrix()
+        n_multi = sum(np.unique(G[i]).size >= 3 for i in range(ts.num_sites))
+        assert n_multi > 50, f"fixture not multiallelic enough: {n_multi}"
+        hm = HaplotypeMatrix.from_ts(ts)
+        n = hm.num_haplotypes
+        hm.sample_sets = {"p1": list(range(n // 2)),
+                          "p2": list(range(n // 2, n))}
+        return hm
+
+    def _window_subset(self, hm, start, stop):
+        import cupy as cp
+        pos = hm.positions.get() if isinstance(hm.positions, cp.ndarray) else np.asarray(hm.positions)
+        hap = hm.haplotypes.get() if isinstance(hm.haplotypes, cp.ndarray) else np.asarray(hm.haplotypes)
+        mask = (pos >= start) & (pos < stop)
+        sub = HaplotypeMatrix(hap[:, mask], pos[mask],
+                              chrom_start=int(start), chrom_end=int(stop))
+        sub.sample_sets = hm.sample_sets
+        return sub
+
+    def test_scatter_dxy_fst_da_match_scalar(self, sim_hm):
+        window_size = 25_000
+        df = windowed_analysis(sim_hm, window_size=window_size,
+                               step_size=window_size,
+                               statistics=['dxy', 'fst', 'da'],
+                               populations=['p1', 'p2'], span_normalize=False)
+        for start, dxy_w, fst_w, da_w in zip(
+                df['start'], df['dxy'], df['fst'], df['da']):
+            stop = start + window_size
+            if stop > sim_hm.chrom_end:
+                continue
+            sub = self._window_subset(sim_hm, start, stop)
+            if sub.num_variants == 0:
+                continue
+            assert np.isclose(dxy_w,
+                              divergence.dxy(sub, 'p1', 'p2', span_normalize=False),
+                              rtol=1e-9, atol=1e-12)
+            assert np.isclose(da_w,
+                              divergence.da(sub, 'p1', 'p2', span_normalize=False),
+                              rtol=1e-9, atol=1e-12)
+            fst_ref = divergence.fst_hudson(sub, 'p1', 'p2')
+            if np.isnan(fst_w) or np.isnan(fst_ref):
+                assert np.isnan(fst_w) and np.isnan(fst_ref)
+            else:
+                assert np.isclose(fst_w, fst_ref, rtol=1e-9, atol=1e-12)
+
+    def test_fused_dxy_fst_da_match_scalar(self, sim_hm):
+        """Fused CUDA two-pop kernel: dxy/fst_hudson/da per window == scalar.
+        (fst_wc is excluded: the fused kernel's WC is a haploid estimator that
+        differs from the scalar diploid fst_weir_cockerham, a separate issue.)"""
+        from pg_gpu.windowed_analysis import windowed_statistics_fused
+        window_size = 25_000
+        bp = np.arange(0, int(sim_hm.chrom_end) + window_size, window_size,
+                       dtype=float)
+        r = windowed_statistics_fused(
+            sim_hm, bp_bins=bp, statistics=('dxy', 'fst_hudson', 'da'),
+            pop1='p1', pop2='p2', per_base=False, chrom='1')
+        for start, dxy_w, fst_w, da_w in zip(
+                r['start'], r['dxy'], r['fst_hudson'], r['da']):
+            stop = start + window_size
+            if stop > sim_hm.chrom_end:
+                continue
+            sub = self._window_subset(sim_hm, start, stop)
+            if sub.num_variants == 0:
+                continue
+            assert np.isclose(dxy_w,
+                              divergence.dxy(sub, 'p1', 'p2', span_normalize=False),
+                              rtol=1e-9, atol=1e-12)
+            assert np.isclose(da_w,
+                              divergence.da(sub, 'p1', 'p2', span_normalize=False),
+                              rtol=1e-9, atol=1e-12)
+            fst_ref = divergence.fst_hudson(sub, 'p1', 'p2')
+            if np.isnan(fst_w) or np.isnan(fst_ref):
+                assert np.isnan(fst_w) and np.isnan(fst_ref)
+            else:
+                assert np.isclose(fst_w, fst_ref, rtol=1e-9, atol=1e-12)
+
+    def test_per_variant_dxy_fst_match_scalar(self, sim_hm):
+        """Per-variant engine (windowed_statistics): two-pop dxy/fst per window
+        == scalar. Inherits the per-allele _twopop_site_components fix."""
+        from pg_gpu.windowed_analysis import windowed_statistics
+        window_size = 25_000
+        bp = np.arange(0, int(sim_hm.chrom_end) + window_size, window_size,
+                       dtype=float)
+        r = windowed_statistics(
+            sim_hm, bp_bins=bp, statistics=['fst', 'dxy'],
+            pop1='p1', pop2='p2', per_base=False, chrom='1')
+        for start, dxy_w, fst_w in zip(r['start'], r['dxy'], r['fst']):
+            stop = start + window_size
+            if stop > sim_hm.chrom_end:
+                continue
+            sub = self._window_subset(sim_hm, start, stop)
+            if sub.num_variants == 0:
+                continue
+            assert np.isclose(dxy_w,
+                              divergence.dxy(sub, 'p1', 'p2', span_normalize=False),
+                              rtol=1e-9, atol=1e-12)
+            fst_ref = divergence.fst_hudson(sub, 'p1', 'p2')
+            if np.isnan(fst_w) or np.isnan(fst_ref):
+                assert np.isnan(fst_w) and np.isnan(fst_ref)
+            else:
+                assert np.isclose(fst_w, fst_ref, rtol=1e-9, atol=1e-12)
 
 
 class TestCanonicalWindowSchema:

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -942,6 +942,41 @@ class TestMultiallelicSinglePop:
             assert np.isclose(seg_w, diversity.segregating_sites(sub),
                               rtol=1e-9, atol=1e-12)
 
+    def test_per_variant_matches_scalar(self, sim_hm):
+        """Per-variant engine (windowed_statistics): all six single-pop stats
+        per window == the per-allele scalar functions on the window subset."""
+        from pg_gpu.windowed_analysis import windowed_statistics
+        window_size = 25_000
+        bp = np.arange(0, int(sim_hm.chrom_end) + window_size, window_size,
+                       dtype=float)
+        stats = ['pi', 'theta_w', 'segregating_sites', 'singletons',
+                 'het_expected', 'tajimas_d']
+        r = windowed_statistics(sim_hm, bp_bins=bp, statistics=stats,
+                                per_base=False, chrom='1')
+        for i, start in enumerate(r['start']):
+            stop = start + window_size
+            if stop > sim_hm.chrom_end:
+                continue
+            sub = self._window_subset(sim_hm, start, stop)
+            if sub.num_variants == 0:
+                continue
+            assert np.isclose(r['pi'][i], diversity.pi(sub, span_normalize=False),
+                              rtol=1e-9, atol=1e-11)
+            assert np.isclose(r['theta_w'][i],
+                              diversity.theta_w(sub, span_normalize=False),
+                              rtol=1e-9, atol=1e-11)
+            assert r['segregating_sites'][i] == diversity.segregating_sites(sub)
+            assert r['singletons'][i] == diversity.singleton_count(sub)
+            assert np.isclose(
+                r['het_expected'][i],
+                float(np.nanmean(diversity.heterozygosity_expected(sub))),
+                rtol=1e-9, atol=1e-11)
+            td_w, td_ref = r['tajimas_d'][i], diversity.tajimas_d(sub)
+            if np.isnan(td_w) or np.isnan(td_ref):
+                assert np.isnan(td_w) and np.isnan(td_ref)
+            else:
+                assert np.isclose(td_w, td_ref, rtol=1e-9, atol=1e-11)
+
 
 class TestMultiallelicTwoPop:
     """Issue #100: two-pop windowed scalar stats must be

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -1172,6 +1172,95 @@ class TestMultiallelicTwoPop:
                 assert np.isclose(fst_w, fst_ref, rtol=1e-9, atol=1e-12)
 
 
+class TestMultiallelicCap:
+    """The fused windowed kernels can't represent an allele index at/above the
+    per-allele cap (``_FUSED_MAX_ALLELES``); such sites are dropped before launch
+    with a MultiallelicCapWarning, and the retained sites are computed exactly as
+    if the over-cap sites were absent. (The host scatter engine has no cap, so
+    this is fused-only.)"""
+
+    def _build(self, seed=0):
+        """Data with two over-cap sites among normal biallelic/low-multiallelic
+        sites. Returns (hm, hm_clean, bp, overcap)."""
+        from pg_gpu.windowed_analysis import _FUSED_MAX_ALLELES
+        rng = np.random.RandomState(seed)
+        n_hap, n_var, seq_len = 30, 60, 60_000
+        # nucleotide-scale alleles that stay strictly under the cap
+        within = min(4, _FUSED_MAX_ALLELES)
+        positions = np.sort(rng.choice(np.arange(1, seq_len), size=n_var,
+                                       replace=False)).astype(float)
+        hap = rng.randint(0, 2, (n_hap, n_var)).astype(np.int8)
+        # a few genuine multiallelic sites within the cap
+        for j in range(0, n_var, 12):
+            hap[:, j] = rng.randint(0, within, n_hap)
+        # two sites that hit the cap: one allele index == _FUSED_MAX_ALLELES,
+        # which the filter (>= cap) must drop
+        overcap = [15, 37]
+        for j in overcap:
+            hap[:, j] = rng.randint(0, within, n_hap)
+            hap[0, j] = _FUSED_MAX_ALLELES
+        hm = HaplotypeMatrix(hap, positions, chrom_start=0, chrom_end=seq_len)
+        keep = np.ones(n_var, dtype=bool)
+        keep[overcap] = False
+        hm_clean = HaplotypeMatrix(hap[:, keep], positions[keep],
+                                   chrom_start=0, chrom_end=seq_len)
+        for h in (hm, hm_clean):
+            n = h.num_haplotypes
+            h.sample_sets = {"p1": list(range(n // 2)),
+                             "p2": list(range(n // 2, n))}
+        bp = np.arange(0, seq_len + 20_000, 20_000, dtype=float)
+        return hm, hm_clean, bp, overcap
+
+    def test_fused_single_pop_cap_warns_and_matches(self):
+        from pg_gpu import MultiallelicCapWarning
+        from pg_gpu.windowed_analysis import windowed_statistics_fused
+        hm, hm_clean, bp, _ = self._build()
+        stats = ('pi', 'segregating_sites', 'theta_h')
+        with pytest.warns(MultiallelicCapWarning):
+            r = windowed_statistics_fused(hm, bp_bins=bp, statistics=stats,
+                                          per_base=False, chrom='1')
+        r_clean = windowed_statistics_fused(hm_clean, bp_bins=bp,
+                                            statistics=stats, per_base=False,
+                                            chrom='1')
+        for k in stats:
+            np.testing.assert_allclose(r[k], r_clean[k], rtol=1e-12,
+                                       equal_nan=True)
+        # dropped sites are not counted
+        np.testing.assert_array_equal(r['n_variants'], r_clean['n_variants'])
+
+    def test_fused_chunked_cap_warns_and_matches(self):
+        from pg_gpu import MultiallelicCapWarning
+        from pg_gpu.windowed_analysis import windowed_statistics_fused_chunked
+        hm, hm_clean, bp, _ = self._build()
+        stats = ('pi', 'segregating_sites')
+        with pytest.warns(MultiallelicCapWarning):
+            r = windowed_statistics_fused_chunked(hm, bp_bins=bp,
+                                                  statistics=stats,
+                                                  per_base=False, chrom='1')
+        r_clean = windowed_statistics_fused_chunked(hm_clean, bp_bins=bp,
+                                                    statistics=stats,
+                                                    per_base=False, chrom='1')
+        for k in stats:
+            np.testing.assert_allclose(r[k], r_clean[k], rtol=1e-12,
+                                       equal_nan=True)
+
+    def test_fused_two_pop_cap_warns_and_matches(self):
+        from pg_gpu import MultiallelicCapWarning
+        from pg_gpu.windowed_analysis import windowed_statistics_fused
+        hm, hm_clean, bp, _ = self._build()
+        stats = ('dxy', 'fst_hudson')
+        with pytest.warns(MultiallelicCapWarning):
+            r = windowed_statistics_fused(hm, bp_bins=bp, statistics=stats,
+                                          pop1='p1', pop2='p2', per_base=False,
+                                          chrom='1')
+        r_clean = windowed_statistics_fused(hm_clean, bp_bins=bp, statistics=stats,
+                                            pop1='p1', pop2='p2', per_base=False,
+                                            chrom='1')
+        for k in stats:
+            np.testing.assert_allclose(r[k], r_clean[k], rtol=1e-12,
+                                       equal_nan=True)
+
+
 class TestCanonicalWindowSchema:
     """Regression for issue #70: every dispatch path must emit the same
     window prefix columns so that cross-path requests and downstream joins

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -977,6 +977,82 @@ class TestMultiallelicSinglePop:
             else:
                 assert np.isclose(td_w, td_ref, rtol=1e-9, atol=1e-11)
 
+    @pytest.fixture(scope="class")
+    def sim_hm_missing(self, sim_hm):
+        """Multiallelic data with ~10% missing calls injected (-1)."""
+        import cupy as cp
+        hap = (sim_hm.haplotypes.get()
+               if isinstance(sim_hm.haplotypes, cp.ndarray)
+               else np.asarray(sim_hm.haplotypes)).copy()
+        pos = (sim_hm.positions.get()
+               if isinstance(sim_hm.positions, cp.ndarray)
+               else np.asarray(sim_hm.positions))
+        rng = np.random.RandomState(7)
+        hap[rng.random(hap.shape) < 0.1] = -1
+        return HaplotypeMatrix(hap, pos, chrom_start=sim_hm.chrom_start,
+                               chrom_end=sim_hm.chrom_end)
+
+    def test_per_variant_missing_data_matches_scalar(self, sim_hm_missing):
+        """With missing data, the per-variant engine still matches the scalar for
+        the stats that use per-site n_valid (everything except tajimas_d, whose
+        variance effective-n is a separate issue -- see the xfail below)."""
+        from pg_gpu.windowed_analysis import windowed_statistics
+        hm = sim_hm_missing
+        window_size = 25_000
+        bp = np.arange(0, int(hm.chrom_end) + window_size, window_size,
+                       dtype=float)
+        stats = ['pi', 'theta_w', 'segregating_sites', 'singletons',
+                 'het_expected']
+        r = windowed_statistics(hm, bp_bins=bp, statistics=stats,
+                                per_base=False, chrom='1')
+        for i, start in enumerate(r['start']):
+            stop = start + window_size
+            if stop > hm.chrom_end:
+                continue
+            sub = self._window_subset(hm, start, stop)
+            if sub.num_variants == 0:
+                continue
+            assert np.isclose(r['pi'][i], diversity.pi(sub, span_normalize=False),
+                              rtol=1e-9, atol=1e-11)
+            assert np.isclose(r['theta_w'][i],
+                              diversity.theta_w(sub, span_normalize=False),
+                              rtol=1e-9, atol=1e-11)
+            assert r['segregating_sites'][i] == diversity.segregating_sites(sub)
+            assert r['singletons'][i] == diversity.singleton_count(sub)
+            assert np.isclose(
+                r['het_expected'][i],
+                float(np.nanmean(diversity.heterozygosity_expected(sub))),
+                rtol=1e-9, atol=1e-11)
+
+    @pytest.mark.xfail(strict=True, reason=(
+        "windowed tajimas_d variance uses nominal n_hap; the scalar uses the "
+        "harmonic-mean effective n over per-site n_valid, so they diverge under "
+        "missing data (issue #100). Fixing the windowed effective-n convention "
+        "needs outside input; remove this marker when reconciled."))
+    def test_per_variant_missing_data_tajimas_d_matches_scalar(self,
+                                                               sim_hm_missing):
+        """Per-window tajimas_d should equal the scalar on the window subset;
+        currently diverges with missing data (effective-n convention)."""
+        from pg_gpu.windowed_analysis import windowed_statistics
+        hm = sim_hm_missing
+        window_size = 25_000
+        bp = np.arange(0, int(hm.chrom_end) + window_size, window_size,
+                       dtype=float)
+        r = windowed_statistics(hm, bp_bins=bp, statistics=['tajimas_d'],
+                                per_base=False, chrom='1')
+        for i, start in enumerate(r['start']):
+            stop = start + window_size
+            if stop > hm.chrom_end:
+                continue
+            sub = self._window_subset(hm, start, stop)
+            if sub.num_variants == 0:
+                continue
+            td_w, td_ref = r['tajimas_d'][i], diversity.tajimas_d(sub)
+            if np.isnan(td_w) or np.isnan(td_ref):
+                assert np.isnan(td_w) and np.isnan(td_ref)
+            else:
+                assert np.isclose(td_w, td_ref, rtol=1e-9, atol=1e-11)
+
 
 class TestMultiallelicTwoPop:
     """Issue #100: two-pop windowed scalar stats must be

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -799,13 +799,9 @@ class TestOverlappingWindowsScatter:
             assert df['fst'].notna().any()
             assert (df['fst'].dropna() >= -0.5).all()
 
-    @pytest.mark.xfail(strict=True, reason=(
-        "windowed_analysis pi still uses the legacy collapsed multiallelic "
-        "convention (pre-existing bug); it now detectably diverges from the "
-        "per-allele scalar diversity.pi on multiallelic data. Fixed in the "
-        "windowed subproject (kr-colab/pg_gpu#100) -- remove this marker then."))
     def test_non_overlapping_unchanged(self, sim_hm):
-        """Guard: step==window path (n_per_var=1) matches per-window reference."""
+        """Guard: step==window windowed pi equals per-window diversity.pi, now
+        that windowed_analysis uses the per-allele path (issue #100 / 0005a)."""
         window_size, step_size = 50_000, 50_000
         df = windowed_analysis(sim_hm, window_size=window_size,
                                step_size=step_size, statistics=['pi'],
@@ -871,6 +867,86 @@ class TestOverlappingWindowsScatter:
             assert np.isclose(max_daf_scatter, ref, atol=1e-12), (
                 f"window [{start}, {stop}): scatter={max_daf_scatter}, "
                 f"ref={ref}")
+
+
+class TestMultiallelicSinglePop:
+    """Issue #100 / subproject 0005a: single-pop windowed scalar stats must
+    be multiallelic-correct -- each window equals the per-allele scalar
+    ``diversity`` function on that window's subset -- on BOTH single-pop
+    engines: the host scatter path (``_windowed_thetas_scatter``, reached by a
+    pure single-pop scalar request) and the fused CUDA kernel
+    (``_fused_windowed_kernel_v2`` via ``windowed_statistics_fused``)."""
+
+    @pytest.fixture(scope="class")
+    def sim_hm(self):
+        import msprime
+        ts = msprime.sim_ancestry(
+            samples=25, sequence_length=100_000, recombination_rate=1e-8,
+            population_size=20_000, ploidy=2, random_seed=42)
+        ts = msprime.sim_mutations(
+            ts, rate=1e-6, model=msprime.JC69(state_independent=True),
+            random_seed=43)
+        # Sanity: this configuration produces genuinely multiallelic sites,
+        # so the per-allele path is actually exercised (not just biallelic).
+        G = ts.genotype_matrix()
+        n_multi = sum(np.unique(G[i]).size >= 3 for i in range(ts.num_sites))
+        assert n_multi > 50, f"fixture not multiallelic enough: {n_multi}"
+        return HaplotypeMatrix.from_ts(ts)
+
+    def _window_subset(self, hm, start, stop):
+        import cupy as cp
+        pos = hm.positions.get() if isinstance(hm.positions, cp.ndarray) else np.asarray(hm.positions)
+        hap = hm.haplotypes.get() if isinstance(hm.haplotypes, cp.ndarray) else np.asarray(hm.haplotypes)
+        mask = (pos >= start) & (pos < stop)
+        return HaplotypeMatrix(hap[:, mask], pos[mask],
+                               chrom_start=int(start), chrom_end=int(stop))
+
+    def test_scatter_path_matches_scalar(self, sim_hm):
+        """Host scatter engine: per-window pi/theta_w/segregating equal the
+        per-allele scalar functions on the window subset."""
+        window_size = 25_000
+        df = windowed_analysis(sim_hm, window_size=window_size,
+                               step_size=window_size,
+                               statistics=['pi', 'theta_w', 'segregating_sites'],
+                               span_normalize=False)
+        for start, pi_w, tw_w, seg_w in zip(
+                df['start'], df['pi'], df['theta_w'], df['segregating_sites']):
+            stop = start + window_size
+            if stop > sim_hm.chrom_end:
+                continue
+            sub = self._window_subset(sim_hm, start, stop)
+            if sub.num_variants == 0:
+                continue
+            assert np.isclose(pi_w, diversity.pi(sub, span_normalize=False),
+                              rtol=1e-9, atol=1e-12)
+            assert np.isclose(tw_w, diversity.theta_w(sub, span_normalize=False),
+                              rtol=1e-9, atol=1e-12)
+            assert np.isclose(seg_w, diversity.segregating_sites(sub),
+                              rtol=1e-9, atol=1e-12)
+
+    def test_fused_kernel_matches_scalar(self, sim_hm):
+        """Fused CUDA kernel: per-window pi/segregating/theta_h equal the
+        per-allele scalar functions on the window subset."""
+        from pg_gpu.windowed_analysis import windowed_statistics_fused
+        window_size = 25_000
+        bp = np.arange(0, int(sim_hm.chrom_end) + window_size, window_size,
+                       dtype=float)
+        r = windowed_statistics_fused(
+            sim_hm, bp_bins=bp,
+            statistics=('pi', 'segregating_sites', 'theta_h'),
+            per_base=False, chrom='1')
+        for start, pi_w, seg_w in zip(r['start'], r['pi'],
+                                      r['segregating_sites']):
+            stop = start + window_size
+            if stop > sim_hm.chrom_end:
+                continue
+            sub = self._window_subset(sim_hm, start, stop)
+            if sub.num_variants == 0:
+                continue
+            assert np.isclose(pi_w, diversity.pi(sub, span_normalize=False),
+                              rtol=1e-9, atol=1e-12)
+            assert np.isclose(seg_w, diversity.segregating_sites(sub),
+                              rtol=1e-9, atol=1e-12)
 
 
 class TestCanonicalWindowSchema:


### PR DESCRIPTION
Based on #130 for a clean diff.

**Background:** `windowed_analysis.py` computes its scalar statistics through three separate engines -- a host scatter-add path, fused CUDA kernels, and a per-variant path. All three collapsed multiallelic sites, so windowed pi/theta/Tajima/segregating/singletons and dxy/fst/da were wrong on multiallelic sites. This PR makes every windowed engine per-allele so each window equals the scalar function on that window's variants (with some exceptions that require discussion). Biallelic data is unchanged except where noted below.

### What changed

**Single-pop, all three engines**:
- Host scatter `_windowed_thetas_scatter`: `_prepare_dac`/`_site_contribution` changed to `diversity._prepare_allele_counts`/`_ac_contribution`. Covers pi, theta_w/h/l, tajimas_d, segregating_sites, singletons, the Fay-Wu/Zeng neutrality tests, max_daf.
- Fused kernel `_fused_windowed_kernel_v2` (drives `windowed_statistics_fused` and `_chunked`): uses per-variant `cnt[MAX_ALLELES]` array instead of a single `dac`. Covers per-allele pi / mutation-count segregating / singleton / theta_h / max_daf.
- Per-variant `windowed_statistics`: per-allele pi, theta_w, segregating_sites, singletons, tajimas_d, and "het_expected" (which only this engine exposes).

**Two-pop, all three engines**:
- `_twopop_site_components` (used by both the scatter engine and the per-variant path) and `_fused_windowed_twopop_kernel`: per-allele within-pop (`sum_a c(c-1)`) and between-pop (`sum_a c1*c2`) pair counts 
- The fused kernel's `fst_wc` output is left untouched (see Deferred).

**Scalar bugfix (divergence.py):** `dxy(span_normalize=False)` (and therefore `da(span_normalize=False)`) returned `dxy_sum / n_sites` while `pi` and every other statistic return the raw sum. Now `dxy` falls through to the
shared `_apply_span_normalize` and returns the raw sum.

**MAX_ALLELES cap:** the fused CUDA kernels need a fixed-size per-allele array with hardcoded size `MAX_ALLELES = 8`. Sites with an allele index >= 8 are dropped before kernel launch with a new `MultiallelicCapWarning`. The added overhead seems to be ~2% of the end-to-end call. However the `cnt[]` array stays in registers (out of local memory) so it is sample-size independent. However we should benchmark further when this whole multiallelic thrust is wrapped up.

**Cleanup:** removed the now-dead collapsed helpers `_allele_sum_and_n`, `_per_variant_mpd`, `_per_variant_is_seg`, `_per_variant_is_singleton`.

## Behaviour changes

We want the windowed statistics to mirror the scalar path---we should always try to be internally consistent.

**Multiallelic corrected**: pi, theta_w/h/l, tajimas_d, segregating_sites, singletons, max_daf, het_expected, dxy, fst/fst_hudson, da from all windowed engines now match the per-allele scalar functions per window if there's no missing data (see below). Output on biallelic data is unaffected.

**Span normalisation bugfix in `divergence.dxy` / `da`:** see description above.

**`windowed_statistics` changes for consistency with scalar path:**
- `singletons`: was folded (`dac==1 or dac==n-1`, counting ancestral-allele singletons too); now unfolded (derived alleles observed exactly once.
- `segregating_sites`: now the mutation count (`#alleles_present - 1`); identical to the old boolean is-segregating flag for biallelic and matches tskit for multiallelic.
- `theta_w` / `tajimas_d` numerator: now use the per-site `a1(n_valid)` instead of a single `a1(n_hap)`. Identical without missing data; corrected under missing data.

## Deferred (tracked as separate issues)

1. Windowed `fst_wc` (Weir-Cockerham) computed by the fused kernel is a haploid estimator, and disagrees with the scalar diploid `fst_weir_cockerham` even on biallelic data. This PR didn't touch fst_wc, as it will likely need to be rewritten for parity.

2. Windowed neutrality-test variance uses nominal `n_hap`, while the scalar uses the harmonic-mean effective `n` over per-site `n_valid`. So windowed `tajimas_d` (and `normalized_fay_wu_h`, `zeng_e`, `zeng_dh`) diverge from the scalar under missing data.

3. We need some more stringent testing for cross-implementation parity

## Verification

New coverage in `tests/test_windowed_analysis.py`:
- `TestMultiallelicSinglePop`: scatter, fused, and per-variant engines vs scalar for the six single-pop stats on a genuinely multiallelic (JC69) fixture; plus a missing-data parity test (pi/theta_w/segregating_sites/singletons/het_expected pass) and a `xfail(strict)` missing-data `tajimas_d` test (the effective-n issue above).
- `TestMultiallelicTwoPop`: scatter, fused, and per-variant engines vs scalar for dxy/fst_hudson/da on the multiallelic fixture.