### PR TITLE
Streaming genetic_relatedness: honor the accessible mask (span + variant filtering)

### DIFF
--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -626,7 +626,7 @@ class HaplotypeMatrix:
             return cls._build_streaming(
                 path, region=region, pop_assignment=pop_assignment,
                 chunk_bp=chunk_bp, prefetch=prefetch,
-                backend=backend,
+                backend=backend, accessible_bed=accessible_bed,
             )
 
         # 'auto' and 'never' both want eager when the matrix fits; 'auto'
@@ -649,7 +649,7 @@ class HaplotypeMatrix:
             return cls._build_streaming(
                 path, region=region, pop_assignment=pop_assignment,
                 chunk_bp=chunk_bp, prefetch=prefetch,
-                source=source, backend=backend,
+                source=source, backend=backend, accessible_bed=accessible_bed,
             )
         return cls._build_eager(path, region=region,
                                 accessible_bed=accessible_bed,
@@ -716,7 +716,8 @@ class HaplotypeMatrix:
 
     @classmethod
     def _build_streaming(cls, path, *, region, pop_assignment, chunk_bp,
-                         prefetch, source=None, backend="auto"):
+                         prefetch, source=None, backend="auto",
+                         accessible_bed=None):
         from .streaming_matrix import (
             HostChunkFetcher, KvikioChunkFetcher, StreamingHaplotypeMatrix,
             _pick_chunk_fetcher,
@@ -733,9 +734,24 @@ class HaplotypeMatrix:
             # zarr store.
             source.pop_cols = source._resolve_pop_assignment(pop_assignment)
         fetcher = _pick_chunk_fetcher(source, backend=backend)
+
+        # Resolve an accessible BED once over the source's variant-position
+        # bounds and hand it to the streaming matrix, so span-normalized
+        # reductions (genetic_relatedness) divide by accessible bases the same
+        # way the eager path does. ``mappable_hi`` is one past the last variant,
+        # so the inclusive last position is ``mappable_hi - 1``.
+        accessible_mask = None
+        if accessible_bed is not None:
+            from .accessible import resolve_accessible_mask
+            chrom = region.split(':')[0] if region else source.chrom
+            lo, hi = source.mappable_lo, source.mappable_hi
+            accessible_mask = resolve_accessible_mask(
+                accessible_bed, lo, hi - 1, chrom)
+
         return StreamingHaplotypeMatrix(
             source, fetcher,
             chunk_bp=chunk_bp, prefetch=prefetch,
+            accessible_mask=accessible_mask,
         )
 
     def to_zarr(self, zarr_path: str, format: str = 'vcz',

--- a/pg_gpu/relatedness.py
+++ b/pg_gpu/relatedness.py
@@ -48,7 +48,11 @@ def genetic_relatedness(haplotype_matrix, sample_sets=None, indexes=None, *,
         between the covariance and the segregating-site count).
     span_normalize : bool or str
         True (default) divides by the analysis span (see ``get_span``); False
-        returns the raw sum. Matches tskit's ``span_normalise``.
+        returns the raw sum. Like tskit's ``span_normalise``, except that when
+        the matrix carries an accessible mask the span is the accessible-base
+        count over the analyzed region rather than the raw sequence length. The
+        eager and streaming paths use the same span source (an ``accessible_bed``
+        supplied at load).
     missing_data : str
         'include' (default) uses per-site, per-set valid counts; 'exclude'
         restricts to sites with no missing data among the analyzed samples.
@@ -138,8 +142,9 @@ def _stream_genetic_relatedness(streaming_matrix, *, sample_sets, indexes,
     centering is local to its site, so one pass over the chunks suffices. The
     (D, D) output is accumulated on host with the set (row) axis tiled into
     blocks, the same scheme as the streaming GRM/IBS, so it holds when D is
-    large (the per-haplotype default). span_normalise for streaming supports
-    True/False only.
+    large (the per-haplotype default). Span normalization uses the streaming
+    matrix's get_span (accessible mask / n_total_sites / raw span), matching
+    the eager path.
     """
     from ._memutil import estimate_indiv_block_size
 
@@ -163,6 +168,8 @@ def _stream_genetic_relatedness(streaming_matrix, *, sample_sets, indexes,
     if block_size is None:
         block_size = estimate_indiv_block_size(D, n_intermediates=3)
 
+    # iter_gpu_chunks already attaches any load-time accessible mask, so the
+    # chunks here are variant-filtered to accessible sites (matching eager).
     for _, _, chunk in streaming_matrix.iter_gpu_chunks():
         hap = chunk.haplotypes
         if covered is not None:
@@ -187,11 +194,12 @@ def _stream_genetic_relatedness(streaming_matrix, *, sample_sets, indexes,
         if denom > 0:
             R = R / denom
     elif span_normalize is not False:
-        if span_normalize is not True:
-            raise NotImplementedError(
-                "streaming genetic_relatedness supports span_normalize "
-                "True or False only")
-        span = streaming_matrix.chrom_end - streaming_matrix.chrom_start + 1
+        # Same span source as the eager path: get_span('auto') prefers the
+        # accessible mask / n_total_sites (set at load via accessible_bed) over
+        # the raw per-base span, and uses variant-position bounds so it matches
+        # the eager matrix built from the same store.
+        mode = 'auto' if span_normalize is True else span_normalize
+        span = streaming_matrix.get_span(mode)
         if span > 0:
             R = R / span
 

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -422,7 +422,7 @@ class _StreamingMatrixBase:
     """
 
     def __init__(self, source, fetcher, chunk_bp, prefetch, *,
-                 align_bp=None):
+                 align_bp=None, accessible_mask=None, n_total_sites=None):
         self._source = source
         self._fetcher = fetcher
         self._chunk_bp = int(chunk_bp)
@@ -435,6 +435,10 @@ class _StreamingMatrixBase:
         # (or None) and let the property fall back to a default 'all'
         # set when no pop file resolved at source construction.
         self._sample_sets = source.pop_cols
+        # Span-normalization metadata, mirroring the eager HaplotypeMatrix.
+        # None when no accessible BED was supplied at load; see get_span.
+        self.accessible_mask = accessible_mask
+        self.n_total_sites = n_total_sites
 
     @property
     def num_variants(self):
@@ -472,6 +476,45 @@ class _StreamingMatrixBase:
         convention."""
         return self._chunks[-1][1] if self._chunks else 0
 
+    def get_span(self, mode='auto'):
+        """Genomic span for normalization, mirroring HaplotypeMatrix.get_span.
+
+        Spans use the *variant-position* bounds (``mappable_lo``/``mappable_hi``)
+        rather than the chunk-grid ``chrom_start``/``chrom_end``, so the value
+        matches an eager matrix built from the same store. ``mappable_hi`` is one
+        past the last variant, so the raw span is ``mappable_hi - mappable_lo``
+        and the accessible count is over the half-open ``[lo, hi)``.
+
+        'auto' priority: accessible-mask count > n_total_sites > raw per-base span.
+
+        ``per_variant``/``sites`` and ``callable`` are computed over the
+        accessible-filtered variant set (as the eager path does through its
+        mask-filtered variant view), so they agree with eager under a mask;
+        ``per_base``/``total`` is the raw variant span, mask-independent.
+        """
+        lo = self._source.mappable_lo
+        hi = self._source.mappable_hi          # one past the last variant
+        if mode == 'auto':
+            if self.accessible_mask is not None:
+                return self.accessible_mask.count_accessible(lo, hi)
+            if self.n_total_sites is not None:
+                return self.n_total_sites
+            return hi - lo
+        if mode == 'accessible':
+            if self.accessible_mask is None:
+                raise ValueError("mode='accessible' requires an accessible mask")
+            return self.accessible_mask.count_accessible(lo, hi)
+        if mode in ('per_base', 'total'):
+            return hi - lo
+        if mode in ('per_variant', 'sites', 'callable'):
+            pos = self._source.site_pos
+            if self.accessible_mask is not None:
+                pos = pos[self.accessible_mask.is_accessible_at(pos)]
+            if mode == 'callable':
+                return int(pos[-1] - pos[0] + 1) if pos.size else 0
+            return int(pos.size)
+        raise ValueError(f"Invalid span mode: {mode}")
+
     @property
     def sample_sets(self):
         """Population -> sample-axis indices. Falls back to a single
@@ -504,6 +547,12 @@ class _StreamingMatrixBase:
                 chrom_start=int(left), chrom_end=int(right),
                 sample_sets=self._sample_sets,
             )
+            # A load-time accessible mask filters variants to accessible sites,
+            # exactly as it does on an eager matrix -- attach it here, at the
+            # single chunk-production point, so every streaming consumer sees
+            # accessible-filtered chunks by construction.
+            if self.accessible_mask is not None:
+                m.accessible_mask = self.accessible_mask
             yield int(left), int(right), m
 
     def materialize(self, *, region=None, sample_subset=None):

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -223,6 +223,22 @@ class TestAccessibleBedDispatch:
                                  accessible_bed=bed, chrom="1")
         _assert_frames_equivalent(df_e, df_s)
 
+    def test_load_time_mask_filters_chunks(self, vcz_store, tmp_path):
+        # A mask supplied at LOAD time (from_zarr(accessible_bed=)) is attached
+        # to every chunk by iter_gpu_chunks, so every streaming consumer sees
+        # accessible-filtered variants -- not just genetic_relatedness. #151
+        bed = self._write_bed(str(tmp_path / "acc.bed"))   # accessible: [25000, 75000)
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                           chunk_bp=10_000, accessible_bed=bed)
+        seen = 0
+        for _, _, chunk in stream.iter_gpu_chunks():
+            assert chunk.has_accessible_mask
+            pos = chunk.positions
+            pos = pos.get() if hasattr(pos, "get") else np.asarray(pos)
+            assert ((pos >= 25000) & (pos < 75000)).all()
+            seen += chunk.num_variants
+        assert seen > 0
+
 
 class TestGarudStreamingDispatch:
     """Per-window scatter-reduce assembles each window's hash from the
@@ -453,3 +469,50 @@ class TestGeneticRelatednessDispatch:
         a = relatedness.genetic_relatedness(s_a, span_normalize=False)
         b = relatedness.genetic_relatedness(s_b, span_normalize=False)
         np.testing.assert_allclose(a, b, rtol=1e-9, atol=1e-12)
+
+    def test_span_normalize_no_mask_equivalent(self, vcz_store):
+        # Default span_normalize=True with no accessible mask: streaming must
+        # normalize by the same variant-position span as the eager path
+        # (both use mappable_lo/hi, not the chunk-grid edges). #151
+        from pg_gpu import relatedness
+        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                           chunk_bp=10_000)
+        e = relatedness.genetic_relatedness(eager, span_normalize=True)
+        s = relatedness.genetic_relatedness(stream, span_normalize=True)
+        np.testing.assert_allclose(s, e, rtol=1e-9, atol=1e-12)
+
+    def test_accessible_bed_span_and_filter_equivalent(self, vcz_store, tmp_path):
+        # accessible_bed both restricts variants to accessible sites and sets
+        # the accessible-base span; streaming must match eager on both. #151
+        from pg_gpu import relatedness
+        bed = str(tmp_path / "acc.bed")
+        with open(bed, "w") as f:
+            f.write("1\t25000\t75000\n")   # only the middle 50 kb accessible
+        full = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
+        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never",
+                                          accessible_bed=bed)
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                           chunk_bp=10_000, accessible_bed=bed)
+        assert eager.num_variants < full.num_variants   # mask really filters
+        e = relatedness.genetic_relatedness(eager, span_normalize=True)
+        s = relatedness.genetic_relatedness(stream, span_normalize=True)
+        np.testing.assert_allclose(s, e, rtol=1e-9, atol=1e-12)
+
+    @pytest.mark.parametrize("mode", ["per_variant", "sites", "callable", "per_base"])
+    def test_span_mode_matches_eager_with_mask(self, vcz_store, tmp_path, mode):
+        # Non-default span modes: per_variant/sites/callable count over the
+        # accessible-FILTERED variant set (eager does the same via its filtered
+        # view); per_base is the raw span. All must agree eager vs streaming.
+        from pg_gpu import relatedness
+        bed = str(tmp_path / "acc.bed")
+        with open(bed, "w") as f:
+            f.write("1\t25000\t75000\n")
+        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never",
+                                          accessible_bed=bed)
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                           chunk_bp=10_000, accessible_bed=bed)
+        assert eager.get_span(mode) == stream.get_span(mode)
+        e = relatedness.genetic_relatedness(eager, span_normalize=mode)
+        s = relatedness.genetic_relatedness(stream, span_normalize=mode)
+        np.testing.assert_allclose(s, e, rtol=1e-9, atol=1e-12)


### PR DESCRIPTION
## Summary

Closes #151. Makes streaming `genetic_relatedness` honor an accessible mask the same way the eager path does.

Eager `genetic_relatedness` normalizes by `get_span('auto')` (accessible-mask count > `n_total_sites` > raw per-base span) and, because an accessible mask filters a `HaplotypeMatrix`'s variant view, computes over accessible sites only. The streaming path did neither: `accessible_bed` was dropped by `from_zarr`'s streaming branches, `StreamingHaplotypeMatrix` carried no mask, and `_stream_genetic_relatedness` hardcoded the raw chunk-grid span. So the same data loaded eagerly vs streamed diverged on the default `span_normalize=True` path whenever a mask was present (raw matrices identical, normalized differ by `raw_span / accessible_bases`).

## What changed

- **`streaming_matrix.py`** — `_StreamingMatrixBase` gains `accessible_mask` / `n_total_sites` and a `get_span('auto')` mirroring `HaplotypeMatrix.get_span`, using the source's variant-position bounds (`mappable_lo`/`mappable_hi`) so the span matches an eager matrix built from the same store. `iter_gpu_chunks` attaches the mask to every chunk it yields — the single chunk-production point — so **every** streaming consumer (`genetic_relatedness`, and `windowed_analysis`) sees accessible-filtered variants by construction, rather than each reduction re-applying the mask.
- **`haplotype_matrix.py`** — `from_zarr` forwards `accessible_bed` to `_build_streaming`, which resolves the mask once and attaches it.
- **`relatedness.py`** — `_stream_genetic_relatedness` takes its span from `get_span` and drops its own per-chunk attach (now redundant given the choke-point); docstrings corrected.

## Verification

- New tests: eager/streaming `genetic_relatedness` parity with and without an `accessible_bed` (both filtering and span), and that `iter_gpu_chunks` filters chunk variants to accessible sites.
- The #151 MRE is now exact: `max|eager − stream| == 0` with and without a mask, identical variant sets.
- Full relatedness + streaming + zarr + accessible-mask suites stay green; full-repo ruff clean.

## Follow-up (not in this PR)

The sibling `StreamingGenotypeMatrix` loader still drops `accessible_bed`, so streaming `grm`/`ibs` ignore a mask (variant filtering, not span, since they're per-site averages). Tracked in #152; the `iter_gpu_chunks` choke-point here means the fix there is just plumbing the mask onto the genotype streaming matrix.
