### PR TITLE
Multiallelic support for grm and ibs; new genetic_relatedness that is general haplotype form

### DIFF
--- a/pg_gpu/_utils.py
+++ b/pg_gpu/_utils.py
@@ -6,38 +6,49 @@ from typing import Union
 from .haplotype_matrix import HaplotypeMatrix
 
 
-def get_population_matrix(haplotype_matrix: HaplotypeMatrix,
-                          population: Union[str, list]) -> HaplotypeMatrix:
-    """Extract a population-specific HaplotypeMatrix.
+def get_population_matrix(matrix, population: Union[str, list]):
+    """Extract a population-specific subset matrix.
 
     Parameters
     ----------
-    haplotype_matrix : HaplotypeMatrix
-        The full haplotype data.
+    matrix : HaplotypeMatrix or GenotypeMatrix
+        The full data. Rows are haplotypes (HaplotypeMatrix) or individuals
+        (GenotypeMatrix); the subset is taken along that row axis.
     population : str or list
-        Population name (looked up in sample_sets) or list of sample indices.
+        Population name (looked up in sample_sets) or list of row indices.
 
     Returns
     -------
-    HaplotypeMatrix
-        Subset matrix for the specified population.
+    HaplotypeMatrix or GenotypeMatrix
+        Subset matrix of the same type for the specified population.
     """
+    from .genotype_matrix import GenotypeMatrix
+
     if isinstance(population, str):
-        if haplotype_matrix.sample_sets is None:
-            raise ValueError("No sample_sets defined in haplotype matrix")
-        if population not in haplotype_matrix.sample_sets:
+        if matrix.sample_sets is None:
+            raise ValueError("No sample_sets defined in matrix")
+        if population not in matrix.sample_sets:
             raise ValueError(
                 f"Population {population} not found in sample_sets")
-        pop_indices = haplotype_matrix.sample_sets[population]
+        pop_indices = matrix.sample_sets[population]
     else:
         pop_indices = list(population)
 
-    pop_haplotypes = haplotype_matrix.haplotypes[pop_indices, :]
+    subset_sets = {'all': list(range(len(pop_indices)))}
+    if isinstance(matrix, GenotypeMatrix):
+        return GenotypeMatrix(
+            matrix.genotypes[pop_indices, :],
+            matrix.positions,
+            matrix.chrom_start,
+            matrix.chrom_end,
+            sample_sets=subset_sets,
+            n_total_sites=matrix.n_total_sites,
+        )
     return HaplotypeMatrix(
-        pop_haplotypes,
-        haplotype_matrix.positions,
-        haplotype_matrix.chrom_start,
-        haplotype_matrix.chrom_end,
-        sample_sets={'all': list(range(len(pop_indices)))},
-        n_total_sites=haplotype_matrix.n_total_sites,
+        matrix.haplotypes[pop_indices, :],
+        matrix.positions,
+        matrix.chrom_start,
+        matrix.chrom_end,
+        sample_sets=subset_sets,
+        n_total_sites=matrix.n_total_sites,
     )

--- a/pg_gpu/relatedness.py
+++ b/pg_gpu/relatedness.py
@@ -201,7 +201,7 @@ def _stream_genetic_relatedness(streaming_matrix, *, sample_sets, indexes,
     return R[idx[:, 0], idx[:, 1]]
 
 
-def grm(genotype_matrix_or_haplotype_matrix,
+def grm(genotype_matrix,
         population: Optional[Union[str, list]] = None,
         missing_data: str = 'include') -> np.ndarray:
     """Compute the Genetic Relationship Matrix (GRM).
@@ -215,11 +215,15 @@ def grm(genotype_matrix_or_haplotype_matrix,
 
     where g is genotype (0/1/2), p is allele frequency, M is number of sites.
 
+    This is a diploid, biallelic estimator, so it takes a GenotypeMatrix (or
+    a streaming genotype matrix), which is diploid and biallelic by
+    construction. For relatedness between haplotypes or arbitrary sample sets,
+    or on multiallelic data, use ``genetic_relatedness``.
+
     Parameters
     ----------
-    genotype_matrix_or_haplotype_matrix : GenotypeMatrix or HaplotypeMatrix
-        Diploid genotypes (0/1/2) or haplotype data (auto-converted to
-        diploid by pairing consecutive haplotypes).
+    genotype_matrix : GenotypeMatrix or StreamingGenotypeMatrix
+        Diploid genotypes (0/1/2).
     population : str or list, optional
         Population subset.
     missing_data : str
@@ -233,14 +237,21 @@ def grm(genotype_matrix_or_haplotype_matrix,
         coefficients + 1. Off-diagonal entries are pairwise relatedness.
     """
     from ._memutil import estimate_variant_chunk_size
-    from .streaming_matrix import _StreamingMatrixBase
-    if isinstance(genotype_matrix_or_haplotype_matrix, _StreamingMatrixBase):
-        return _stream_grm(genotype_matrix_or_haplotype_matrix,
+    from .streaming_matrix import _StreamingMatrixBase, StreamingHaplotypeMatrix
+    from .haplotype_matrix import HaplotypeMatrix
+    if isinstance(genotype_matrix, (HaplotypeMatrix, StreamingHaplotypeMatrix)):
+        raise TypeError(
+            "grm is the diploid biallelic GCTA GRM and requires a "
+            "GenotypeMatrix. For haplotype or sample-set relatedness (and "
+            "multiallelic data) use genetic_relatedness; to run the GCTA GRM "
+            "on haplotype data convert it with "
+            "GenotypeMatrix.from_haplotype_matrix first.")
+    if isinstance(genotype_matrix, _StreamingMatrixBase):
+        return _stream_grm(genotype_matrix,
                             population=population,
                             missing_data=missing_data)
 
-    geno, n_ind = _get_genotype_data(genotype_matrix_or_haplotype_matrix,
-                                      population)
+    geno, n_ind = _get_genotype_data(genotype_matrix, population)
     n_var = geno.shape[1]
 
     # Allele frequency from genotypes, chunked to avoid large temporaries.

--- a/pg_gpu/relatedness.py
+++ b/pg_gpu/relatedness.py
@@ -10,6 +10,197 @@ import cupy as cp
 from typing import Optional, Union
 
 
+def genetic_relatedness(haplotype_matrix, sample_sets=None, indexes=None, *,
+                        centre: bool = True, polarised: bool = False,
+                        proportion: bool = False, span_normalize=True,
+                        missing_data: str = 'include'):
+    """Site-mode genetic relatedness between sample sets.
+
+    Matches ``tskit.TreeSequence.genetic_relatedness`` (site mode): the
+    centered per-allele allele-frequency covariance. For sample sets ``i`` and
+    ``j`` it is the sum over sites and over every allele ``a`` of
+    ``(p_i(a) - pbar(a)) * (p_j(a) - pbar(a))``, where ``p_k(a)`` is allele
+    ``a``'s frequency in set ``k`` and ``pbar(a)`` the unweighted mean of
+    ``p_k(a)`` across the sample sets. There is no variance standardization.
+
+    Parameters
+    ----------
+    haplotype_matrix : HaplotypeMatrix
+        Sample (haplotype) data. Samples are the unit; individuals or
+        populations are expressed by grouping samples into ``sample_sets``.
+    sample_sets : list of sequences of int, optional
+        Disjoint groups of haplotype (row) indices. Default is one set per
+        haplotype, giving the sample-by-sample matrix.
+    indexes : list of (int, int), optional
+        Pairs of sample-set indices to return. Default returns the full
+        symmetric ``(D, D)`` matrix.
+    centre : bool
+        Center each allele frequency by the across-set mean (True, the default
+        and the standard relatedness) or use the raw frequencies (False, the
+        noncentred form).
+    polarised : bool
+        Sum over all alleles including the reference (False, the default) or
+        over derived alleles only (True).
+    proportion : bool
+        Divide by the number of segregating sites among the analyzed samples
+        (the per-site sum of ``num_alleles - 1``), giving a relatedness
+        proportion. When True, ``span_normalize`` has no effect (it cancels
+        between the covariance and the segregating-site count).
+    span_normalize : bool or str
+        True (default) divides by the analysis span (see ``get_span``); False
+        returns the raw sum. Matches tskit's ``span_normalise``.
+    missing_data : str
+        'include' (default) uses per-site, per-set valid counts; 'exclude'
+        restricts to sites with no missing data among the analyzed samples.
+
+    Returns
+    -------
+    ndarray, float64
+        The ``(D, D)`` matrix, or a 1-D array of values for the requested
+        ``indexes``.
+    """
+    from ._memutil import estimate_variant_chunk_size
+    from .streaming_matrix import _StreamingMatrixBase
+    from .haplotype_matrix import HaplotypeMatrix
+
+    if isinstance(haplotype_matrix, _StreamingMatrixBase):
+        return _stream_genetic_relatedness(
+            haplotype_matrix, sample_sets=sample_sets, indexes=indexes,
+            centre=centre, polarised=polarised, proportion=proportion,
+            span_normalize=span_normalize, missing_data=missing_data)
+    if not isinstance(haplotype_matrix, HaplotypeMatrix):
+        raise TypeError(
+            "genetic_relatedness requires a HaplotypeMatrix (samples are "
+            f"haplotypes); got {type(haplotype_matrix)}")
+
+    if getattr(haplotype_matrix, 'device', 'GPU') == 'CPU':
+        haplotype_matrix.transfer_to_gpu()
+    hap = haplotype_matrix.haplotypes
+    n_hap = hap.shape[0]
+    D = n_hap if sample_sets is None else len(sample_sets)
+
+    # missing_data='exclude': keep only sites called in every analyzed sample.
+    if missing_data == 'exclude':
+        if sample_sets is None:
+            covered = cp.ones(n_hap, dtype=bool)
+        else:
+            covered = cp.zeros(n_hap, dtype=bool)
+            for members in sample_sets:
+                covered[cp.asarray(members)] = True
+        complete = cp.all(hap[covered] >= 0, axis=0)
+        hap = hap[:, complete]
+
+    R = cp.zeros((D, D), dtype=cp.float64)
+    # Segregating sites among the analyzed samples: per-site sum of
+    # (present alleles - 1), accumulated on device (only when needed).
+    seg_cols = 0
+    seg_sites = cp.zeros((), dtype=cp.float64)
+    if hap.shape[1] > 0:
+        K = int(hap.max()) + 1
+        chunk = estimate_variant_chunk_size(n_hap, bytes_per_element=8,
+                                            n_intermediates=3,
+                                            memory_fraction=0.25)
+        for start in range(0, hap.shape[1], chunk):
+            end = min(start + chunk, hap.shape[1])
+            cols, col_site, col_allele = _relatedness_columns(
+                hap[:, start:end], sample_sets, K, centre=centre)
+            if proportion and col_site.size:
+                # col_site is site-major sorted; distinct sites = jumps + 1.
+                seg_cols += col_site.size
+                seg_sites += 1 + (cp.diff(col_site) != 0).sum()
+            if polarised:
+                cols = cols[:, col_allele != 0]
+            R += cols @ cols.T
+
+    if proportion:
+        # Divide by segregating sites; span_normalise cancels, so it is ignored.
+        denom = float(seg_cols - seg_sites)
+        if denom > 0:
+            R = R / denom
+    elif span_normalize is not False:
+        mode = 'auto' if span_normalize is True else span_normalize
+        span = haplotype_matrix.get_span(mode)
+        if span > 0:
+            R = R / span
+
+    if indexes is None:
+        return R.get()
+    idx = np.asarray(indexes, dtype=np.intp)
+    return R[cp.asarray(idx[:, 0]), cp.asarray(idx[:, 1])].get()
+
+
+def _stream_genetic_relatedness(streaming_matrix, *, sample_sets, indexes,
+                                centre, polarised, proportion, span_normalize,
+                                missing_data, block_size=None):
+    """Streaming genetic_relatedness: single pass over variant chunks.
+
+    The relatedness is additive over (site, allele) columns and each column's
+    centering is local to its site, so one pass over the chunks suffices. The
+    (D, D) output is accumulated on host with the set (row) axis tiled into
+    blocks, the same scheme as the streaming GRM/IBS, so it holds when D is
+    large (the per-haplotype default). span_normalise for streaming supports
+    True/False only.
+    """
+    from ._memutil import estimate_indiv_block_size
+
+    n_hap = streaming_matrix.num_haplotypes
+    D = n_hap if sample_sets is None else len(sample_sets)
+
+    covered = None
+    if missing_data == 'exclude':
+        if sample_sets is None:
+            covered = cp.ones(n_hap, dtype=bool)
+        else:
+            covered = cp.zeros(n_hap, dtype=bool)
+            for members in sample_sets:
+                covered[cp.asarray(members)] = True
+
+    # D is known from the sample sets without peeking a chunk, so an empty
+    # source falls through to this zero matrix (relatedness of nothing is 0).
+    R = np.zeros((D, D), dtype=np.float64)
+    seg_cols = 0
+    seg_sites = cp.zeros((), dtype=cp.float64)
+    if block_size is None:
+        block_size = estimate_indiv_block_size(D, n_intermediates=3)
+
+    for _, _, chunk in streaming_matrix.iter_gpu_chunks():
+        hap = chunk.haplotypes
+        if covered is not None:
+            complete = cp.all(hap[covered] >= 0, axis=0)
+            hap = hap[:, complete]
+        if hap.shape[1] == 0:
+            continue
+        K = int(hap.max()) + 1
+        cols, col_site, col_allele = _relatedness_columns(
+            hap, sample_sets, K, centre=centre)
+        if proportion and col_site.size:
+            seg_cols += col_site.size
+            seg_sites += 1 + (cp.diff(col_site) != 0).sum()
+        if polarised:
+            cols = cols[:, col_allele != 0]
+        for r0 in range(0, D, block_size):
+            r1 = min(r0 + block_size, D)
+            R[r0:r1] += (cols[r0:r1] @ cols.T).get()
+
+    if proportion:
+        denom = seg_cols - float(seg_sites.get())
+        if denom > 0:
+            R = R / denom
+    elif span_normalize is not False:
+        if span_normalize is not True:
+            raise NotImplementedError(
+                "streaming genetic_relatedness supports span_normalize "
+                "True or False only")
+        span = streaming_matrix.chrom_end - streaming_matrix.chrom_start + 1
+        if span > 0:
+            R = R / span
+
+    if indexes is None:
+        return R
+    idx = np.asarray(indexes, dtype=np.intp)
+    return R[idx[:, 0], idx[:, 1]]
+
+
 def grm(genotype_matrix_or_haplotype_matrix,
         population: Optional[Union[str, list]] = None,
         missing_data: str = 'include') -> np.ndarray:
@@ -192,6 +383,96 @@ def ibs(genotype_matrix_or_haplotype_matrix,
     cp.fill_diagonal(ibs_mat, 1.0)
 
     return ibs_mat.get()
+
+
+# ---------------------------------------------------------------------------
+# genetic_relatedness: per-set, per-allele centered frequency columns
+# ---------------------------------------------------------------------------
+
+def _relatedness_columns(hap, sample_sets, n_alleles, centre=True):
+    """Per-set, per-allele frequency columns for genetic_relatedness.
+
+    Builds a matrix whose row ``k`` is sample set ``k``'s per-allele frequency.
+    Writing ``p_k(a)`` for the frequency of allele ``a`` in set ``k`` and
+    ``pbar(a)`` for the mean of ``p_k(a)`` over the ``D`` sets, with ``centre``
+    the columns are ``p_k(a) - pbar(a)`` and the relatedness of a set pair
+    ``(i, j)`` is the sum over every allele and site of
+    ``(p_i(a) - pbar(a)) * (p_j(a) - pbar(a))``, i.e. ``(C @ C.T)[i, j]`` (the
+    product is formed in a later step); without ``centre`` the columns are the
+    raw ``p_k(a)`` and ``C @ C.T`` is the noncentred form. All alleles including
+    the reference are represented, and there is no variance standardization; a
+    caller wanting derived alleles only drops the ``col_allele == 0`` columns.
+
+    Each present ``(site, allele)`` pair among the analyzed samples is one
+    column; columns are ordered site-major, allele-minor. "Present" is relative
+    to the samples that appear in some set, so passing a subset of samples
+    restricts the alleles considered.
+
+    Parameters
+    ----------
+    hap : cupy.ndarray, int8, shape (n_hap, n_var)
+        Allele indices (0 reference, 1.. alternate), -1 missing.
+    sample_sets : list of 1D index arrays, or None
+        Disjoint groups of haplotype indices. None means one set per haplotype
+        (the tskit-native singleton grouping, ``D = n_hap``).
+    n_alleles : int
+        Global allele-index width ``K`` so allele ``a`` aligns across sets.
+    centre : bool
+        Subtract the across-set mean ``pbar(a)`` from each column (True), or
+        leave the raw per-set frequencies (False, the noncentred form).
+
+    Returns
+    -------
+    cols : cupy.ndarray, float64, shape (D, n_cols)
+    col_site : cupy.ndarray, int64, shape (n_cols,)
+        Site index each column belongs to.
+    col_allele : cupy.ndarray, int64, shape (n_cols,)
+        Allele index each column represents (0 is the reference).
+
+    Notes
+    -----
+    Per-set frequencies use per-site valid counts, so a missing entry lowers only
+    its own set's denominator. The exact missing-data policy (a set with no valid
+    sample at a site, and the include/exclude modes) is applied by the caller; on
+    complete data every set's denominator is its size.
+    """
+    n_hap, n_var = hap.shape
+    K = int(n_alleles)
+    valid = hap >= 0
+
+    if sample_sets is None:
+        M = None
+        D = n_hap
+        covered = valid                                  # every haplotype is a set
+    else:
+        D = len(sample_sets)
+        M = cp.zeros((D, n_hap), dtype=cp.float64)
+        for k, members in enumerate(sample_sets):
+            M[k, cp.asarray(members)] = 1.0
+        covered = valid & (M.sum(axis=0) > 0)[:, None]
+
+    # Present (site, allele) pairs among the analyzed samples -> one argwhere sync.
+    pooled_ac = cp.zeros((n_var, K), dtype=cp.int64)
+    for a in range(K):
+        pooled_ac[:, a] = (covered & (hap == a)).sum(axis=0, dtype=cp.int64)
+    pairs = cp.argwhere(pooled_ac > 0)
+    col_site = pairs[:, 0]
+    col_allele = pairs[:, 1]
+
+    # Per-set count and valid count for each present column.
+    hs = hap[:, col_site]                                # (n_hap, n_cols)
+    carries = ((hs == col_allele[None, :]) & valid[:, col_site]).astype(cp.float64)
+    valid_cols = valid[:, col_site].astype(cp.float64)
+    if M is None:
+        cnt = carries                                    # (D, n_cols), D == n_hap
+        nvalid = valid_cols
+    else:
+        cnt = M @ carries                                # (D, n_cols)
+        nvalid = M @ valid_cols
+
+    p = cp.where(nvalid > 0, cnt / nvalid, 0.0)          # per-set frequency
+    cols = p - p.mean(axis=0, keepdims=True) if centre else p
+    return cols, col_site, col_allele
 
 
 # ---------------------------------------------------------------------------

--- a/pg_gpu/relatedness.py
+++ b/pg_gpu/relatedness.py
@@ -311,24 +311,30 @@ def grm(genotype_matrix,
     return A.get()
 
 
-def ibs(genotype_matrix_or_haplotype_matrix,
+def ibs(genotype_matrix,
         population: Optional[Union[str, list]] = None,
         missing_data: str = 'include') -> np.ndarray:
     """Compute pairwise IBS (Identity by State) proportions.
 
-    IBS measures the proportion of alleles shared identical by state
-    between all pairs of individuals. Equivalent to PLINK's --distance
-    ibs matrix.
+    IBS measures the proportion of alleles shared identical by state between
+    all pairs of individuals. Equivalent to PLINK's --distance ibs matrix. For
+    each site the shared count is (2 - abs(g_i - g_j)) and the matrix is the
+    summed shared count over jointly-called sites divided by twice that site
+    count.
 
-    For each site, IBS between individuals i and j is
-    ``IBS = (2 - abs(g_i - g_j)) / 2``.
-
-    The matrix contains the mean IBS across all jointly-called sites.
+    This is a diploid, biallelic estimator (the shared count is the diploid
+    max-matching of two genotypes), so it takes a GenotypeMatrix (or a streaming
+    genotype matrix), which is diploid and biallelic by construction. For the
+    general allele-sharing quantity between arbitrary sample sets (haplotypes,
+    individuals, or populations), and on multiallelic data, use
+    ``genetic_relatedness`` with ``centre=False``: the noncentred relatedness is
+    the allele-match probability between sample sets, the sample-set
+    generalization of allele sharing.
 
     Parameters
     ----------
-    genotype_matrix_or_haplotype_matrix : GenotypeMatrix or HaplotypeMatrix
-        Diploid genotypes (0/1/2) or haplotype data.
+    genotype_matrix : GenotypeMatrix or StreamingGenotypeMatrix
+        Diploid genotypes (0/1/2).
     population : str or list, optional
         Population subset.
     missing_data : str
@@ -342,14 +348,21 @@ def ibs(genotype_matrix_or_haplotype_matrix,
         Diagonal is always 1.
     """
     from ._memutil import estimate_variant_chunk_size
-    from .streaming_matrix import _StreamingMatrixBase
-    if isinstance(genotype_matrix_or_haplotype_matrix, _StreamingMatrixBase):
-        return _stream_ibs(genotype_matrix_or_haplotype_matrix,
+    from .streaming_matrix import _StreamingMatrixBase, StreamingHaplotypeMatrix
+    from .haplotype_matrix import HaplotypeMatrix
+    if isinstance(genotype_matrix, (HaplotypeMatrix, StreamingHaplotypeMatrix)):
+        raise TypeError(
+            "ibs is the diploid biallelic PLINK IBS and requires a "
+            "GenotypeMatrix. For allele sharing between haplotypes or arbitrary "
+            "sample sets (and multiallelic data) use genetic_relatedness with "
+            "centre=False; to run the diploid IBS on haplotype data convert it "
+            "with GenotypeMatrix.from_haplotype_matrix first.")
+    if isinstance(genotype_matrix, _StreamingMatrixBase):
+        return _stream_ibs(genotype_matrix,
                             population=population,
                             missing_data=missing_data)
 
-    geno, n_ind = _get_genotype_data(genotype_matrix_or_haplotype_matrix,
-                                      population)
+    geno, n_ind = _get_genotype_data(genotype_matrix, population)
     n_var = geno.shape[1]
     # Peak per-chunk: 1 float64 indicator + matmul workspace.
     chunk_size = estimate_variant_chunk_size(n_ind, bytes_per_element=8,
@@ -374,17 +387,17 @@ def ibs(genotype_matrix_or_haplotype_matrix,
 
         n_joint += valid @ valid.T
 
-        # Compute ibs2 and ibs1 one indicator at a time to avoid
-        # materializing i0, i1, i2 simultaneously.
+        # ibs2 (both alleles shared) and ibs1 (one shared) via genotype-state
+        # indicators, one at a time to avoid materializing all three together.
+        ind_curr = (g == 0) * valid
         for gval in (0, 1, 2):
-            ind = (g == gval) * valid
-            ibs2 += ind @ ind.T
             if gval < 2:
                 ind_next = (g == (gval + 1)) * valid
-                cross = ind @ ind_next.T
+            ibs2 += ind_curr @ ind_curr.T
+            if gval < 2:
+                cross = ind_curr @ ind_next.T
                 ibs1 += cross + cross.T
-                del ind_next
-            del ind
+                ind_curr = ind_next
 
         del g, valid
 
@@ -392,7 +405,6 @@ def ibs(genotype_matrix_or_haplotype_matrix,
                         (2.0 * ibs2 + ibs1) / (2.0 * n_joint),
                         0.0)
     cp.fill_diagonal(ibs_mat, 1.0)
-
     return ibs_mat.get()
 
 
@@ -629,8 +641,7 @@ def _stream_ibs(streaming_matrix, *, population, missing_data,
     for _, _, chunk in chunks:
         geno, _ = _get_genotype_data(chunk, population)
         _accumulate_ibs_chunk(geno, ibs2_host, ibs1_host, n_joint_host,
-                              block_size=block_size,
-                              missing_data=missing_data)
+                              block_size=block_size, missing_data=missing_data)
         del geno
 
     ibs_mat = np.where(n_joint_host > 0,
@@ -642,17 +653,12 @@ def _stream_ibs(streaming_matrix, *, population, missing_data,
 
 def _accumulate_ibs_chunk(geno, ibs2_host, ibs1_host, n_joint_host, *,
                           block_size, missing_data):
-    """Add one variant-chunk's contribution to the three host accumulators.
+    """Add one variant-chunk's contribution to the host accumulators.
 
-    ``geno`` is ``(n_ind, n_var_chunk)`` on GPU. The genotype-value loop
-    is outermost so each full-pop indicator ``ind_full`` is built once
-    per chunk rather than once per chunk per row block; the row-block
-    loop only does matmuls and host transfers.
-
-    In the eager kernel ``ibs1 += cross + cross.T`` where
-    ``cross = (g==gval) @ (g==gval+1).T``; here the row-block slice of
-    ``cross`` is ``ind_curr[r0:r1] @ ind_next.T`` and the row-block
-    slice of ``cross.T`` is ``ind_next[r0:r1] @ ind_curr.T``.
+    ``geno`` is (n_ind, n_var_chunk) on GPU. The genotype-state indicators are
+    built once per chunk; the row-block loop tiles the individual axis so only
+    one block's (block_size, n_ind) matmul output sits on the GPU at a time
+    before it is added to the host accumulators.
     """
     valid_full = (geno >= 0).astype(cp.float64)
     g = cp.where(geno >= 0, geno, 0).astype(cp.float64)
@@ -668,9 +674,6 @@ def _accumulate_ibs_chunk(geno, ibs2_host, ibs1_host, n_joint_host, *,
         r1 = min(r0 + block_size, n_ind)
         n_joint_host[r0:r1] += (valid_full[r0:r1] @ valid_full.T).get()
 
-    # Two indicator matrices live at a time: the current g==k and the
-    # next g==k+1 needed for the ibs1 cross. Reuse ``ind_next`` from
-    # the previous iter as the next ``ind_curr`` so g==1 is built once.
     ind_curr = (g == 0) * valid_full
     for gval in (0, 1, 2):
         if gval < 2:
@@ -679,12 +682,8 @@ def _accumulate_ibs_chunk(geno, ibs2_host, ibs1_host, n_joint_host, *,
             r1 = min(r0 + block_size, n_ind)
             ibs2_host[r0:r1] += (ind_curr[r0:r1] @ ind_curr.T).get()
             if gval < 2:
-                ibs1_host[r0:r1] += (
-                    ind_curr[r0:r1] @ ind_next.T
-                ).get()
-                ibs1_host[r0:r1] += (
-                    ind_next[r0:r1] @ ind_curr.T
-                ).get()
+                ibs1_host[r0:r1] += (ind_curr[r0:r1] @ ind_next.T).get()
+                ibs1_host[r0:r1] += (ind_next[r0:r1] @ ind_curr.T).get()
         del ind_curr
         if gval < 2:
             ind_curr = ind_next

--- a/tests/test_relatedness.py
+++ b/tests/test_relatedness.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pytest
-from pg_gpu import HaplotypeMatrix, relatedness
+from pg_gpu import GenotypeMatrix, HaplotypeMatrix, relatedness
 
 
 @pytest.fixture
@@ -14,10 +14,17 @@ def small_haplotype_matrix():
     return HaplotypeMatrix(hap, positions)
 
 
-def _reference_grm(hap):
-    """Compute GRM from haplotypes using numpy (reference implementation)."""
-    n_ind = hap.shape[0] // 2
-    g = hap[:n_ind, :] + hap[n_ind:, :]
+@pytest.fixture
+def small_genotype_matrix():
+    """Small diploid genotype dataset: 3 individuals, 20 variants (0/1/2)."""
+    rng = np.random.RandomState(42)
+    geno = rng.randint(0, 3, size=(3, 20)).astype(np.int8)
+    positions = np.arange(20) * 1000
+    return GenotypeMatrix(geno, positions)
+
+
+def _reference_grm(g):
+    """GCTA GRM from a diploid genotype array (0/1/2), numpy reference."""
     g = g.astype(float)
     p = g.mean(axis=0) / 2
     poly = (p > 0) & (p < 1)
@@ -43,37 +50,41 @@ def _reference_ibs(hap):
     return ibs_mat
 
 
+def _geno_of(gm):
+    g = gm.genotypes
+    return g.get() if hasattr(g, 'get') else g
+
+
 class TestGRM:
-    def test_shape(self, small_haplotype_matrix):
-        grm = relatedness.grm(small_haplotype_matrix)
+    def test_shape(self, small_genotype_matrix):
+        grm = relatedness.grm(small_genotype_matrix)
         assert grm.shape == (3, 3)
 
-    def test_symmetric(self, small_haplotype_matrix):
-        grm = relatedness.grm(small_haplotype_matrix)
+    def test_symmetric(self, small_genotype_matrix):
+        grm = relatedness.grm(small_genotype_matrix)
         np.testing.assert_allclose(grm, grm.T)
 
-    def test_matches_reference(self, small_haplotype_matrix):
-        grm_pg = relatedness.grm(small_haplotype_matrix)
-        hap = small_haplotype_matrix.haplotypes
-        if hasattr(hap, 'get'):
-            hap = hap.get()
-        grm_ref = _reference_grm(hap)
+    def test_matches_reference(self, small_genotype_matrix):
+        grm_pg = relatedness.grm(small_genotype_matrix)
+        grm_ref = _reference_grm(_geno_of(small_genotype_matrix))
         np.testing.assert_allclose(grm_pg, grm_ref, atol=1e-10)
 
     def test_identical_individuals(self):
         """Two identical individuals should have GRM off-diagonal = diagonal."""
-        # pg_gpu layout: [allele1_ind0, allele1_ind1, allele2_ind0, allele2_ind1]
-        hap = np.array([[0, 1, 0, 1, 0],   # ind0 allele1
-                         [0, 1, 0, 1, 0],   # ind1 allele1 (same as ind0)
-                         [1, 0, 1, 0, 1],   # ind0 allele2
-                         [1, 0, 1, 0, 1]], dtype=np.int8)  # ind1 allele2 (same)
-        hm = HaplotypeMatrix(hap, np.arange(5) * 100)
-        grm = relatedness.grm(hm)
+        geno = np.array([[0, 1, 2, 1, 0],
+                         [0, 1, 2, 1, 0],   # identical to individual 0
+                         [2, 1, 0, 1, 2]], dtype=np.int8)
+        gm = GenotypeMatrix(geno, np.arange(5) * 100)
+        grm = relatedness.grm(gm)
         np.testing.assert_allclose(grm[0, 1], grm[0, 0], atol=1e-10)
 
-    def test_returns_numpy(self, small_haplotype_matrix):
-        grm = relatedness.grm(small_haplotype_matrix)
+    def test_returns_numpy(self, small_genotype_matrix):
+        grm = relatedness.grm(small_genotype_matrix)
         assert isinstance(grm, np.ndarray)
+
+    def test_rejects_haplotype_matrix(self, small_haplotype_matrix):
+        with pytest.raises(TypeError, match="genetic_relatedness"):
+            relatedness.grm(small_haplotype_matrix)
 
 
 class TestIBS:

--- a/tests/test_relatedness.py
+++ b/tests/test_relatedness.py
@@ -36,17 +36,25 @@ def _reference_grm(g):
     return (std @ std.T) / poly.sum()
 
 
-def _reference_ibs(hap):
-    """Compute IBS from haplotypes using numpy (reference implementation)."""
-    n_ind = hap.shape[0] // 2
-    g = hap[:n_ind, :] + hap[n_ind:, :]
-    n_snps = g.shape[1]
+def _reference_ibs(g):
+    """Biallelic diploid IBS from a genotype array (0/1/2), numpy reference.
+
+    Per jointly-called site the shared-allele count is 2 - abs(g_i - g_j); IBS
+    is the summed shared count over jointly-called sites divided by twice that
+    site count.
+    """
+    n_ind = g.shape[0]
     ibs_mat = np.eye(n_ind)
     for i in range(n_ind):
         for j in range(i + 1, n_ind):
-            ibs_val = (2 - np.abs(g[i] - g[j])).sum() / (2 * n_snps)
-            ibs_mat[i, j] = ibs_val
-            ibs_mat[j, i] = ibs_val
+            valid = (g[i] >= 0) & (g[j] >= 0)
+            n_joint = int(valid.sum())
+            if n_joint == 0:
+                continue
+            shared = (2 - np.abs(g[i] - g[j]))[valid].sum()
+            val = shared / (2 * n_joint)
+            ibs_mat[i, j] = val
+            ibs_mat[j, i] = val
     return ibs_mat
 
 
@@ -88,54 +96,59 @@ class TestGRM:
 
 
 class TestIBS:
-    def test_shape(self, small_haplotype_matrix):
-        ibs_mat = relatedness.ibs(small_haplotype_matrix)
+    def test_shape(self, small_genotype_matrix):
+        ibs_mat = relatedness.ibs(small_genotype_matrix)
         assert ibs_mat.shape == (3, 3)
 
-    def test_diagonal_is_one(self, small_haplotype_matrix):
-        ibs_mat = relatedness.ibs(small_haplotype_matrix)
+    def test_diagonal_is_one(self, small_genotype_matrix):
+        ibs_mat = relatedness.ibs(small_genotype_matrix)
         np.testing.assert_allclose(ibs_mat.diagonal(), 1.0)
 
-    def test_symmetric(self, small_haplotype_matrix):
-        ibs_mat = relatedness.ibs(small_haplotype_matrix)
+    def test_symmetric(self, small_genotype_matrix):
+        ibs_mat = relatedness.ibs(small_genotype_matrix)
         np.testing.assert_allclose(ibs_mat, ibs_mat.T)
 
-    def test_range(self, small_haplotype_matrix):
-        ibs_mat = relatedness.ibs(small_haplotype_matrix)
+    def test_range(self, small_genotype_matrix):
+        ibs_mat = relatedness.ibs(small_genotype_matrix)
         assert np.all(ibs_mat >= 0)
         assert np.all(ibs_mat <= 1)
 
-    def test_matches_reference(self, small_haplotype_matrix):
-        ibs_pg = relatedness.ibs(small_haplotype_matrix)
-        hap = small_haplotype_matrix.haplotypes
-        if hasattr(hap, 'get'):
-            hap = hap.get()
-        ibs_ref = _reference_ibs(hap)
-        np.testing.assert_allclose(ibs_pg, ibs_ref, atol=1e-10)
+    def test_matches_reference(self, small_genotype_matrix):
+        ibs_pg = relatedness.ibs(small_genotype_matrix)
+        np.testing.assert_allclose(ibs_pg, _reference_ibs(_geno_of(small_genotype_matrix)),
+                                   atol=1e-10)
+
+    def test_missing_matches_reference(self):
+        rng = np.random.RandomState(4)
+        geno = rng.randint(0, 3, size=(5, 40)).astype(np.int8)
+        geno[rng.random(geno.shape) < 0.1] = -1
+        gm = GenotypeMatrix(geno, np.arange(40) * 100)
+        np.testing.assert_allclose(relatedness.ibs(gm), _reference_ibs(geno),
+                                   atol=1e-10)
 
     def test_identical_individuals(self):
-        # pg_gpu layout: [allele1_ind0, allele1_ind1, allele2_ind0, allele2_ind1]
-        hap = np.array([[0, 1, 0, 1, 0],   # ind0 allele1
-                         [0, 1, 0, 1, 0],   # ind1 allele1
-                         [1, 0, 1, 0, 1],   # ind0 allele2
-                         [1, 0, 1, 0, 1]], dtype=np.int8)  # ind1 allele2
-        hm = HaplotypeMatrix(hap, np.arange(5) * 100)
-        ibs_mat = relatedness.ibs(hm)
+        geno = np.array([[0, 1, 2, 1],
+                         [0, 1, 2, 1],   # identical to individual 0
+                         [2, 1, 0, 1]], dtype=np.int8)
+        gm = GenotypeMatrix(geno, np.arange(4) * 100)
+        ibs_mat = relatedness.ibs(gm)
         assert ibs_mat[0, 1] == 1.0
 
     def test_completely_different(self):
-        # ind0 = 0/0 at all sites, ind1 = 2/2 at all sites
-        hap = np.array([[0, 0, 0, 0, 0],   # ind0 allele1
-                         [1, 1, 1, 1, 1],   # ind1 allele1
-                         [0, 0, 0, 0, 0],   # ind0 allele2
-                         [1, 1, 1, 1, 1]], dtype=np.int8)  # ind1 allele2
-        hm = HaplotypeMatrix(hap, np.arange(5) * 100)
-        ibs_mat = relatedness.ibs(hm)
+        # individual 0 = 0/0 everywhere, individual 1 = 1/1 everywhere.
+        geno = np.array([[0, 0, 0],
+                         [2, 2, 2]], dtype=np.int8)
+        gm = GenotypeMatrix(geno, np.arange(3) * 100)
+        ibs_mat = relatedness.ibs(gm)
         assert ibs_mat[0, 1] == 0.0
 
-    def test_returns_numpy(self, small_haplotype_matrix):
-        ibs_mat = relatedness.ibs(small_haplotype_matrix)
+    def test_returns_numpy(self, small_genotype_matrix):
+        ibs_mat = relatedness.ibs(small_genotype_matrix)
         assert isinstance(ibs_mat, np.ndarray)
+
+    def test_rejects_haplotype_matrix(self, small_haplotype_matrix):
+        with pytest.raises(TypeError, match="genetic_relatedness"):
+            relatedness.ibs(small_haplotype_matrix)
 
 
 def _reference_relatedness_columns(hap, sample_sets, n_alleles):

--- a/tests/test_relatedness.py
+++ b/tests/test_relatedness.py
@@ -125,3 +125,204 @@ class TestIBS:
     def test_returns_numpy(self, small_haplotype_matrix):
         ibs_mat = relatedness.ibs(small_haplotype_matrix)
         assert isinstance(ibs_mat, np.ndarray)
+
+
+def _reference_relatedness_columns(hap, sample_sets, n_alleles):
+    """Independent host reference for _relatedness_columns (complete or missing).
+
+    Returns (C, col_site): per-set per-allele frequencies centered by the
+    unweighted across-set mean, columns ordered site-major then allele-minor.
+    """
+    n_hap, n_var = hap.shape
+    valid = hap >= 0
+    sets = ([[h] for h in range(n_hap)] if sample_sets is None
+            else [list(s) for s in sample_sets])
+    covered = np.zeros(n_hap, dtype=bool)
+    for s in sets:
+        covered[s] = True
+    p_cols, site_cols = [], []
+    for s_idx in range(n_var):
+        for a in range(n_alleles):
+            if np.any(covered & (hap[:, s_idx] == a) & valid[:, s_idx]):
+                col = []
+                for st in sets:
+                    nv = int(valid[st, s_idx].sum())
+                    cnt = int(((hap[st, s_idx] == a) & valid[st, s_idx]).sum())
+                    col.append(cnt / nv if nv > 0 else 0.0)
+                p_cols.append(np.array(col))
+                site_cols.append(s_idx)
+    D = len(sets)
+    P = np.stack(p_cols, axis=1) if p_cols else np.zeros((D, 0))
+    C = P - P.mean(axis=0, keepdims=True)
+    return C, np.array(site_cols, dtype=np.int64)
+
+
+class TestRelatednessColumns:
+    """Per-set per-allele centered frequency plumbing for genetic_relatedness."""
+
+    def _run(self, hap, sample_sets):
+        import cupy as cp
+        k = int(hap.max()) + 1 if hap.size else 1
+        C, col_site, _ = relatedness._relatedness_columns(
+            cp.asarray(hap), sample_sets, k)
+        ref_C, ref_site = _reference_relatedness_columns(hap, sample_sets, k)
+        return C.get(), col_site.get(), ref_C, ref_site
+
+    def test_singleton_biallelic(self):
+        rng = np.random.RandomState(0)
+        hap = rng.randint(0, 2, size=(8, 30)).astype(np.int8)
+        C, site, ref_C, ref_site = self._run(hap, None)
+        np.testing.assert_array_equal(site, ref_site)
+        np.testing.assert_allclose(C, ref_C)
+        assert C.shape[0] == 8  # one row per haplotype
+
+    def test_singleton_multiallelic(self):
+        rng = np.random.RandomState(1)
+        hap = rng.randint(0, 3, size=(8, 40)).astype(np.int8)
+        C, site, ref_C, ref_site = self._run(hap, None)
+        np.testing.assert_array_equal(site, ref_site)
+        np.testing.assert_allclose(C, ref_C)
+
+    def test_columns_are_mean_centered(self):
+        # Each column is centered by the across-set mean -> column sums ~ 0.
+        rng = np.random.RandomState(2)
+        hap = rng.randint(0, 3, size=(6, 25)).astype(np.int8)
+        C, *_ = self._run(hap, None)
+        np.testing.assert_allclose(C.sum(axis=0), 0.0, atol=1e-9)
+
+    def test_grouped_sample_sets_multiallelic(self):
+        # Two sample sets of unequal size; centering is the unweighted mean of
+        # the two set frequencies (not the pooled frequency).
+        rng = np.random.RandomState(3)
+        hap = rng.randint(0, 3, size=(10, 30)).astype(np.int8)
+        sample_sets = [np.arange(0, 4), np.arange(4, 10)]
+        C, site, ref_C, ref_site = self._run(hap, sample_sets)
+        np.testing.assert_array_equal(site, ref_site)
+        np.testing.assert_allclose(C, ref_C)
+        assert C.shape[0] == 2
+
+    def test_subset_of_samples_restricts_present_alleles(self):
+        # An allele carried only by an excluded sample must not create a column.
+        hap = np.array([[0], [0], [1], [2]], dtype=np.int8)  # 4 haps, 1 site
+        sample_sets = [np.array([0, 1, 2])]  # excludes hap 3 (the only allele-2)
+        C, site, ref_C, ref_site = self._run(hap, sample_sets)
+        np.testing.assert_array_equal(site, ref_site)
+        np.testing.assert_allclose(C, ref_C)
+        # alleles 0 and 1 present among {0,1,2}; allele 2 excluded -> 2 columns
+        assert C.shape[1] == 2
+
+    def test_relatedness_matrix_symmetric_psd_ish(self):
+        # C @ C.T (the genetic_relatedness matrix) is symmetric with a
+        # non-negative diagonal.
+        rng = np.random.RandomState(4)
+        hap = rng.randint(0, 3, size=(8, 50)).astype(np.int8)
+        C, *_ = self._run(hap, None)
+        R = C @ C.T
+        np.testing.assert_allclose(R, R.T, atol=1e-9)
+        assert bool((np.diag(R) >= -1e-9).all())
+
+
+class TestGeneticRelatedness:
+    """genetic_relatedness pinned to tskit.TreeSequence.genetic_relatedness."""
+
+    def _tskit_matrix(self, ts, sample_sets, proportion=False, **kw):
+        # proportion=False gives the raw centered covariance; proportion=True
+        # divides by segregating sites (per-site sum of num_alleles - 1).
+        D = len(sample_sets)
+        idx = [(i, j) for i in range(D) for j in range(D)]
+        vals = ts.genetic_relatedness(sample_sets, indexes=idx, mode='site',
+                                      proportion=proportion, **kw)
+        return np.asarray(vals).reshape(D, D)
+
+    def test_singleton_pin_raw(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        tsk_sets = [[s] for s in ts.samples()]
+        exp = self._tskit_matrix(ts, tsk_sets, centre=True, polarised=False,
+                                 span_normalise=False)
+        got = relatedness.genetic_relatedness(hm, span_normalize=False)
+        np.testing.assert_allclose(got, exp, atol=1e-9, rtol=1e-6)
+
+    def test_singleton_pin_span_normalised(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        tsk_sets = [[s] for s in ts.samples()]
+        exp = self._tskit_matrix(ts, tsk_sets, centre=True, polarised=False,
+                                 span_normalise=True)
+        got = relatedness.genetic_relatedness(hm, span_normalize=True)
+        np.testing.assert_allclose(got, exp, atol=1e-12, rtol=1e-6)
+
+    def test_grouped_sample_sets_pin(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        samples = list(ts.samples())
+        n = len(samples)
+        half = n // 2
+        pg_sets = [list(range(0, half)), list(range(half, n))]
+        tsk_sets = [[samples[i] for i in grp] for grp in pg_sets]
+        exp = self._tskit_matrix(ts, tsk_sets, centre=True, polarised=False,
+                                 span_normalise=False)
+        got = relatedness.genetic_relatedness(hm, sample_sets=pg_sets,
+                                              span_normalize=False)
+        np.testing.assert_allclose(got, exp, atol=1e-9, rtol=1e-6)
+
+    def test_noncentred_pin(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        tsk_sets = [[s] for s in ts.samples()]
+        exp = self._tskit_matrix(ts, tsk_sets, centre=False, polarised=False,
+                                 span_normalise=False)
+        got = relatedness.genetic_relatedness(hm, centre=False,
+                                              span_normalize=False)
+        np.testing.assert_allclose(got, exp, atol=1e-9, rtol=1e-6)
+
+    def test_polarised_pin(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        tsk_sets = [[s] for s in ts.samples()]
+        exp = self._tskit_matrix(ts, tsk_sets, centre=True, polarised=True,
+                                 span_normalise=False)
+        got = relatedness.genetic_relatedness(hm, polarised=True,
+                                              span_normalize=False)
+        np.testing.assert_allclose(got, exp, atol=1e-9, rtol=1e-6)
+
+    def test_proportion_pin(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        tsk_sets = [[s] for s in ts.samples()]
+        exp = self._tskit_matrix(ts, tsk_sets, proportion=True, centre=True,
+                                 polarised=False, span_normalise=False)
+        got = relatedness.genetic_relatedness(hm, proportion=True)
+        np.testing.assert_allclose(got, exp, atol=1e-12, rtol=1e-6)
+
+    def test_proportion_ignores_span_normalize(self, multiallelic_hm):
+        _, hm = multiallelic_hm
+        a = relatedness.genetic_relatedness(hm, proportion=True,
+                                            span_normalize=False)
+        b = relatedness.genetic_relatedness(hm, proportion=True,
+                                            span_normalize=True)
+        np.testing.assert_allclose(a, b)
+
+    def test_indexes_selection(self, multiallelic_hm):
+        _, hm = multiallelic_hm
+        full = relatedness.genetic_relatedness(hm, span_normalize=False)
+        pairs = [(0, 1), (2, 3), (0, 0)]
+        sub = relatedness.genetic_relatedness(hm, indexes=pairs,
+                                              span_normalize=False)
+        np.testing.assert_allclose(sub, [full[i, j] for i, j in pairs])
+
+    def test_missing_include_matches_host(self):
+        rng = np.random.RandomState(5)
+        hap = rng.randint(0, 3, size=(10, 40)).astype(np.int8)
+        hap[rng.random(hap.shape) < 0.1] = -1
+        hm = HaplotypeMatrix(hap, np.arange(40) * 100)
+        got = relatedness.genetic_relatedness(hm, span_normalize=False)
+        k = int(hap.max()) + 1
+        Cref, _ = _reference_relatedness_columns(hap, None, k)
+        np.testing.assert_allclose(got, Cref @ Cref.T, atol=1e-9)
+
+    def test_missing_exclude_matches_host(self):
+        rng = np.random.RandomState(6)
+        hap = rng.randint(0, 3, size=(10, 40)).astype(np.int8)
+        hap[rng.random(hap.shape) < 0.1] = -1
+        hm = HaplotypeMatrix(hap, np.arange(40) * 100)
+        got = relatedness.genetic_relatedness(hm, missing_data='exclude',
+                                              span_normalize=False)
+        complete = (hap >= 0).all(axis=0)
+        k = int(hap.max()) + 1
+        Cref, _ = _reference_relatedness_columns(hap[:, complete], None, k)
+        np.testing.assert_allclose(got, Cref @ Cref.T, atol=1e-9)

--- a/tests/test_streaming_grm.py
+++ b/tests/test_streaming_grm.py
@@ -1,11 +1,11 @@
 """Equivalence tests for streaming-aware GRM.
 
-``grm(matrix, ...)`` dispatches at the top: a ``StreamingHaplotypeMatrix``
-/ ``StreamingGenotypeMatrix`` routes through a two-pass streaming
-implementation (chromosome-wide allele frequencies first, then a
-standardized outer-product accumulated on host with row-block tiling
-on the individual axis). Tests assert streaming-vs-eager parity on
-small msprime stores.
+``grm`` is the diploid biallelic GCTA GRM and takes genotype matrices; a
+``StreamingGenotypeMatrix`` routes through a two-pass streaming implementation
+(chromosome-wide allele frequencies first, then a standardized outer-product
+accumulated on host with row-block tiling on the individual axis). Haplotype
+matrices are rejected in favor of ``genetic_relatedness``. Tests assert
+streaming-vs-eager parity on small msprime stores.
 """
 
 import numpy as np
@@ -49,17 +49,18 @@ def two_pop_vcz_store(tmp_path):
 
 class TestGrmStreaming:
 
-    def test_haplotype_parity(self, vcz_store):
-        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
+    def test_rejects_streaming_haplotype_matrix(self, vcz_store):
+        # grm is the diploid biallelic GCTA GRM; a streaming haplotype
+        # matrix is rejected in favor of genetic_relatedness.
         stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
-                                            chunk_bp=10_000)
-        # rtol looser than IBS because GRM has a two-pass float accumulation
-        # (frequencies then standardized outer product) where the chunked
-        # vs whole-matrix orderings can differ at the last ULP.
-        np.testing.assert_allclose(grm(stream), grm(eager),
-                                    rtol=1e-7, atol=1e-10)
+                                           chunk_bp=10_000)
+        with pytest.raises(TypeError, match="genetic_relatedness"):
+            grm(stream)
 
     def test_genotype_parity(self, vcz_store):
+        # rtol looser because GRM has a two-pass float accumulation
+        # (frequencies then standardized outer product) where the chunked
+        # vs whole-matrix orderings can differ at the last ULP.
         eager = GenotypeMatrix.from_zarr(vcz_store, streaming="never")
         stream = GenotypeMatrix.from_zarr(vcz_store, streaming="always",
                                            chunk_bp=10_000)
@@ -67,8 +68,8 @@ class TestGrmStreaming:
                                     rtol=1e-7, atol=1e-10)
 
     def test_missing_data_exclude(self, vcz_store):
-        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
-        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+        eager = GenotypeMatrix.from_zarr(vcz_store, streaming="never")
+        stream = GenotypeMatrix.from_zarr(vcz_store, streaming="always",
                                             chunk_bp=10_000)
         np.testing.assert_allclose(
             grm(stream, missing_data='exclude'),
@@ -77,23 +78,30 @@ class TestGrmStreaming:
         )
 
     def test_population_subset(self, two_pop_vcz_store):
+        # Eager genotype population subsetting equals running the GRM on the
+        # manually extracted individuals. (Streaming genotype population
+        # subsetting is a separate pre-existing gap: the streaming matrix
+        # keeps sample_sets in haplotype coordinates.)
         path, popfile = two_pop_vcz_store
-        eager = HaplotypeMatrix.from_zarr(path, streaming="never",
-                                            pop_assignment=popfile)
-        stream = HaplotypeMatrix.from_zarr(path, streaming="always",
-                                             pop_assignment=popfile,
-                                             chunk_bp=10_000)
+        eager = GenotypeMatrix.from_zarr(path, streaming="never",
+                                         pop_assignment=popfile)
+        idx = eager.sample_sets['pop1']
+        g = eager.genotypes
+        g = g.get() if hasattr(g, 'get') else g
+        pos = eager.positions
+        pos = pos.get() if hasattr(pos, 'get') else pos
+        subset = GenotypeMatrix(np.asarray(g)[idx], np.asarray(pos),
+                                eager.chrom_start, eager.chrom_end)
         np.testing.assert_allclose(
-            grm(stream, population='pop1'),
-            grm(eager, population='pop1'),
+            grm(eager, population='pop1'), grm(subset),
             rtol=1e-7, atol=1e-10,
         )
 
     @pytest.mark.parametrize("block_size", [1, 4, 1000])
     def test_block_size_invariance(self, vcz_store, block_size):
         from pg_gpu.relatedness import _stream_grm
-        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
-        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+        eager = GenotypeMatrix.from_zarr(vcz_store, streaming="never")
+        stream = GenotypeMatrix.from_zarr(vcz_store, streaming="always",
                                             chunk_bp=10_000)
         e = grm(eager)
         s = _stream_grm(stream, population=None, missing_data='include',
@@ -112,8 +120,8 @@ class TestGrmStreaming:
         hm.samples = [f"s{i}" for i in range(hm.num_haplotypes // 2)]
         path = str(tmp_path / "mono.vcz")
         hm.to_zarr(path, format="vcz", contig_name="1")
-        eager = HaplotypeMatrix.from_zarr(path, streaming="never")
-        stream = HaplotypeMatrix.from_zarr(path, streaming="always",
+        eager = GenotypeMatrix.from_zarr(path, streaming="never")
+        stream = GenotypeMatrix.from_zarr(path, streaming="always",
                                             chunk_bp=5_000)
         np.testing.assert_allclose(grm(stream), grm(eager),
                                     rtol=1e-7, atol=1e-10)

--- a/tests/test_streaming_ibs.py
+++ b/tests/test_streaming_ibs.py
@@ -1,12 +1,12 @@
 """Equivalence tests for streaming-aware IBS.
 
-``ibs(matrix, ...)`` dispatches at the top: if the argument is a
-``StreamingHaplotypeMatrix`` / ``StreamingGenotypeMatrix``, the variant
-axis is streamed chunk-by-chunk and the individual axis is tiled into
-row blocks so the (n_ind, n_ind) accumulators never have to fit on the
-GPU. Per-chunk contributions sum on the host; the final ratio is
-applied once. Tests assert that streaming and eager produce the same
-matrix on small msprime stores.
+``ibs`` is the diploid biallelic PLINK IBS and takes genotype matrices; a
+``StreamingGenotypeMatrix`` streams the variant axis chunk-by-chunk and tiles
+the individual axis into row blocks so the (n_ind, n_ind) accumulators never
+have to fit on the GPU. Per-chunk contributions sum on the host; the final
+ratio is applied once. Haplotype matrices are rejected in favor of
+``genetic_relatedness``. Tests assert streaming-vs-eager parity on small
+msprime stores.
 """
 
 import numpy as np
@@ -50,13 +50,11 @@ def two_pop_vcz_store(tmp_path):
 
 class TestIbsStreaming:
 
-    def test_haplotype_parity(self, vcz_store):
-        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
+    def test_rejects_streaming_haplotype_matrix(self, vcz_store):
         stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
-                                            chunk_bp=10_000)
-        e = ibs(eager)
-        s = ibs(stream)
-        np.testing.assert_allclose(s, e, rtol=1e-9, atol=1e-12)
+                                           chunk_bp=10_000)
+        with pytest.raises(TypeError, match="genetic_relatedness"):
+            ibs(stream)
 
     def test_genotype_parity(self, vcz_store):
         eager = GenotypeMatrix.from_zarr(vcz_store, streaming="never")
@@ -67,32 +65,38 @@ class TestIbsStreaming:
         np.testing.assert_allclose(s, e, rtol=1e-9, atol=1e-12)
 
     def test_missing_data_exclude(self, vcz_store):
-        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
-        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+        eager = GenotypeMatrix.from_zarr(vcz_store, streaming="never")
+        stream = GenotypeMatrix.from_zarr(vcz_store, streaming="always",
                                             chunk_bp=10_000)
         e = ibs(eager, missing_data='exclude')
         s = ibs(stream, missing_data='exclude')
         np.testing.assert_allclose(s, e, rtol=1e-9, atol=1e-12)
 
     def test_population_subset(self, two_pop_vcz_store):
+        # Eager genotype population subsetting equals ibs on the manually
+        # extracted individuals. (Streaming genotype population subsetting is a
+        # separate pre-existing gap: sample_sets stay in haplotype coordinates.)
         path, popfile = two_pop_vcz_store
-        eager = HaplotypeMatrix.from_zarr(path, streaming="never",
-                                            pop_assignment=popfile)
-        stream = HaplotypeMatrix.from_zarr(path, streaming="always",
-                                             pop_assignment=popfile,
-                                             chunk_bp=10_000)
-        e = ibs(eager, population='pop1')
-        s = ibs(stream, population='pop1')
-        np.testing.assert_allclose(s, e, rtol=1e-9, atol=1e-12)
+        eager = GenotypeMatrix.from_zarr(path, streaming="never",
+                                         pop_assignment=popfile)
+        idx = eager.sample_sets['pop1']
+        g = eager.genotypes
+        g = g.get() if hasattr(g, 'get') else g
+        pos = eager.positions
+        pos = pos.get() if hasattr(pos, 'get') else pos
+        subset = GenotypeMatrix(np.asarray(g)[idx], np.asarray(pos),
+                                eager.chrom_start, eager.chrom_end)
+        np.testing.assert_allclose(ibs(eager, population='pop1'), ibs(subset),
+                                   rtol=1e-9, atol=1e-12)
 
     @pytest.mark.parametrize("block_size", [1, 4, 1000])
     def test_block_size_invariance(self, vcz_store, block_size):
         # Streaming output must not depend on the row-block tile size
         # -- only the (block_size, n_ind) working memory does.
         from pg_gpu.relatedness import _stream_ibs
-        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+        stream = GenotypeMatrix.from_zarr(vcz_store, streaming="always",
                                             chunk_bp=10_000)
-        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
+        eager = GenotypeMatrix.from_zarr(vcz_store, streaming="never")
         e = ibs(eager)
         s = _stream_ibs(stream, population=None, missing_data='include',
                         block_size=block_size)
@@ -101,7 +105,7 @@ class TestIbsStreaming:
     def test_diagonal_is_one(self, vcz_store):
         # Eager and streaming both pin the diagonal at 1.0 -- check the
         # streaming path keeps that invariant.
-        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+        stream = GenotypeMatrix.from_zarr(vcz_store, streaming="always",
                                             chunk_bp=10_000)
         s = ibs(stream)
         np.testing.assert_allclose(np.diag(s), 1.0)

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -405,3 +405,51 @@ class TestStreamingGuardrails:
             windowed_analysis(stream, window_size=5_000,
                               statistics=["local_pca"])
 
+
+
+class TestGeneticRelatednessDispatch:
+    """Streaming genetic_relatedness matches the eager result row-for-row."""
+
+    def _both(self, vcz_store, **kw):
+        from pg_gpu import relatedness
+        eager, stream = _aligned_pair(vcz_store, chunk_bp=10_000)
+        return (relatedness.genetic_relatedness(eager, **kw),
+                relatedness.genetic_relatedness(stream, **kw))
+
+    def test_singleton_raw_equivalent(self, vcz_store):
+        e, s = self._both(vcz_store, span_normalize=False)
+        np.testing.assert_allclose(s, e, rtol=1e-6, atol=1e-9)
+
+    def test_proportion_equivalent(self, vcz_store):
+        e, s = self._both(vcz_store, proportion=True)
+        np.testing.assert_allclose(s, e, rtol=1e-6, atol=1e-9)
+
+    def test_noncentred_equivalent(self, vcz_store):
+        e, s = self._both(vcz_store, centre=False, span_normalize=False)
+        np.testing.assert_allclose(s, e, rtol=1e-6, atol=1e-9)
+
+    def test_polarised_equivalent(self, vcz_store):
+        e, s = self._both(vcz_store, polarised=True, span_normalize=False)
+        np.testing.assert_allclose(s, e, rtol=1e-6, atol=1e-9)
+
+    def test_grouped_sample_sets_equivalent(self, vcz_store):
+        from pg_gpu import relatedness
+        eager, stream = _aligned_pair(vcz_store, chunk_bp=10_000)
+        n_hap = stream.num_haplotypes
+        half = n_hap // 2
+        sets = [list(range(0, half)), list(range(half, n_hap))]
+        e = relatedness.genetic_relatedness(eager, sample_sets=sets,
+                                            span_normalize=False)
+        s = relatedness.genetic_relatedness(stream, sample_sets=sets,
+                                            span_normalize=False)
+        np.testing.assert_allclose(s, e, rtol=1e-6, atol=1e-9)
+
+    def test_chunk_boundary_invariance(self, vcz_store):
+        from pg_gpu import relatedness
+        s_a = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                        chunk_bp=10_000)
+        s_b = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                        chunk_bp=20_000)
+        a = relatedness.genetic_relatedness(s_a, span_normalize=False)
+        b = relatedness.genetic_relatedness(s_b, span_normalize=False)
+        np.testing.assert_allclose(a, b, rtol=1e-9, atol=1e-12)


### PR DESCRIPTION
**Background** relatedness reconstructed diploids from haplotypes by summing paired allele indices, so on a site with an allele index >= 2 the "dosage" became 3, 4, ... and the GRM's frequency and standardization went out of range. This PR makes relatedness multiallelic-correct by reframing it around what tskit actually computes. `genetic_relatedness` is a new statistic pinned exactly to `tskit.genetic_relatedness`; `grm` and `ibs` become the two diploid biallelic estimators scoped to `GenotypeMatrix`.

#### What changed

Added `genetic_relatedness(haplotype_matrix, sample_sets, indexes, *, centre, polarised, proportion, span_normalize, missing_data)`: the site-mode centered per-allele allele-frequency covariance between sample sets. For sets i and j it sums over sites and alleles `(p_i(a) - pbar(a)) * (p_j(a) - pbar(a))`, where `p_k(a)` is allele a's frequency in set k and `pbar(a)` the unweighted mean across sets, with no variance standardization. As a matrix this is `C @ C.T` where `C` holds the per-set per-allele frequencies centered by `pbar`. It is multiallelic-correct by construction (it is already per-allele) and one computation covers every grouping: one set per haplotype (the default) gives the sample-by-sample matrix, two-haplotype sets give per-individual, and population sets give per-population relatedness. It pins exactly to tskit for centre, polarised, proportion, and span_normalise; proportion=True divides by the segregating-site count and, as in tskit, then makes span_normalize a no-op.

`grm` is now scoped to `GenotypeMatrix` (and `StreamingGenotypeMatrix`), which are diploid and biallelic by construction, and keeps the GCTA convention there unchanged. A `HaplotypeMatrix` is hard-rejected with a message pointing to `genetic_relatedness` (or to `GenotypeMatrix.from_haplotype_matrix` for the GCTA GRM). This surfaced and fixed a pre-existing bug where `grm(GenotypeMatrix, population=...)` raised, because `get_population_matrix` only indexed haplotypes; it now subsets a `GenotypeMatrix` too.

`ibs` is also scoped to `GenotypeMatrix` and stays the diploid biallelic PLINK IBS (per-site shared count `2 - abs(g_i - g_j)`, summed over jointly-called sites over twice the count); it hard-rejects haplotype input like `grm`. It is deliberately not generalized to haplotypes or multiallelic sites: the only coherent sample-set allele-sharing quantity, sum over alleles of `p_i(a) p_j(a)`, is exactly the noncentred `genetic_relatedness`, so a general `ibs` would only re-expose that. The docstring points users wanting the general or multiallelic allele sharing to `genetic_relatedness` with `centre=False`.

Streaming: `genetic_relatedness` streams the variant axis in one pass and accumulates `C @ C.T` into a host matrix tiled on the sample axis, the same host-accumulate plus row-block scheme as the streaming GRM/IBS, so it holds when the output is large (the per-haplotype default). It reuses `iter_gpu_chunks` and the existing block-size estimators.

#### Verification

`genetic_relatedness` is pinned exactly to `ts.genetic_relatedness` on a multiallelic tree sequence across singleton and grouped sample sets, centre True and False, polarised True and False, proportion, span-normalized and raw, and index selection; missing include/exclude is checked against an independent host reference (pg_gpu's own extension, since tree sequences have no missing data). `grm` keeps a biallelic GCTA host reference; `ibs` keeps a biallelic dosage host reference (including missing data); both add a haplotype-rejection test. Streaming equals eager for all three, with chunk-boundary invariance.