### PR TITLE
Multiallelic support for iHS and nSL selection statistics

### DIFF
--- a/pg_gpu/selection.py
+++ b/pg_gpu/selection.py
@@ -321,6 +321,14 @@ def nsl(haplotype_matrix: HaplotypeMatrix,
         is absent at a site). ``standardize_by_allele_count`` takes 1-D input,
         so standardize each derived-allele column separately, pairing column
         ``j`` with that allele's per-site derived count.
+
+    Notes
+    -----
+    nSL scans the shared-haplotype length in both directions across the whole
+    input, so scores depend on the full region. Subsetting or chunking the
+    variants (e.g. windowing via ``mean_nsl``, or a StreamingHaplotypeMatrix)
+    truncates the scan and changes the scores; materialize the region eagerly
+    for a chromosome-wide result.
     """
     if population is not None:
         matrix = _get_population_matrix(haplotype_matrix, population)
@@ -476,6 +484,13 @@ def ihs(haplotype_matrix: HaplotypeMatrix,
         is absent, or the allele is MAF-filtered). ``standardize_by_allele_count``
         takes 1-D input, so standardize each derived-allele column separately,
         pairing column ``j`` with that allele's per-site derived count.
+
+    Notes
+    -----
+    iHS integrates EHH outward from each focal site across the whole input, so
+    scores depend on the full region. Subsetting or chunking the variants (e.g.
+    windowing, or a StreamingHaplotypeMatrix) truncates the scan and changes the
+    scores; materialize the region eagerly for a chromosome-wide result.
     """
     if population is not None:
         matrix = _get_population_matrix(haplotype_matrix, population)

--- a/pg_gpu/selection.py
+++ b/pg_gpu/selection.py
@@ -12,6 +12,7 @@ import cupy as cp
 from typing import Union, Optional, Tuple
 from .haplotype_matrix import HaplotypeMatrix
 from ._utils import get_population_matrix as _get_population_matrix
+from ._memutil import allele_counts
 
 
 # ---------------------------------------------------------------------------
@@ -295,8 +296,10 @@ def nsl(haplotype_matrix: HaplotypeMatrix,
         missing_data: str = 'include'):
     """Compute the unstandardized nSL statistic for each variant.
 
-    Compares the mean shared haplotype length around the reference (0)
-    vs alternate (1) allele at each site.
+    Compares the mean shared haplotype length around the ancestral (0) vs each
+    derived allele at a site, one-vs-ancestral. On a biallelic site this is the
+    classic nSL. On a multiallelic focal site each derived allele gets its own
+    score.
 
     Parameters
     ----------
@@ -310,8 +313,14 @@ def nsl(haplotype_matrix: HaplotypeMatrix,
 
     Returns
     -------
-    score : ndarray, float, shape (n_variants,)
-        Unstandardized nSL scores: log(nSL1 / nSL0).
+    score : ndarray, float
+        Unstandardized nSL scores ``log(nSL_a / nSL_0)``. Shape
+        ``(n_variants,)`` for biallelic data; ``(n_variants, K-1)`` when the
+        matrix has ``K > 2`` alleles, where column ``j`` is the score for
+        derived allele ``j+1`` (NaN where that allele or the ancestral allele
+        is absent at a site). ``standardize_by_allele_count`` takes 1-D input,
+        so standardize each derived-allele column separately, pairing column
+        ``j`` with that allele's per-site derived count.
     """
     if population is not None:
         matrix = _get_population_matrix(haplotype_matrix, population)
@@ -331,19 +340,24 @@ def nsl(haplotype_matrix: HaplotypeMatrix,
     # pg_gpu: (n_haplotypes, n_variants) -> allel convention: (n_variants, n_haplotypes)
     hap = matrix.haplotypes.T  # now (n_variants, n_haplotypes)
 
-    # forward scan
-    nsl0_fwd, nsl1_fwd = _nsl01_scan_gpu(hap)
+    # One log(nSL_a / nSL_0) column per derived allele a (one-vs-ancestral).
+    # Biallelic data has a single derived allele and returns a 1-D array
+    # identical to the classic nSL.
+    max_allele = int(matrix.haplotypes.max()) if matrix.num_variants else 0
+    if max_allele < 1:
+        return np.full(matrix.num_variants, np.nan)
 
-    # backward scan
-    nsl0_rev, nsl1_rev = _nsl01_scan_gpu(hap[::-1])
-    nsl0_rev = nsl0_rev[::-1]
-    nsl1_rev = nsl1_rev[::-1]
+    cols = []
+    for a in range(1, max_allele + 1):
+        nsl0_fwd, nsla_fwd = _nsl01_scan_gpu(hap, focal_allele=a)
+        nsl0_rev, nsla_rev = _nsl01_scan_gpu(hap[::-1], focal_allele=a)
+        nsl0 = nsl0_fwd + nsl0_rev[::-1]
+        nsla = nsla_fwd + nsla_rev[::-1]
+        cols.append(cp.log(nsla / nsl0))
 
-    nsl0 = nsl0_fwd + nsl0_rev
-    nsl1 = nsl1_fwd + nsl1_rev
-
-    score = cp.log(nsl1 / nsl0)
-    return score.get()
+    if len(cols) == 1:
+        return cols[0].get()
+    return cp.stack(cols, axis=1).get()
 
 
 def xpnsl(haplotype_matrix: HaplotypeMatrix,
@@ -421,8 +435,10 @@ def ihs(haplotype_matrix: HaplotypeMatrix,
         missing_data: str = 'include'):
     """Compute the unstandardized integrated haplotype score (iHS).
 
-    Compares the integrated EHH for the reference vs alternate allele
-    at each variant.
+    Compares the integrated EHH for the ancestral (0) vs each derived allele at
+    a site, one-vs-ancestral. On a biallelic site this is the classic iHS. On a
+    multiallelic focal site each derived allele gets its own score, and
+    ``min_maf`` is applied per derived allele.
 
     Parameters
     ----------
@@ -452,8 +468,14 @@ def ihs(haplotype_matrix: HaplotypeMatrix,
 
     Returns
     -------
-    score : ndarray, float, shape (n_variants,)
-        Unstandardized iHS scores: log(IHH1 / IHH0).
+    score : ndarray, float
+        Unstandardized iHS scores ``log(IHH_a / IHH_0)``. Shape
+        ``(n_variants,)`` for biallelic data; ``(n_variants, K-1)`` when the
+        matrix has ``K > 2`` alleles, where column ``j`` is the score for
+        derived allele ``j+1`` (NaN where that allele or the ancestral allele
+        is absent, or the allele is MAF-filtered). ``standardize_by_allele_count``
+        takes 1-D input, so standardize each derived-allele column separately,
+        pairing column ``j`` with that allele's per-site derived count.
     """
     if population is not None:
         matrix = _get_population_matrix(haplotype_matrix, population)
@@ -487,25 +509,34 @@ def ihs(haplotype_matrix: HaplotypeMatrix,
     gaps = _compute_gaps(pos, map_pos, gap_scale, max_gap, is_accessible)
     gaps_gpu = cp.asarray(gaps)
 
-    # Histogram kernel with warp-aggregated atomics, stride-based access,
-    # and on-the-fly pair computation. No contiguous copies needed.
-    scan_fn = _ihh01_scan_hist_gpu
+    # Per-allele counts, computed once and reused (forward + reversed) for
+    # every derived allele: column a of ac is the count of allele a, column 0
+    # is the ancestral allele.
+    max_allele = int(matrix.haplotypes.max()) if matrix.num_variants else 0
+    if max_allele < 1:
+        return np.full(matrix.num_variants, np.nan)
+    ac, n_valid = allele_counts(matrix.haplotypes, n_alleles=max_allele + 1)
+    n0 = ac[:, 0]
 
-    # forward scan
-    ihh0_fwd, ihh1_fwd = scan_fn(hap, gaps_gpu, min_ehh, min_maf,
-                                  include_edges)
-    # backward scan (reversed view, no copy)
-    ihh0_rev, ihh1_rev = scan_fn(
-        hap[::-1], gaps_gpu[::-1],
-        min_ehh, min_maf, include_edges)
-    ihh0_rev = ihh0_rev[::-1]
-    ihh1_rev = ihh1_rev[::-1]
+    # One log(IHH_a / IHH_0) column per derived allele a (one-vs-ancestral).
+    # Biallelic data has a single derived allele and returns a 1-D array
+    # identical to the classic iHS.
+    cols = []
+    for a in range(1, max_allele + 1):
+        na = ac[:, a]
+        ihh0_fwd, ihha_fwd = _ihh01_scan_hist_gpu(
+            hap, gaps_gpu, n0, na, n_valid, a,
+            min_ehh, min_maf, include_edges)
+        ihh0_rev, ihha_rev = _ihh01_scan_hist_gpu(
+            hap[::-1], gaps_gpu[::-1], n0[::-1], na[::-1], n_valid[::-1], a,
+            min_ehh, min_maf, include_edges)
+        ihh0 = ihh0_fwd + ihh0_rev[::-1]
+        ihha = ihha_fwd + ihha_rev[::-1]
+        cols.append(cp.log(ihha / ihh0))
 
-    # Combine and score on GPU, single D2H transfer at end
-    ihh0 = ihh0_fwd + ihh0_rev
-    ihh1 = ihh1_fwd + ihh1_rev
-    score = cp.log(ihh1 / ihh0)
-    return score.get()
+    if len(cols) == 1:
+        return cols[0].get()
+    return cp.stack(cols, axis=1).get()
 
 
 def xpehh(haplotype_matrix: HaplotypeMatrix,
@@ -731,6 +762,7 @@ extern "C" __global__
 void nsl01_scan_kernel(const signed char* h, int n_variants, int n_haplotypes,
                        long long stride_var, long long stride_hap,
                        const int* pair_j, const int* pair_k, int n_pairs,
+                       int focal_allele,
                        double* ssl_sum_00, double* ssl_sum_11,
                        int* count_00, int* count_11) {
     // Each thread handles one haplotype pair across all variants.
@@ -751,12 +783,16 @@ void nsl01_scan_kernel(const signed char* h, int n_variants, int n_haplotypes,
         double sv00 = 0.0, sv11 = 0.0;
         int c00 = 0, c11 = 0;
 
+        // One-vs-ancestral focal split: a homozygous ancestral pair scores
+        // class 0, a homozygous focal-allele pair scores class 1. A homozygous
+        // pair of any other allele extends the shared run but scores neither
+        // (it belongs to a different derived allele's one-vs-ancestral test).
         if (a1 < 0 || a2 < 0) {
             ssl += 1;
         } else if (a1 == a2) {
             ssl += 1;
             if (a1 == 0) { sv00 = (double)ssl; c00 = 1; }
-            else          { sv11 = (double)ssl; c11 = 1; }
+            else if (a1 == focal_allele) { sv11 = (double)ssl; c11 = 1; }
         } else {
             ssl = 0;
         }
@@ -831,8 +867,9 @@ def _get_pair_indices(n_haplotypes):
 # Private helpers: SSL-based scans for nSL
 # ---------------------------------------------------------------------------
 
-def _nsl01_scan_gpu(h):
-    """Forward scan computing mean SSL for ref (0) and alt (1) allele classes.
+def _nsl01_scan_gpu(h, focal_allele=1):
+    """Forward scan computing mean SSL for the ancestral (0) and focal-allele
+    classes.
 
     Uses a stride-aware CUDA kernel with one thread per haplotype pair.
     Reads transposed/reversed views directly without copying.
@@ -841,6 +878,9 @@ def _nsl01_scan_gpu(h):
     ----------
     h : cupy.ndarray, shape (n_variants, n_haplotypes)
         Can be a non-contiguous view (e.g., from .T or [::-1]).
+    focal_allele : int
+        Derived allele index scored against the ancestral (0) class. On
+        biallelic data this is 1 and reproduces the classic nSL.
 
     Returns
     -------
@@ -867,7 +907,7 @@ def _nsl01_scan_gpu(h):
     _nsl01_kernel((grid,), (block,),
                   (h_view, np.int32(n_variants), np.int32(n_haplotypes),
                    np.int64(s0), np.int64(s1),
-                   pair_j, pair_k, np.int32(n_pairs),
+                   pair_j, pair_k, np.int32(n_pairs), np.int32(focal_allele),
                    ssl_sum_00, ssl_sum_11, count_00, count_11))
 
     nsl0 = cp.where(count_00 > 0, ssl_sum_00 / count_00, cp.nan)
@@ -986,10 +1026,11 @@ void ihh01_ssl_pervar_kernel_v2(
     int n_haplotypes,
     int n_pairs,
     int* hist00,              // (chunk_len, hist_size) for 0-0 pairs
-    int* hist11,              // (chunk_len, hist_size) for 1-1 pairs
+    int* hist11,              // (chunk_len, hist_size) for focal-focal pairs
     int* ssl_state,           // (n_pairs,) persistent across chunks
     int hist_size,
-    int chunk_start           // offset into global variant index
+    int chunk_start,          // offset into global variant index
+    int focal_allele          // derived allele scored against the ancestral (0)
 ) {
     int pid = blockDim.x * blockIdx.x + threadIdx.x;
     if (pid >= n_pairs) return;
@@ -1017,7 +1058,7 @@ void ihh01_ssl_pervar_kernel_v2(
 
         int bucket = ssl < hist_size ? ssl : hist_size - 1;
         int is_class00 = (h1 == 0 && h2 == 0) ? 1 : 0;
-        int is_class11 = (h1 == 1 && h2 == 1) ? 1 : 0;
+        int is_class11 = (h1 == focal_allele && h2 == focal_allele) ? 1 : 0;
 
         // Warp-aggregated histogram deposits using __match_any_sync
         unsigned match_bucket = __match_any_sync(0xFFFFFFFF, bucket);
@@ -1038,34 +1079,6 @@ void ihh01_ssl_pervar_kernel_v2(
     ssl_state[pid] = ssl;
 }
 ''', 'ihh01_ssl_pervar_kernel_v2')
-
-
-_count_alleles_kernel = cp.RawKernel(r'''
-extern "C" __global__
-void count_alleles_kernel(
-    const signed char* h,     // haplotype matrix base pointer
-    long long stride_var,     // byte stride between variant rows
-    long long stride_hap,     // byte stride between haplotype columns
-    int chunk_len,
-    int n_haplotypes,
-    int chunk_start,
-    int* n0,                  // (chunk_len,) output count of 0 alleles
-    int* n1                   // (chunk_len,) output count of 1 alleles
-) {
-    int ci = blockDim.x * blockIdx.x + threadIdx.x;
-    if (ci >= chunk_len) return;
-
-    long long vi = chunk_start + ci;
-    int c0 = 0, c1 = 0;
-    for (int j = 0; j < n_haplotypes; j++) {
-        signed char v = h[vi * stride_var + j * stride_hap];
-        if (v == 0) c0++;
-        else if (v == 1) c1++;
-    }
-    n0[ci] = c0;
-    n1[ci] = c1;
-}
-''', 'count_alleles_kernel')
 
 
 _ihh_ssl_kernel = cp.RawKernel(r'''
@@ -1232,9 +1245,11 @@ def _integrate_ihh_gpu(hist, gaps, n_pairs_arr, chunk_start, min_ehh,
 # Private helpers: SSL-based scans for IHS
 # ---------------------------------------------------------------------------
 
-def _ihh01_scan_hist_gpu(h, gaps, min_ehh=0.05, min_maf=0.05,
+def _ihh01_scan_hist_gpu(h, gaps, n0_counts, na_counts, n_valid, focal_allele,
+                         min_ehh=0.05, min_maf=0.05,
                          include_edges=False, max_ssl_cap=None):
-    """Forward scan computing IHH for ref/alt allele classes via histograms.
+    """Forward scan computing IHH for the ancestral (0) and focal-allele
+    classes via histograms.
 
     Uses warp-aggregated atomics, on-the-fly pair index computation, and
     stride-based access to eliminate pair arrays and contiguous copies.
@@ -1245,6 +1260,14 @@ def _ihh01_scan_hist_gpu(h, gaps, min_ehh=0.05, min_maf=0.05,
     h : cupy.ndarray, shape (n_variants, n_haplotypes)
         Can be a non-contiguous view (e.g., from [::-1]).
     gaps : cupy.ndarray, float64, shape (n_variants - 1,)
+    n0_counts, na_counts : cupy.ndarray, shape (n_variants,)
+        Per-site counts of the ancestral allele (0) and the focal derived
+        allele, in the same variant order as ``h`` (reverse them for a
+        reversed scan). Precomputed once via ``allele_counts`` and reused.
+    n_valid : cupy.ndarray, shape (n_variants,)
+        Non-missing haplotypes per site, same order as ``h``.
+    focal_allele : int
+        Derived allele scored against the ancestral (0) class.
     min_ehh, min_maf : float
     include_edges : bool
     max_ssl_cap : int or None
@@ -1252,7 +1275,7 @@ def _ihh01_scan_hist_gpu(h, gaps, min_ehh=0.05, min_maf=0.05,
     Returns
     -------
     ihh0 : cp.ndarray, float64, shape (n_variants,)
-    ihh1 : cp.ndarray, float64, shape (n_variants,)
+    ihh_a : cp.ndarray, float64, shape (n_variants,)
     """
     n_variants, n_haplotypes = h.shape
     n_pairs = (n_haplotypes * (n_haplotypes - 1)) // 2
@@ -1274,16 +1297,12 @@ def _ihh01_scan_hist_gpu(h, gaps, min_ehh=0.05, min_maf=0.05,
 
     block_ssl = 256
     grid_ssl = (n_pairs + block_ssl - 1) // block_ssl
-    block_ac = 256
-    grid_ac_fn = lambda c: (c + block_ac - 1) // block_ac  # noqa: E731
 
     ihh0_out = cp.empty(n_variants, dtype=cp.float64)
-    ihh1_out = cp.empty(n_variants, dtype=cp.float64)
+    ihha_out = cp.empty(n_variants, dtype=cp.float64)
     ssl_state = cp.zeros(n_pairs, dtype=cp.int32)
 
     # Pre-allocate per-chunk buffers (reused across chunks; ~2 GB hists)
-    n0_buf = cp.empty(chunk_size, dtype=cp.int32)
-    n1_buf = cp.empty(chunk_size, dtype=cp.int32)
     hist00_buf = cp.empty((chunk_size, hist_size), dtype=cp.int32)
     hist11_buf = cp.empty((chunk_size, hist_size), dtype=cp.int32)
 
@@ -1300,33 +1319,33 @@ def _ihh01_scan_hist_gpu(h, gaps, min_ehh=0.05, min_maf=0.05,
             (h_view, np.int64(s0), np.int64(s1),
              np.int32(c_len), np.int32(n_haplotypes), np.int32(n_pairs),
              hist00, hist11, ssl_state, np.int32(hist_size),
-             np.int32(chunk_start)))
+             np.int32(chunk_start), np.int32(focal_allele)))
 
-        n0_chunk = n0_buf[:c_len]
-        n1_chunk = n1_buf[:c_len]
-        _count_alleles_kernel((grid_ac_fn(c_len),), (block_ac,),
-            (h_view, np.int64(s0), np.int64(s1),
-             np.int32(c_len), np.int32(n_haplotypes),
-             np.int32(chunk_start), n0_chunk, n1_chunk))
+        n0_chunk = n0_counts[chunk_start:chunk_end]
+        na_chunk = na_counts[chunk_start:chunk_end]
+        nv_chunk = n_valid[chunk_start:chunk_end]
 
         n00 = (n0_chunk * (n0_chunk - 1) // 2).astype(cp.int32)
-        n11 = (n1_chunk * (n1_chunk - 1) // 2).astype(cp.int32)
+        naa = (na_chunk * (na_chunk - 1) // 2).astype(cp.int32)
 
         ihh0_chunk = _integrate_ihh_gpu(hist00, gaps_contig, n00,
                                          chunk_start, min_ehh, include_edges)
-        ihh1_chunk = _integrate_ihh_gpu(hist11, gaps_contig, n11,
+        ihha_chunk = _integrate_ihh_gpu(hist11, gaps_contig, naa,
                                          chunk_start, min_ehh, include_edges)
 
-        total = (n0_chunk + n1_chunk).astype(cp.float64)
-        minor = cp.minimum(n0_chunk, n1_chunk).astype(cp.float64)
-        maf_fail = (total == 0) | (minor / cp.maximum(total, 1) < min_maf)
+        # Per-allele MAF: the focal allele's own frequency among valid
+        # haplotypes. Reduces to min(n0,n1)/(n0+n1) on biallelic sites and
+        # makes a common allele with index >= 2 visible to the filter.
+        freq_a = na_chunk.astype(cp.float64) / cp.maximum(nv_chunk.astype(cp.float64), 1.0)
+        maf = cp.minimum(freq_a, 1.0 - freq_a)
+        maf_fail = (nv_chunk == 0) | (maf < min_maf)
         ihh0_chunk[maf_fail] = cp.nan
-        ihh1_chunk[maf_fail] = cp.nan
+        ihha_chunk[maf_fail] = cp.nan
 
         ihh0_out[chunk_start:chunk_end] = ihh0_chunk
-        ihh1_out[chunk_start:chunk_end] = ihh1_chunk
+        ihha_out[chunk_start:chunk_end] = ihha_chunk
 
-    return ihh0_out, ihh1_out
+    return ihh0_out, ihha_out
 
 
 def _ihh_scan_gpu(h, gaps, min_ehh=0.05, include_edges=False,

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -1083,6 +1083,12 @@ def _stream_windowed_analysis(streaming_hm, *, window_size, step_size,
     dispatch both need cross-chunk state and are not yet supported on the
     streaming path; both raise rather than silently returning wrong
     results.
+
+    ``mean_nsl`` is computed per chunk. Unlike the per-site statistics, nSL
+    integrates the shared-haplotype length in both directions across every
+    variant, so a per-chunk scan is truncated at the chunk boundaries: the
+    streaming result approximates the eager whole-region computation rather
+    than reproducing it. Materialize the region eagerly for an exact nSL scan.
     """
     if step_size is None:
         step_size = window_size
@@ -2129,6 +2135,10 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
     if 'mean_nsl' in statistics:
         from . import selection as sel
         # matrix is already population-subsetted (line 1533); don't re-subset.
+        # nSL is scanned once over this whole (eager) matrix, so each per-site
+        # score sees the full region before being binned into windows. Over a
+        # StreamingHaplotypeMatrix this runs per chunk, truncating the scan at
+        # chunk boundaries (see _stream_windowed_analysis).
         # nsl() returns (n_var,) for biallelic data and (n_var, n_derived) when
         # multiallelic focal sites are present; average every finite
         # (site, allele) score falling in each window.

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -2128,10 +2128,17 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
 
     if 'mean_nsl' in statistics:
         from . import selection as sel
-        # matrix is already population-subsetted (line 1533); don't re-subset
-        nsl_gpu = cp.asarray(sel.nsl(matrix))
-        valid = cp.isfinite(nsl_gpu) & in_range
-        results['mean_nsl'] = _windowed_mean(nsl_gpu, bin_idx, valid, n_windows)
+        # matrix is already population-subsetted (line 1533); don't re-subset.
+        # nsl() returns (n_var,) for biallelic data and (n_var, n_derived) when
+        # multiallelic focal sites are present; average every finite
+        # (site, allele) score falling in each window.
+        nsl_2d = cp.asarray(sel.nsl(matrix)).reshape(matrix.num_variants, -1)
+        m = nsl_2d.shape[1]
+        vals_flat = nsl_2d.reshape(-1)
+        bin_flat = cp.repeat(bin_idx, m)
+        inrange_flat = cp.repeat(in_range, m)
+        valid = cp.isfinite(vals_flat) & inrange_flat
+        results['mean_nsl'] = _windowed_mean(vals_flat, bin_flat, valid, n_windows)
 
     # SNP distance stats per window
     snp_dist_stats = {'snp_dist_mean', 'snp_dist_var', 'snp_dist_min',

--- a/tests/test_selection_multiallelic.py
+++ b/tests/test_selection_multiallelic.py
@@ -1,0 +1,250 @@
+"""Multiallelic support for iHS / nSL (issue #140).
+
+scikit-allel's ihs/nsl and tskit have no multiallelic iHS/nSL, so there is no
+external oracle. The multiallelic path is validated three ways:
+
+  * biallelic reduction -- on biallelic data the new code returns a 1-D array
+    and matches the scikit-allel oracle (the existing parity behaviour).
+  * relabel invariance -- recoding the single derived allele 1 -> 2 must move
+    the score to column 1 and leave column 0 (now-absent allele 1) all-NaN,
+    with the allele-2 score bit-identical to the original biallelic score.
+  * brute-force reference -- a pure-numpy one-vs-ancestral nSL scan reproduces
+    the GPU per-allele scores on genuinely triallelic data.
+"""
+
+import numpy as np
+import pytest
+import allel
+
+from pg_gpu import HaplotypeMatrix, selection
+from pg_gpu.windowed_analysis import windowed_analysis
+
+
+def _mat(hap, pos=None):
+    hap = np.asarray(hap, dtype=np.int8)
+    n_var = hap.shape[1]
+    if pos is None:
+        pos = np.arange(n_var, dtype=np.float64) * 1000 + 1
+    return HaplotypeMatrix(hap.copy(), pos, 0, int(pos[-1]) + 1)
+
+
+# ---------------------------------------------------------------------------
+# Brute-force pure-numpy nSL reference (one derived allele vs ancestral 0)
+# ---------------------------------------------------------------------------
+
+def _nsl_scan_ref(hap, focal_allele):
+    """One-direction mean-SSL scan, mirroring _nsl01_kernel exactly.
+
+    hap : (n_hap, n_var). Returns per-site mean SSL for the ancestral (0) and
+    focal-allele homozygous pair classes (NaN where a class is empty).
+    """
+    n_hap, n_var = hap.shape
+    s0 = np.zeros(n_var)
+    c0 = np.zeros(n_var, dtype=int)
+    sa = np.zeros(n_var)
+    ca = np.zeros(n_var, dtype=int)
+    for j in range(n_hap):
+        for k in range(j + 1, n_hap):
+            ssl = 0
+            for i in range(n_var):
+                a1 = int(hap[j, i])
+                a2 = int(hap[k, i])
+                if a1 < 0 or a2 < 0:
+                    ssl += 1
+                elif a1 == a2:
+                    ssl += 1
+                    if a1 == 0:
+                        s0[i] += ssl
+                        c0[i] += 1
+                    elif a1 == focal_allele:
+                        sa[i] += ssl
+                        ca[i] += 1
+                else:
+                    ssl = 0
+    nsl0 = np.where(c0 > 0, s0 / np.maximum(c0, 1), np.nan)
+    nsla = np.where(ca > 0, sa / np.maximum(ca, 1), np.nan)
+    return nsl0, nsla
+
+
+def _nsl_ref(hap, focal_allele):
+    """Full forward+reverse nSL reference for one derived allele."""
+    f0, fa = _nsl_scan_ref(hap, focal_allele)
+    r0, ra = _nsl_scan_ref(hap[:, ::-1], focal_allele)
+    nsl0 = f0 + r0[::-1]
+    nsla = fa + ra[::-1]
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return np.log(nsla / nsl0)
+
+
+# ---------------------------------------------------------------------------
+# Biallelic reduction: 1-D output that matches the scikit-allel oracle
+# ---------------------------------------------------------------------------
+
+class TestBiallelicReduction:
+    @pytest.fixture
+    def biallelic(self):
+        rng = np.random.RandomState(42)
+        hap = rng.randint(0, 2, (40, 200)).astype(np.int8)
+        pos = (np.arange(200) * 500 + 1).astype(np.float64)
+        return hap, pos
+
+    def test_nsl_biallelic_is_1d_and_matches_allel(self, biallelic):
+        hap, pos = biallelic
+        score = selection.nsl(_mat(hap, pos))
+        assert score.ndim == 1 and score.shape == (200,)
+        ref = allel.nsl(hap.T, use_threads=False)  # allel layout (n_var, n_hap)
+        both = ~np.isnan(score) & ~np.isnan(ref)
+        np.testing.assert_allclose(score[both], ref[both], rtol=1e-5)
+
+    def test_ihs_biallelic_is_1d_and_matches_allel(self, biallelic):
+        hap, pos = biallelic
+        score = selection.ihs(_mat(hap, pos), include_edges=False)
+        assert score.ndim == 1 and score.shape == (200,)
+        ref = allel.ihs(hap.T, pos, include_edges=False, use_threads=False)
+        both = ~np.isnan(score) & ~np.isnan(ref)
+        assert both.sum() > 0
+        np.testing.assert_allclose(score[both], ref[both], rtol=1e-5)
+
+    def test_biallelic_filter_of_multiallelic_fixture(self, multiallelic_hm):
+        _, hm = multiallelic_hm
+        hm_bi = hm.apply_biallelic_filter()
+        hap = np.asarray(hm_bi.haplotypes.get()
+                         if hasattr(hm_bi.haplotypes, "get") else hm_bi.haplotypes)
+        assert hap.max() <= 1  # genuinely biallelic after the filter
+        score = selection.nsl(hm_bi)
+        assert score.ndim == 1
+        ref = allel.nsl(hap.T, use_threads=False)  # allel layout (n_var, n_hap)
+        both = ~np.isnan(score) & ~np.isnan(ref)
+        np.testing.assert_allclose(score[both], ref[both], rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Relabel invariance: derived allele 1 -> 2 shifts the score to column 1
+# ---------------------------------------------------------------------------
+
+class TestRelabelInvariance:
+    @pytest.fixture
+    def data(self):
+        rng = np.random.RandomState(0)
+        hap = rng.randint(0, 2, (30, 120)).astype(np.int8)
+        pos = (np.arange(120) * 1000 + 1).astype(np.float64)
+        relabel = np.where(hap == 1, np.int8(2), np.int8(0)).astype(np.int8)
+        return hap, relabel, pos
+
+    def _check(self, base, re):
+        assert base.ndim == 1
+        assert re.ndim == 2 and re.shape[1] == 2
+        assert np.all(np.isnan(re[:, 0]))  # allele 1 now absent everywhere
+        both = np.isfinite(base) & np.isfinite(re[:, 1])
+        assert both.sum() > 0
+        np.testing.assert_allclose(re[both, 1], base[both], rtol=1e-9, atol=1e-9)
+
+    def test_nsl_relabel(self, data):
+        hap, relabel, pos = data
+        self._check(selection.nsl(_mat(hap, pos)), selection.nsl(_mat(relabel, pos)))
+
+    def test_ihs_relabel(self, data):
+        hap, relabel, pos = data
+        self._check(selection.ihs(_mat(hap, pos)), selection.ihs(_mat(relabel, pos)))
+
+
+# ---------------------------------------------------------------------------
+# Brute-force reference on genuinely triallelic data
+# ---------------------------------------------------------------------------
+
+class TestMultiallelicBruteForce:
+    def test_nsl_triallelic_matches_reference(self):
+        rng = np.random.RandomState(7)
+        n_hap, n_var = 10, 25
+        hap = rng.randint(0, 2, (n_hap, n_var)).astype(np.int8)
+        # inject derived allele 2 at a few sites (some {0,2}, some {0,1,2})
+        hap[:4, 5] = 2
+        hap[:3, 12] = 2
+        hap[3:6, 12] = 1
+        hap[:5, 18] = 2
+
+        score = selection.nsl(_mat(hap))
+        assert score.shape == (n_var, 2)
+
+        ref = np.stack([_nsl_ref(hap, 1), _nsl_ref(hap, 2)], axis=1)
+
+        assert np.array_equal(np.isnan(score), np.isnan(ref))
+        both = np.isfinite(score) & np.isfinite(ref)
+        assert both.sum() > 0
+        np.testing.assert_allclose(score[both], ref[both], rtol=1e-9, atol=1e-9)
+
+
+class TestReferenceAbsent:
+    def test_no_ancestral_allele_is_nan(self):
+        # A focal site with no ancestral (0) allele has no reference class, so
+        # every derived allele's one-vs-ancestral score is NaN there.
+        rng = np.random.RandomState(5)
+        n_hap, n_var = 20, 40
+        hap = rng.randint(0, 2, (n_hap, n_var)).astype(np.int8)
+        focal = 20
+        hap[:10, focal] = 1   # no allele 0 remains at the focal site
+        hap[10:, focal] = 2
+        for score in (selection.ihs(_mat(hap), min_maf=0.0), selection.nsl(_mat(hap))):
+            assert score.shape == (n_var, 2)
+            assert np.all(np.isnan(score[focal]))
+
+
+# ---------------------------------------------------------------------------
+# Per-allele MAF: a common allele with index >= 2 is now visible to min_maf
+# ---------------------------------------------------------------------------
+
+class TestPerAlleleMAF:
+    def test_common_high_index_allele_visible(self):
+        rng = np.random.RandomState(3)
+        n_hap, n_var = 40, 60
+        hap = rng.randint(0, 2, (n_hap, n_var)).astype(np.int8)
+        focal = 30
+        # focal site: ancestral common, allele 1 rare (1/40 = 0.025 < min_maf),
+        # allele 2 common (20/40 = 0.5). Old counts (0/1 only) would hide allele 2.
+        col = np.zeros(n_hap, dtype=np.int8)
+        col[0] = 1
+        col[1:21] = 2
+        hap[:, focal] = col
+
+        score = selection.ihs(_mat(hap), min_maf=0.05)
+        assert score.shape == (n_var, 2)
+        assert np.isnan(score[focal, 0])       # allele 1 fails per-allele MAF
+        assert np.isfinite(score[focal, 1])    # common allele 2 passes
+
+
+# ---------------------------------------------------------------------------
+# mean_nsl (windowed) -- first coverage; must accept 1-D and 2-D nsl output
+# ---------------------------------------------------------------------------
+
+class TestMeanNSL:
+    def test_mean_nsl_biallelic_matches_manual(self):
+        rng = np.random.RandomState(11)
+        n_hap, n_var = 30, 300
+        hap = rng.randint(0, 2, (n_hap, n_var)).astype(np.int8)
+        pos = (np.arange(n_var) * 100 + 1).astype(np.float64)
+        hm = _mat(hap, pos)
+
+        df = windowed_analysis(hm, window_size=5000, statistics=["mean_nsl"])
+        nsl = selection.nsl(hm)
+        # manual per-window mean of finite nsl
+        for _, row in df.iterrows():
+            mask = (pos >= row["start"]) & (pos < row["end"]) & np.isfinite(nsl)
+            expected = np.nanmean(nsl[mask]) if mask.any() else np.nan
+            got = row["mean_nsl"]
+            if np.isnan(expected):
+                assert np.isnan(got)
+            else:
+                np.testing.assert_allclose(got, expected, rtol=1e-6)
+
+    def test_mean_nsl_multiallelic_runs(self):
+        rng = np.random.RandomState(13)
+        n_hap, n_var = 30, 300
+        hap = rng.randint(0, 2, (n_hap, n_var)).astype(np.int8)
+        hap[:6, ::7] = 2  # scatter a derived allele 2
+        pos = (np.arange(n_var) * 100 + 1).astype(np.float64)
+        hm = _mat(hap, pos)
+        assert selection.nsl(hm).ndim == 2  # 2-D per-allele output
+
+        df = windowed_analysis(hm, window_size=5000, statistics=["mean_nsl"])
+        assert "mean_nsl" in df.columns
+        assert np.isfinite(df["mean_nsl"].to_numpy()).any()


### PR DESCRIPTION
## Summary

Closes #140. Adds multiallelic support to the `iHS` and `nSL` selection statistics. Targets `nsp-multiallelic-trunk`.

iHS and nSL assumed a biallelic focal SNP: the ancestral/derived split **dropped** (iHS) or **merged** (nSL) haplotypes carrying an allele index `>= 2`, and the shared allele-count/MAF filter (`_count_alleles_kernel`) counted only alleles 0 and 1, so a common high-index allele was invisible to `min_maf`.

The shared-haplotype homozygosity core is already allele-agnostic (it decays on `h1 != h2`), so only the **focal grouping** changes: each derived allele is scored **one-vs-ancestral**.

## What changed

- **`pg_gpu/selection.py`**
  - Both focal CUDA kernels gain a `focal_allele` parameter: class 0 = ancestral (`h == 0`), class 1 = the focal derived allele (`h == focal_allele`); a homozygous pair of any other allele extends the shared run but scores neither. `focal_allele = 1` reproduces the old kernels bit-for-bit.
  - `nsl`/`ihs` loop over derived alleles and return the same `(n_variants,)` array as before on biallelic data, or `(n_variants, K-1)` when the matrix has `K > 2` alleles (column `j` = score for derived allele `j+1`; NaN where that allele or the ancestral allele is absent, or the allele is MAF-filtered).
  - MAF now counts **per allele** via `_memutil.allele_counts` (the bespoke 0/1-only `_count_alleles_kernel` is deleted): `min_maf` gates on each derived allele's own frequency `min(freq_a, 1 - freq_a)`, reducing exactly to `min(n0,n1)/(n0+n1)` on biallelic sites.
- **`pg_gpu/windowed_analysis.py`** — `mean_nsl` averages every finite `(site, allele)` score in a window (accepts the 1-D or 2-D `nsl` output).
- `xpEHH`, `XP-nSL`, `EHH decay`, and `Garud H` are allele-agnostic and untouched.

Everything reduces **exactly** to the classic biallelic result.

## Validation

No external oracle exists (scikit-allel `ihs`/`nsl` are biallelic-only; tskit has no iHS/nSL), so `tests/test_selection_multiallelic.py` validates via:

1. **Biallelic reduction** — 1-D output matching the scikit-allel oracle (`rtol=1e-5`), including on `apply_biallelic_filter()` of the multiallelic fixture.
2. **Relabel invariance** — recoding the single derived allele `1 -> 2` moves the score to column 1, leaves column 0 all-NaN, and matches the biallelic score to `atol=1e-9`.
3. **Brute-force reference** — a pure-numpy one-vs-ancestral nSL scan reproduces the GPU per-allele scores on genuine triallelic data.
4. **Per-allele MAF** — a common allele with index `>= 2` is now visible to `min_maf`.
5. **Reference-absent** sites and first-ever **`mean_nsl`** coverage.

All existing selection/windowed tests stay green; full-repo ruff is clean.

## Follow-up (not in this PR)

The per-allele wrapper reruns the full SSL scan once per derived allele — an `M`x factor on multiallelic data (gated on the global max allele index). A single-pass kernel depositing into all allele classes at once would remove it. The biallelic path is one iteration and unaffected.
