### PR TITLE
Multiallelic-correct statistics: integrate nsp-multiallelic-trunk into main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,12 @@ simulations/
 commit_message.txt
 *.png
 *.csv
+
 CLAUDE.md
 TODO_*.md
+.claude/
+plans/
+debug/
 
 # Local-only design specs and brainstorming notes
 docs/superpowers/

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -264,6 +264,8 @@ PCA
 
 .. autofunction:: pg_gpu.decomposition.pca
 .. autofunction:: pg_gpu.decomposition.randomized_pca
+.. autofunction:: pg_gpu.decomposition.pca_dosage
+.. autofunction:: pg_gpu.decomposition.randomized_pca_dosage
 
 Distance
 ~~~~~~~~

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -111,7 +111,6 @@ Core Functions
 .. autofunction:: pg_gpu.diversity.theta_w
 .. autofunction:: pg_gpu.diversity.tajimas_d
 .. autofunction:: pg_gpu.diversity.haplotype_diversity
-.. autofunction:: pg_gpu.diversity.allele_frequency_spectrum
 .. autofunction:: pg_gpu.diversity.segregating_sites
 .. autofunction:: pg_gpu.diversity.singleton_count
 .. autofunction:: pg_gpu.diversity.fay_wus_h

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -190,8 +190,7 @@ PCA and Dimensionality Reduction
    from pg_gpu import decomposition
 
    # GPU-accelerated PCA (up to 56x faster than allel)
-   coords, var_ratio = decomposition.pca(h, n_components=10,
-                                          scaler='patterson')
+   coords, var_ratio = decomposition.pca(h, n_components=10)
 
    # Randomized PCA for very large datasets
    coords, var_ratio = decomposition.randomized_pca(

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -189,16 +189,17 @@ PCA and Dimensionality Reduction
 
    from pg_gpu import decomposition
 
-   # tskit PCA: eigendecomposition of the genetic_relatedness matrix
-   # (all alleles kept, multiallelic-correct). Takes a HaplotypeMatrix.
+   # Multi-allele haploid PCA: eigendecomposition of the genetic relatedness
+   # matrix, keeping all alleles (multiallelic-correct). Takes a HaplotypeMatrix.
    coords, var_ratio = decomposition.pca(h, n_components=10)
 
    # Randomized approximation for very large datasets
    coords, var_ratio = decomposition.randomized_pca(
        h, n_components=10, random_state=42)
 
-   # Patterson/GCTA PCA of biallelic diploid dosages (EIGENSTRAT, matches
-   # scikit-allel). Takes a GenotypeMatrix; has a randomized counterpart.
+   # Diploid dosage PCA standardized by binomial variance (center each biallelic
+   # variant's dosage, scale by sqrt(p(1-p))). Takes a GenotypeMatrix; has a
+   # randomized counterpart.
    from pg_gpu import GenotypeMatrix
    g = GenotypeMatrix.from_haplotype_matrix(h)  # pair haplotypes as diploids
    coords, var_ratio = decomposition.pca_dosage(g, n_components=10)

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -189,12 +189,21 @@ PCA and Dimensionality Reduction
 
    from pg_gpu import decomposition
 
-   # GPU-accelerated PCA (up to 56x faster than allel)
+   # tskit PCA: eigendecomposition of the genetic_relatedness matrix
+   # (all alleles kept, multiallelic-correct). Takes a HaplotypeMatrix.
    coords, var_ratio = decomposition.pca(h, n_components=10)
 
-   # Randomized PCA for very large datasets
+   # Randomized approximation for very large datasets
    coords, var_ratio = decomposition.randomized_pca(
        h, n_components=10, random_state=42)
+
+   # Patterson/GCTA PCA of biallelic diploid dosages (EIGENSTRAT, matches
+   # scikit-allel). Takes a GenotypeMatrix; has a randomized counterpart.
+   from pg_gpu import GenotypeMatrix
+   g = GenotypeMatrix.from_haplotype_matrix(h)  # pair haplotypes as diploids
+   coords, var_ratio = decomposition.pca_dosage(g, n_components=10)
+   coords, var_ratio = decomposition.randomized_pca_dosage(
+       g, n_components=10, random_state=42)
 
    # Pairwise genetic distance (batched for memory safety)
    dist = decomposition.pairwise_distance(h, metric='euclidean')

--- a/pg_gpu/__init__.py
+++ b/pg_gpu/__init__.py
@@ -56,6 +56,10 @@ from .windowed_analysis import WindowedAnalyzer, windowed_analysis
 from .decomposition import (
     LocalPCAResult,
     LostructResult,
+    pca,
+    randomized_pca,
+    pca_dosage,
+    randomized_pca_dosage,
     local_pca,
     local_pca_jackknife,
     lostruct,
@@ -68,7 +72,7 @@ from ._warnings import (
     MultiallelicCapWarning,
 )
 
-__all__ = ['ld_statistics', 'diversity', 'divergence', 'windowed_analysis', 'selection', 'sfs', 'admixture', 'decomposition', 'plotting', 'distance_stats', 'resampling', 'HaplotypeMatrix', 'GenotypeMatrix', 'WindowedAnalyzer', 'windowed_analysis', 'AccessibleMask', 'bed_to_mask', 'parse_bed', 'LocalPCAResult', 'LostructResult', 'local_pca', 'local_pca_jackknife', 'lostruct', 'pc_dist', 'corners', 'block_jackknife', 'block_bootstrap', 'MemoryLimitedWarning', 'HaploidDataWarning', 'BadlyChunkedWarning', 'MultiallelicCapWarning']
+__all__ = ['ld_statistics', 'diversity', 'divergence', 'windowed_analysis', 'selection', 'sfs', 'admixture', 'decomposition', 'plotting', 'distance_stats', 'resampling', 'HaplotypeMatrix', 'GenotypeMatrix', 'WindowedAnalyzer', 'windowed_analysis', 'AccessibleMask', 'bed_to_mask', 'parse_bed', 'LocalPCAResult', 'LostructResult', 'pca', 'randomized_pca', 'pca_dosage', 'randomized_pca_dosage', 'local_pca', 'local_pca_jackknife', 'lostruct', 'pc_dist', 'corners', 'block_jackknife', 'block_bootstrap', 'MemoryLimitedWarning', 'HaploidDataWarning', 'BadlyChunkedWarning', 'MultiallelicCapWarning']
 
 # Version is derived from the git tag at build time (hatch-vcs) and read here
 # from the installed package metadata, so there is no hardcoded string to keep

--- a/pg_gpu/__init__.py
+++ b/pg_gpu/__init__.py
@@ -65,9 +65,10 @@ from .decomposition import (
 from .resampling import block_jackknife, block_bootstrap
 from ._warnings import (
     BadlyChunkedWarning, HaploidDataWarning, MemoryLimitedWarning,
+    MultiallelicCapWarning,
 )
 
-__all__ = ['ld_statistics', 'diversity', 'divergence', 'windowed_analysis', 'selection', 'sfs', 'admixture', 'decomposition', 'plotting', 'distance_stats', 'resampling', 'HaplotypeMatrix', 'GenotypeMatrix', 'WindowedAnalyzer', 'windowed_analysis', 'AccessibleMask', 'bed_to_mask', 'parse_bed', 'LocalPCAResult', 'LostructResult', 'local_pca', 'local_pca_jackknife', 'lostruct', 'pc_dist', 'corners', 'block_jackknife', 'block_bootstrap', 'MemoryLimitedWarning', 'HaploidDataWarning', 'BadlyChunkedWarning']
+__all__ = ['ld_statistics', 'diversity', 'divergence', 'windowed_analysis', 'selection', 'sfs', 'admixture', 'decomposition', 'plotting', 'distance_stats', 'resampling', 'HaplotypeMatrix', 'GenotypeMatrix', 'WindowedAnalyzer', 'windowed_analysis', 'AccessibleMask', 'bed_to_mask', 'parse_bed', 'LocalPCAResult', 'LostructResult', 'local_pca', 'local_pca_jackknife', 'lostruct', 'pc_dist', 'corners', 'block_jackknife', 'block_bootstrap', 'MemoryLimitedWarning', 'HaploidDataWarning', 'BadlyChunkedWarning', 'MultiallelicCapWarning']
 
 # Version is derived from the git tag at build time (hatch-vcs) and read here
 # from the installed package metadata, so there is no hardcoded string to keep

--- a/pg_gpu/_memutil.py
+++ b/pg_gpu/_memutil.py
@@ -2,6 +2,9 @@
 
 import cupy as cp
 
+# Threads per block for the one-thread-per-variant fused kernels.
+_THREADS_PER_BLOCK = 256
+
 
 def estimate_variant_chunk_size(n_hap, bytes_per_element=4, n_intermediates=3,
                                  memory_fraction=0.4):
@@ -149,7 +152,7 @@ def dac_and_n(hap):
     out_dac = cp.empty(n_var, dtype=cp.int64)
     out_n = cp.empty(n_var, dtype=cp.int64)
     s0, s1 = hap.strides
-    threads = 256
+    threads = _THREADS_PER_BLOCK
     blocks = (n_var + threads - 1) // threads
     _dac_and_n_kernel((blocks,), (threads,),
                       (hap, n_hap, n_var, s0, s1, out_dac, out_n))
@@ -158,6 +161,76 @@ def dac_and_n(hap):
 
 # Backward-compatible alias
 chunked_dac_and_n = dac_and_n
+
+
+_allele_counts_kernel = cp.RawKernel(r'''
+extern "C" __global__
+void allele_counts(const signed char* hap, int n_hap, int n_var,
+                   long long stride0, long long stride1, int K,
+                   long long* out_ac, long long* out_n) {
+    int j = blockIdx.x * blockDim.x + threadIdx.x;
+    if (j >= n_var) return;
+    // One thread owns variant j's output row, so no atomics are needed:
+    // the row doubles as this thread's histogram. Zero it, then tally.
+    long long base = (long long)j * K;
+    for (int a = 0; a < K; a++) out_ac[base + a] = 0;
+    int nv = 0;
+    for (int i = 0; i < n_hap; i++) {
+        signed char v = hap[i * stride0 + j * stride1];
+        if (v >= 0) {
+            nv++;
+            if (v < K) out_ac[base + v]++;  // v < K guaranteed when K == max+1
+        }
+    }
+    out_n[j] = nv;
+}
+''', 'allele_counts')
+
+
+def allele_counts(hap, n_alleles=None):
+    """Compute per-allele sample counts and valid counts via fused CUDA kernel.
+
+    Single-pass kernel: one thread per variant reads each element once and
+    tallies a per-allele histogram directly into its own output row (no
+    intermediate array, no atomics). This is the per-allele analogue of
+    ``dac_and_n`` and the multiallelic-correct primitive: allele ``a`` at a
+    site gets its own count, rather than all non-reference alleles being
+    collapsed into one derived class.
+
+    Parameters
+    ----------
+    hap : cupy.ndarray, int8, shape (n_hap, n_var)
+        Allele indices (0 = reference/ancestral, 1.. = alternate), -1 missing.
+    n_alleles : int, optional
+        Output width ``K`` (number of allele columns). If None, derived as
+        ``max(hap) + 1`` via a one-shot reduction. Pass a global value when
+        several calls (e.g. per population) must produce aligned matrices;
+        it must be at least ``max(hap) + 1`` (counts for larger indices are
+        dropped from ``ac`` but still counted in ``n_valid``).
+
+    Returns
+    -------
+    ac : cupy.ndarray, int64, shape (n_var, K)
+        Per-allele sample count; column ``a`` is the count of allele ``a``.
+    n_valid : cupy.ndarray, int64, shape (n_var,)
+        Number of non-missing haplotypes per site (== ac.sum(axis=1) when
+        n_alleles covers the true allele range).
+    """
+    n_hap, n_var = hap.shape
+    if n_alleles is None:
+        K = (max(int(hap.max()), 0) + 1) if hap.size else 1
+    else:
+        K = int(n_alleles)
+    if n_var == 0:
+        return cp.empty((0, K), dtype=cp.int64), cp.empty(0, dtype=cp.int64)
+    out_ac = cp.empty((n_var, K), dtype=cp.int64)
+    out_n = cp.empty(n_var, dtype=cp.int64)
+    s0, s1 = hap.strides
+    threads = _THREADS_PER_BLOCK
+    blocks = (n_var + threads - 1) // threads
+    _allele_counts_kernel((blocks,), (threads,),
+                          (hap, n_hap, n_var, s0, s1, K, out_ac, out_n))
+    return out_ac, out_n
 
 
 def chunked_matmul_accumulate(X, chunk_size=None):

--- a/pg_gpu/_utils.py
+++ b/pg_gpu/_utils.py
@@ -6,38 +6,49 @@ from typing import Union
 from .haplotype_matrix import HaplotypeMatrix
 
 
-def get_population_matrix(haplotype_matrix: HaplotypeMatrix,
-                          population: Union[str, list]) -> HaplotypeMatrix:
-    """Extract a population-specific HaplotypeMatrix.
+def get_population_matrix(matrix, population: Union[str, list]):
+    """Extract a population-specific subset matrix.
 
     Parameters
     ----------
-    haplotype_matrix : HaplotypeMatrix
-        The full haplotype data.
+    matrix : HaplotypeMatrix or GenotypeMatrix
+        The full data. Rows are haplotypes (HaplotypeMatrix) or individuals
+        (GenotypeMatrix); the subset is taken along that row axis.
     population : str or list
-        Population name (looked up in sample_sets) or list of sample indices.
+        Population name (looked up in sample_sets) or list of row indices.
 
     Returns
     -------
-    HaplotypeMatrix
-        Subset matrix for the specified population.
+    HaplotypeMatrix or GenotypeMatrix
+        Subset matrix of the same type for the specified population.
     """
+    from .genotype_matrix import GenotypeMatrix
+
     if isinstance(population, str):
-        if haplotype_matrix.sample_sets is None:
-            raise ValueError("No sample_sets defined in haplotype matrix")
-        if population not in haplotype_matrix.sample_sets:
+        if matrix.sample_sets is None:
+            raise ValueError("No sample_sets defined in matrix")
+        if population not in matrix.sample_sets:
             raise ValueError(
                 f"Population {population} not found in sample_sets")
-        pop_indices = haplotype_matrix.sample_sets[population]
+        pop_indices = matrix.sample_sets[population]
     else:
         pop_indices = list(population)
 
-    pop_haplotypes = haplotype_matrix.haplotypes[pop_indices, :]
+    subset_sets = {'all': list(range(len(pop_indices)))}
+    if isinstance(matrix, GenotypeMatrix):
+        return GenotypeMatrix(
+            matrix.genotypes[pop_indices, :],
+            matrix.positions,
+            matrix.chrom_start,
+            matrix.chrom_end,
+            sample_sets=subset_sets,
+            n_total_sites=matrix.n_total_sites,
+        )
     return HaplotypeMatrix(
-        pop_haplotypes,
-        haplotype_matrix.positions,
-        haplotype_matrix.chrom_start,
-        haplotype_matrix.chrom_end,
-        sample_sets={'all': list(range(len(pop_indices)))},
-        n_total_sites=haplotype_matrix.n_total_sites,
+        matrix.haplotypes[pop_indices, :],
+        matrix.positions,
+        matrix.chrom_start,
+        matrix.chrom_end,
+        sample_sets=subset_sets,
+        n_total_sites=matrix.n_total_sites,
     )

--- a/pg_gpu/_warnings.py
+++ b/pg_gpu/_warnings.py
@@ -67,6 +67,23 @@ class BadlyChunkedWarning(UserWarning):
     unlock the GPU-decode fast path."""
 
 
+class MultiallelicCapWarning(UserWarning):
+    """Emitted when a fused windowed kernel drops sites with more alleles
+    than the kernel's fixed per-allele capacity.
+
+    The fused windowed-statistics CUDA kernels count alleles into a fixed-size
+    per-variant array (``MAX_ALLELES``), so any site with more alleles than that
+    cap is excluded from the windowed scalar statistics and a count is reported.
+    The cap is generous (nucleotide data has at most 4 alleles); this only fires
+    on unusually multiallelic input. The (non-windowed) scalar functions in
+    ``diversity`` / ``divergence`` handle arbitrary allele counts. Silence with::
+
+        import warnings
+        from pg_gpu import MultiallelicCapWarning
+        warnings.filterwarnings("ignore", category=MultiallelicCapWarning)
+    """
+
+
 # ── VCF size heuristic ──────────────────────────────────────────────────────
 #
 # VCF text parsing is single-threaded in htslib and the whole genotype matrix

--- a/pg_gpu/admixture.py
+++ b/pg_gpu/admixture.py
@@ -13,49 +13,76 @@ from ._utils import get_population_matrix as _get_population_matrix
 from .resampling import block_jackknife, _moving_nansum, _moving_nanmean
 
 
-def _allele_freq(haplotype_matrix):
-    """Compute alternate allele frequency from per-site valid data."""
-    if haplotype_matrix.device == 'CPU':
-        haplotype_matrix.transfer_to_gpu()
+def _aligned_allele_counts(haplotype_matrix, pops):
+    """Per-allele counts for a list of populations on a shared global K.
 
-    hap = haplotype_matrix.haplotypes
-    valid_mask = hap >= 0
-    n_valid = cp.sum(valid_mask, axis=0).astype(cp.float64)
-    n1 = cp.sum(cp.where(valid_mask, hap, 0), axis=0).astype(cp.float64)
-    return cp.where(n_valid > 0, n1 / n_valid, 0.0)
-
-
-def _allele_freq_and_het(haplotype_matrix):
-    """Compute alternate allele frequency and unbiased heterozygosity.
-
-    Parameters
-    ----------
-    haplotype_matrix : HaplotypeMatrix
-
-    Returns
-    -------
-    freq : cupy.ndarray, float64, shape (n_variants,)
-        Alternate allele frequency.
-    h : cupy.ndarray, float64, shape (n_variants,)
-        Unbiased heterozygosity estimator: n0*n1 / (n*(n-1)).
-    n : cupy.ndarray, float64, shape (n_variants,)
-        Allele number per site (n_valid).
+    Returns a list of ``(x, n)`` per pop, where ``x`` is ``(n_var, K)`` allele
+    counts (float64) and ``n`` is ``(n_var,)`` valid haplotype counts. K is the
+    max allele index over ALL listed pops + 1, so column ``a`` denotes the same
+    allele in every pop (the alignment discipline from the joint SFS /
+    divergence). This is the counting substrate for the tskit f-statistics.
     """
-    if haplotype_matrix.device == 'CPU':
-        haplotype_matrix.transfer_to_gpu()
+    from ._memutil import allele_counts
+    mats = [_get_population_matrix(haplotype_matrix, p) for p in pops]
+    for m in mats:
+        if m.device == 'CPU':
+            m.transfer_to_gpu()
+    k = max((int(m.haplotypes.max()) for m in mats if m.haplotypes.size),
+            default=0)
+    n_alleles = max(k, 0) + 1
+    out = []
+    for m in mats:
+        x, n = allele_counts(m.haplotypes, n_alleles=n_alleles)
+        out.append((x.astype(cp.float64), n.astype(cp.float64)))
+    return out
 
-    hap = haplotype_matrix.haplotypes
 
-    valid_mask = hap >= 0
-    an = cp.sum(valid_mask, axis=0).astype(cp.float64)
-    n1 = cp.sum(cp.where(valid_mask, hap, 0), axis=0).astype(cp.float64)
-    n0 = an - n1
+def _f2_terms(xa, na, xb, nb):
+    """Per-variant f2(A,B), the tskit unbiased U-statistic summed over alleles.
 
-    freq = cp.where(an > 0, n1 / an, 0.0)
-    h = cp.where(an > 1, (n0 * n1) / (an * (an - 1)), 0.0)
+    x* are (n_var, K) per-allele counts on a shared K; n* are (n_var,) valid
+    counts. Matches tskit's ``ts.f2``. Non-estimable sites (n < 2 in either pop)
+    contribute 0.
+    """
+    na_, nb_ = na[:, None], nb[:, None]
+    num = (xa * (xa - 1) * (nb_ - xb) * (nb_ - xb - 1)
+           - xa * (na_ - xa) * (nb_ - xb) * xb)
+    den = na_ * (na_ - 1) * nb_ * (nb_ - 1)
+    return cp.where(den > 0, num / den, 0.0).sum(axis=1)
 
-    return freq, h, an
 
+def _f3_terms(xi, ni, xj, nj, xk, nk):
+    """Per-variant f3(I; J, K), the tskit unbiased U-statistic over alleles.
+
+    I is the target population (tskit's first sample set). Matches ``ts.f3``.
+    """
+    ni_, nj_, nk_ = ni[:, None], nj[:, None], nk[:, None]
+    num = (xi * (xi - 1) * (nj_ - xj) * (nk_ - xk)
+           - xi * (ni_ - xi) * (nj_ - xj) * xk)
+    den = ni_ * (ni_ - 1) * nj_ * nk_
+    return cp.where(den > 0, num / den, 0.0).sum(axis=1)
+
+
+def _het_unbiased(x, n):
+    """Per-variant unbiased heterozygosity: (n^2 - sum_a x_a^2) / (n(n-1)).
+
+    Per-allele; reduces to the biallelic 2*n0*n1/(n(n-1)) form. Used as the f3
+    normalization (B = heterozygosity of the target population).
+    """
+    sumsq = (x * x).sum(axis=1)
+    return cp.where(n > 1, (n * n - sumsq) / (n * (n - 1)), 0.0)
+
+
+def _f4_terms(xa, na, xb, nb, xc, nc, xd, nd):
+    """Per-variant f4(A,B,C,D), the tskit unbiased U-statistic over alleles.
+
+    Matches tskit's ``ts.f4``.
+    """
+    na_, nb_, nc_, nd_ = na[:, None], nb[:, None], nc[:, None], nd[:, None]
+    num = (xa * xc * (nb_ - xb) * (nd_ - xd)
+           - xa * xd * (nb_ - xb) * (nc_ - xc))
+    den = na_ * nb_ * nc_ * nd_
+    return cp.where(den > 0, num / den, 0.0).sum(axis=1)
 
 
 # ---------------------------------------------------------------------------
@@ -88,14 +115,9 @@ def patterson_f2(haplotype_matrix: HaplotypeMatrix,
         if haplotype_matrix.num_variants == 0:
             return np.array([])
 
-    ma = _get_population_matrix(haplotype_matrix, pop_a)
-    mb = _get_population_matrix(haplotype_matrix, pop_b)
-
-    a, ha, sa = _allele_freq_and_het(ma)
-    b, hb, sb = _allele_freq_and_het(mb)
-
-    f2 = ((a - b) ** 2) - (ha / sa) - (hb / sb)
-    return f2.get()
+    (xa, na), (xb, nb) = _aligned_allele_counts(haplotype_matrix,
+                                                [pop_a, pop_b])
+    return _f2_terms(xa, na, xb, nb).get()
 
 
 def patterson_f3(haplotype_matrix: HaplotypeMatrix,
@@ -122,50 +144,69 @@ def patterson_f3(haplotype_matrix: HaplotypeMatrix,
     Returns
     -------
     T : ndarray, float64, shape (n_variants,)
-        Un-normalized F3 estimates per variant.
+        Un-normalized F3 estimates per variant (matches tskit f3(C; A, B)).
     B : ndarray, float64, shape (n_variants,)
-        Heterozygosity estimates (2 * h_hat) for population C.
+        Unbiased heterozygosity of the target population C (f3 normalization).
     """
-    if missing_data == 'exclude':
-        haplotype_matrix = haplotype_matrix.exclude_missing_sites(
-            populations=[pop_c, pop_a, pop_b])
-        if haplotype_matrix.num_variants == 0:
-            return np.array([]), np.array([])
-
-    mc = _get_population_matrix(haplotype_matrix, pop_c)
-    ma = _get_population_matrix(haplotype_matrix, pop_a)
-    mb = _get_population_matrix(haplotype_matrix, pop_b)
-
-    c, hc, sc = _allele_freq_and_het(mc)
-    a, _, _ = _allele_freq_and_het(ma)
-    b, _, _ = _allele_freq_and_het(mb)
-
-    T = ((c - a) * (c - b)) - (hc / sc)
-    B = 2 * hc
-
-    return T.get(), B.get()
+    return tuple(v.get() for v in
+                 _patterson_f3_gpu(haplotype_matrix, pop_c, pop_a, pop_b,
+                                   missing_data))
 
 
 def _patterson_f3_gpu(haplotype_matrix, pop_c, pop_a, pop_b,
                       missing_data='include'):
-    """Like patterson_f3 but returns CuPy arrays (no D2H transfer)."""
+    """Like patterson_f3 but returns CuPy arrays (no D2H transfer).
+
+    T = tskit f3(C; A, B) per variant (unbiased U-statistic); B = unbiased
+    heterozygosity of the target population C (the f3 normalization).
+    """
     if missing_data == 'exclude':
         haplotype_matrix = haplotype_matrix.exclude_missing_sites(
             populations=[pop_c, pop_a, pop_b])
         if haplotype_matrix.num_variants == 0:
             return cp.array([]), cp.array([])
 
-    mc = _get_population_matrix(haplotype_matrix, pop_c)
-    ma = _get_population_matrix(haplotype_matrix, pop_a)
-    mb = _get_population_matrix(haplotype_matrix, pop_b)
+    (xc, nc), (xa, na), (xb, nb) = _aligned_allele_counts(
+        haplotype_matrix, [pop_c, pop_a, pop_b])
 
-    c, hc, sc = _allele_freq_and_het(mc)
-    a, _, _ = _allele_freq_and_het(ma)
-    b, _, _ = _allele_freq_and_het(mb)
-
-    T = ((c - a) * (c - b)) - (hc / sc)
-    B = 2 * hc
+    T = _f3_terms(xc, nc, xa, na, xb, nb)   # target C is tskit's first set
+    B = _het_unbiased(xc, nc)
     return T, B
+
+
+def patterson_f4(haplotype_matrix: HaplotypeMatrix,
+                 pop_a: Union[str, list],
+                 pop_b: Union[str, list],
+                 pop_c: Union[str, list],
+                 pop_d: Union[str, list],
+                 missing_data: str = 'include'):
+    """Patterson's f4(A, B; C, D) statistic (per variant).
+
+    The unbiased per-allele U-statistic, matching tskit's ``f4`` (site mode).
+    A tree-of-populations under (A,B),(C,D) has f4 == 0; a nonzero value
+    indicates gene flow.
+
+    Parameters
+    ----------
+    haplotype_matrix : HaplotypeMatrix
+    pop_a, pop_b, pop_c, pop_d : str or list
+        Population names or sample indices.
+    missing_data : str
+        'include' - per-site n_valid; 'exclude' - filter complete sites.
+
+    Returns
+    -------
+    f4 : ndarray, float64, shape (n_variants,)
+        Per-variant f4 estimates (sum over variants gives the statistic).
+    """
+    if missing_data == 'exclude':
+        haplotype_matrix = haplotype_matrix.exclude_missing_sites(
+            populations=[pop_a, pop_b, pop_c, pop_d])
+        if haplotype_matrix.num_variants == 0:
+            return np.array([])
+    (xa, na), (xb, nb), (xc, nc), (xd, nd) = _aligned_allele_counts(
+        haplotype_matrix, [pop_a, pop_b, pop_c, pop_d])
+    return _f4_terms(xa, na, xb, nb, xc, nc, xd, nd).get()
 
 
 def patterson_d(haplotype_matrix: HaplotypeMatrix,
@@ -193,50 +234,59 @@ def patterson_d(haplotype_matrix: HaplotypeMatrix,
         Numerator (un-normalized F4 estimates).
     den : ndarray, float64, shape (n_variants,)
         Denominator.
+
+    Notes
+    -----
+    D is a biallelic-SNP statistic: sites with more than two alleles across the
+    four populations are excluded (num = den = 0), silently, as biallelic
+    filtering is handled elsewhere in the package. A multiallelic generalization
+    is a possible future extension.
     """
-    if missing_data == 'exclude':
-        haplotype_matrix = haplotype_matrix.exclude_missing_sites(
-            populations=[pop_a, pop_b, pop_c, pop_d])
-        if haplotype_matrix.num_variants == 0:
-            return np.array([]), np.array([])
-
-    ma = _get_population_matrix(haplotype_matrix, pop_a)
-    mb = _get_population_matrix(haplotype_matrix, pop_b)
-    mc = _get_population_matrix(haplotype_matrix, pop_c)
-    md = _get_population_matrix(haplotype_matrix, pop_d)
-
-    a = _allele_freq(ma)
-    b = _allele_freq(mb)
-    c = _allele_freq(mc)
-    d = _allele_freq(md)
-
-    num = (a - b) * (c - d)
-    den = (a + b - 2 * a * b) * (c + d - 2 * c * d)
-
-    return num.get(), den.get()
+    return tuple(v.get() for v in
+                 _patterson_d_gpu(haplotype_matrix, pop_a, pop_b, pop_c, pop_d,
+                                  missing_data))
 
 
 def _patterson_d_gpu(haplotype_matrix, pop_a, pop_b, pop_c, pop_d,
                      missing_data='include'):
-    """Like patterson_d but returns CuPy arrays (no D2H transfer)."""
+    """Like patterson_d but returns CuPy arrays (no D2H transfer).
+
+    BIALLELIC-RESTRICTED: D (ABBA-BABA) is defined on biallelic SNPs; sites with
+    >2 alleles across the four pops are excluded (num=den=0). On the retained
+    sites the allele frequency is a proper per-allele frequency (count of the
+    single alt allele / n), NOT cp.sum(hap)/n -- so a biallelic {0,2}-type site
+    is handled correctly, not index-inflated. The multiallelic generalization is
+    deferred (needs validation; no reference implementation to pin to).
+    """
     if missing_data == 'exclude':
         haplotype_matrix = haplotype_matrix.exclude_missing_sites(
             populations=[pop_a, pop_b, pop_c, pop_d])
         if haplotype_matrix.num_variants == 0:
             return cp.array([]), cp.array([])
 
-    ma = _get_population_matrix(haplotype_matrix, pop_a)
-    mb = _get_population_matrix(haplotype_matrix, pop_b)
-    mc = _get_population_matrix(haplotype_matrix, pop_c)
-    md = _get_population_matrix(haplotype_matrix, pop_d)
+    (xa, na), (xb, nb), (xc, nc), (xd, nd) = _aligned_allele_counts(
+        haplotype_matrix, [pop_a, pop_b, pop_c, pop_d])
 
-    a = _allele_freq(ma)
-    b = _allele_freq(mb)
-    c = _allele_freq(mc)
-    d = _allele_freq(md)
+    # Sites with >2 alleles across the four pops are dropped (num=den=0),
+    # silently -- consistent with the package's biallelic filtering elsewhere
+    # (e.g. GenotypeMatrix.from_vcf); the biallelic-only contract is documented.
+    present = (xa + xb + xc + xd) > 0
+    biallelic = present.sum(axis=1) <= 2
 
-    num = (a - b) * (c - d)
-    den = (a + b - 2 * a * b) * (c + d - 2 * c * d)
+    # Alt allele = highest-index present allele (== allele 1 for a {0,1} site,
+    # so this reduces to the previous behaviour on standard biallelic data);
+    # D is invariant to which of the two alleles is chosen.
+    k = xa.shape[1]
+    alt = cp.where(present, cp.arange(k)[None, :], -1).argmax(axis=1)[:, None]
+
+    def freq(x, n):
+        alt_count = cp.take_along_axis(x, alt, axis=1)[:, 0]
+        return cp.where(n > 0, alt_count / n, 0.0)
+
+    a, b, c, d = freq(xa, na), freq(xb, nb), freq(xc, nc), freq(xd, nd)
+    num = cp.where(biallelic, (a - b) * (c - d), 0.0)
+    den = cp.where(biallelic,
+                   (a + b - 2 * a * b) * (c + d - 2 * c * d), 0.0)
     return num, den
 
 

--- a/pg_gpu/decomposition.py
+++ b/pg_gpu/decomposition.py
@@ -168,7 +168,8 @@ def _prepare_matrix(haplotype_matrix, scaler, population, missing_data='include'
     return _DeferredPCA(hap_bi, site_mean, scale, scaler, multi_cols)
 
 
-def _prepare_centered(haplotype_matrix, population=None, missing_data='include'):
+def _prepare_centered(haplotype_matrix, population=None, missing_data='include',
+                      need_segregating=True, n_alleles=None):
     """All-allele centered one-hot standardization (the tskit convention).
 
     For each present (site, allele) pair -- ALL alleles including the reference --
@@ -180,7 +181,10 @@ def _prepare_centered(haplotype_matrix, population=None, missing_data='include')
 
     Returns (X, n_segregating), where X is (n_samples, n_cols) float64 and
     n_segregating is the per-site sum of (present alleles - 1) -- tskit's
-    segregating-site count, used to normalize the Gram (proportion=True).
+    segregating-site count, used to normalize the Gram (proportion=True). When
+    ``need_segregating`` is False the count is not computed (returned as 0),
+    avoiding its host sync on the per-window path (lostruct normalizes by ncol,
+    not segregating sites).
     """
     from ._memutil import allele_counts
 
@@ -198,7 +202,10 @@ def _prepare_centered(haplotype_matrix, population=None, missing_data='include')
     if hap.shape[1] == 0:
         return cp.zeros((n_samples, 0), dtype=cp.float64), 0
 
-    K = int(hap.max()) + 1 if hap.size else 1
+    if n_alleles is not None:
+        K = int(n_alleles)                             # hoisted (avoids a per-call max sync)
+    else:
+        K = int(hap.max()) + 1 if hap.size else 1
     ac, n_valid = allele_counts(hap, n_alleles=K)     # (n_var, K), (n_var,)
     pairs = cp.argwhere(ac > 0)                        # present (site, allele), all alleles
     if pairs.shape[0] == 0:
@@ -213,7 +220,10 @@ def _prepare_centered(haplotype_matrix, population=None, missing_data='include')
     X = cp.where(valid, ind, p[None, :]) - p[None, :]  # center; missing -> 0
 
     # segregating sites = sum_site (present alleles - 1) = n_cols - n_present_sites.
-    n_segregating = int(pairs.shape[0] - cp.unique(sites).size)
+    if need_segregating:
+        n_segregating = int(pairs.shape[0] - cp.unique(sites).size)
+    else:
+        n_segregating = 0
     return X, n_segregating
 
 
@@ -666,7 +676,6 @@ class LocalPCAResult:
         `pc_dist` for the proportion-of-variance denominator.
     k : int
         Number of PCs retained.
-    scaler : str or None
     missing_data : str
     jackknife_se : numpy.ndarray or None
         Delete-1 block jackknife SE of the top-k eigenvectors. Shape
@@ -680,7 +689,6 @@ class LocalPCAResult:
     eigvecs: np.ndarray
     sumsq: np.ndarray
     k: int
-    scaler: Optional[str]
     missing_data: str
     jackknife_se: Optional[np.ndarray] = None
 
@@ -829,7 +837,7 @@ def _local_pca_window_rsvd(X: "cp.ndarray", n_var: int, k: int,
     return eigvals, eigvecs, sumsq
 
 
-def _local_pca_streaming(matrix, iterator, k, scaler, missing_data,
+def _local_pca_streaming(matrix, iterator, k, missing_data,
                           engine, tile_size, oversample,
                           n_subspace_iter, random_state, window_params):
     """Streaming local PCA dispatcher (engine='streaming-dense' or
@@ -848,6 +856,10 @@ def _local_pca_streaming(matrix, iterator, k, scaler, missing_data,
     peak fragmentation at a small per-call cost.
     """
     n_samples = matrix.num_haplotypes
+    # Global allele width, computed once, so the per-window standardization does
+    # not pay an int(hap.max()) host sync per window (keeps the streaming sync
+    # footprint at the pre-reframe level).
+    n_alleles_all = int(matrix.haplotypes.max()) + 1 if matrix.num_variants else 1
 
     if tile_size is None:
         tile_size = 16
@@ -886,9 +898,8 @@ def _local_pca_streaming(matrix, iterator, k, scaler, missing_data,
             del window
             continue
 
-        X = _prepare_matrix(window.matrix, scaler, population=None,
-                            missing_data=missing_data)
-        X = _materialize_prepared(X)
+        X, _ = _prepare_centered(window.matrix, missing_data=missing_data,
+                                 need_segregating=False, n_alleles=n_alleles_all)
 
         if engine == 'streaming-dense':
             evals, evecs, sumsq = _local_pca_window_dense(
@@ -927,6 +938,7 @@ def _local_pca_streaming(matrix, iterator, k, scaler, missing_data,
 
     eigvals_host[~valid_mask] = np.nan
     eigvecs_host[~valid_mask] = np.nan
+    _sign_align_windows(eigvecs_host)
     sumsq_host[~valid_mask] = np.nan
 
     chrom_col, start_col, end_col, center_col, nvar_col, wid_col, _ = zip(
@@ -946,7 +958,6 @@ def _local_pca_streaming(matrix, iterator, k, scaler, missing_data,
         eigvecs=eigvecs_host,
         sumsq=sumsq_host,
         k=k,
-        scaler=scaler,
         missing_data=missing_data,
     )
 
@@ -1089,10 +1100,36 @@ def _pick_dense_engine(matrix, window_params,
     return 'streaming-dense'
 
 
+def _sign_align_windows(eigvecs):
+    """Flip per-window eigenvector signs so adjacent windows are consistent.
+
+    ``eigvecs`` is (n_windows, k, n_samples); each eigenvector is defined only up
+    to sign, so the raw per-window PCs flip arbitrarily along the genome. For each
+    PC, walk the windows in order and negate a window's eigenvector when its dot
+    product with the last valid window's eigenvector is negative. Invalid (NaN)
+    windows are skipped. Operates in place on the host array and returns it. Only
+    the sign of the coordinates changes; eigenvalues and lostruct distances (which
+    are sign-invariant) are unaffected.
+    """
+    if eigvecs.size == 0:
+        return eigvecs
+    n_windows, k, _ = eigvecs.shape
+    for p in range(k):
+        prev = None
+        for w in range(n_windows):
+            v = eigvecs[w, p]
+            if np.isnan(v).any():
+                continue
+            if prev is not None and float(np.dot(v, prev)) < 0.0:
+                eigvecs[w, p] = -v
+                v = eigvecs[w, p]
+            prev = v
+    return eigvecs
+
+
 def local_pca(haplotype_matrix: "HaplotypeMatrix",
               window_params=None,
               k: int = 2,
-              scaler: Optional[str] = None,
               missing_data: str = 'include',
               population: Optional[Union[str, list]] = None,
               batch_size: Optional[int] = None,
@@ -1119,8 +1156,6 @@ def local_pca(haplotype_matrix: "HaplotypeMatrix",
         Pre-built window spec. Required when ``window_size`` is not given.
     k : int
         Number of PCs to retain per window.
-    scaler : str or None
-        None (lostruct default), 'patterson', or 'standard'. See `pca()`.
     missing_data : str
         'include' (impute to per-site mean) or 'exclude' (drop missing sites).
         lostruct uses pairwise-complete; we approximate with mean imputation.
@@ -1174,7 +1209,6 @@ def local_pca(haplotype_matrix: "HaplotypeMatrix",
             matrix=matrix,
             iterator=iterator,
             k=k,
-            scaler=scaler,
             missing_data=missing_data,
             engine=engine,
             tile_size=tile_size,
@@ -1200,9 +1234,8 @@ def local_pca(haplotype_matrix: "HaplotypeMatrix",
             valid_flags.append(False)
             continue
 
-        X = _prepare_matrix(window.matrix, scaler, population=None,
-                            missing_data=missing_data)
-        X = _materialize_prepared(X)
+        X, _ = _prepare_centered(window.matrix, missing_data=missing_data,
+                                 need_segregating=False)
         C, sumsq = _window_gram(X, X.shape[1])
         gram_list.append(C)
         sumsq_list.append(sumsq)
@@ -1218,6 +1251,7 @@ def local_pca(haplotype_matrix: "HaplotypeMatrix",
     valid_mask = np.array(valid_flags, dtype=bool)
     eigvals_host[~valid_mask] = np.nan
     eigvecs_host[~valid_mask] = np.nan
+    _sign_align_windows(eigvecs_host)
     sumsq_host[~valid_mask] = np.nan
 
     windows_df = pd.DataFrame({
@@ -1235,7 +1269,6 @@ def local_pca(haplotype_matrix: "HaplotypeMatrix",
         eigvecs=eigvecs_host,
         sumsq=sumsq_host,
         k=k,
-        scaler=scaler,
         missing_data=missing_data,
     )
 
@@ -1245,7 +1278,6 @@ def _local_pca_with_jackknife(
     window_params=None,
     k: int = 2,
     n_blocks: int = 10,
-    scaler: Optional[str] = None,
     missing_data: str = 'include',
     population: Optional[Union[str, list]] = None,
     aggregate: Optional[str] = 'mean',
@@ -1307,9 +1339,8 @@ def _local_pca_with_jackknife(
             valid_jk.append(False)
             continue
 
-        X = _prepare_matrix(window.matrix, scaler, population=None,
-                            missing_data=missing_data)
-        X = _materialize_prepared(X)
+        X, _ = _prepare_centered(window.matrix, missing_data=missing_data,
+                                 need_segregating=False)
         n_var_win = X.shape[1]
 
         # Full Gram for local_pca.
@@ -1350,6 +1381,7 @@ def _local_pca_with_jackknife(
     pca_mask = np.array(valid_pca, dtype=bool)
     eigvals_host[~pca_mask] = np.nan
     eigvecs_host[~pca_mask] = np.nan
+    _sign_align_windows(eigvecs_host)
     sumsq_host[~pca_mask] = np.nan
 
     # --- Jackknife eigendecomposition ---
@@ -1387,7 +1419,6 @@ def _local_pca_with_jackknife(
         eigvecs=eigvecs_host,
         sumsq=sumsq_host,
         k=k,
-        scaler=scaler,
         missing_data=missing_data,
         jackknife_se=jackknife_se,
     )
@@ -1706,7 +1737,6 @@ def lostruct(haplotype_matrix: "HaplotypeMatrix",
              # local_pca params
              window_params=None,
              k: int = 2,
-             scaler: Optional[str] = None,
              missing_data: str = 'include',
              population: Optional[Union[str, list]] = None,
              batch_size: Optional[int] = None,
@@ -1754,7 +1784,7 @@ def lostruct(haplotype_matrix: "HaplotypeMatrix",
         Pre-built window spec. Required when ``window_size`` is not given.
     k : int
         Number of PCs retained per window in the local PCA step.
-    scaler, missing_data, population, batch_size : see :func:`local_pca`.
+    missing_data, population, batch_size : see :func:`local_pca`.
     window_size, step_size, window_type, regions
         Short-hand for constructing a ``WindowParams``.
 
@@ -1811,14 +1841,14 @@ def lostruct(haplotype_matrix: "HaplotypeMatrix",
         pca = _local_pca_with_jackknife(
             haplotype_matrix,
             window_params=window_params, k=k, n_blocks=n_blocks,
-            scaler=scaler, missing_data=missing_data,
+            missing_data=missing_data,
             population=population, aggregate=jackknife_aggregate,
             batch_size=batch_size, window_size=window_size,
             step_size=step_size, window_type=window_type, regions=regions)
     else:
         pca = local_pca(haplotype_matrix,
                         window_params=window_params, k=k,
-                        scaler=scaler, missing_data=missing_data,
+                        missing_data=missing_data,
                         population=population, batch_size=batch_size,
                         window_size=window_size, step_size=step_size,
                         window_type=window_type, regions=regions,
@@ -1873,7 +1903,6 @@ def local_pca_jackknife(haplotype_matrix: "HaplotypeMatrix",
                         window_params=None,
                         k: int = 2,
                         n_blocks: int = 10,
-                        scaler: Optional[str] = None,
                         missing_data: str = 'include',
                         population: Optional[Union[str, list]] = None,
                         aggregate: Optional[str] = 'mean',
@@ -1932,9 +1961,8 @@ def local_pca_jackknife(haplotype_matrix: "HaplotypeMatrix",
             valid_flags.append(False)
             continue
 
-        X = _prepare_matrix(window.matrix, scaler, population=None,
-                            missing_data=missing_data)
-        X = _materialize_prepared(X)
+        X, _ = _prepare_centered(window.matrix, missing_data=missing_data,
+                                 need_segregating=False)
         n_var_win = X.shape[1]
         # Block width truncates (matches R's `round(nrow/10)` in DPGP_jackknife_var.R).
         step = n_var_win // n_blocks

--- a/pg_gpu/decomposition.py
+++ b/pg_gpu/decomposition.py
@@ -20,21 +20,20 @@ _GPU_MEM_BUDGET = 0.3
 
 def _prepare_centered(haplotype_matrix, population=None, missing_data='include',
                       need_segregating=True, n_alleles=None):
-    """All-allele centered one-hot standardization (the tskit convention).
+    """All-allele centered one-hot standardization for the multi-allele PCA.
 
     For each present (site, allele) pair -- ALL alleles including the reference --
     the column is the indicator (hap == a) centered by the allele frequency p_a,
     with missing rows imputed to p_a so they contribute 0. There is no variance
-    scaling. The Gram X @ X.T is then the site-mode genetic_relatedness matrix at
-    haplotype granularity (each haplotype is its own sample), which is what tskit's
-    PCA decomposes.
+    scaling. The Gram X @ X.T is then the genetic relatedness matrix (the centered
+    per-allele covariance between samples) at haplotype granularity, with each
+    haplotype treated as its own sample.
 
     Returns (X, n_segregating), where X is (n_samples, n_cols) float64 and
-    n_segregating is the per-site sum of (present alleles - 1) -- tskit's
-    segregating-site count, used to normalize the Gram (proportion=True). When
-    ``need_segregating`` is False the count is not computed (returned as 0),
-    avoiding its host sync on the per-window path (lostruct normalizes by ncol,
-    not segregating sites).
+    n_segregating is the per-site sum of (present alleles - 1), the number of
+    segregating sites, used to normalize the Gram. When ``need_segregating`` is
+    False the count is not computed (returned as 0), avoiding its host sync on the
+    per-window path (local PCA normalizes by ncol, not segregating sites).
     """
     from ._memutil import allele_counts
 
@@ -97,14 +96,15 @@ def pca(haplotype_matrix: HaplotypeMatrix,
         n_components: int = 10,
         population: Optional[Union[str, list]] = None,
         missing_data: str = 'include'):
-    """Principal Component Analysis on haplotype data (tskit convention).
+    """Multi-allele haploid PCA.
 
-    Eigendecomposition of the site-mode genetic_relatedness matrix: the
-    haplotypes are centered per allele (all alleles including the reference, no
-    variance scaling), the Gram X @ X.T is that relatedness matrix, and it is
-    normalized by the number of segregating sites (proportion=True). This
-    matches tskit's PCA of the GRM. For the diploid biallelic Patterson/GCTA PCA
-    (EIGENSTRAT), use pca_dosage on a GenotypeMatrix.
+    Eigendecomposition of the genetic relatedness matrix: the haplotypes are
+    one-hot encoded keeping all alleles (including the reference), each column is
+    centered by its allele frequency with no variance scaling, and the
+    sample-by-sample Gram X @ X.T is normalized by the number of segregating
+    sites. Every haplotype is treated as its own sample, so this is
+    multiallelic-correct at any ploidy. For the diploid dosage PCA standardized by
+    binomial variance, use pca_dosage on a GenotypeMatrix.
 
     Parameters
     ----------
@@ -128,8 +128,8 @@ def pca(haplotype_matrix: HaplotypeMatrix,
     from .genotype_matrix import GenotypeMatrix
     if isinstance(haplotype_matrix, GenotypeMatrix):
         raise TypeError(
-            "pca is the tskit PCA of genetic_relatedness and requires a "
-            "HaplotypeMatrix; for the diploid biallelic Patterson/GCTA PCA use "
+            "pca is the multi-allele haploid PCA and requires a HaplotypeMatrix; "
+            "for the diploid dosage PCA standardized by binomial variance use "
             "pca_dosage on a GenotypeMatrix.")
 
     X, n_segregating = _prepare_centered(haplotype_matrix, population, missing_data)
@@ -148,13 +148,13 @@ def randomized_pca(haplotype_matrix: HaplotypeMatrix,
                    n_iter: int = 3,
                    random_state: Optional[int] = None,
                    missing_data: str = 'include'):
-    """Randomized truncated-SVD approximation of pca (tskit convention).
+    """Randomized truncated-SVD approximation of the multi-allele haploid PCA.
 
     Same standardization as pca: haplotypes centered per allele (all alleles
     including the reference, no variance scaling), so this approximates the top
-    components of the site-mode genetic_relatedness matrix normalized by the
-    number of segregating sites. Faster than full pca when only a few components
-    are needed. For the diploid biallelic Patterson/GCTA PCA use
+    components of the genetic relatedness matrix normalized by the number of
+    segregating sites. Faster than full pca when only a few components are needed.
+    For the diploid dosage PCA standardized by binomial variance use
     randomized_pca_dosage on a GenotypeMatrix.
 
     Parameters
@@ -181,9 +181,9 @@ def randomized_pca(haplotype_matrix: HaplotypeMatrix,
     from .genotype_matrix import GenotypeMatrix
     if isinstance(haplotype_matrix, GenotypeMatrix):
         raise TypeError(
-            "randomized_pca is the tskit PCA of genetic_relatedness and requires "
-            "a HaplotypeMatrix; for the diploid biallelic Patterson/GCTA PCA use "
-            "randomized_pca_dosage on a GenotypeMatrix.")
+            "randomized_pca is the multi-allele haploid PCA and requires a "
+            "HaplotypeMatrix; for the diploid dosage PCA standardized by binomial "
+            "variance use randomized_pca_dosage on a GenotypeMatrix.")
 
     X, n_segregating = _prepare_centered(haplotype_matrix, population, missing_data)
     n_samples, n_variants = X.shape
@@ -227,15 +227,13 @@ def randomized_pca(haplotype_matrix: HaplotypeMatrix,
 
 
 def _prepare_dosage(genotype_matrix, population=None, missing_data='include'):
-    """Patterson/GCTA standardization of biallelic diploid dosages.
+    """Binomial-variance standardization of biallelic diploid dosages.
 
     For each biallelic variant the alt-allele dosage (0/1/2) is centered by its
-    mean m across individuals and scaled by sqrt(p (1 - p)) with p = m / 2
-    (Patterson et al. 2006), missing imputed to m so it contributes 0 after
-    centering. Returns X (n_individuals, n_variants) float64. This is the
-    preprocessing scikit-allel applies in its diploid Patterson PCA (center by
-    the per-variant mean, scale by sqrt(p (1 - p)) with p the mean over the
-    ploidy).
+    mean m across individuals and scaled by the binomial standard deviation
+    sqrt(p (1 - p)), where p = m / 2 is the alt-allele frequency, with missing
+    imputed to m so it contributes 0 after centering. Returns X (n_individuals,
+    n_variants) float64.
     """
     matrix = genotype_matrix
     if matrix.device == 'CPU':
@@ -275,7 +273,7 @@ def _prepare_dosage(genotype_matrix, population=None, missing_data='include'):
     scale = cp.sqrt(p * (1.0 - p))
     scale = cp.where(scale > 0, scale, 1.0)                     # monomorphic -> no scale
     X = cp.where(valid, geno, m[None, :]).astype(cp.float64)    # impute missing -> m
-    X = (X - m[None, :]) / scale[None, :]                       # center + Patterson scale
+    X = (X - m[None, :]) / scale[None, :]                       # center + binomial-sd scale
     return X
 
 
@@ -283,14 +281,13 @@ def pca_dosage(genotype_matrix,
                n_components: int = 10,
                population: Optional[Union[str, list]] = None,
                missing_data: str = 'include'):
-    """Patterson/GCTA PCA of biallelic diploid dosages (scikit-allel convention).
+    """Diploid dosage PCA standardized by binomial variance.
 
     Standardizes each biallelic variant's alt-allele dosage (0/1/2) by centering
-    on its mean and scaling by sqrt(p (1 - p)), p = mean / 2, then eigendecomposes
-    the individual-by-individual Gram X @ X.T. This is the classical EIGENSTRAT /
-    GCTA PCA and matches scikit-allel's diploid Patterson PCA. For the tskit PCA of
-    genetic_relatedness (all-allele, multiallelic-correct) use pca on a
-    HaplotypeMatrix.
+    on its mean and scaling by the binomial standard deviation sqrt(p (1 - p)),
+    p = mean / 2, then eigendecomposes the individual-by-individual Gram X @ X.T.
+    For the multi-allele haploid PCA (all alleles kept, multiallelic-correct) use
+    pca on a HaplotypeMatrix.
 
     Parameters
     ----------
@@ -312,9 +309,9 @@ def pca_dosage(genotype_matrix,
     from .genotype_matrix import GenotypeMatrix
     if not isinstance(genotype_matrix, GenotypeMatrix):
         raise TypeError(
-            "pca_dosage is the Patterson/GCTA PCA of biallelic diploid dosages "
-            "and requires a GenotypeMatrix; for the tskit PCA of "
-            "genetic_relatedness use pca on a HaplotypeMatrix.")
+            "pca_dosage is the diploid dosage PCA standardized by binomial "
+            "variance and requires a GenotypeMatrix; for the multi-allele haploid "
+            "PCA use pca on a HaplotypeMatrix.")
 
     X = _prepare_dosage(genotype_matrix, population, missing_data)
     n_ind, n_var = X.shape
@@ -328,12 +325,11 @@ def randomized_pca_dosage(genotype_matrix,
                           n_iter: int = 3,
                           random_state: Optional[int] = None,
                           missing_data: str = 'include'):
-    """Randomized truncated-SVD approximation of pca_dosage (scikit-allel).
+    """Randomized truncated-SVD approximation of pca_dosage.
 
-    Same Patterson standardization as pca_dosage, approximating the top
+    Same binomial-variance standardization as pca_dosage, approximating the top
     components for large biallelic panels (the common biobank / SNP-array case).
-    For the tskit PCA of genetic_relatedness use randomized_pca on a
-    HaplotypeMatrix.
+    For the multi-allele haploid PCA use randomized_pca on a HaplotypeMatrix.
 
     Parameters
     ----------
@@ -359,9 +355,9 @@ def randomized_pca_dosage(genotype_matrix,
     from .genotype_matrix import GenotypeMatrix
     if not isinstance(genotype_matrix, GenotypeMatrix):
         raise TypeError(
-            "randomized_pca_dosage is the Patterson/GCTA PCA of biallelic diploid "
-            "dosages and requires a GenotypeMatrix; for the tskit PCA of "
-            "genetic_relatedness use randomized_pca on a HaplotypeMatrix.")
+            "randomized_pca_dosage is the diploid dosage PCA standardized by "
+            "binomial variance and requires a GenotypeMatrix; for the multi-allele "
+            "haploid PCA use randomized_pca on a HaplotypeMatrix.")
 
     X = _prepare_dosage(genotype_matrix, population, missing_data)
     n_samples, n_variants = X.shape
@@ -1655,6 +1651,15 @@ def lostruct(haplotype_matrix: "HaplotypeMatrix",
     when requested the SE is computed in the same window pass as the
     base eigendecomposition (shared matrix prep), and is exposed via
     ``LostructResult.jackknife_se``.
+
+    Each window uses the same all-allele centered standardization as
+    :func:`pca` (all present alleles kept, centered by frequency, no
+    variance scaling), but its own per-window covariance ``X @ X.T /
+    (ncol - 1)`` rather than the segregating-site normalization. So the
+    per-window PC directions agree with :func:`pca` while the eigenvalue
+    and coordinate scale do not. Because all alleles are kept and only the
+    variant axis is centered, the per-window covariance differs from a
+    dosage-per-site, doubly-centered local PCA on biallelic data.
 
     Parameters
     ----------

--- a/pg_gpu/decomposition.py
+++ b/pg_gpu/decomposition.py
@@ -18,156 +18,6 @@ from ._utils import get_population_matrix as _get_population_matrix
 _GPU_MEM_BUDGET = 0.3
 
 
-def _multiallelic_onehot_dense(hap_multi, scaler):
-    """Standardized per-present-derived-allele one-hot columns for multiallelic sites.
-
-    ``hap_multi`` is (n_samples, n_sites) with allele indices (>= 2 present at some
-    site) and -1 for missing. Each site contributes one column per PRESENT derived
-    allele (index >= 1); the reference allele (index 0) is dropped. Columns are
-    compacted to present (site, allele) pairs -- never padded to the global allele
-    width -- so a site costs exactly its number of present derived alleles.
-
-    Each column is the indicator (hap == a), with missing rows imputed to p_a and
-    centered by the same p_a (so a missing haplotype contributes exactly 0 while a
-    reference carrier stays at -p_a), then scaled per ``scaler``. p_a = ac_a /
-    n_valid uses the per-site non-missing count. Returns (cols float64
-    (n_samples, n_pairs), n_pairs).
-    """
-    from ._memutil import allele_counts
-
-    n_samp = hap_multi.shape[0]
-    if hap_multi.shape[1] == 0:
-        return cp.zeros((n_samp, 0), dtype=cp.float64), 0
-
-    ac, n_valid = allele_counts(hap_multi)          # (n_sites, K), (n_sites,)
-    if ac.shape[1] < 2:
-        return cp.zeros((n_samp, 0), dtype=cp.float64), 0
-    nv = n_valid.astype(cp.float64)
-
-    present = ac[:, 1:] > 0                          # derived alleles present per site
-    pairs = cp.argwhere(present)                     # (n_pairs, 2): (site, allele-1)
-    n_pairs = int(pairs.shape[0])
-    if n_pairs == 0:
-        return cp.zeros((n_samp, 0), dtype=cp.float64), 0
-
-    sites = pairs[:, 0]
-    alleles = pairs[:, 1] + 1                         # actual allele index (>= 1)
-
-    g = hap_multi[:, sites]                           # (n_samp, n_pairs)
-    valid = g >= 0
-    ac_pairs = ac[sites, alleles].astype(cp.float64)  # count of allele a at the site
-    nvp = nv[sites]
-    p = cp.where(nvp > 0, ac_pairs / nvp, 0.0)        # p_a per column
-
-    ind = (g == alleles[None, :]).astype(cp.float64)
-    col = cp.where(valid, ind, p[None, :])            # missing -> p_a
-    col -= p[None, :]                                 # missing -> 0; ref carrier -> -p_a
-
-    if scaler == 'patterson':
-        scale = cp.sqrt(p * (1.0 - p))
-        scale = cp.where(scale > 0, scale, 1.0)
-        col /= scale[None, :]
-    elif scaler == 'standard':
-        std = cp.std(col, axis=0)
-        good = std > 0
-        col[:, good] /= std[good]
-        col[:, ~good] = 0.0
-    return col, n_pairs
-
-
-def _prepare_matrix(haplotype_matrix, scaler, population, missing_data='include'):
-    """Center and scale haplotype matrix for PCA.
-
-    Multiallelic-correct via a split: sites coded {0,1} (max allele index <= 1) go
-    through the existing biallelic standardization unchanged; sites with an allele
-    index >= 2 go through the per-allele one-hot (``_multiallelic_onehot_dense``).
-    The two column blocks are concatenated, so X @ X.T sums their contributions
-    (Gram additivity), and any downstream normalization divides by the total column
-    count. Biallelic-only data is bit-identical to the previous implementation.
-
-    Uses chunked processing for large matrices to avoid OOM.
-    Returns the prepared matrix X on GPU (or a _DeferredPCA).
-    """
-    from ._memutil import allele_counts
-
-    if population is not None:
-        matrix = _get_population_matrix(haplotype_matrix, population)
-    else:
-        matrix = haplotype_matrix
-
-    if matrix.device == 'CPU':
-        matrix.transfer_to_gpu()
-
-    hap = matrix.haplotypes
-    n_samples, n_var = hap.shape
-
-    max_allele = hap.max(axis=0)
-    # One host transfer for all branch flags, so the common biallelic path pays
-    # no per-window syncs beyond what the original code did (it already
-    # transferred has_missing). exclude-completeness is folded in too.
-    probes = [cp.any(hap < 0), cp.any(max_allele > 1)]
-    if missing_data == 'exclude':
-        complete_col = cp.sum(hap >= 0, axis=0) == n_samples
-        probes.append(cp.all(complete_col))
-    flags = cp.stack(probes).get()
-    has_missing = bool(flags[0])
-    has_multi = bool(flags[1])
-    if missing_data == 'exclude' and not bool(flags[2]):
-        hap = hap[:, complete_col]
-        max_allele = hap.max(axis=0)
-        has_missing = False  # incomplete sites dropped
-
-    # Partition sites: {0,1}-coded sites (max allele index <= 1) use the existing
-    # biallelic standardization unchanged; sites with an allele index >= 2 use the
-    # per-allele one-hot. The physical split (boolean column indexing, which syncs)
-    # only happens when a multiallelic site is actually present.
-    if has_multi:
-        bi_mask = max_allele <= 1
-        hap_bi = hap[:, bi_mask]
-        hap_multi = hap[:, ~bi_mask]
-        multi_cols, n_multi = _multiallelic_onehot_dense(hap_multi, scaler)
-    else:
-        hap_bi = hap
-        multi_cols, n_multi = None, 0
-    n_bi = hap_bi.shape[1]
-
-    # Biallelic block scaling metadata via the per-allele primitive. For {0,1}
-    # sites the summed derived count equals the old dac_and_n exactly (so this is
-    # bit-identical), and using allele_counts drops decomposition's last dependence
-    # on the collapsed dac_and_n. ac[:, 1:].sum handles the all-monomorphic (K == 1)
-    # case where there is no derived column.
-    # n_alleles=2 is exact for the biallelic block (partition guarantees max index
-    # <= 1) and avoids the int(hap.max()) reduction (a host sync) that the default
-    # would do -- keeping the per-window sync footprint at the original level.
-    ac_bi, nv = allele_counts(hap_bi, n_alleles=2)
-    dac = ac_bi[:, 1:].sum(axis=1)
-    site_mean = cp.where(nv > 0, dac.astype(cp.float64) / nv.astype(cp.float64), 0.0)
-    if scaler == 'patterson':
-        scale = cp.sqrt(site_mean * (1 - site_mean))
-        scale = cp.where(scale > 0, scale, 1.0)
-    else:
-        scale = None  # 'standard' handled at materialization; None -> center only
-
-    n_cols_total = n_bi + n_multi
-
-    free = cp.cuda.Device().mem_info[0]
-    needed = n_samples * n_cols_total * 8  # float64
-    if needed < free * 0.4:
-        # Dense path: build the biallelic block (existing logic on hap_bi) and
-        # concatenate the multiallelic columns.
-        X_bi = _biallelic_standardize_dense(hap_bi, site_mean, scale, scaler,
-                                            has_missing)
-        if not n_multi:
-            return X_bi
-        if n_bi == 0:
-            return multi_cols
-        return cp.concatenate([X_bi, multi_cols], axis=1)
-
-    # Memory-constrained path: chunk the (large) biallelic block; the small
-    # multiallelic block rides along densely.
-    return _DeferredPCA(hap_bi, site_mean, scale, scaler, multi_cols)
-
-
 def _prepare_centered(haplotype_matrix, population=None, missing_data='include',
                       need_segregating=True, n_alleles=None):
     """All-allele centered one-hot standardization (the tskit convention).
@@ -225,127 +75,6 @@ def _prepare_centered(haplotype_matrix, population=None, missing_data='include',
     else:
         n_segregating = 0
     return X, n_segregating
-
-
-def _biallelic_standardize_dense(hap_bi, site_mean, scale, scaler, has_missing):
-    """Dense standardized biallelic block (the original standardization, verbatim).
-
-    Bit-identical to the previous _prepare_matrix fast path when all sites are
-    {0,1}-coded. ``has_missing`` is passed in (computed once in _prepare_matrix)
-    to avoid a per-call host sync.
-    """
-    if has_missing:
-        valid_mask = hap_bi >= 0
-        X = cp.where(valid_mask, hap_bi, 0).astype(cp.float64)
-        X = cp.where(valid_mask, X, site_mean[None, :])
-    else:
-        X = hap_bi.astype(cp.float64)
-    X -= site_mean
-    if scaler == 'patterson':
-        X /= scale
-    elif scaler == 'standard':
-        std = cp.std(X, axis=0)
-        valid = std > 0
-        X[:, valid] /= std[valid]
-        X[:, ~valid] = 0
-    return X
-
-
-class _DeferredPCA:
-    """Wrapper for memory-constrained PCA: stores the biallelic hap block +
-    scaling metadata (chunked lazily) plus a dense standardized multiallelic
-    one-hot block, so the caller can compute X @ X.T (and X @ Y, X.T @ Y) over
-    the concatenated columns [biallelic | multiallelic] without materializing
-    the full biallelic float64 matrix. Column order is biallelic first."""
-
-    def __init__(self, hap, site_mean, scale, scaler, multi_cols=None):
-        self.hap = hap                       # biallelic sites only
-        self.site_mean = site_mean
-        self.scale = scale
-        self.scaler = scaler
-        self.n_bi = hap.shape[1]
-        # multi_cols is None when there are no multiallelic sites; otherwise it is
-        # built from a site with an allele index >= 2, which always yields at least
-        # one present-derived-allele column. An empty non-None array is a caller bug.
-        if multi_cols is not None:
-            assert multi_cols.shape[1] > 0, "multi_cols must be None, not empty"
-        self.multi_cols = multi_cols
-        self.n_multi = 0 if multi_cols is None else multi_cols.shape[1]
-        self.shape = (hap.shape[0], self.n_bi + self.n_multi)
-
-    def _scale_chunk(self, start, end):
-        """Prepare a scaled float64 chunk of the biallelic block [start, end)."""
-        chunk = self.hap[:, start:end]
-        # Check this chunk for missing (avoids full-matrix boolean allocation)
-        has_missing_chunk = bool(cp.any(chunk < 0).get())
-        if has_missing_chunk:
-            valid = chunk >= 0
-            x = cp.where(valid, chunk, 0).astype(cp.float64)
-            x = cp.where(valid, x, self.site_mean[start:end])
-        else:
-            x = chunk.astype(cp.float64)
-        x -= self.site_mean[start:end]
-        if self.scaler == 'patterson' and self.scale is not None:
-            x /= self.scale[start:end]
-        return x
-
-    @property
-    def _chunk_size(self):
-        from ._memutil import estimate_variant_chunk_size
-        return estimate_variant_chunk_size(self.shape[0], bytes_per_element=8,
-                                           n_intermediates=2)
-
-    def chunked_gram(self):
-        """Compute X @ X.T via chunked processing (biallelic block + multiallelic)."""
-        n_samples = self.shape[0]
-        C = cp.zeros((n_samples, n_samples), dtype=cp.float64)
-        for start in range(0, self.n_bi, self._chunk_size):
-            end = min(start + self._chunk_size, self.n_bi)
-            x = self._scale_chunk(start, end)
-            C += x @ x.T
-            del x
-        if self.multi_cols is not None:
-            C += self.multi_cols @ self.multi_cols.T
-        return C
-
-    def __matmul__(self, other):
-        """Compute X @ other over concatenated [biallelic | multiallelic] columns."""
-        n_samples = self.shape[0]
-        result = cp.zeros((n_samples, other.shape[1]), dtype=cp.float64)
-        for start in range(0, self.n_bi, self._chunk_size):
-            end = min(start + self._chunk_size, self.n_bi)
-            x = self._scale_chunk(start, end)
-            result += x @ other[start:end, :]
-            del x
-        if self.multi_cols is not None:
-            result += self.multi_cols @ other[self.n_bi:, :]
-        return result
-
-    @property
-    def T(self):
-        """Return a transposed view for X.T @ Y operations."""
-        return _DeferredPCATranspose(self)
-
-
-class _DeferredPCATranspose:
-    """Transpose view of _DeferredPCA for X.T @ Y operations."""
-
-    def __init__(self, parent):
-        self.parent = parent
-        self.shape = (parent.shape[1], parent.shape[0])
-
-    def __matmul__(self, other):
-        """Compute X.T @ other, returning rows [biallelic; multiallelic]."""
-        p = self.parent
-        result = cp.zeros((p.shape[1], other.shape[1]), dtype=cp.float64)
-        for start in range(0, p.n_bi, p._chunk_size):
-            end = min(start + p._chunk_size, p.n_bi)
-            x = p._scale_chunk(start, end)
-            result[start:end, :] = x.T @ other
-            del x
-        if p.multi_cols is not None:
-            result[p.n_bi:, :] = p.multi_cols.T @ other
-        return result
 
 
 def _pca_from_gram(C, n_samples, n_components):
@@ -415,39 +144,50 @@ def pca(haplotype_matrix: HaplotypeMatrix,
 
 def randomized_pca(haplotype_matrix: HaplotypeMatrix,
                    n_components: int = 10,
-                   scaler: Optional[str] = 'patterson',
                    population: Optional[Union[str, list]] = None,
                    n_iter: int = 3,
                    random_state: Optional[int] = None,
                    missing_data: str = 'include'):
-    """Randomized PCA using truncated SVD approximation.
+    """Randomized truncated-SVD approximation of pca (tskit convention).
 
-    Faster than full PCA for large datasets where only a few
-    components are needed.
+    Same standardization as pca: haplotypes centered per allele (all alleles
+    including the reference, no variance scaling), so this approximates the top
+    components of the site-mode genetic_relatedness matrix normalized by the
+    number of segregating sites. Faster than full pca when only a few components
+    are needed. For the diploid biallelic Patterson/GCTA PCA use
+    randomized_pca_dosage on a GenotypeMatrix.
 
     Parameters
     ----------
     haplotype_matrix : HaplotypeMatrix
-        Haplotype data.
+        Haplotype data. Rows are haplotypes, columns are variants.
     n_components : int
         Number of components.
-    scaler : str or None
-        'patterson', 'standard', or None.
     population : str or list, optional
         Population subset.
     n_iter : int
         Number of power iterations for accuracy.
     random_state : int, optional
         Random seed for reproducibility.
+    missing_data : str
+        'include' - impute missing to per-site allele frequency
+        'exclude' - filter sites with any missing
 
     Returns
     -------
     coords : ndarray, float64, shape (n_samples, n_components)
     explained_variance_ratio : ndarray, float64, shape (n_components,)
     """
-    X = _prepare_matrix(haplotype_matrix, scaler, population, missing_data)
+    from .genotype_matrix import GenotypeMatrix
+    if isinstance(haplotype_matrix, GenotypeMatrix):
+        raise TypeError(
+            "randomized_pca is the tskit PCA of genetic_relatedness and requires "
+            "a HaplotypeMatrix; for the diploid biallelic Patterson/GCTA PCA use "
+            "randomized_pca_dosage on a GenotypeMatrix.")
+
+    X, n_segregating = _prepare_centered(haplotype_matrix, population, missing_data)
     n_samples, n_variants = X.shape
-    n_components = min(n_components, min(n_samples, n_variants))
+    n_components = min(n_components, n_samples, max(n_variants, 1))
 
     # randomized SVD on GPU
     if random_state is not None:
@@ -455,7 +195,7 @@ def randomized_pca(haplotype_matrix: HaplotypeMatrix,
 
     # random projection
     k = n_components + 10  # oversampling
-    k = min(k, min(n_samples, n_variants))
+    k = min(k, min(n_samples, max(n_variants, 1)))
     Omega = cp.random.randn(n_variants, k, dtype=cp.float64)
     Y = X @ Omega
 
@@ -467,31 +207,19 @@ def randomized_pca(haplotype_matrix: HaplotypeMatrix,
     Q, _ = cp.linalg.qr(Y)
 
     # project and SVD in reduced space
-    if isinstance(X, _DeferredPCA):
-        # B = Q.T @ X has shape (k, n_var) — too wide for cuSOLVER SVD.
-        # Instead compute B @ B.T = Q.T @ (X @ X.T) @ Q = Q.T @ gram @ Q
-        # and eigendecompose the small (k, k) matrix.
-        gram = X.chunked_gram()  # (n_samples, n_samples)
-        M = Q.T @ gram @ Q  # (k, k)
-        eigvals, eigvecs = cp.linalg.eigh(M)
-        idx = cp.argsort(eigvals)[::-1]
-        eigvals = eigvals[idx]
-        eigvecs = eigvecs[:, idx]
-        S = cp.sqrt(cp.maximum(eigvals, 0))
-        Uhat = eigvecs
-    else:
-        B = Q.T @ X
-        Uhat, S, Vt = cp.linalg.svd(B, full_matrices=False)
+    B = Q.T @ X
+    Uhat, S, Vt = cp.linalg.svd(B, full_matrices=False)
     U = Q @ Uhat
 
+    # S are singular values of X; the pca Gram is X @ X.T / n_segregating
+    # (proportion=True), so coords scale by 1 / sqrt(n_segregating).
     coords = U[:, :n_components] * S[:n_components]
+    if n_segregating > 0:
+        coords = coords / cp.sqrt(n_segregating)
 
-    # explained variance
-    if isinstance(X, _DeferredPCA):
-        # Reuse gram from above (already computed for eigendecomposition)
-        total_var = cp.trace(gram) / n_samples
-    else:
-        total_var = cp.sum(cp.var(X, axis=0))
+    # explained variance ratio is scale-invariant, so the n_segregating and
+    # n_samples factors cancel: it equals S**2 / trace(X @ X.T).
+    total_var = cp.sum(cp.var(X, axis=0))
     var = (S[:n_components] ** 2) / n_samples
     explained_variance_ratio = var / total_var
 
@@ -742,8 +470,8 @@ def _local_pca_window_dense(X: "cp.ndarray", n_var: int, k: int
     Parameters
     ----------
     X : cupy.ndarray, shape (n_hap, n_var_w)
-        Variant-centred haplotype block (the caller has already
-        applied per-variant centering / scaling via ``_prepare_matrix``).
+        All-allele centered haplotype block (the caller has already
+        applied the per-allele centering via ``_prepare_centered``).
     n_var : int
         Span normaliser (matches ``_window_gram`` -- usually
         ``X.shape[1]`` but exposed so the caller can pass the original
@@ -1022,20 +750,6 @@ def _resolve_window_params(window_params, window_size, step_size, window_type,
     )
 
 
-def _materialize_prepared(X):
-    """If `_prepare_matrix` returned a deferred chunked view, concatenate it.
-
-    Per-window matrices are small enough that a single contiguous copy is fine
-    and it lets us apply additional in-place centering downstream.
-    """
-    if isinstance(X, _DeferredPCA):
-        n_var = X.shape[1]
-        return cp.concatenate(
-            [X._scale_chunk(s, min(s + X._chunk_size, n_var))
-             for s in range(0, n_var, X._chunk_size)], axis=1)
-    return X
-
-
 def _estimate_n_windows(matrix, window_params) -> int:
     """Upper bound on the number of windows ``WindowIterator`` will yield.
 
@@ -1289,8 +1003,8 @@ def _local_pca_with_jackknife(
 ) -> LocalPCAResult:
     """Local PCA with fused jackknife SE, sharing per-window matrix preparation.
 
-    Iterates windows once; for each valid window calls ``_prepare_matrix`` once
-    and from the same materialized ``X`` computes both the full Gram matrix (for
+    Iterates windows once; for each valid window calls ``_prepare_centered`` once
+    and from the same ``X`` computes both the full Gram matrix (for
     eigvals/eigvecs) and the leave-one-block-out Gram matrices (for jackknife).
 
     Two-tier validity: windows with enough variants for PCA (``>= max(k, 2)``)

--- a/pg_gpu/decomposition.py
+++ b/pg_gpu/decomposition.py
@@ -168,6 +168,55 @@ def _prepare_matrix(haplotype_matrix, scaler, population, missing_data='include'
     return _DeferredPCA(hap_bi, site_mean, scale, scaler, multi_cols)
 
 
+def _prepare_centered(haplotype_matrix, population=None, missing_data='include'):
+    """All-allele centered one-hot standardization (the tskit convention).
+
+    For each present (site, allele) pair -- ALL alleles including the reference --
+    the column is the indicator (hap == a) centered by the allele frequency p_a,
+    with missing rows imputed to p_a so they contribute 0. There is no variance
+    scaling. The Gram X @ X.T is then the site-mode genetic_relatedness matrix at
+    haplotype granularity (each haplotype is its own sample), which is what tskit's
+    PCA decomposes.
+
+    Returns (X, n_segregating), where X is (n_samples, n_cols) float64 and
+    n_segregating is the per-site sum of (present alleles - 1) -- tskit's
+    segregating-site count, used to normalize the Gram (proportion=True).
+    """
+    from ._memutil import allele_counts
+
+    matrix = (_get_population_matrix(haplotype_matrix, population)
+              if population is not None else haplotype_matrix)
+    if matrix.device == 'CPU':
+        matrix.transfer_to_gpu()
+
+    hap = matrix.haplotypes
+    n_samples, n_var = hap.shape
+    if missing_data == 'exclude' and n_var:
+        complete = cp.sum(hap >= 0, axis=0) == n_samples
+        hap = hap[:, complete]
+
+    if hap.shape[1] == 0:
+        return cp.zeros((n_samples, 0), dtype=cp.float64), 0
+
+    K = int(hap.max()) + 1 if hap.size else 1
+    ac, n_valid = allele_counts(hap, n_alleles=K)     # (n_var, K), (n_var,)
+    pairs = cp.argwhere(ac > 0)                        # present (site, allele), all alleles
+    if pairs.shape[0] == 0:
+        return cp.zeros((n_samples, 0), dtype=cp.float64), 0
+
+    sites = pairs[:, 0]
+    alleles = pairs[:, 1]
+    g = hap[:, sites]                                  # (n_samples, n_cols)
+    valid = g >= 0
+    p = ac[sites, alleles].astype(cp.float64) / n_valid[sites].astype(cp.float64)
+    ind = (g == alleles[None, :]).astype(cp.float64)
+    X = cp.where(valid, ind, p[None, :]) - p[None, :]  # center; missing -> 0
+
+    # segregating sites = sum_site (present alleles - 1) = n_cols - n_present_sites.
+    n_segregating = int(pairs.shape[0] - cp.unique(sites).size)
+    return X, n_segregating
+
+
 def _biallelic_standardize_dense(hap_bi, site_mean, scale, scaler, has_missing):
     """Dense standardized biallelic block (the original standardization, verbatim).
 
@@ -307,10 +356,16 @@ def _pca_from_gram(C, n_samples, n_components):
 
 def pca(haplotype_matrix: HaplotypeMatrix,
         n_components: int = 10,
-        scaler: Optional[str] = 'patterson',
         population: Optional[Union[str, list]] = None,
         missing_data: str = 'include'):
-    """Principal Component Analysis on haplotype data.
+    """Principal Component Analysis on haplotype data (tskit convention).
+
+    Eigendecomposition of the site-mode genetic_relatedness matrix: the
+    haplotypes are centered per allele (all alleles including the reference, no
+    variance scaling), the Gram X @ X.T is that relatedness matrix, and it is
+    normalized by the number of segregating sites (proportion=True). This
+    matches tskit's PCA of the GRM. For the diploid biallelic Patterson/GCTA PCA
+    (EIGENSTRAT), use pca_dosage on a GenotypeMatrix.
 
     Parameters
     ----------
@@ -318,15 +373,10 @@ def pca(haplotype_matrix: HaplotypeMatrix,
         Haplotype data. Rows are haplotypes, columns are variants.
     n_components : int
         Number of principal components to compute.
-    scaler : str or None
-        Scaling method before PCA:
-        'patterson' - scale by sqrt(p*(1-p)), Patterson et al. (2006)
-        'standard' - standardize to unit variance per variant
-        None - center only (subtract mean)
     population : str or list, optional
         Population subset to use.
     missing_data : str
-        'include' - impute missing to per-site mean
+        'include' - impute missing to per-site allele frequency
         'exclude' - filter sites with any missing
 
     Returns
@@ -336,40 +386,21 @@ def pca(haplotype_matrix: HaplotypeMatrix,
     explained_variance_ratio : ndarray, float64, shape (n_components,)
         Proportion of variance explained by each component.
     """
-    prepared = _prepare_matrix(haplotype_matrix, scaler, population, missing_data)
+    from .genotype_matrix import GenotypeMatrix
+    if isinstance(haplotype_matrix, GenotypeMatrix):
+        raise TypeError(
+            "pca is the tskit PCA of genetic_relatedness and requires a "
+            "HaplotypeMatrix; for the diploid biallelic Patterson/GCTA PCA use "
+            "pca_dosage on a GenotypeMatrix.")
 
-    if isinstance(prepared, _DeferredPCA):
-        n_samples = prepared.shape[0]
-        n_components = min(n_components, n_samples)
-        C = prepared.chunked_gram()
-        return _pca_from_gram(C, n_samples, n_components)
+    X, n_segregating = _prepare_centered(haplotype_matrix, population, missing_data)
+    n_samples, n_cols = X.shape
+    n_components = min(n_components, n_samples, max(n_cols, 1))
 
-    X = prepared
-    n_samples, n_variants = X.shape
-    n_components = min(n_components, min(n_samples, n_variants))
-
-    # When n_samples <= n_variants (typical for popgen), eigendecompose
-    # the n x n Gram matrix X @ X.T instead of full SVD on n x m.
-    if n_samples <= n_variants:
-        C = X @ X.T
-        return _pca_from_gram(C, n_samples, n_components)
-
-    # Fallback: full SVD when n_samples > n_variants
-    try:
-        U, S, Vt = cp.linalg.svd(X, full_matrices=False)
-    except Exception as e:
-        if 'CUSOLVER' in str(type(e).__name__) or 'CUSOLVER' in str(e):
-            raise RuntimeError(
-                f"Full SVD failed on matrix of shape ({n_samples}, {n_variants}). "
-                f"This dataset is too large for exact PCA. "
-                f"Use randomized_pca() instead, which handles large datasets efficiently."
-            ) from e
-        raise
-    coords = U[:, :n_components] * S[:n_components]
-    var = (S ** 2) / n_samples
-    explained_variance_ratio = var[:n_components] / cp.sum(var)
-
-    return coords.get(), explained_variance_ratio.get()
+    C = X @ X.T
+    if n_segregating > 0:
+        C = C / n_segregating
+    return _pca_from_gram(C, n_samples, n_components)
 
 
 def randomized_pca(haplotype_matrix: HaplotypeMatrix,

--- a/pg_gpu/decomposition.py
+++ b/pg_gpu/decomposition.py
@@ -226,6 +226,172 @@ def randomized_pca(haplotype_matrix: HaplotypeMatrix,
     return coords.get(), explained_variance_ratio.get()
 
 
+def _prepare_dosage(genotype_matrix, population=None, missing_data='include'):
+    """Patterson/GCTA standardization of biallelic diploid dosages.
+
+    For each biallelic variant the alt-allele dosage (0/1/2) is centered by its
+    mean m across individuals and scaled by sqrt(p (1 - p)) with p = m / 2
+    (Patterson et al. 2006), missing imputed to m so it contributes 0 after
+    centering. Returns X (n_individuals, n_variants) float64. This is the
+    preprocessing scikit-allel applies in its diploid Patterson PCA (center by
+    the per-variant mean, scale by sqrt(p (1 - p)) with p the mean over the
+    ploidy).
+    """
+    matrix = genotype_matrix
+    if matrix.device == 'CPU':
+        matrix.transfer_to_gpu()
+
+    geno = matrix.genotypes
+    # Subset individuals inline (the shared get_population_matrix is haplotype
+    # granularity; genotype/haplotype population subsetting is unified in the
+    # type-domain-consistency follow-up).
+    if population is not None:
+        if isinstance(population, str):
+            if matrix.sample_sets is None or population not in matrix.sample_sets:
+                raise ValueError(
+                    f"Population {population} not found in sample_sets")
+            idx = matrix.sample_sets[population]
+        else:
+            idx = list(population)
+        geno = geno[idx, :]
+
+    n_ind, n_var = geno.shape
+    if n_var and int(geno.max()) > 2:
+        raise ValueError(
+            "pca_dosage requires biallelic diploid dosages coded 0/1/2; found a "
+            "genotype > 2. Apply a biallelic filter first.")
+
+    if missing_data == 'exclude' and n_var:
+        complete = cp.sum(geno >= 0, axis=0) == n_ind
+        geno = geno[:, complete]
+    if geno.shape[1] == 0:
+        return cp.zeros((n_ind, 0), dtype=cp.float64)
+
+    valid = geno >= 0
+    n_valid = cp.sum(valid, axis=0).astype(cp.float64)          # per-variant
+    dsum = cp.sum(cp.where(valid, geno, 0), axis=0).astype(cp.float64)
+    m = cp.where(n_valid > 0, dsum / n_valid, 0.0)              # mean dosage
+    p = m / 2.0                                                 # ploidy 2
+    scale = cp.sqrt(p * (1.0 - p))
+    scale = cp.where(scale > 0, scale, 1.0)                     # monomorphic -> no scale
+    X = cp.where(valid, geno, m[None, :]).astype(cp.float64)    # impute missing -> m
+    X = (X - m[None, :]) / scale[None, :]                       # center + Patterson scale
+    return X
+
+
+def pca_dosage(genotype_matrix,
+               n_components: int = 10,
+               population: Optional[Union[str, list]] = None,
+               missing_data: str = 'include'):
+    """Patterson/GCTA PCA of biallelic diploid dosages (scikit-allel convention).
+
+    Standardizes each biallelic variant's alt-allele dosage (0/1/2) by centering
+    on its mean and scaling by sqrt(p (1 - p)), p = mean / 2, then eigendecomposes
+    the individual-by-individual Gram X @ X.T. This is the classical EIGENSTRAT /
+    GCTA PCA and matches scikit-allel's diploid Patterson PCA. For the tskit PCA of
+    genetic_relatedness (all-allele, multiallelic-correct) use pca on a
+    HaplotypeMatrix.
+
+    Parameters
+    ----------
+    genotype_matrix : GenotypeMatrix
+        Biallelic diploid dosages. Rows are individuals, columns are variants.
+    n_components : int
+        Number of principal components to compute.
+    population : str or list, optional
+        Population subset to use.
+    missing_data : str
+        'include' - impute missing to the per-variant mean dosage
+        'exclude' - filter variants with any missing genotype
+
+    Returns
+    -------
+    coords : ndarray, float64, shape (n_individuals, n_components)
+    explained_variance_ratio : ndarray, float64, shape (n_components,)
+    """
+    from .genotype_matrix import GenotypeMatrix
+    if not isinstance(genotype_matrix, GenotypeMatrix):
+        raise TypeError(
+            "pca_dosage is the Patterson/GCTA PCA of biallelic diploid dosages "
+            "and requires a GenotypeMatrix; for the tskit PCA of "
+            "genetic_relatedness use pca on a HaplotypeMatrix.")
+
+    X = _prepare_dosage(genotype_matrix, population, missing_data)
+    n_ind, n_var = X.shape
+    n_components = min(n_components, n_ind, max(n_var, 1))
+    return _pca_from_gram(X @ X.T, n_ind, n_components)
+
+
+def randomized_pca_dosage(genotype_matrix,
+                          n_components: int = 10,
+                          population: Optional[Union[str, list]] = None,
+                          n_iter: int = 3,
+                          random_state: Optional[int] = None,
+                          missing_data: str = 'include'):
+    """Randomized truncated-SVD approximation of pca_dosage (scikit-allel).
+
+    Same Patterson standardization as pca_dosage, approximating the top
+    components for large biallelic panels (the common biobank / SNP-array case).
+    For the tskit PCA of genetic_relatedness use randomized_pca on a
+    HaplotypeMatrix.
+
+    Parameters
+    ----------
+    genotype_matrix : GenotypeMatrix
+        Biallelic diploid dosages. Rows are individuals, columns are variants.
+    n_components : int
+        Number of components.
+    population : str or list, optional
+        Population subset.
+    n_iter : int
+        Number of power iterations for accuracy.
+    random_state : int, optional
+        Random seed for reproducibility.
+    missing_data : str
+        'include' - impute missing to the per-variant mean dosage
+        'exclude' - filter variants with any missing genotype
+
+    Returns
+    -------
+    coords : ndarray, float64, shape (n_individuals, n_components)
+    explained_variance_ratio : ndarray, float64, shape (n_components,)
+    """
+    from .genotype_matrix import GenotypeMatrix
+    if not isinstance(genotype_matrix, GenotypeMatrix):
+        raise TypeError(
+            "randomized_pca_dosage is the Patterson/GCTA PCA of biallelic diploid "
+            "dosages and requires a GenotypeMatrix; for the tskit PCA of "
+            "genetic_relatedness use randomized_pca on a HaplotypeMatrix.")
+
+    X = _prepare_dosage(genotype_matrix, population, missing_data)
+    n_samples, n_variants = X.shape
+    n_components = min(n_components, n_samples, max(n_variants, 1))
+
+    if random_state is not None:
+        cp.random.seed(random_state)
+
+    # random projection
+    k = min(n_components + 10, n_samples, max(n_variants, 1))
+    Omega = cp.random.randn(n_variants, k, dtype=cp.float64)
+    Y = X @ Omega
+
+    # power iteration for accuracy
+    for _ in range(n_iter):
+        Y = X @ (X.T @ Y)
+
+    Q, _ = cp.linalg.qr(Y)
+    B = Q.T @ X
+    Uhat, S, Vt = cp.linalg.svd(B, full_matrices=False)
+    U = Q @ Uhat
+
+    coords = U[:, :n_components] * S[:n_components]
+    total_var = cp.sum(cp.var(X, axis=0))
+    var = (S[:n_components] ** 2) / n_samples
+    explained_variance_ratio = var / total_var
+
+    return coords.get(), explained_variance_ratio.get()
+
+
 def pairwise_distance(haplotype_matrix: HaplotypeMatrix,
                       metric: str = 'euclidean',
                       population: Optional[Union[str, list]] = None,

--- a/pg_gpu/decomposition.py
+++ b/pg_gpu/decomposition.py
@@ -18,13 +18,77 @@ from ._utils import get_population_matrix as _get_population_matrix
 _GPU_MEM_BUDGET = 0.3
 
 
+def _multiallelic_onehot_dense(hap_multi, scaler):
+    """Standardized per-present-derived-allele one-hot columns for multiallelic sites.
+
+    ``hap_multi`` is (n_samples, n_sites) with allele indices (>= 2 present at some
+    site) and -1 for missing. Each site contributes one column per PRESENT derived
+    allele (index >= 1); the reference allele (index 0) is dropped. Columns are
+    compacted to present (site, allele) pairs -- never padded to the global allele
+    width -- so a site costs exactly its number of present derived alleles.
+
+    Each column is the indicator (hap == a), with missing rows imputed to p_a and
+    centered by the same p_a (so a missing haplotype contributes exactly 0 while a
+    reference carrier stays at -p_a), then scaled per ``scaler``. p_a = ac_a /
+    n_valid uses the per-site non-missing count. Returns (cols float64
+    (n_samples, n_pairs), n_pairs).
+    """
+    from ._memutil import allele_counts
+
+    n_samp = hap_multi.shape[0]
+    if hap_multi.shape[1] == 0:
+        return cp.zeros((n_samp, 0), dtype=cp.float64), 0
+
+    ac, n_valid = allele_counts(hap_multi)          # (n_sites, K), (n_sites,)
+    if ac.shape[1] < 2:
+        return cp.zeros((n_samp, 0), dtype=cp.float64), 0
+    nv = n_valid.astype(cp.float64)
+
+    present = ac[:, 1:] > 0                          # derived alleles present per site
+    pairs = cp.argwhere(present)                     # (n_pairs, 2): (site, allele-1)
+    n_pairs = int(pairs.shape[0])
+    if n_pairs == 0:
+        return cp.zeros((n_samp, 0), dtype=cp.float64), 0
+
+    sites = pairs[:, 0]
+    alleles = pairs[:, 1] + 1                         # actual allele index (>= 1)
+
+    g = hap_multi[:, sites]                           # (n_samp, n_pairs)
+    valid = g >= 0
+    ac_pairs = ac[sites, alleles].astype(cp.float64)  # count of allele a at the site
+    nvp = nv[sites]
+    p = cp.where(nvp > 0, ac_pairs / nvp, 0.0)        # p_a per column
+
+    ind = (g == alleles[None, :]).astype(cp.float64)
+    col = cp.where(valid, ind, p[None, :])            # missing -> p_a
+    col -= p[None, :]                                 # missing -> 0; ref carrier -> -p_a
+
+    if scaler == 'patterson':
+        scale = cp.sqrt(p * (1.0 - p))
+        scale = cp.where(scale > 0, scale, 1.0)
+        col /= scale[None, :]
+    elif scaler == 'standard':
+        std = cp.std(col, axis=0)
+        good = std > 0
+        col[:, good] /= std[good]
+        col[:, ~good] = 0.0
+    return col, n_pairs
+
+
 def _prepare_matrix(haplotype_matrix, scaler, population, missing_data='include'):
     """Center and scale haplotype matrix for PCA.
 
+    Multiallelic-correct via a split: sites coded {0,1} (max allele index <= 1) go
+    through the existing biallelic standardization unchanged; sites with an allele
+    index >= 2 go through the per-allele one-hot (``_multiallelic_onehot_dense``).
+    The two column blocks are concatenated, so X @ X.T sums their contributions
+    (Gram additivity), and any downstream normalization divides by the total column
+    count. Biallelic-only data is bit-identical to the previous implementation.
+
     Uses chunked processing for large matrices to avoid OOM.
-    Returns the prepared matrix X on GPU.
+    Returns the prepared matrix X on GPU (or a _DeferredPCA).
     """
-    from ._memutil import dac_and_n, estimate_variant_chunk_size
+    from ._memutil import allele_counts
 
     if population is not None:
         matrix = _get_population_matrix(haplotype_matrix, population)
@@ -37,68 +101,121 @@ def _prepare_matrix(haplotype_matrix, scaler, population, missing_data='include'
     hap = matrix.haplotypes
     n_samples, n_var = hap.shape
 
+    max_allele = hap.max(axis=0)
+    # One host transfer for all branch flags, so the common biallelic path pays
+    # no per-window syncs beyond what the original code did (it already
+    # transferred has_missing). exclude-completeness is folded in too.
+    probes = [cp.any(hap < 0), cp.any(max_allele > 1)]
     if missing_data == 'exclude':
-        dac, nv = dac_and_n(hap)
-        complete = nv == n_samples
-        if not cp.all(complete):
-            hap = hap[:, complete]
-            n_var = hap.shape[1]
+        complete_col = cp.sum(hap >= 0, axis=0) == n_samples
+        probes.append(cp.all(complete_col))
+    flags = cp.stack(probes).get()
+    has_missing = bool(flags[0])
+    has_multi = bool(flags[1])
+    if missing_data == 'exclude' and not bool(flags[2]):
+        hap = hap[:, complete_col]
+        max_allele = hap.max(axis=0)
+        has_missing = False  # incomplete sites dropped
 
-    # Compute per-site mean and scale from allele counts (memory-safe)
-    dac, nv = dac_and_n(hap)
-    site_mean = cp.where(nv > 0, dac.astype(cp.float64) / nv.astype(cp.float64), 0.0)
-
-    if scaler == 'patterson':
-        p = site_mean
-        scale = cp.sqrt(p * (1 - p))
-        scale = cp.where(scale > 0, scale, 1.0)
-    elif scaler == 'standard':
-        # Need variance -- compute via second pass or approximate
-        scale = None  # handled below
+    # Partition sites: {0,1}-coded sites (max allele index <= 1) use the existing
+    # biallelic standardization unchanged; sites with an allele index >= 2 use the
+    # per-allele one-hot. The physical split (boolean column indexing, which syncs)
+    # only happens when a multiallelic site is actually present.
+    if has_multi:
+        bi_mask = max_allele <= 1
+        hap_bi = hap[:, bi_mask]
+        hap_multi = hap[:, ~bi_mask]
+        multi_cols, n_multi = _multiallelic_onehot_dense(hap_multi, scaler)
     else:
-        scale = None
+        hap_bi = hap
+        multi_cols, n_multi = None, 0
+    n_bi = hap_bi.shape[1]
 
-    # Check if full float64 matrix fits in memory
+    # Biallelic block scaling metadata via the per-allele primitive. For {0,1}
+    # sites the summed derived count equals the old dac_and_n exactly (so this is
+    # bit-identical), and using allele_counts drops decomposition's last dependence
+    # on the collapsed dac_and_n. ac[:, 1:].sum handles the all-monomorphic (K == 1)
+    # case where there is no derived column.
+    # n_alleles=2 is exact for the biallelic block (partition guarantees max index
+    # <= 1) and avoids the int(hap.max()) reduction (a host sync) that the default
+    # would do -- keeping the per-window sync footprint at the original level.
+    ac_bi, nv = allele_counts(hap_bi, n_alleles=2)
+    dac = ac_bi[:, 1:].sum(axis=1)
+    site_mean = cp.where(nv > 0, dac.astype(cp.float64) / nv.astype(cp.float64), 0.0)
+    if scaler == 'patterson':
+        scale = cp.sqrt(site_mean * (1 - site_mean))
+        scale = cp.where(scale > 0, scale, 1.0)
+    else:
+        scale = None  # 'standard' handled at materialization; None -> center only
+
+    n_cols_total = n_bi + n_multi
+
     free = cp.cuda.Device().mem_info[0]
-    needed = n_samples * n_var * 8  # float64
+    needed = n_samples * n_cols_total * 8  # float64
     if needed < free * 0.4:
-        # Fast path: materialize full matrix
-        has_missing = bool(cp.any(hap < 0).get())
-        if has_missing:
-            valid_mask = hap >= 0
-            X = cp.where(valid_mask, hap, 0).astype(cp.float64)
-            X = cp.where(valid_mask, X, site_mean[None, :])
-        else:
-            X = hap.astype(cp.float64)
-        X -= site_mean
-        if scaler == 'patterson':
-            X /= scale
-        elif scaler == 'standard':
-            std = cp.std(X, axis=0)
-            valid = std > 0
-            X[:, valid] /= std[valid]
-            X[:, ~valid] = 0
-        return X
+        # Dense path: build the biallelic block (existing logic on hap_bi) and
+        # concatenate the multiallelic columns.
+        X_bi = _biallelic_standardize_dense(hap_bi, site_mean, scale, scaler,
+                                            has_missing)
+        if not n_multi:
+            return X_bi
+        if n_bi == 0:
+            return multi_cols
+        return cp.concatenate([X_bi, multi_cols], axis=1)
 
-    # Memory-constrained path: return hap + metadata for chunked PCA
-    # Store scaling info so pca() can chunk the matmul
-    return _DeferredPCA(hap, site_mean, scale, scaler)
+    # Memory-constrained path: chunk the (large) biallelic block; the small
+    # multiallelic block rides along densely.
+    return _DeferredPCA(hap_bi, site_mean, scale, scaler, multi_cols)
+
+
+def _biallelic_standardize_dense(hap_bi, site_mean, scale, scaler, has_missing):
+    """Dense standardized biallelic block (the original standardization, verbatim).
+
+    Bit-identical to the previous _prepare_matrix fast path when all sites are
+    {0,1}-coded. ``has_missing`` is passed in (computed once in _prepare_matrix)
+    to avoid a per-call host sync.
+    """
+    if has_missing:
+        valid_mask = hap_bi >= 0
+        X = cp.where(valid_mask, hap_bi, 0).astype(cp.float64)
+        X = cp.where(valid_mask, X, site_mean[None, :])
+    else:
+        X = hap_bi.astype(cp.float64)
+    X -= site_mean
+    if scaler == 'patterson':
+        X /= scale
+    elif scaler == 'standard':
+        std = cp.std(X, axis=0)
+        valid = std > 0
+        X[:, valid] /= std[valid]
+        X[:, ~valid] = 0
+    return X
 
 
 class _DeferredPCA:
-    """Wrapper for memory-constrained PCA: stores hap + scaling metadata
-    so the caller can compute X @ X.T via chunked matmul without
-    materializing the full float64 matrix."""
+    """Wrapper for memory-constrained PCA: stores the biallelic hap block +
+    scaling metadata (chunked lazily) plus a dense standardized multiallelic
+    one-hot block, so the caller can compute X @ X.T (and X @ Y, X.T @ Y) over
+    the concatenated columns [biallelic | multiallelic] without materializing
+    the full biallelic float64 matrix. Column order is biallelic first."""
 
-    def __init__(self, hap, site_mean, scale, scaler):
-        self.hap = hap
+    def __init__(self, hap, site_mean, scale, scaler, multi_cols=None):
+        self.hap = hap                       # biallelic sites only
         self.site_mean = site_mean
         self.scale = scale
         self.scaler = scaler
-        self.shape = hap.shape
+        self.n_bi = hap.shape[1]
+        # multi_cols is None when there are no multiallelic sites; otherwise it is
+        # built from a site with an allele index >= 2, which always yields at least
+        # one present-derived-allele column. An empty non-None array is a caller bug.
+        if multi_cols is not None:
+            assert multi_cols.shape[1] > 0, "multi_cols must be None, not empty"
+        self.multi_cols = multi_cols
+        self.n_multi = 0 if multi_cols is None else multi_cols.shape[1]
+        self.shape = (hap.shape[0], self.n_bi + self.n_multi)
 
     def _scale_chunk(self, start, end):
-        """Prepare a scaled float64 chunk of the matrix."""
+        """Prepare a scaled float64 chunk of the biallelic block [start, end)."""
         chunk = self.hap[:, start:end]
         # Check this chunk for missing (avoids full-matrix boolean allocation)
         has_missing_chunk = bool(cp.any(chunk < 0).get())
@@ -120,25 +237,29 @@ class _DeferredPCA:
                                            n_intermediates=2)
 
     def chunked_gram(self):
-        """Compute X @ X.T via chunked processing."""
-        n_samples, n_var = self.shape
+        """Compute X @ X.T via chunked processing (biallelic block + multiallelic)."""
+        n_samples = self.shape[0]
         C = cp.zeros((n_samples, n_samples), dtype=cp.float64)
-        for start in range(0, n_var, self._chunk_size):
-            end = min(start + self._chunk_size, n_var)
+        for start in range(0, self.n_bi, self._chunk_size):
+            end = min(start + self._chunk_size, self.n_bi)
             x = self._scale_chunk(start, end)
             C += x @ x.T
             del x
+        if self.multi_cols is not None:
+            C += self.multi_cols @ self.multi_cols.T
         return C
 
     def __matmul__(self, other):
-        """Compute X @ other via chunked processing."""
-        n_samples, n_var = self.shape
+        """Compute X @ other over concatenated [biallelic | multiallelic] columns."""
+        n_samples = self.shape[0]
         result = cp.zeros((n_samples, other.shape[1]), dtype=cp.float64)
-        for start in range(0, n_var, self._chunk_size):
-            end = min(start + self._chunk_size, n_var)
+        for start in range(0, self.n_bi, self._chunk_size):
+            end = min(start + self._chunk_size, self.n_bi)
             x = self._scale_chunk(start, end)
             result += x @ other[start:end, :]
             del x
+        if self.multi_cols is not None:
+            result += self.multi_cols @ other[self.n_bi:, :]
         return result
 
     @property
@@ -155,14 +276,16 @@ class _DeferredPCATranspose:
         self.shape = (parent.shape[1], parent.shape[0])
 
     def __matmul__(self, other):
-        """Compute X.T @ other via chunked processing."""
-        n_samples, n_var = self.parent.shape
-        result = cp.zeros((n_var, other.shape[1]), dtype=cp.float64)
-        for start in range(0, n_var, self.parent._chunk_size):
-            end = min(start + self.parent._chunk_size, n_var)
-            x = self.parent._scale_chunk(start, end)
+        """Compute X.T @ other, returning rows [biallelic; multiallelic]."""
+        p = self.parent
+        result = cp.zeros((p.shape[1], other.shape[1]), dtype=cp.float64)
+        for start in range(0, p.n_bi, p._chunk_size):
+            end = min(start + p._chunk_size, p.n_bi)
+            x = p._scale_chunk(start, end)
             result[start:end, :] = x.T @ other
             del x
+        if p.multi_cols is not None:
+            result[p.n_bi:, :] = p.multi_cols.T @ other
         return result
 
 

--- a/pg_gpu/distance_stats.py
+++ b/pg_gpu/distance_stats.py
@@ -32,6 +32,15 @@ def _pairwise_diffs_matrix_gpu(hap, missing_data='include'):
     chunks to GPU on-the-fly so the full matrix never needs to reside
     on GPU at once.
 
+    Multiallelic-correct Hamming: the number of DIFFERING jointly-valid sites is
+    ``joint_valid - same``, where ``same`` counts sites at which the two
+    haplotypes carry the same allele, summed over allele values via one-hot
+    indicators (``same = sum_v I_v @ I_v.T``, ``I_v[h,s] = 1 if hap[h,s] == v``).
+    This generalizes the biallelic ``sum_i + sum_j - 2*X@X.T`` gram identity
+    (which silently assumes ``v^2 = v``) to any number of alleles, and reduces
+    to it exactly on ``{0, 1}`` data. Missing entries (``-1``) match no allele
+    value and are excluded from ``joint_valid``, so they never contribute.
+
     Parameters
     ----------
     hap : numpy.ndarray or cupy.ndarray, shape (n_haplotypes, n_variants)
@@ -50,28 +59,31 @@ def _pairwise_diffs_matrix_gpu(hap, missing_data='include'):
     n_hap, n_var = hap.shape
     is_numpy = isinstance(hap, np.ndarray)
     chunk_size = estimate_variant_chunk_size(n_hap, bytes_per_element=8,
-                                             n_intermediates=2)
+                                             n_intermediates=3)
 
-    gram = cp.zeros((n_hap, n_hap), dtype=cp.float64)
-    row_sums = cp.zeros(n_hap, dtype=cp.float64)
-    need_valid = missing_data == 'normalize'
-    joint_valid = cp.zeros((n_hap, n_hap), dtype=cp.float64) if need_valid else None
+    # One-hot Hamming over K allele values. K matmuls/chunk (vs 1 for the old
+    # binary-only gram trick); K is the number of allele values, typically small.
+    max_allele = int(hap.max()) if hap.size else -1
+    n_alleles = max(max_allele + 1, 0)
+
+    matches = cp.zeros((n_hap, n_hap), dtype=cp.float64)
+    joint_valid = cp.zeros((n_hap, n_hap), dtype=cp.float64)
 
     for start in range(0, n_var, chunk_size):
         end = min(start + chunk_size, n_var)
         h_chunk = cp.asarray(hap[:, start:end]) if is_numpy else hap[:, start:end]
-        x_chunk = cp.where(h_chunk >= 0, h_chunk, 0).astype(cp.float64)
-        row_sums += cp.sum(x_chunk, axis=1)
-        gram += x_chunk @ x_chunk.T
-        if need_valid:
-            v_chunk = (h_chunk >= 0).astype(cp.float64)
-            joint_valid += v_chunk @ v_chunk.T
-            del v_chunk
-        del h_chunk, x_chunk
+        v_chunk = (h_chunk >= 0).astype(cp.float64)
+        joint_valid += v_chunk @ v_chunk.T
+        # sites where both carry allele v (missing is -1, matches no v >= 0)
+        for v in range(n_alleles):
+            iv = (h_chunk == v).astype(cp.float64)
+            matches += iv @ iv.T
+            del iv
+        del h_chunk, v_chunk
 
-    diffs_mat = row_sums[:, None] + row_sums[None, :] - 2.0 * gram
+    diffs_mat = joint_valid - matches
 
-    if joint_valid is not None:
+    if missing_data == 'normalize':
         diffs_mat = cp.where(joint_valid > 0, diffs_mat / joint_valid, 0.0)
 
     return diffs_mat
@@ -81,8 +93,9 @@ def pairwise_diffs_haploid(haplotype_matrix, population=None,
                            missing_data='include'):
     """Compute pairwise Hamming distances between haplotypes on GPU.
 
-    Uses a single matrix multiply: for 0/1 data,
-    diffs_ij = sum_i + sum_j - 2 * (X @ X.T)_ij.
+    Per-site average allele differences over jointly non-missing sites,
+    multiallelic-correct (one-hot indicators per allele value; see
+    ``_pairwise_diffs_matrix_gpu``).
 
     Parameters
     ----------
@@ -123,6 +136,13 @@ def pairwise_diffs_diploid(genotype_matrix, population=None,
 
     For 0/1/2 genotypes, uses indicator matrices: matches = I0.T@I0 +
     I1.T@I1 + I2.T@I2, then diffs = n_var - matches.
+
+    Biallelic only: the input is a ``GenotypeMatrix`` of 0/1/2 alt-allele dosage,
+    which is a biallelic representation by construction (multiallelic sites are
+    filtered/collapsed when the matrix is built). For multiallelic data, use the
+    allele-index haplotype path (``pairwise_diffs_haploid`` /
+    ``divergence.pairwise_distance_matrix`` on a ``HaplotypeMatrix``), which is
+    multiallelic-correct.
 
     Parameters
     ----------

--- a/pg_gpu/divergence.py
+++ b/pg_gpu/divergence.py
@@ -243,6 +243,40 @@ def fst_tskit(haplotype_matrix: HaplotypeMatrix,
     return 0.0
 
 
+def _pop_wc_stats(pop_haps, k):
+    """Per-allele diploid stats for Weir & Cockerham from one population.
+
+    Consecutive haplotypes are one diploid individual (a trailing unpaired
+    haplotype is dropped). For each allele ``a`` in ``0..k-1`` returns the
+    number of copies and the number of individuals heterozygous FOR THAT ALLELE
+    (exactly one copy) -- the per-allele observed het that WC's c component
+    needs (see the NOTE in ``fst_weir_cockerham``).
+
+    Returns
+    -------
+    ac : cupy.ndarray, float64, shape (n_variants, k)
+        Allele copies from complete diploid pairs.
+    het : cupy.ndarray, float64, shape (n_variants, k)
+        Per-allele heterozygote counts.
+    n : cupy.ndarray, float64, shape (n_variants,)
+        Complete diploid individuals per site.
+    """
+    n_pairs = pop_haps.shape[0] // 2
+    ha = pop_haps[0:2 * n_pairs:2, :]
+    hb = pop_haps[1:2 * n_pairs:2, :]
+    both = (ha >= 0) & (hb >= 0)
+    n = cp.sum(both, axis=0).astype(cp.float64)     # complete individuals/site
+    n_var = pop_haps.shape[1]
+    ac = cp.zeros((n_var, k), dtype=cp.float64)      # allele copies (from pairs)
+    het = cp.zeros((n_var, k), dtype=cp.float64)     # per-allele heterozygotes
+    for allele in range(k):
+        a_ha = (ha == allele) & both
+        a_hb = (hb == allele) & both
+        ac[:, allele] = cp.sum(a_ha, axis=0) + cp.sum(a_hb, axis=0)
+        het[:, allele] = cp.sum(a_ha != a_hb, axis=0)  # exactly one copy
+    return ac, het, n
+
+
 def fst_weir_cockerham(haplotype_matrix,
                        pop1: Union[str, list],
                        pop2: Union[str, list],
@@ -287,90 +321,73 @@ def fst_weir_cockerham(haplotype_matrix,
     pop1_haps = haplotype_matrix.haplotypes[pop1_idx, :]
     pop2_haps = haplotype_matrix.haplotypes[pop2_idx, :]
 
-    # Compute per-site observed heterozygosity and allele counts from
-    # complete diploid pairs only. WC FST requires that frequencies and
-    # het are computed from the same set of individuals — using all valid
-    # haplotypes for counts but only complete pairs for n inflates
-    # frequencies by 1/(1-miss_rate) under MCAR.
-    def _pop_diploid_stats(pop_haps):
-        ha = pop_haps[0::2, :]  # first haplotype of each diploid
-        hb = pop_haps[1::2, :]  # second haplotype
-        both_valid = (ha >= 0) & (hb >= 0)
-        het = (ha != hb) & both_valid
-        n_called = cp.sum(both_valid, axis=0).astype(cp.float64)
-        h_bar = cp.where(n_called > 0,
-                         cp.sum(het, axis=0).astype(cp.float64) / n_called, 0.0)
-        # Derived allele count from complete pairs only
-        derived = cp.sum(
-            cp.where(both_valid, ha, 0) + cp.where(both_valid, hb, 0),
-            axis=0).astype(cp.float64)
-        return h_bar, n_called, derived
+    # NOTE: WC is a per-allele one-vs-rest ANOVA. For each allele it splits the
+    # variance of the "carries this allele" gamete indicator into between-pop
+    # (a), between-individual-within-pop (b), and between-gamete-within-
+    # individual (c) components, and FST = sum_alleles a / sum_alleles (a+b+c).
+    # The c component IS the per-allele observed heterozygosity -- individuals
+    # with exactly ONE copy of the allele -- so het is counted PER ALLELE, not
+    # the site-level "any difference" H_obs in diversity.heterozygosity_observed.
+    # The two coincide only for biallelic sites; for 3+ alleles a 1/2 individual
+    # is het for alleles 1 and 2 but homozygous for allele 0. Multiallelic form
+    # matches scikit-allel's weir_cockerham_fst (a/b/c are (n_var, K); sum over
+    # alleles and sites).
+    k = max(int(pop1_haps.max()) if pop1_haps.size else 0,
+            int(pop2_haps.max()) if pop2_haps.size else 0, 0) + 1
 
-    if len(pop1_idx) >= 2 and len(pop2_idx) >= 2:
-        h_bar1, n1, pop1_counts = _pop_diploid_stats(pop1_haps)
-        h_bar2, n2, pop2_counts = _pop_diploid_stats(pop2_haps)
-    else:
-        pop1_counts, pop1_n = _pop_dac_and_n(pop1_haps)
-        pop2_counts, pop2_n = _pop_dac_and_n(pop2_haps)
-        pop1_counts = pop1_counts.astype(cp.float64)
-        pop2_counts = pop2_counts.astype(cp.float64)
-        n1 = pop1_n.astype(cp.float64)
-        n2 = pop2_n.astype(cp.float64)
-        h_bar1 = cp.zeros_like(n1)
-        h_bar2 = cp.zeros_like(n2)
-
-    # Allele frequencies from complete diploid pairs
-    pop1_freqs = cp.where(n1 > 0, pop1_counts / (2.0 * n1), 0.0)
-    pop2_freqs = cp.where(n2 > 0, pop2_counts / (2.0 * n2), 0.0)
+    ac1, het1, n1 = _pop_wc_stats(pop1_haps, k)
+    ac2, het2, n2 = _pop_wc_stats(pop2_haps, k)
 
     r = 2.0
     n_total = n1 + n2
     n_bar = n_total / r
 
-    # n_C: sample size correction factor
+    # Per-allele frequencies within each pop (diploid: 2 gametes per individual);
+    # only where the pop has complete individuals (freq 0 elsewhere, unused).
+    p1 = cp.zeros_like(ac1)
+    p2 = cp.zeros_like(ac2)
+    v1 = n1 > 0
+    v2 = n2 > 0
+    p1[v1] = ac1[v1] / (2.0 * n1[v1])[:, None]
+    p2[v2] = ac2[v2] / (2.0 * n2[v2])[:, None]
+
+    # Sample-size correction, pooled freq, allele-freq variance, per-allele het,
+    # computed only at sites with data (subset on the mask, as the biallelic
+    # code did -- avoids the div-by-zero guards).
     nc = cp.zeros_like(n_total)
-    valid = n_total > 0
-    nc[valid] = (n_total[valid] - (n1[valid]**2 + n2[valid]**2) / n_total[valid]) / (r - 1)
+    p_bar = cp.zeros_like(ac1)
+    s_squared = cp.zeros_like(ac1)
+    h_bar = cp.zeros_like(ac1)
+    vt = n_total > 0
+    nt = n_total[vt]
+    n1t = n1[vt][:, None]
+    n2t = n2[vt][:, None]
+    nc[vt] = (nt - (n1[vt]**2 + n2[vt]**2) / nt) / (r - 1)
+    p_bar[vt] = (n1t * p1[vt] + n2t * p2[vt]) / nt[:, None]
+    s_squared[vt] = (n1t * (p1[vt] - p_bar[vt])**2
+                     + n2t * (p2[vt] - p_bar[vt])**2) / ((r - 1) * (nt / r)[:, None])
+    h_bar[vt] = (het1[vt] + het2[vt]) / nt[:, None]       # per-allele obs het
 
-    # Weighted average allele frequency
-    p_bar = cp.zeros_like(pop1_freqs)
-    valid = n_total > 0
-    p_bar[valid] = (n1[valid] * pop1_freqs[valid] + n2[valid] * pop2_freqs[valid]) / n_total[valid]
-
-    # Sample variance of allele frequencies
-    s_squared = cp.zeros_like(p_bar)
-    valid = n_bar > 0
-    s_squared[valid] = (n1[valid] * (pop1_freqs[valid] - p_bar[valid])**2 +
-                       n2[valid] * (pop2_freqs[valid] - p_bar[valid])**2) / ((r - 1) * n_bar[valid])
-
-    # Average observed heterozygosity weighted by sample size
-    h_bar = cp.zeros_like(p_bar)
-    valid = n_total > 0
-    h_bar[valid] = (n1[valid] * h_bar1[valid] + n2[valid] * h_bar2[valid]) / n_total[valid]
-
-    # W-C variance components (Eqs 2, 3, 4 from Weir & Cockerham 1984)
-    a = cp.zeros_like(p_bar)
-    b = cp.zeros_like(p_bar)
-    c = cp.zeros_like(p_bar)
-
+    # W-C variance components (Eqs 2, 3, 4 from Weir & Cockerham 1984), per
+    # allele, only where estimable (n_bar > 1). Sum over alleles AND sites.
+    a = cp.zeros_like(ac1)
+    b = cp.zeros_like(ac1)
+    c = cp.zeros_like(ac1)
     valid = (n_bar > 1) & (nc > 0)
+    nb = n_bar[valid][:, None]
+    ncc = nc[valid][:, None]
     pq = p_bar[valid] * (1 - p_bar[valid])
     s2 = s_squared[valid]
-    nb = n_bar[valid]
-    ncc = nc[valid]
     hb = h_bar[valid]
-
     a[valid] = (nb / ncc) * (s2 - (1.0 / (nb - 1)) * (pq - (r - 1) * s2 / r - hb / 4.0))
     b[valid] = (nb / (nb - 1)) * (pq - (r - 1) * s2 / r - (2 * nb - 1) * hb / (4.0 * nb))
     c[valid] = hb / 2.0
 
-    # Global FST = sum(a) / sum(a + b + c)
-    valid_mask = (n1 > 0) & (n2 > 0)
-    if cp.any(valid_mask):
-        sum_a = float(cp.sum(a[valid_mask]).get())
-        sum_abc = float(cp.sum((a + b + c)[valid_mask]).get())
-        if sum_abc > 0:
-            return sum_a / sum_abc
+    # Global FST = sum(a) / sum(a + b + c), summed over alleles AND sites.
+    sum_a = float(cp.sum(a).get())
+    sum_abc = float(cp.sum(a + b + c).get())
+    if sum_abc > 0:
+        return sum_a / sum_abc
     return 0.0
 
 

--- a/pg_gpu/divergence.py
+++ b/pg_gpu/divergence.py
@@ -15,10 +15,46 @@ from ._memutil import dac_and_n as _pop_dac_and_n
 from .diversity import _apply_span_normalize, pi as _diversity_pi
 
 
+def _aligned_pop_counts(pop1_haps, pop2_haps):
+    """Per-allele counts for two populations on a shared global K.
+
+    Both populations are counted with the same allele-index width
+    K = max allele index over both pops + 1, so column ``a`` denotes the same
+    allele in each (the alignment discipline from the joint SFS). This is what
+    makes ``sum_a ac1[:, a] * ac2[:, a]`` a valid per-allele cross term.
+
+    Parameters
+    ----------
+    pop1_haps, pop2_haps : cupy.ndarray, shape (n_haplotypes, n_variants)
+        Haplotype data for each population, with -1 for missing.
+
+    Returns
+    -------
+    ac1, ac2 : cupy.ndarray, int64, shape (n_variants, K)
+        Per-allele counts on the shared K.
+    nv1, nv2 : cupy.ndarray, int64, shape (n_variants,)
+        Per-site valid (non-missing) haplotype counts.
+    """
+    from ._memutil import allele_counts
+    k1 = int(pop1_haps.max()) if pop1_haps.size else 0
+    k2 = int(pop2_haps.max()) if pop2_haps.size else 0
+    k = max(k1, k2, 0) + 1
+    ac1, nv1 = allele_counts(pop1_haps, n_alleles=k)
+    ac2, nv2 = allele_counts(pop2_haps, n_alleles=k)
+    return ac1, ac2, nv1, nv2
+
+
 def dxy_components(pop1_haps, pop2_haps):
     """Compute between-population pairwise differences and comparisons.
 
     Returns raw counts for custom aggregation (e.g., windowed analysis).
+    Per-allele (multiallelic-correct): at a site the number of differing
+    cross-population pairs is
+
+        diffs = nv1 * nv2 - sum_a ac1_a * ac2_a
+
+    (comparisons minus same-allele pairs, summed over every allele a), which
+    reduces to the biallelic ancestral/derived form when there are two alleles.
 
     Parameters
     ----------
@@ -34,19 +70,14 @@ def dxy_components(pop1_haps, pop2_haps):
     n_sites : int
         Number of sites with data in both populations.
     """
-    pop1_derived, pop1_n = _pop_dac_and_n(pop1_haps)
-    pop2_derived, pop2_n = _pop_dac_and_n(pop2_haps)
-    pop1_n = pop1_n.astype(cp.float64)
-    pop2_n = pop2_n.astype(cp.float64)
-    pop1_derived = pop1_derived.astype(cp.float64)
-    pop2_derived = pop2_derived.astype(cp.float64)
-    pop1_ancestral = pop1_n - pop1_derived
-    pop2_ancestral = pop2_n - pop2_derived
+    ac1, ac2, nv1, nv2 = _aligned_pop_counts(pop1_haps, pop2_haps)
+    nv1 = nv1.astype(cp.float64)
+    nv2 = nv2.astype(cp.float64)
+    same = cp.sum(ac1.astype(cp.float64) * ac2.astype(cp.float64), axis=1)
+    site_comps = nv1 * nv2
+    site_diffs = site_comps - same
 
-    site_diffs = pop1_derived * pop2_ancestral + pop1_ancestral * pop2_derived
-    site_comps = pop1_n * pop2_n
-
-    usable = (pop1_n > 0) & (pop2_n > 0)
+    usable = (nv1 > 0) & (nv2 > 0)
     total_diffs = float(cp.sum(site_diffs[usable]).get())
     total_comps = float(cp.sum(site_comps[usable]).get())
     n_sites = int(cp.sum(usable).get())
@@ -434,22 +465,18 @@ def dxy(haplotype_matrix: HaplotypeMatrix,
 
     n_filtered = pop1_haps.shape[1]
 
-    # Get allele frequencies from non-missing data per site
-    pop1_counts, pop1_n = _pop_dac_and_n(pop1_haps)
-    pop2_counts, pop2_n = _pop_dac_and_n(pop2_haps)
-    pop1_counts = pop1_counts.astype(cp.float64)
-    pop2_counts = pop2_counts.astype(cp.float64)
-    pop1_n = pop1_n.astype(cp.float64)
-    pop2_n = pop2_n.astype(cp.float64)
+    # Per-allele Dxy: dxy = 1 - sum_a p1_a * p2_a, from non-missing data per
+    # site. Reduces to the biallelic p1 + p2 - 2*p1*p2 when there are two
+    # alleles; multiallelic-correct (matches tskit divergence).
+    ac1, ac2, nv1, nv2 = _aligned_pop_counts(pop1_haps, pop2_haps)
+    nv1 = nv1.astype(cp.float64)
+    nv2 = nv2.astype(cp.float64)
 
-    pop1_freqs = cp.where(pop1_n > 0, pop1_counts / pop1_n, 0.0)
-    pop2_freqs = cp.where(pop2_n > 0, pop2_counts / pop2_n, 0.0)
-
-    # Calculate Dxy only for sites with data
-    valid_mask = (pop1_n > 0) & (pop2_n > 0)
+    valid_mask = (nv1 > 0) & (nv2 > 0)
+    p1 = cp.where(valid_mask[:, None], ac1.astype(cp.float64) / nv1[:, None], 0.0)
+    p2 = cp.where(valid_mask[:, None], ac2.astype(cp.float64) / nv2[:, None], 0.0)
     dxy_per_site = cp.zeros(n_filtered)
-    dxy_per_site[valid_mask] = (pop1_freqs[valid_mask] + pop2_freqs[valid_mask] -
-                               2 * pop1_freqs[valid_mask] * pop2_freqs[valid_mask])
+    dxy_per_site[valid_mask] = 1.0 - cp.sum(p1 * p2, axis=1)[valid_mask]
 
     if per_site:
         return dxy_per_site.get()

--- a/pg_gpu/divergence.py
+++ b/pg_gpu/divergence.py
@@ -165,43 +165,16 @@ def fst_hudson(haplotype_matrix: HaplotypeMatrix,
     pop1_haps = haplotype_matrix.haplotypes[pop1_idx, :]
     pop2_haps = haplotype_matrix.haplotypes[pop2_idx, :]
 
-    pop1_counts, pop1_n = _pop_dac_and_n(pop1_haps)
-    pop2_counts, pop2_n = _pop_dac_and_n(pop2_haps)
-    pop1_counts = pop1_counts.astype(cp.float64)
-    pop2_counts = pop2_counts.astype(cp.float64)
-    n1 = pop1_n.astype(cp.float64)
-    n2 = pop2_n.astype(cp.float64)
+    # Per-allele Hudson: within = mean within-pop pairwise diff, between = dxy,
+    # FST = 1 - sum(within)/sum(between) (ratio-of-averages). den > 0 already
+    # implies both pops have data and the site is polymorphic between them.
+    ac1, ac2, nv1, nv2 = _aligned_pop_counts(pop1_haps, pop2_haps)
+    num, den = _hudson_fst_from_counts(ac1, nv1, ac2, nv2)
 
-    pop1_freqs = cp.where(n1 > 0, pop1_counts / n1, 0.0)
-    pop2_freqs = cp.where(n2 > 0, pop2_counts / n2, 0.0)
-
-    # Per-site within-population mean pairwise difference
-    # mpd(p, n) = p*(1-p)*n/(n-1)  (unbiased heterozygosity)
-    within1 = cp.zeros_like(pop1_freqs)
-    within2 = cp.zeros_like(pop2_freqs)
-    valid1 = n1 > 1
-    valid2 = n2 > 1
-    within1[valid1] = (pop1_freqs[valid1] * (1 - pop1_freqs[valid1])
-                       * n1[valid1] / (n1[valid1] - 1))
-    within2[valid2] = (pop2_freqs[valid2] * (1 - pop2_freqs[valid2])
-                       * n2[valid2] / (n2[valid2] - 1))
-    within = (within1 + within2) / 2.0
-
-    # Per-site between-population mean pairwise difference
-    between = (pop1_freqs * (1 - pop2_freqs)
-               + pop2_freqs * (1 - pop1_freqs)) / 2.0
-
-    # Numerator and denominator per SNP (ratio-of-averages)
-    num = between - within
-    den = between
-
-    valid_mask = (den > 0) & (n1 > 0) & (n2 > 0)
-
+    valid_mask = den > 0
     if cp.any(valid_mask):
-        fst_val = float((cp.sum(num[valid_mask]) / cp.sum(den[valid_mask])).get())
-        return fst_val
-    else:
-        return 0.0
+        return float((cp.sum(num[valid_mask]) / cp.sum(den[valid_mask])).get())
+    return 0.0
 
 
 def fst_weir_cockerham(haplotype_matrix,
@@ -693,43 +666,44 @@ def _get_population_indices(haplotype_matrix: HaplotypeMatrix,
         return list(pop)
 
 
-def _pop_allele_counts(haplotype_matrix, pop, missing_data='include'):
-    """Compute per-variant allele counts for a population on GPU.
+def _hudson_fst_from_counts(ac1, nv1, ac2, nv2):
+    """Per-variant Hudson FST num/den from per-allele counts on a shared K.
 
-    Returns (ac_0, ac_1, n) as CuPy arrays. n is per-site (array)
-    for 'include' mode, and also per-site after filtering
-    for 'exclude' mode.
+    Classic Hudson estimator (== scikit-allel): FST = sum(num) / sum(den) with
+    per-site num = Hb - Hw, den = Hb, where Hw is the mean within-population
+    pairwise difference and Hb the between-population divergence. The
+    same-allele pair counts sum over every allele column, so this is
+    multiallelic-correct and reduces to the biallelic ancestral/derived form
+    (ac columns [ref, alt]) exactly.
+
+    Parameters
+    ----------
+    ac1, ac2 : cupy.ndarray, shape (n_variants, K)
+        Per-allele counts on the SAME K (see _aligned_pop_counts).
+    nv1, nv2 : cupy.ndarray, shape (n_variants,)
+        Per-site valid haplotype counts.
+
+    Returns
+    -------
+    num, den : cupy.ndarray, float64, shape (n_variants,)
     """
-    if missing_data == 'exclude':
-        haplotype_matrix = haplotype_matrix.exclude_missing_sites(
-            populations=[pop])
+    nv1 = nv1.astype(cp.float64)
+    nv2 = nv2.astype(cp.float64)
+    ac1 = ac1.astype(cp.float64)
+    ac2 = ac2.astype(cp.float64)
 
-    pop_idx = _get_population_indices(haplotype_matrix, pop)
-    h = haplotype_matrix.haplotypes[pop_idx, :]
-    ac_1, n = _pop_dac_and_n(h)
-    n = n.astype(cp.float64)
-    ac_1 = ac_1.astype(cp.float64)
-    ac_0 = n - ac_1
-    return ac_0, ac_1, n
-
-
-def _hudson_fst_from_counts(ac1_0, ac1_1, n1, ac2_0, ac2_1, n2):
-    """Compute per-variant Hudson FST num/den from precomputed allele counts.
-
-    Returns (num, den) as CuPy arrays on GPU.
-    """
-    n1_pairs = n1 * (n1 - 1) / 2
-    n1_same = (ac1_0 * (ac1_0 - 1) + ac1_1 * (ac1_1 - 1)) / 2
+    n1_pairs = nv1 * (nv1 - 1) / 2
+    n1_same = cp.sum(ac1 * (ac1 - 1), axis=1) / 2
     mpd1 = cp.where(n1_pairs > 0, (n1_pairs - n1_same) / n1_pairs, 0.0)
 
-    n2_pairs = n2 * (n2 - 1) / 2
-    n2_same = (ac2_0 * (ac2_0 - 1) + ac2_1 * (ac2_1 - 1)) / 2
+    n2_pairs = nv2 * (nv2 - 1) / 2
+    n2_same = cp.sum(ac2 * (ac2 - 1), axis=1) / 2
     mpd2 = cp.where(n2_pairs > 0, (n2_pairs - n2_same) / n2_pairs, 0.0)
 
     within = (mpd1 + mpd2) / 2.0
 
-    n_between = n1 * n2
-    n_between_same = ac1_0 * ac2_0 + ac1_1 * ac2_1
+    n_between = nv1 * nv2
+    n_between_same = cp.sum(ac1 * ac2, axis=1)
     between = cp.where(n_between > 0,
                        (n_between - n_between_same) / n_between, 0.0)
 
@@ -800,15 +774,27 @@ def pbs(haplotype_matrix: HaplotypeMatrix,
     if haplotype_matrix.device == 'CPU':
         haplotype_matrix.transfer_to_gpu()
 
-    # precompute allele counts once per population
-    ac1_0, ac1_1, n1 = _pop_allele_counts(haplotype_matrix, pop1, missing_data)
-    ac2_0, ac2_1, n2 = _pop_allele_counts(haplotype_matrix, pop2, missing_data)
-    ac3_0, ac3_1, n3 = _pop_allele_counts(haplotype_matrix, pop3, missing_data)
+    if missing_data == 'exclude':
+        haplotype_matrix = haplotype_matrix.exclude_missing_sites(
+            populations=[pop1, pop2, pop3])
+
+    # Per-allele counts for all three pops on a shared global K, so each pair's
+    # cross term sum_a ac_i,a * ac_j,a is over aligned alleles.
+    from ._memutil import allele_counts
+    h1 = haplotype_matrix.haplotypes[_get_population_indices(haplotype_matrix, pop1), :]
+    h2 = haplotype_matrix.haplotypes[_get_population_indices(haplotype_matrix, pop2), :]
+    h3 = haplotype_matrix.haplotypes[_get_population_indices(haplotype_matrix, pop3), :]
+    k = max(int(h1.max()) if h1.size else 0,
+            int(h2.max()) if h2.size else 0,
+            int(h3.max()) if h3.size else 0, 0) + 1
+    ac1, nv1 = allele_counts(h1, n_alleles=k)
+    ac2, nv2 = allele_counts(h2, n_alleles=k)
+    ac3, nv3 = allele_counts(h3, n_alleles=k)
 
     # compute all three pairwise FST num/den from shared counts
-    num12, den12 = _hudson_fst_from_counts(ac1_0, ac1_1, n1, ac2_0, ac2_1, n2)
-    num13, den13 = _hudson_fst_from_counts(ac1_0, ac1_1, n1, ac3_0, ac3_1, n3)
-    num23, den23 = _hudson_fst_from_counts(ac2_0, ac2_1, n2, ac3_0, ac3_1, n3)
+    num12, den12 = _hudson_fst_from_counts(ac1, nv1, ac2, nv2)
+    num13, den13 = _hudson_fst_from_counts(ac1, nv1, ac3, nv3)
+    num23, den23 = _hudson_fst_from_counts(ac2, nv2, ac3, nv3)
 
     fst12 = _windowed_fst(num12, den12, window_size, window_start,
                           window_stop, window_step)

--- a/pg_gpu/divergence.py
+++ b/pg_gpu/divergence.py
@@ -416,27 +416,28 @@ def fst_nei(haplotype_matrix: HaplotypeMatrix,
     pop1_haps = haplotype_matrix.haplotypes[pop1_idx, :]
     pop2_haps = haplotype_matrix.haplotypes[pop2_idx, :]
 
-    pop1_counts, pop1_n = _pop_dac_and_n(pop1_haps)
-    pop2_counts, pop2_n = _pop_dac_and_n(pop2_haps)
-    pop1_counts = pop1_counts.astype(cp.float64)
-    pop2_counts = pop2_counts.astype(cp.float64)
-    n1 = pop1_n.astype(cp.float64)
-    n2 = pop2_n.astype(cp.float64)
+    # Per-allele Nei GST: within het HS = 1 - sum_a p_a^2 (per pop, sample-size
+    # weighted), total het HT = 1 - sum_a pbar_a^2 with the pooled allele freq
+    # pbar_a = (n1*p1_a + n2*p2_a)/(n1+n2). Reduces to the biallelic 2p(1-p)
+    # forms; multiallelic-correct.
+    ac1, ac2, nv1, nv2 = _aligned_pop_counts(pop1_haps, pop2_haps)
+    n1 = nv1.astype(cp.float64)
+    n2 = nv2.astype(cp.float64)
+    tot = n1 + n2
+    both = tot > 0
 
-    pop1_freqs = cp.where(n1 > 0, pop1_counts / n1, 0.0)
-    pop2_freqs = cp.where(n2 > 0, pop2_counts / n2, 0.0)
+    p1 = cp.where((n1 > 0)[:, None], ac1.astype(cp.float64) / n1[:, None], 0.0)
+    p2 = cp.where((n2 > 0)[:, None], ac2.astype(cp.float64) / n2[:, None], 0.0)
 
-    # Within-population heterozygosity
-    hs1 = 2.0 * pop1_freqs * (1 - pop1_freqs)
-    hs2 = 2.0 * pop2_freqs * (1 - pop2_freqs)
+    h1 = 1.0 - cp.sum(p1 * p1, axis=1)
+    h2 = 1.0 - cp.sum(p2 * p2, axis=1)
 
-    hs = cp.zeros_like(hs1)
-    p_total = cp.zeros_like(pop1_freqs)
-    valid = (n1 + n2) > 0
-    hs[valid] = (hs1[valid] * n1[valid] + hs2[valid] * n2[valid]) / (n1[valid] + n2[valid])
-    p_total[valid] = (pop1_freqs[valid] * n1[valid] + pop2_freqs[valid] * n2[valid]) / (n1[valid] + n2[valid])
+    hs = cp.zeros_like(h1)
+    hs[both] = (h1[both] * n1[both] + h2[both] * n2[both]) / tot[both]
 
-    ht = 2.0 * p_total * (1 - p_total)
+    pbar = cp.zeros_like(p1)
+    pbar[both] = (n1[both, None] * p1[both] + n2[both, None] * p2[both]) / tot[both, None]
+    ht = 1.0 - cp.sum(pbar * pbar, axis=1)
 
     # Calculate GST - only for sites with sufficient data
     valid_mask = (ht > 0) & (n1 > 0) & (n2 > 0)

--- a/pg_gpu/divergence.py
+++ b/pg_gpu/divergence.py
@@ -11,7 +11,6 @@ import numpy as np
 import cupy as cp
 from typing import Union, Tuple, Optional, Dict
 from .haplotype_matrix import HaplotypeMatrix
-from ._memutil import dac_and_n as _pop_dac_and_n
 from .diversity import _apply_span_normalize, pi as _diversity_pi
 
 
@@ -658,6 +657,8 @@ def divergence_stats(haplotype_matrix: HaplotypeMatrix,
             results['fst'] = fst(haplotype_matrix, pop1, pop2, missing_data=missing_data)
         elif stat == 'fst_hudson':
             results['fst_hudson'] = fst_hudson(haplotype_matrix, pop1, pop2, missing_data=missing_data)
+        elif stat == 'fst_tskit':
+            results['fst_tskit'] = fst_tskit(haplotype_matrix, pop1, pop2, missing_data=missing_data)
         elif stat == 'fst_wc':
             results['fst_wc'] = fst_weir_cockerham(haplotype_matrix, pop1, pop2, missing_data=missing_data)
         elif stat == 'fst_nei':

--- a/pg_gpu/divergence.py
+++ b/pg_gpu/divergence.py
@@ -102,7 +102,9 @@ def fst(haplotype_matrix: HaplotypeMatrix,
     pop2 : str or list
         Second population (name from sample_sets or list of indices)
     method : str
-        FST estimation method ('hudson', 'weir_cockerham', 'nei')
+        FST estimation method ('hudson', 'tskit', 'weir_cockerham', 'nei').
+        'hudson' is the classic 1 - Hw/Hb estimator (== scikit-allel); 'tskit'
+        is tskit's (Hb - Hw)/(Hb + Hw) combination. See fst_tskit.
     missing_data : str
         'include' - Use all sites, calculate from available data per site
         'exclude' - Only use sites with no missing data
@@ -114,6 +116,8 @@ def fst(haplotype_matrix: HaplotypeMatrix,
     """
     if method == 'hudson':
         return fst_hudson(haplotype_matrix, pop1, pop2, missing_data)
+    elif method == 'tskit':
+        return fst_tskit(haplotype_matrix, pop1, pop2, missing_data)
     elif method == 'weir_cockerham':
         return fst_weir_cockerham(haplotype_matrix, pop1, pop2, missing_data)
     elif method == 'nei':
@@ -174,6 +178,68 @@ def fst_hudson(haplotype_matrix: HaplotypeMatrix,
     valid_mask = den > 0
     if cp.any(valid_mask):
         return float((cp.sum(num[valid_mask]) / cp.sum(den[valid_mask])).get())
+    return 0.0
+
+
+def fst_tskit(haplotype_matrix: HaplotypeMatrix,
+              pop1: Union[str, list],
+              pop2: Union[str, list],
+              missing_data: str = 'include') -> float:
+    """
+    Compute tskit's FST estimator between two populations.
+
+    tskit assembles the same within/between pieces as Hudson but with a
+    different combination (added here for tskit parity; NOT the classic Hudson
+    ``1 - Hw/Hb`` returned by ``fst_hudson``):
+
+        FST = (sum(Hb) - sum(Hw)) / (sum(Hb) + sum(Hw))
+
+    where, per site, Hw = (pi_1 + pi_2) / 2 is the mean within-population
+    pairwise difference (unbiased) and Hb = dxy is the between-population
+    divergence. Both are per-allele, so this matches
+    ``ts.Fst([pop1, pop2], mode='site')`` on multiallelic data. See
+    ``plans/NOTES_fst_estimators.md`` (untracked) for the estimator comparison.
+
+    Parameters
+    ----------
+    haplotype_matrix : HaplotypeMatrix
+        The haplotype data
+    pop1 : str or list
+        First population
+    pop2 : str or list
+        Second population
+    missing_data : str
+        'include' - Use all sites, calculate from available data per site
+        'exclude' - Only use sites with no missing data
+
+    Returns
+    -------
+    float
+        tskit's FST estimate
+    """
+    if haplotype_matrix.device == 'CPU':
+        haplotype_matrix.transfer_to_gpu()
+
+    if missing_data == 'exclude':
+        haplotype_matrix = haplotype_matrix.exclude_missing_sites(
+            populations=[pop1, pop2])
+        if haplotype_matrix.num_variants == 0:
+            return 0.0
+
+    pop1_idx = _get_population_indices(haplotype_matrix, pop1)
+    pop2_idx = _get_population_indices(haplotype_matrix, pop2)
+    pop1_haps = haplotype_matrix.haplotypes[pop1_idx, :]
+    pop2_haps = haplotype_matrix.haplotypes[pop2_idx, :]
+
+    # Reuse the per-allele Hudson pieces: den = Hb (between), den - num = Hw
+    # (within). tskit combines them as (Hb - Hw) / (Hb + Hw), summed over sites.
+    ac1, ac2, nv1, nv2 = _aligned_pop_counts(pop1_haps, pop2_haps)
+    num, den = _hudson_fst_from_counts(ac1, nv1, ac2, nv2)
+    between_sum = float(cp.sum(den).get())
+    within_sum = float(cp.sum(den - num).get())
+    total = between_sum + within_sum
+    if total > 0:
+        return (between_sum - within_sum) / total
     return 0.0
 
 

--- a/pg_gpu/divergence.py
+++ b/pg_gpu/divergence.py
@@ -196,8 +196,7 @@ def fst_tskit(haplotype_matrix: HaplotypeMatrix,
     where, per site, Hw = (pi_1 + pi_2) / 2 is the mean within-population
     pairwise difference (unbiased) and Hb = dxy is the between-population
     divergence. Both are per-allele, so this matches
-    ``ts.Fst([pop1, pop2], mode='site')`` on multiallelic data. See
-    ``plans/NOTES_fst_estimators.md`` (untracked) for the estimator comparison.
+    ``ts.Fst([pop1, pop2], mode='site')`` on multiallelic data.
 
     Parameters
     ----------

--- a/pg_gpu/divergence.py
+++ b/pg_gpu/divergence.py
@@ -495,8 +495,9 @@ def dxy(haplotype_matrix: HaplotypeMatrix,
         ``'include'`` (default) uses per-site valid data.
         ``'exclude'`` filters to sites with no missing data.
     span_normalize : bool
-        ``True`` (default): auto-detect best denominator.
-        ``False``: return raw sum / sites-with-data average.
+        ``True`` (default): auto-detect best denominator (per-base rate).
+        ``False``: return the raw sum of per-site Dxy over sites with data
+        (consistent with ``diversity.pi`` and the other raw-sum statistics).
 
     Returns
     -------
@@ -537,9 +538,6 @@ def dxy(haplotype_matrix: HaplotypeMatrix,
         return dxy_per_site.get()
     else:
         dxy_sum = cp.sum(dxy_per_site)
-        if span_normalize is False:
-            n_sites = int(cp.sum(valid_mask).get())
-            return float(dxy_sum.get() / n_sites) if n_sites > 0 else 0.0
         return _apply_span_normalize(dxy_sum, haplotype_matrix, span_normalize)
 
 

--- a/pg_gpu/diversity.py
+++ b/pg_gpu/diversity.py
@@ -193,8 +193,7 @@ def _site_contribution(name, d, n_safe, seg, n_valid, n_hap, dac=None):
     LEGACY (collapsed, biallelic) path: derived alleles are lumped into a single
     ``dac`` count, so this is not multiallelic-correct. The scalar diversity path
     now uses the per-allele ``_ac_contribution``; this function is retained only
-    for ``windowed_analysis``, which still imports it and is migrated to the
-    per-allele primitive in a later subproject.
+    for ``windowed_analysis``, which still imports it.
 
     Parameters
     ----------

--- a/pg_gpu/diversity.py
+++ b/pg_gpu/diversity.py
@@ -642,16 +642,25 @@ class FrequencySpectrum:
         if n_total_sites is None:
             n_total_sites = matrix.n_total_sites
 
-        from ._memutil import dac_and_n as _dac_n
-        dac, n_valid = _dac_n(matrix.haplotypes)
+        from ._memutil import allele_counts
+        ac, n_valid = allele_counts(matrix.haplotypes)
 
         if missing_data == 'exclude':
             complete = n_valid == n_hap
-            dac = dac[complete]
+            ac = ac[complete]
             n_valid = n_valid[complete]
 
+        # NOTE (issue #100): per-allele polarised SFS -- each derived allele
+        # contributes at its own frequency for 0 < count < n (both fixed classes,
+        # bin 0 and bin n, excluded, matching tskit). The SFS is marginal (it
+        # forgets which derived alleles co-occur at a site), so on MULTIALLELIC
+        # data the estimators that depend on co-occurrence diverge from the
+        # authoritative scalar functions (diversity.pi etc.): pi -- and hence
+        # Tajima's D and Fay-Wu H -- overcount, and Watterson (sum of xi) differs
+        # from the scalar distinct-alleles-1 at reference-absent sites.
+        # theta_h/theta_l and the eta-family are exact.
         self.sfs_by_n = {}
-        if len(dac) == 0:
+        if len(n_valid) == 0:
             self.n_max = 0
             self.n_segregating = 0
         else:
@@ -662,7 +671,12 @@ class FrequencySpectrum:
                 if ni < 2:
                     continue
                 mask = n_valid == ni
-                xi = cp.bincount(dac[mask], minlength=ni + 1)[:ni + 1]
+                vals = ac[mask][:, 1:]
+                vals = vals[(vals > 0) & (vals < ni)]
+                if vals.size:
+                    xi = cp.bincount(vals, minlength=ni + 1)[:ni + 1]
+                else:  # no segregating derived alleles (cupy bincount rejects empty)
+                    xi = cp.zeros(ni + 1, dtype=cp.int64)
                 self.sfs_by_n[ni] = xi.astype(cp.float64).get()
             self.n_segregating = sum(
                 int(np.sum(xi[1:n])) for n, xi in self.sfs_by_n.items())
@@ -1000,7 +1014,9 @@ def allele_frequency_spectrum(haplotype_matrix: HaplotypeMatrix,
     Returns
     -------
     ndarray
-        Array where element i contains the number of sites with i derived alleles
+        Per-allele (unfolded) SFS: element i is the number of derived alleles
+        carried by i samples. A multiallelic site contributes one entry per
+        derived allele.
     """
 
     # Get population subset if specified
@@ -1013,50 +1029,27 @@ def allele_frequency_spectrum(haplotype_matrix: HaplotypeMatrix,
     if matrix.device == 'CPU':
         matrix.transfer_to_gpu()
 
+    from ._memutil import allele_counts
+    max_n = matrix.num_haplotypes
+
     if missing_data == 'exclude':
         matrix = matrix.exclude_missing_sites()
         if matrix.num_variants == 0:
-            return np.zeros(matrix.num_haplotypes + 1, dtype=np.int64)
-        n_haplotypes = matrix.num_haplotypes
-        freqs = cp.sum(matrix.haplotypes, axis=0)
-
-    else:  # missing_data == 'include'
-        max_n = matrix.num_haplotypes
-        derived_counts, n_valid_per_site = _dac_and_n(matrix.haplotypes)
-
-        sites_with_data = n_valid_per_site > 0
-        if not cp.any(sites_with_data):
             return np.zeros(max_n + 1, dtype=np.int64)
 
-        # Filter to sites with valid data and check they're biallelic
-        valid_sites = cp.where(sites_with_data)[0]
-        derived_at_valid = derived_counts[valid_sites]
-        n_valid_at_valid = n_valid_per_site[valid_sites]
-
-        # Check biallelic assumption: derived count should be <= n_valid
-        biallelic_mask = derived_at_valid <= n_valid_at_valid
-        final_derived = derived_at_valid[biallelic_mask]
-
-        # Create AFS histogram
-        # Use bincount which is more efficient than a loop
-        if len(final_derived) > 0:
-            # Ensure derived counts don't exceed max_n
-            final_derived = cp.minimum(final_derived, max_n)
-            afs = cp.bincount(final_derived, minlength=max_n + 1)
-            # Ensure correct size and type
-            if len(afs) < max_n + 1:
-                afs_full = cp.zeros(max_n + 1, dtype=cp.int64)
-                afs_full[:len(afs)] = afs
-                afs = afs_full
-            else:
-                afs = afs[:max_n + 1].astype(cp.int64)
-        else:
-            return np.zeros(max_n + 1, dtype=np.int64)
-
-        return afs.get()
-
-    # For exclude mode, create standard histogram
-    return cp.histogram(freqs, bins=cp.arange(n_haplotypes + 2))[0].get()
+    ac, n_valid = allele_counts(matrix.haplotypes)
+    # Per-allele polarised SFS: each derived allele contributes one count at its
+    # sample frequency, for 0 < count < n. Both fixed classes are excluded --
+    # bin 0 (invariant-ancestral: no derived allele) and bin n (monomorphic-
+    # derived) -- so this matches tskit's polarised allele_frequency_spectrum
+    # exactly. Invariant-site counting is a separate concern (see
+    # FrequencySpectrum's n_total_sites).
+    derived = ac[:, 1:]
+    vals = derived[(derived > 0) & (derived < n_valid[:, None])]
+    if vals.size == 0:  # no segregating derived alleles (cupy bincount rejects empty)
+        return np.zeros(max_n + 1, dtype=np.int64)
+    afs = cp.bincount(vals, minlength=max_n + 1)[:max_n + 1]
+    return afs.astype(cp.int64).get()
 
 
 def segregating_sites(haplotype_matrix: HaplotypeMatrix,

--- a/pg_gpu/diversity.py
+++ b/pg_gpu/diversity.py
@@ -872,24 +872,6 @@ def pi_components(haplotypes, n_total_sites=None, n_haplotypes_full=None):
     return total_diffs, total_comps, total_missing, n_sites
 
 
-def _dac_and_n(haplotypes):
-    """Shared helper: derived allele counts and valid sample counts per site.
-
-    Uses adaptive chunking from _memutil for memory safety on large matrices.
-
-    Parameters
-    ----------
-    haplotypes : cupy.ndarray, int8, shape (n_hap, n_var)
-
-    Returns
-    -------
-    dac : cupy.ndarray, int64, shape (n_var,)
-    n_valid : cupy.ndarray, int64, shape (n_var,)
-    """
-    from ._memutil import dac_and_n
-    return dac_and_n(haplotypes)
-
-
 
 def pi(haplotype_matrix: HaplotypeMatrix,
        population: Optional[Union[str, list]] = None,
@@ -1137,24 +1119,18 @@ def singleton_count(haplotype_matrix: HaplotypeMatrix,
     if matrix.device == 'CPU':
         matrix.transfer_to_gpu()
 
+    from ._memutil import allele_counts
     if missing_data == 'exclude':
         matrix = matrix.exclude_missing_sites()
         if matrix.num_variants == 0:
             return 0
-        allele_counts = cp.sum(matrix.haplotypes, axis=0)
 
-    else:  # missing_data == 'include'
-        derived_counts, n_valid_per_site = _dac_and_n(matrix.haplotypes)
-        sites_with_data = n_valid_per_site >= 1
-
-        if not cp.any(sites_with_data):
-            return 0
-
-        valid_sites = cp.where(sites_with_data)[0]
-        return int(cp.sum(derived_counts[valid_sites] == 1).get())
-
-    # For exclude mode
-    return int(cp.sum(allele_counts == 1).get())
+    ac, n_valid = allele_counts(matrix.haplotypes)
+    # A singleton is a derived allele carried by exactly one sample at a
+    # segregating site (count == 1, which is < n whenever n >= 2). A
+    # multiallelic site can contribute more than one singleton.
+    derived = ac[:, 1:]
+    return int(cp.sum((derived == 1) & (derived < n_valid[:, None])).get())
 
 
 def diversity_stats(haplotype_matrix: HaplotypeMatrix,
@@ -1620,18 +1596,22 @@ def max_daf(haplotype_matrix: HaplotypeMatrix,
     if matrix.device == 'CPU':
         matrix.transfer_to_gpu()
 
-    dac_i, n_valid_i = _dac_and_n(matrix.haplotypes)
-    dac = dac_i.astype(cp.float64)
+    from ._memutil import allele_counts
+    ac, n_valid_i = allele_counts(matrix.haplotypes)
+    if ac.shape[1] < 2:  # no derived alleles present anywhere
+        return 0.0
     n_valid = n_valid_i.astype(cp.float64)
-
+    # Per-allele DAF: the frequency of each individual derived allele. NOTE
+    # (issue #100): "max DAF" is the frequency of the single most common derived
+    # allele, not the total non-ancestral fraction of the sample.
+    freq = ac[:, 1:].astype(cp.float64) / cp.maximum(n_valid[:, None], 1.0)
+    present = ac[:, 1:] > 0
     if missing_data == 'exclude':
-        complete = n_valid_i == matrix.haplotypes.shape[0]
-        freqs = cp.where(complete, dac / n_valid, -1.0)
+        keep = present & (n_valid_i[:, None] == matrix.haplotypes.shape[0])
+        freq = cp.where(keep, freq, -1.0)
     else:
-        usable = n_valid > 0
-        freqs = cp.where(usable, dac / n_valid, 0.0)
-
-    return float(cp.max(freqs).get())
+        freq = cp.where(present & (n_valid_i[:, None] > 0), freq, 0.0)
+    return float(cp.max(freq).get())
 
 
 def haplotype_count(haplotype_matrix: HaplotypeMatrix,
@@ -1718,18 +1698,20 @@ def daf_histogram(matrix, n_bins: int = 20,
     if matrix.device == 'CPU':
         matrix.transfer_to_gpu()
 
-    dac_i, n_valid_i = _dac_and_n(matrix.haplotypes)
-    dac = dac_i.astype(cp.float64)
+    from ._memutil import allele_counts
+    ac, n_valid_i = allele_counts(matrix.haplotypes)
     n_valid = n_valid_i.astype(cp.float64)
-
+    # Per-allele DAF: each derived allele contributes its own frequency. NOTE
+    # (issue #100): this histograms individual derived-allele frequencies (was
+    # the per-site total non-ancestral fraction), and only present derived
+    # alleles are binned (no 0-frequency spike from monomorphic sites).
+    freq = ac[:, 1:].astype(cp.float64) / cp.maximum(n_valid[:, None], 1.0)
+    present = ac[:, 1:] > 0
     if missing_data == 'exclude':
-        complete = n_valid_i == matrix.haplotypes.shape[0]
-        dafs = (dac / n_valid)[complete]
+        keep = present & (n_valid_i[:, None] == matrix.haplotypes.shape[0])
     else:
-        usable = n_valid > 0
-        dafs = cp.where(usable, dac / n_valid, 0.0)
-
-    return _histogram_from_dafs(dafs, n_bins)
+        keep = present & (n_valid_i[:, None] > 0)
+    return _histogram_from_dafs(freq[keep], n_bins)
 
 
 def diplotype_frequency_spectrum(genotype_matrix,
@@ -1874,22 +1856,23 @@ def heterozygosity_expected(haplotype_matrix: HaplotypeMatrix,
     if matrix.device == 'CPU':
         matrix.transfer_to_gpu()
 
-    dac_i, n_valid_i = _dac_and_n(matrix.haplotypes)
-    dac = dac_i.astype(cp.float64)
+    from ._memutil import allele_counts
+    ac, n_valid_i = allele_counts(matrix.haplotypes)
     n_valid = n_valid_i.astype(cp.float64)
     n = matrix.haplotypes.shape[0]
+    ac_f = ac.astype(cp.float64)
 
+    # He = 1 - sum_a p_a^2 over ALL alleles (per-allele; reduces to 2p(1-p) for
+    # biallelic). The old 2p(1-p) with p = total-derived collapsed multiallelic
+    # alleles into one class (issue #100).
     if missing_data == 'include':
-        p = cp.where(n_valid > 0, dac / n_valid, 0.0)
-        he = 2.0 * p * (1.0 - p)
-        he = cp.where(n_valid >= 2, he, cp.nan)
+        p_sq = (ac_f ** 2).sum(axis=1) / cp.maximum(n_valid, 1.0) ** 2
+        he = cp.where(n_valid >= 2, 1.0 - p_sq, cp.nan)
     else:
-        p = dac / n
-        he = 2.0 * p * (1.0 - p)
-
+        p_sq = (ac_f ** 2).sum(axis=1) / (n ** 2)
+        he = 1.0 - p_sq
         if missing_data == 'exclude':
-            incomplete = n_valid_i < n
-            he[incomplete] = cp.nan
+            he = cp.where(n_valid_i < n, cp.nan, he)
 
     return he.get()
 
@@ -2070,21 +2053,19 @@ def mu_sfs(haplotype_matrix: HaplotypeMatrix,
     if matrix.device == 'CPU':
         matrix.transfer_to_gpu()
 
-    dac, n_valid = _dac_and_n(matrix.haplotypes)
-
+    from ._memutil import allele_counts
+    ac, n_valid = allele_counts(matrix.haplotypes)
+    derived = ac[:, 1:]
+    nn = n_valid[:, None]
+    # per-derived-allele edge/segregating classification (mutation-count basis)
+    is_seg = (derived > 0) & (derived < nn)
+    is_edge = is_seg & ((derived == 1) | (derived == nn - 1))
     if missing_data == 'exclude':
-        n = matrix.haplotypes.shape[0]
-        complete = n_valid == n
-        is_seg = complete & (dac > 0) & (dac < n)
-        is_edge = complete & ((dac == 1) | (dac == n - 1))
-    else:
-        usable = n_valid >= 2
-        is_seg = usable & (dac > 0) & (dac < n_valid)
-        is_edge = usable & ((dac == 1) | (dac == n_valid - 1))
+        complete = (n_valid == matrix.haplotypes.shape[0])[:, None]
+        is_seg = is_seg & complete
+        is_edge = is_edge & complete
 
-    n_seg = cp.sum(is_seg)
-    if int(n_seg.get()) == 0:
+    n_seg = int(cp.sum(is_seg).get())
+    if n_seg == 0:
         return 0.0
-
-    n_edge = cp.sum(is_edge)
-    return float((n_edge.astype(cp.float64) / n_seg.astype(cp.float64)).get())
+    return float(cp.sum(is_edge).get() / n_seg)

--- a/pg_gpu/diversity.py
+++ b/pg_gpu/diversity.py
@@ -190,9 +190,11 @@ def _achaz_variance(w1_name, w2_name, n, S):
 def _site_contribution(name, d, n_safe, seg, n_valid, n_hap, dac=None):
     """Compute per-site contribution for a theta estimator on GPU.
 
-    This is the single source of truth for what each estimator computes.
-    Both scalar (_compute_thetas) and windowed (_windowed_thetas_scatter)
-    paths call this function.
+    LEGACY (collapsed, biallelic) path: derived alleles are lumped into a single
+    ``dac`` count, so this is not multiallelic-correct. The scalar diversity path
+    now uses the per-allele ``_ac_contribution``; this function is retained only
+    for ``windowed_analysis``, which still imports it and is migrated to the
+    per-allele primitive in a later subproject.
 
     Parameters
     ----------
@@ -266,6 +268,81 @@ def _prepare_dac(matrix):
     return dac, n_valid, d, n_safe, seg, matrix.num_haplotypes
 
 
+def _prepare_allele_counts(matrix):
+    """Compute per-allele counts and valid counts on GPU.
+
+    Returns (ac, n_valid, n_hap): the per-allele count matrix (n_var, K),
+    per-site non-missing counts, and total haplotype count. Shared per-allele
+    intermediate for the scalar diversity path (multiallelic-correct).
+    """
+    if matrix.device == 'CPU':
+        matrix.transfer_to_gpu()
+    from ._memutil import allele_counts
+    ac, n_valid = allele_counts(matrix.haplotypes)
+    return ac, n_valid, matrix.num_haplotypes
+
+
+def _ac_contribution(name, ac, n_valid, n_hap):
+    """Per-site contribution for a theta estimator from per-allele counts.
+
+    Per-allele single source of truth for the scalar theta path. ``ac`` is the
+    (n_var, K) per-allele count matrix (column 0 is the ancestral/reference
+    allele); ``n_valid`` the per-site non-missing count. Each estimator is a
+    closed-form reduction over the allele axis. pi and watterson use
+    self-correcting closed forms; the SFS-weighted estimators (theta_h, theta_l,
+    eta*) count only polymorphic derived alleles (0 < count < n), which excludes
+    fixed-derived alleles to match the per-allele SFS.
+
+    Returns a float64 (n_var,) array (zero for non-contributing sites).
+    """
+    n = n_valid.astype(cp.float64)
+    n_safe = cp.maximum(n, 2.0)
+    has_data = n_valid >= 2
+    dcols = ac[:, 1:]                     # per-derived-allele counts
+    nn = n_valid[:, None]
+    poly = (dcols > 0) & (dcols < nn)     # segregating (non-fixed) derived alleles
+
+    if name in ('pi', 'theta_pi'):
+        pairs = n_safe * (n_safe - 1.0)
+        same = (ac * (ac - 1)).sum(axis=1).astype(cp.float64)
+        return cp.where(n >= 2.0, (pairs - same) / pairs, 0.0)
+    elif name in ('watterson', 'theta_s'):
+        a1_inv = _get_a1_inv(n_hap)
+        alleles_present = (ac > 0).sum(axis=1)
+        return cp.where(
+            has_data, (alleles_present - 1).astype(cp.float64) * a1_inv[n_valid], 0.0)
+    elif name == 'theta_h':
+        num = 2.0 * (dcols.astype(cp.float64) ** 2 * poly).sum(axis=1)
+        return cp.where(has_data, num / (n_safe * (n_safe - 1.0)), 0.0)
+    elif name == 'theta_l':
+        num = (dcols.astype(cp.float64) * poly).sum(axis=1)
+        return cp.where(has_data, num / (n_safe - 1.0), 0.0)
+    elif name == 'eta1':
+        # Singleton derived alleles (count == 1).
+        a1_inv = _get_a1_inv(n_hap)
+        cnt = (dcols == 1).sum(axis=1).astype(cp.float64)
+        return cp.where(has_data, cnt * a1_inv[n_valid], 0.0)
+    elif name == 'eta1_star':
+        # Singletons + (n-1)-tons.
+        a1_inv = _get_a1_inv(n_hap)
+        is_edge = (dcols == 1) | (dcols == (n_valid - 1)[:, None])
+        cnt = is_edge.sum(axis=1).astype(cp.float64)
+        return cp.where(has_data, cnt * a1_inv[n_valid], 0.0)
+    elif name == 'minus_eta1':
+        # Non-singleton segregating derived alleles (2 <= count < n).
+        norm = _get_minus_eta1_norm(n_hap)
+        cnt = ((dcols >= 2) & (dcols < nn)).sum(axis=1).astype(cp.float64)
+        return cp.where(has_data, cnt * norm[n_valid], 0.0)
+    elif name == 'minus_eta1_star':
+        # Interior derived alleles (2 <= count <= n-2).
+        norm = _get_minus_eta1_star_norm(n_hap)
+        cnt = ((dcols >= 2) & (dcols <= (n_valid - 2)[:, None])).sum(axis=1).astype(cp.float64)
+        return cp.where(has_data, cnt * norm[n_valid], 0.0)
+    else:
+        raise ValueError(f"Unknown estimator: {name}. Use FrequencySpectrum "
+                         f"for custom weight functions.")
+
+
 def _compute_thetas(matrix, estimators=('pi', 'watterson', 'theta_h', 'theta_l')):
     """Compute multiple theta estimators via direct vectorized GPU arithmetic.
 
@@ -283,16 +360,18 @@ def _compute_thetas(matrix, estimators=('pi', 'watterson', 'theta_h', 'theta_l')
         'S': int, number of segregating sites
         'n_harmonic_mean': int, harmonic mean of per-site sample sizes
     """
-    dac, n_valid, d, n_safe, seg, n_hap = _prepare_dac(matrix)
+    ac, n_valid, n_hap = _prepare_allele_counts(matrix)
 
     thetas = {}
     for name in estimators:
-        val = cp.sum(_site_contribution(name, d, n_safe, seg, n_valid, n_hap, dac=dac))
+        val = cp.sum(_ac_contribution(name, ac, n_valid, n_hap))
         thetas[name] = float(val.get())
 
-    S = int(cp.sum(seg).get())
-
+    # Segregating sites = number of mutations = sum over sites of (alleles - 1)
+    # (tskit convention: triallelic counts as 2; reference-absent sites count).
     has_data = n_valid >= 2
+    S = int(cp.sum(cp.where(has_data, (ac > 0).sum(axis=1) - 1, 0)).get())
+
     if cp.any(has_data):
         valid_n = n_valid[has_data].astype(cp.float64)
         n_harm = round(float(len(valid_n) / cp.sum(1.0 / valid_n).get()))
@@ -751,13 +830,14 @@ def pi_components(haplotypes, n_total_sites=None, n_haplotypes_full=None):
     total_missing : float
     n_sites : int
     """
-    dac, n_valid_i = _dac_and_n(haplotypes)
+    from ._memutil import allele_counts
+    ac, n_valid_i = allele_counts(haplotypes)
     n_valid = n_valid_i.astype(cp.float64)
-    derived = dac.astype(cp.float64)
-    ancestral = n_valid - derived
 
-    site_diffs = derived * ancestral
+    # Per-allele differing pairs at a site: C(n,2) - sum_a C(ac_a, 2).
+    same_pairs = (ac * (ac - 1)).sum(axis=1).astype(cp.float64) / 2.0
     site_comps = n_valid * (n_valid - 1) / 2.0
+    site_diffs = site_comps - same_pairs
 
     usable = n_valid >= 2
     total_diffs = float(cp.sum(site_diffs[usable]).get())
@@ -1013,26 +1093,21 @@ def segregating_sites(haplotype_matrix: HaplotypeMatrix,
     if matrix.device == 'CPU':
         matrix.transfer_to_gpu()
 
+    from ._memutil import allele_counts
     if missing_data == 'exclude':
         matrix = matrix.exclude_missing_sites()
         if matrix.num_variants == 0:
             return 0
-        allele_counts = cp.sum(matrix.haplotypes, axis=0)
-        n_haplotypes = matrix.num_haplotypes
-        segregating = (allele_counts > 0) & (allele_counts < n_haplotypes)
 
-    else:  # missing_data == 'include'
-        derived_counts, n_valid_per_site = _dac_and_n(matrix.haplotypes)
-        sites_with_data = n_valid_per_site >= 2
+    ac, n_valid_per_site = allele_counts(matrix.haplotypes)
+    sites_with_data = n_valid_per_site >= 2
+    if not cp.any(sites_with_data):
+        return 0
 
-        if not cp.any(sites_with_data):
-            return 0
-
-        valid_sites = cp.where(sites_with_data)[0]
-        segregating_mask = (derived_counts[valid_sites] > 0) & (derived_counts[valid_sites] < n_valid_per_site[valid_sites])
-        return int(cp.sum(segregating_mask).get())
-
-    return int(cp.sum(segregating).get())
+    # tskit convention: segregating count = number of mutations = sum(alleles - 1);
+    # a triallelic site contributes 2, and reference-absent sites are counted.
+    alleles_present = (ac > 0).sum(axis=1)
+    return int(cp.sum(cp.where(sites_with_data, alleles_present - 1, 0)).get())
 
 
 def singleton_count(haplotype_matrix: HaplotypeMatrix,

--- a/pg_gpu/diversity.py
+++ b/pg_gpu/diversity.py
@@ -975,65 +975,6 @@ def tajimas_d(haplotype_matrix: HaplotypeMatrix,
     return _compute_neutrality_test(matrix, 'pi', 'watterson')
 
 
-def allele_frequency_spectrum(haplotype_matrix: HaplotypeMatrix,
-                            population: Optional[Union[str, list]] = None,
-                            missing_data: str = 'include') -> cp.ndarray:
-    """
-    Calculate the allele frequency spectrum (AFS).
-
-    The AFS is a histogram of allele frequencies across all sites.
-
-    Parameters
-    ----------
-    haplotype_matrix : HaplotypeMatrix
-        The haplotype data
-    population : str or list, optional
-        Population name or list of sample indices. If None, uses all samples
-    missing_data : str
-        'include' - Calculate AFS using available data per site.
-        'exclude' - Only use sites with no missing data.
-
-    Returns
-    -------
-    ndarray
-        Per-allele (unfolded) SFS: element i is the number of derived alleles
-        carried by i samples. A multiallelic site contributes one entry per
-        derived allele.
-    """
-
-    # Get population subset if specified
-    if population is not None:
-        matrix = _get_population_matrix(haplotype_matrix, population)
-    else:
-        matrix = haplotype_matrix
-
-    # Ensure on GPU
-    if matrix.device == 'CPU':
-        matrix.transfer_to_gpu()
-
-    from ._memutil import allele_counts
-    max_n = matrix.num_haplotypes
-
-    if missing_data == 'exclude':
-        matrix = matrix.exclude_missing_sites()
-        if matrix.num_variants == 0:
-            return np.zeros(max_n + 1, dtype=np.int64)
-
-    ac, n_valid = allele_counts(matrix.haplotypes)
-    # Per-allele polarised SFS: each derived allele contributes one count at its
-    # sample frequency, for 0 < count < n. Both fixed classes are excluded --
-    # bin 0 (invariant-ancestral: no derived allele) and bin n (monomorphic-
-    # derived) -- so this matches tskit's polarised allele_frequency_spectrum
-    # exactly. Invariant-site counting is a separate concern (see
-    # FrequencySpectrum's n_total_sites).
-    derived = ac[:, 1:]
-    vals = derived[(derived > 0) & (derived < n_valid[:, None])]
-    if vals.size == 0:  # no segregating derived alleles (cupy bincount rejects empty)
-        return np.zeros(max_n + 1, dtype=np.int64)
-    afs = cp.bincount(vals, minlength=max_n + 1)[:max_n + 1]
-    return afs.astype(cp.int64).get()
-
-
 def segregating_sites(haplotype_matrix: HaplotypeMatrix,
                      population: Optional[Union[str, list]] = None,
                      missing_data: str = 'include') -> int:

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -17,6 +17,12 @@ class GenotypeMatrix:
 
     Shape: (n_individuals, n_variants). Missing data encoded as -1.
 
+    Biallelic by construction: values are alt-allele dosage (0/1/2), so this
+    structure cannot represent multiallelic genotypes -- ``from_vcf`` filters
+    multiallelic sites out and ``from_haplotype_matrix`` sums paired haplotypes
+    (well-defined only for {0,1} alleles). For multiallelic data use the
+    allele-index ``HaplotypeMatrix``.
+
     Parameters
     ----------
     genotypes : ndarray, int8, shape (n_individuals, n_variants)

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -1530,15 +1530,6 @@ class HaplotypeMatrix:
             }
 
     ####### some polymorphism statistics #######
-    def allele_frequency_spectrum(self) -> cp.ndarray:
-        """
-        Calculate the allele frequency spectrum for a haplotype matrix.
-
-        Note: This method is deprecated. Use diversity.allele_frequency_spectrum() instead.
-        """
-        from . import diversity
-        return diversity.allele_frequency_spectrum(self)
-
     def diversity(self, span_normalize=True) -> float:
         """
         Calculate the nucleotide diversity (π) for the haplotype matrix.

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -626,7 +626,7 @@ class HaplotypeMatrix:
             return cls._build_streaming(
                 path, region=region, pop_assignment=pop_assignment,
                 chunk_bp=chunk_bp, prefetch=prefetch,
-                backend=backend,
+                backend=backend, accessible_bed=accessible_bed,
             )
 
         # 'auto' and 'never' both want eager when the matrix fits; 'auto'
@@ -649,7 +649,7 @@ class HaplotypeMatrix:
             return cls._build_streaming(
                 path, region=region, pop_assignment=pop_assignment,
                 chunk_bp=chunk_bp, prefetch=prefetch,
-                source=source, backend=backend,
+                source=source, backend=backend, accessible_bed=accessible_bed,
             )
         return cls._build_eager(path, region=region,
                                 accessible_bed=accessible_bed,
@@ -716,7 +716,8 @@ class HaplotypeMatrix:
 
     @classmethod
     def _build_streaming(cls, path, *, region, pop_assignment, chunk_bp,
-                         prefetch, source=None, backend="auto"):
+                         prefetch, source=None, backend="auto",
+                         accessible_bed=None):
         from .streaming_matrix import (
             HostChunkFetcher, KvikioChunkFetcher, StreamingHaplotypeMatrix,
             _pick_chunk_fetcher,
@@ -733,9 +734,24 @@ class HaplotypeMatrix:
             # zarr store.
             source.pop_cols = source._resolve_pop_assignment(pop_assignment)
         fetcher = _pick_chunk_fetcher(source, backend=backend)
+
+        # Resolve an accessible BED once over the source's variant-position
+        # bounds and hand it to the streaming matrix, so span-normalized
+        # reductions (genetic_relatedness) divide by accessible bases the same
+        # way the eager path does. ``mappable_hi`` is one past the last variant,
+        # so the inclusive last position is ``mappable_hi - 1``.
+        accessible_mask = None
+        if accessible_bed is not None:
+            from .accessible import resolve_accessible_mask
+            chrom = region.split(':')[0] if region else source.chrom
+            lo, hi = source.mappable_lo, source.mappable_hi
+            accessible_mask = resolve_accessible_mask(
+                accessible_bed, lo, hi - 1, chrom)
+
         return StreamingHaplotypeMatrix(
             source, fetcher,
             chunk_bp=chunk_bp, prefetch=prefetch,
+            accessible_mask=accessible_mask,
         )
 
     def to_zarr(self, zarr_path: str, format: str = 'vcz',

--- a/pg_gpu/relatedness.py
+++ b/pg_gpu/relatedness.py
@@ -201,7 +201,7 @@ def _stream_genetic_relatedness(streaming_matrix, *, sample_sets, indexes,
     return R[idx[:, 0], idx[:, 1]]
 
 
-def grm(genotype_matrix_or_haplotype_matrix,
+def grm(genotype_matrix,
         population: Optional[Union[str, list]] = None,
         missing_data: str = 'include') -> np.ndarray:
     """Compute the Genetic Relationship Matrix (GRM).
@@ -215,11 +215,15 @@ def grm(genotype_matrix_or_haplotype_matrix,
 
     where g is genotype (0/1/2), p is allele frequency, M is number of sites.
 
+    This is a diploid, biallelic estimator, so it takes a GenotypeMatrix (or
+    a streaming genotype matrix), which is diploid and biallelic by
+    construction. For relatedness between haplotypes or arbitrary sample sets,
+    or on multiallelic data, use ``genetic_relatedness``.
+
     Parameters
     ----------
-    genotype_matrix_or_haplotype_matrix : GenotypeMatrix or HaplotypeMatrix
-        Diploid genotypes (0/1/2) or haplotype data (auto-converted to
-        diploid by pairing consecutive haplotypes).
+    genotype_matrix : GenotypeMatrix or StreamingGenotypeMatrix
+        Diploid genotypes (0/1/2).
     population : str or list, optional
         Population subset.
     missing_data : str
@@ -233,14 +237,21 @@ def grm(genotype_matrix_or_haplotype_matrix,
         coefficients + 1. Off-diagonal entries are pairwise relatedness.
     """
     from ._memutil import estimate_variant_chunk_size
-    from .streaming_matrix import _StreamingMatrixBase
-    if isinstance(genotype_matrix_or_haplotype_matrix, _StreamingMatrixBase):
-        return _stream_grm(genotype_matrix_or_haplotype_matrix,
+    from .streaming_matrix import _StreamingMatrixBase, StreamingHaplotypeMatrix
+    from .haplotype_matrix import HaplotypeMatrix
+    if isinstance(genotype_matrix, (HaplotypeMatrix, StreamingHaplotypeMatrix)):
+        raise TypeError(
+            "grm is the diploid biallelic GCTA GRM and requires a "
+            "GenotypeMatrix. For haplotype or sample-set relatedness (and "
+            "multiallelic data) use genetic_relatedness; to run the GCTA GRM "
+            "on haplotype data convert it with "
+            "GenotypeMatrix.from_haplotype_matrix first.")
+    if isinstance(genotype_matrix, _StreamingMatrixBase):
+        return _stream_grm(genotype_matrix,
                             population=population,
                             missing_data=missing_data)
 
-    geno, n_ind = _get_genotype_data(genotype_matrix_or_haplotype_matrix,
-                                      population)
+    geno, n_ind = _get_genotype_data(genotype_matrix, population)
     n_var = geno.shape[1]
 
     # Allele frequency from genotypes, chunked to avoid large temporaries.

--- a/pg_gpu/relatedness.py
+++ b/pg_gpu/relatedness.py
@@ -10,6 +10,197 @@ import cupy as cp
 from typing import Optional, Union
 
 
+def genetic_relatedness(haplotype_matrix, sample_sets=None, indexes=None, *,
+                        centre: bool = True, polarised: bool = False,
+                        proportion: bool = False, span_normalize=True,
+                        missing_data: str = 'include'):
+    """Site-mode genetic relatedness between sample sets.
+
+    Matches ``tskit.TreeSequence.genetic_relatedness`` (site mode): the
+    centered per-allele allele-frequency covariance. For sample sets ``i`` and
+    ``j`` it is the sum over sites and over every allele ``a`` of
+    ``(p_i(a) - pbar(a)) * (p_j(a) - pbar(a))``, where ``p_k(a)`` is allele
+    ``a``'s frequency in set ``k`` and ``pbar(a)`` the unweighted mean of
+    ``p_k(a)`` across the sample sets. There is no variance standardization.
+
+    Parameters
+    ----------
+    haplotype_matrix : HaplotypeMatrix
+        Sample (haplotype) data. Samples are the unit; individuals or
+        populations are expressed by grouping samples into ``sample_sets``.
+    sample_sets : list of sequences of int, optional
+        Disjoint groups of haplotype (row) indices. Default is one set per
+        haplotype, giving the sample-by-sample matrix.
+    indexes : list of (int, int), optional
+        Pairs of sample-set indices to return. Default returns the full
+        symmetric ``(D, D)`` matrix.
+    centre : bool
+        Center each allele frequency by the across-set mean (True, the default
+        and the standard relatedness) or use the raw frequencies (False, the
+        noncentred form).
+    polarised : bool
+        Sum over all alleles including the reference (False, the default) or
+        over derived alleles only (True).
+    proportion : bool
+        Divide by the number of segregating sites among the analyzed samples
+        (the per-site sum of ``num_alleles - 1``), giving a relatedness
+        proportion. When True, ``span_normalize`` has no effect (it cancels
+        between the covariance and the segregating-site count).
+    span_normalize : bool or str
+        True (default) divides by the analysis span (see ``get_span``); False
+        returns the raw sum. Matches tskit's ``span_normalise``.
+    missing_data : str
+        'include' (default) uses per-site, per-set valid counts; 'exclude'
+        restricts to sites with no missing data among the analyzed samples.
+
+    Returns
+    -------
+    ndarray, float64
+        The ``(D, D)`` matrix, or a 1-D array of values for the requested
+        ``indexes``.
+    """
+    from ._memutil import estimate_variant_chunk_size
+    from .streaming_matrix import _StreamingMatrixBase
+    from .haplotype_matrix import HaplotypeMatrix
+
+    if isinstance(haplotype_matrix, _StreamingMatrixBase):
+        return _stream_genetic_relatedness(
+            haplotype_matrix, sample_sets=sample_sets, indexes=indexes,
+            centre=centre, polarised=polarised, proportion=proportion,
+            span_normalize=span_normalize, missing_data=missing_data)
+    if not isinstance(haplotype_matrix, HaplotypeMatrix):
+        raise TypeError(
+            "genetic_relatedness requires a HaplotypeMatrix (samples are "
+            f"haplotypes); got {type(haplotype_matrix)}")
+
+    if getattr(haplotype_matrix, 'device', 'GPU') == 'CPU':
+        haplotype_matrix.transfer_to_gpu()
+    hap = haplotype_matrix.haplotypes
+    n_hap = hap.shape[0]
+    D = n_hap if sample_sets is None else len(sample_sets)
+
+    # missing_data='exclude': keep only sites called in every analyzed sample.
+    if missing_data == 'exclude':
+        if sample_sets is None:
+            covered = cp.ones(n_hap, dtype=bool)
+        else:
+            covered = cp.zeros(n_hap, dtype=bool)
+            for members in sample_sets:
+                covered[cp.asarray(members)] = True
+        complete = cp.all(hap[covered] >= 0, axis=0)
+        hap = hap[:, complete]
+
+    R = cp.zeros((D, D), dtype=cp.float64)
+    # Segregating sites among the analyzed samples: per-site sum of
+    # (present alleles - 1), accumulated on device (only when needed).
+    seg_cols = 0
+    seg_sites = cp.zeros((), dtype=cp.float64)
+    if hap.shape[1] > 0:
+        K = int(hap.max()) + 1
+        chunk = estimate_variant_chunk_size(n_hap, bytes_per_element=8,
+                                            n_intermediates=3,
+                                            memory_fraction=0.25)
+        for start in range(0, hap.shape[1], chunk):
+            end = min(start + chunk, hap.shape[1])
+            cols, col_site, col_allele = _relatedness_columns(
+                hap[:, start:end], sample_sets, K, centre=centre)
+            if proportion and col_site.size:
+                # col_site is site-major sorted; distinct sites = jumps + 1.
+                seg_cols += col_site.size
+                seg_sites += 1 + (cp.diff(col_site) != 0).sum()
+            if polarised:
+                cols = cols[:, col_allele != 0]
+            R += cols @ cols.T
+
+    if proportion:
+        # Divide by segregating sites; span_normalise cancels, so it is ignored.
+        denom = float(seg_cols - seg_sites)
+        if denom > 0:
+            R = R / denom
+    elif span_normalize is not False:
+        mode = 'auto' if span_normalize is True else span_normalize
+        span = haplotype_matrix.get_span(mode)
+        if span > 0:
+            R = R / span
+
+    if indexes is None:
+        return R.get()
+    idx = np.asarray(indexes, dtype=np.intp)
+    return R[cp.asarray(idx[:, 0]), cp.asarray(idx[:, 1])].get()
+
+
+def _stream_genetic_relatedness(streaming_matrix, *, sample_sets, indexes,
+                                centre, polarised, proportion, span_normalize,
+                                missing_data, block_size=None):
+    """Streaming genetic_relatedness: single pass over variant chunks.
+
+    The relatedness is additive over (site, allele) columns and each column's
+    centering is local to its site, so one pass over the chunks suffices. The
+    (D, D) output is accumulated on host with the set (row) axis tiled into
+    blocks, the same scheme as the streaming GRM/IBS, so it holds when D is
+    large (the per-haplotype default). span_normalise for streaming supports
+    True/False only.
+    """
+    from ._memutil import estimate_indiv_block_size
+
+    n_hap = streaming_matrix.num_haplotypes
+    D = n_hap if sample_sets is None else len(sample_sets)
+
+    covered = None
+    if missing_data == 'exclude':
+        if sample_sets is None:
+            covered = cp.ones(n_hap, dtype=bool)
+        else:
+            covered = cp.zeros(n_hap, dtype=bool)
+            for members in sample_sets:
+                covered[cp.asarray(members)] = True
+
+    # D is known from the sample sets without peeking a chunk, so an empty
+    # source falls through to this zero matrix (relatedness of nothing is 0).
+    R = np.zeros((D, D), dtype=np.float64)
+    seg_cols = 0
+    seg_sites = cp.zeros((), dtype=cp.float64)
+    if block_size is None:
+        block_size = estimate_indiv_block_size(D, n_intermediates=3)
+
+    for _, _, chunk in streaming_matrix.iter_gpu_chunks():
+        hap = chunk.haplotypes
+        if covered is not None:
+            complete = cp.all(hap[covered] >= 0, axis=0)
+            hap = hap[:, complete]
+        if hap.shape[1] == 0:
+            continue
+        K = int(hap.max()) + 1
+        cols, col_site, col_allele = _relatedness_columns(
+            hap, sample_sets, K, centre=centre)
+        if proportion and col_site.size:
+            seg_cols += col_site.size
+            seg_sites += 1 + (cp.diff(col_site) != 0).sum()
+        if polarised:
+            cols = cols[:, col_allele != 0]
+        for r0 in range(0, D, block_size):
+            r1 = min(r0 + block_size, D)
+            R[r0:r1] += (cols[r0:r1] @ cols.T).get()
+
+    if proportion:
+        denom = seg_cols - float(seg_sites.get())
+        if denom > 0:
+            R = R / denom
+    elif span_normalize is not False:
+        if span_normalize is not True:
+            raise NotImplementedError(
+                "streaming genetic_relatedness supports span_normalize "
+                "True or False only")
+        span = streaming_matrix.chrom_end - streaming_matrix.chrom_start + 1
+        if span > 0:
+            R = R / span
+
+    if indexes is None:
+        return R
+    idx = np.asarray(indexes, dtype=np.intp)
+    return R[idx[:, 0], idx[:, 1]]
+
+
 def grm(genotype_matrix_or_haplotype_matrix,
         population: Optional[Union[str, list]] = None,
         missing_data: str = 'include') -> np.ndarray:
@@ -192,6 +383,96 @@ def ibs(genotype_matrix_or_haplotype_matrix,
     cp.fill_diagonal(ibs_mat, 1.0)
 
     return ibs_mat.get()
+
+
+# ---------------------------------------------------------------------------
+# genetic_relatedness: per-set, per-allele centered frequency columns
+# ---------------------------------------------------------------------------
+
+def _relatedness_columns(hap, sample_sets, n_alleles, centre=True):
+    """Per-set, per-allele frequency columns for genetic_relatedness.
+
+    Builds a matrix whose row ``k`` is sample set ``k``'s per-allele frequency.
+    Writing ``p_k(a)`` for the frequency of allele ``a`` in set ``k`` and
+    ``pbar(a)`` for the mean of ``p_k(a)`` over the ``D`` sets, with ``centre``
+    the columns are ``p_k(a) - pbar(a)`` and the relatedness of a set pair
+    ``(i, j)`` is the sum over every allele and site of
+    ``(p_i(a) - pbar(a)) * (p_j(a) - pbar(a))``, i.e. ``(C @ C.T)[i, j]`` (the
+    product is formed in a later step); without ``centre`` the columns are the
+    raw ``p_k(a)`` and ``C @ C.T`` is the noncentred form. All alleles including
+    the reference are represented, and there is no variance standardization; a
+    caller wanting derived alleles only drops the ``col_allele == 0`` columns.
+
+    Each present ``(site, allele)`` pair among the analyzed samples is one
+    column; columns are ordered site-major, allele-minor. "Present" is relative
+    to the samples that appear in some set, so passing a subset of samples
+    restricts the alleles considered.
+
+    Parameters
+    ----------
+    hap : cupy.ndarray, int8, shape (n_hap, n_var)
+        Allele indices (0 reference, 1.. alternate), -1 missing.
+    sample_sets : list of 1D index arrays, or None
+        Disjoint groups of haplotype indices. None means one set per haplotype
+        (the tskit-native singleton grouping, ``D = n_hap``).
+    n_alleles : int
+        Global allele-index width ``K`` so allele ``a`` aligns across sets.
+    centre : bool
+        Subtract the across-set mean ``pbar(a)`` from each column (True), or
+        leave the raw per-set frequencies (False, the noncentred form).
+
+    Returns
+    -------
+    cols : cupy.ndarray, float64, shape (D, n_cols)
+    col_site : cupy.ndarray, int64, shape (n_cols,)
+        Site index each column belongs to.
+    col_allele : cupy.ndarray, int64, shape (n_cols,)
+        Allele index each column represents (0 is the reference).
+
+    Notes
+    -----
+    Per-set frequencies use per-site valid counts, so a missing entry lowers only
+    its own set's denominator. The exact missing-data policy (a set with no valid
+    sample at a site, and the include/exclude modes) is applied by the caller; on
+    complete data every set's denominator is its size.
+    """
+    n_hap, n_var = hap.shape
+    K = int(n_alleles)
+    valid = hap >= 0
+
+    if sample_sets is None:
+        M = None
+        D = n_hap
+        covered = valid                                  # every haplotype is a set
+    else:
+        D = len(sample_sets)
+        M = cp.zeros((D, n_hap), dtype=cp.float64)
+        for k, members in enumerate(sample_sets):
+            M[k, cp.asarray(members)] = 1.0
+        covered = valid & (M.sum(axis=0) > 0)[:, None]
+
+    # Present (site, allele) pairs among the analyzed samples -> one argwhere sync.
+    pooled_ac = cp.zeros((n_var, K), dtype=cp.int64)
+    for a in range(K):
+        pooled_ac[:, a] = (covered & (hap == a)).sum(axis=0, dtype=cp.int64)
+    pairs = cp.argwhere(pooled_ac > 0)
+    col_site = pairs[:, 0]
+    col_allele = pairs[:, 1]
+
+    # Per-set count and valid count for each present column.
+    hs = hap[:, col_site]                                # (n_hap, n_cols)
+    carries = ((hs == col_allele[None, :]) & valid[:, col_site]).astype(cp.float64)
+    valid_cols = valid[:, col_site].astype(cp.float64)
+    if M is None:
+        cnt = carries                                    # (D, n_cols), D == n_hap
+        nvalid = valid_cols
+    else:
+        cnt = M @ carries                                # (D, n_cols)
+        nvalid = M @ valid_cols
+
+    p = cp.where(nvalid > 0, cnt / nvalid, 0.0)          # per-set frequency
+    cols = p - p.mean(axis=0, keepdims=True) if centre else p
+    return cols, col_site, col_allele
 
 
 # ---------------------------------------------------------------------------

--- a/pg_gpu/relatedness.py
+++ b/pg_gpu/relatedness.py
@@ -311,24 +311,30 @@ def grm(genotype_matrix,
     return A.get()
 
 
-def ibs(genotype_matrix_or_haplotype_matrix,
+def ibs(genotype_matrix,
         population: Optional[Union[str, list]] = None,
         missing_data: str = 'include') -> np.ndarray:
     """Compute pairwise IBS (Identity by State) proportions.
 
-    IBS measures the proportion of alleles shared identical by state
-    between all pairs of individuals. Equivalent to PLINK's --distance
-    ibs matrix.
+    IBS measures the proportion of alleles shared identical by state between
+    all pairs of individuals. Equivalent to PLINK's --distance ibs matrix. For
+    each site the shared count is (2 - abs(g_i - g_j)) and the matrix is the
+    summed shared count over jointly-called sites divided by twice that site
+    count.
 
-    For each site, IBS between individuals i and j is
-    ``IBS = (2 - abs(g_i - g_j)) / 2``.
-
-    The matrix contains the mean IBS across all jointly-called sites.
+    This is a diploid, biallelic estimator (the shared count is the diploid
+    max-matching of two genotypes), so it takes a GenotypeMatrix (or a streaming
+    genotype matrix), which is diploid and biallelic by construction. For the
+    general allele-sharing quantity between arbitrary sample sets (haplotypes,
+    individuals, or populations), and on multiallelic data, use
+    ``genetic_relatedness`` with ``centre=False``: the noncentred relatedness is
+    the allele-match probability between sample sets, the sample-set
+    generalization of allele sharing.
 
     Parameters
     ----------
-    genotype_matrix_or_haplotype_matrix : GenotypeMatrix or HaplotypeMatrix
-        Diploid genotypes (0/1/2) or haplotype data.
+    genotype_matrix : GenotypeMatrix or StreamingGenotypeMatrix
+        Diploid genotypes (0/1/2).
     population : str or list, optional
         Population subset.
     missing_data : str
@@ -342,14 +348,21 @@ def ibs(genotype_matrix_or_haplotype_matrix,
         Diagonal is always 1.
     """
     from ._memutil import estimate_variant_chunk_size
-    from .streaming_matrix import _StreamingMatrixBase
-    if isinstance(genotype_matrix_or_haplotype_matrix, _StreamingMatrixBase):
-        return _stream_ibs(genotype_matrix_or_haplotype_matrix,
+    from .streaming_matrix import _StreamingMatrixBase, StreamingHaplotypeMatrix
+    from .haplotype_matrix import HaplotypeMatrix
+    if isinstance(genotype_matrix, (HaplotypeMatrix, StreamingHaplotypeMatrix)):
+        raise TypeError(
+            "ibs is the diploid biallelic PLINK IBS and requires a "
+            "GenotypeMatrix. For allele sharing between haplotypes or arbitrary "
+            "sample sets (and multiallelic data) use genetic_relatedness with "
+            "centre=False; to run the diploid IBS on haplotype data convert it "
+            "with GenotypeMatrix.from_haplotype_matrix first.")
+    if isinstance(genotype_matrix, _StreamingMatrixBase):
+        return _stream_ibs(genotype_matrix,
                             population=population,
                             missing_data=missing_data)
 
-    geno, n_ind = _get_genotype_data(genotype_matrix_or_haplotype_matrix,
-                                      population)
+    geno, n_ind = _get_genotype_data(genotype_matrix, population)
     n_var = geno.shape[1]
     # Peak per-chunk: 1 float64 indicator + matmul workspace.
     chunk_size = estimate_variant_chunk_size(n_ind, bytes_per_element=8,
@@ -374,17 +387,17 @@ def ibs(genotype_matrix_or_haplotype_matrix,
 
         n_joint += valid @ valid.T
 
-        # Compute ibs2 and ibs1 one indicator at a time to avoid
-        # materializing i0, i1, i2 simultaneously.
+        # ibs2 (both alleles shared) and ibs1 (one shared) via genotype-state
+        # indicators, one at a time to avoid materializing all three together.
+        ind_curr = (g == 0) * valid
         for gval in (0, 1, 2):
-            ind = (g == gval) * valid
-            ibs2 += ind @ ind.T
             if gval < 2:
                 ind_next = (g == (gval + 1)) * valid
-                cross = ind @ ind_next.T
+            ibs2 += ind_curr @ ind_curr.T
+            if gval < 2:
+                cross = ind_curr @ ind_next.T
                 ibs1 += cross + cross.T
-                del ind_next
-            del ind
+                ind_curr = ind_next
 
         del g, valid
 
@@ -392,7 +405,6 @@ def ibs(genotype_matrix_or_haplotype_matrix,
                         (2.0 * ibs2 + ibs1) / (2.0 * n_joint),
                         0.0)
     cp.fill_diagonal(ibs_mat, 1.0)
-
     return ibs_mat.get()
 
 
@@ -629,8 +641,7 @@ def _stream_ibs(streaming_matrix, *, population, missing_data,
     for _, _, chunk in chunks:
         geno, _ = _get_genotype_data(chunk, population)
         _accumulate_ibs_chunk(geno, ibs2_host, ibs1_host, n_joint_host,
-                              block_size=block_size,
-                              missing_data=missing_data)
+                              block_size=block_size, missing_data=missing_data)
         del geno
 
     ibs_mat = np.where(n_joint_host > 0,
@@ -642,17 +653,12 @@ def _stream_ibs(streaming_matrix, *, population, missing_data,
 
 def _accumulate_ibs_chunk(geno, ibs2_host, ibs1_host, n_joint_host, *,
                           block_size, missing_data):
-    """Add one variant-chunk's contribution to the three host accumulators.
+    """Add one variant-chunk's contribution to the host accumulators.
 
-    ``geno`` is ``(n_ind, n_var_chunk)`` on GPU. The genotype-value loop
-    is outermost so each full-pop indicator ``ind_full`` is built once
-    per chunk rather than once per chunk per row block; the row-block
-    loop only does matmuls and host transfers.
-
-    In the eager kernel ``ibs1 += cross + cross.T`` where
-    ``cross = (g==gval) @ (g==gval+1).T``; here the row-block slice of
-    ``cross`` is ``ind_curr[r0:r1] @ ind_next.T`` and the row-block
-    slice of ``cross.T`` is ``ind_next[r0:r1] @ ind_curr.T``.
+    ``geno`` is (n_ind, n_var_chunk) on GPU. The genotype-state indicators are
+    built once per chunk; the row-block loop tiles the individual axis so only
+    one block's (block_size, n_ind) matmul output sits on the GPU at a time
+    before it is added to the host accumulators.
     """
     valid_full = (geno >= 0).astype(cp.float64)
     g = cp.where(geno >= 0, geno, 0).astype(cp.float64)
@@ -668,9 +674,6 @@ def _accumulate_ibs_chunk(geno, ibs2_host, ibs1_host, n_joint_host, *,
         r1 = min(r0 + block_size, n_ind)
         n_joint_host[r0:r1] += (valid_full[r0:r1] @ valid_full.T).get()
 
-    # Two indicator matrices live at a time: the current g==k and the
-    # next g==k+1 needed for the ibs1 cross. Reuse ``ind_next`` from
-    # the previous iter as the next ``ind_curr`` so g==1 is built once.
     ind_curr = (g == 0) * valid_full
     for gval in (0, 1, 2):
         if gval < 2:
@@ -679,12 +682,8 @@ def _accumulate_ibs_chunk(geno, ibs2_host, ibs1_host, n_joint_host, *,
             r1 = min(r0 + block_size, n_ind)
             ibs2_host[r0:r1] += (ind_curr[r0:r1] @ ind_curr.T).get()
             if gval < 2:
-                ibs1_host[r0:r1] += (
-                    ind_curr[r0:r1] @ ind_next.T
-                ).get()
-                ibs1_host[r0:r1] += (
-                    ind_next[r0:r1] @ ind_curr.T
-                ).get()
+                ibs1_host[r0:r1] += (ind_curr[r0:r1] @ ind_next.T).get()
+                ibs1_host[r0:r1] += (ind_next[r0:r1] @ ind_curr.T).get()
         del ind_curr
         if gval < 2:
             ind_curr = ind_next

--- a/pg_gpu/relatedness.py
+++ b/pg_gpu/relatedness.py
@@ -48,7 +48,11 @@ def genetic_relatedness(haplotype_matrix, sample_sets=None, indexes=None, *,
         between the covariance and the segregating-site count).
     span_normalize : bool or str
         True (default) divides by the analysis span (see ``get_span``); False
-        returns the raw sum. Matches tskit's ``span_normalise``.
+        returns the raw sum. Like tskit's ``span_normalise``, except that when
+        the matrix carries an accessible mask the span is the accessible-base
+        count over the analyzed region rather than the raw sequence length. The
+        eager and streaming paths use the same span source (an ``accessible_bed``
+        supplied at load).
     missing_data : str
         'include' (default) uses per-site, per-set valid counts; 'exclude'
         restricts to sites with no missing data among the analyzed samples.
@@ -138,8 +142,9 @@ def _stream_genetic_relatedness(streaming_matrix, *, sample_sets, indexes,
     centering is local to its site, so one pass over the chunks suffices. The
     (D, D) output is accumulated on host with the set (row) axis tiled into
     blocks, the same scheme as the streaming GRM/IBS, so it holds when D is
-    large (the per-haplotype default). span_normalise for streaming supports
-    True/False only.
+    large (the per-haplotype default). Span normalization uses the streaming
+    matrix's get_span (accessible mask / n_total_sites / raw span), matching
+    the eager path.
     """
     from ._memutil import estimate_indiv_block_size
 
@@ -163,6 +168,8 @@ def _stream_genetic_relatedness(streaming_matrix, *, sample_sets, indexes,
     if block_size is None:
         block_size = estimate_indiv_block_size(D, n_intermediates=3)
 
+    # iter_gpu_chunks already attaches any load-time accessible mask, so the
+    # chunks here are variant-filtered to accessible sites (matching eager).
     for _, _, chunk in streaming_matrix.iter_gpu_chunks():
         hap = chunk.haplotypes
         if covered is not None:
@@ -187,11 +194,12 @@ def _stream_genetic_relatedness(streaming_matrix, *, sample_sets, indexes,
         if denom > 0:
             R = R / denom
     elif span_normalize is not False:
-        if span_normalize is not True:
-            raise NotImplementedError(
-                "streaming genetic_relatedness supports span_normalize "
-                "True or False only")
-        span = streaming_matrix.chrom_end - streaming_matrix.chrom_start + 1
+        # Same span source as the eager path: get_span('auto') prefers the
+        # accessible mask / n_total_sites (set at load via accessible_bed) over
+        # the raw per-base span, and uses variant-position bounds so it matches
+        # the eager matrix built from the same store.
+        mode = 'auto' if span_normalize is True else span_normalize
+        span = streaming_matrix.get_span(mode)
         if span > 0:
             R = R / span
 

--- a/pg_gpu/selection.py
+++ b/pg_gpu/selection.py
@@ -321,6 +321,14 @@ def nsl(haplotype_matrix: HaplotypeMatrix,
         is absent at a site). ``standardize_by_allele_count`` takes 1-D input,
         so standardize each derived-allele column separately, pairing column
         ``j`` with that allele's per-site derived count.
+
+    Notes
+    -----
+    nSL scans the shared-haplotype length in both directions across the whole
+    input, so scores depend on the full region. Subsetting or chunking the
+    variants (e.g. windowing via ``mean_nsl``, or a StreamingHaplotypeMatrix)
+    truncates the scan and changes the scores; materialize the region eagerly
+    for a chromosome-wide result.
     """
     if population is not None:
         matrix = _get_population_matrix(haplotype_matrix, population)
@@ -476,6 +484,13 @@ def ihs(haplotype_matrix: HaplotypeMatrix,
         is absent, or the allele is MAF-filtered). ``standardize_by_allele_count``
         takes 1-D input, so standardize each derived-allele column separately,
         pairing column ``j`` with that allele's per-site derived count.
+
+    Notes
+    -----
+    iHS integrates EHH outward from each focal site across the whole input, so
+    scores depend on the full region. Subsetting or chunking the variants (e.g.
+    windowing, or a StreamingHaplotypeMatrix) truncates the scan and changes the
+    scores; materialize the region eagerly for a chromosome-wide result.
     """
     if population is not None:
         matrix = _get_population_matrix(haplotype_matrix, population)

--- a/pg_gpu/selection.py
+++ b/pg_gpu/selection.py
@@ -12,6 +12,7 @@ import cupy as cp
 from typing import Union, Optional, Tuple
 from .haplotype_matrix import HaplotypeMatrix
 from ._utils import get_population_matrix as _get_population_matrix
+from ._memutil import allele_counts
 
 
 # ---------------------------------------------------------------------------
@@ -295,8 +296,10 @@ def nsl(haplotype_matrix: HaplotypeMatrix,
         missing_data: str = 'include'):
     """Compute the unstandardized nSL statistic for each variant.
 
-    Compares the mean shared haplotype length around the reference (0)
-    vs alternate (1) allele at each site.
+    Compares the mean shared haplotype length around the ancestral (0) vs each
+    derived allele at a site, one-vs-ancestral. On a biallelic site this is the
+    classic nSL. On a multiallelic focal site each derived allele gets its own
+    score.
 
     Parameters
     ----------
@@ -310,8 +313,14 @@ def nsl(haplotype_matrix: HaplotypeMatrix,
 
     Returns
     -------
-    score : ndarray, float, shape (n_variants,)
-        Unstandardized nSL scores: log(nSL1 / nSL0).
+    score : ndarray, float
+        Unstandardized nSL scores ``log(nSL_a / nSL_0)``. Shape
+        ``(n_variants,)`` for biallelic data; ``(n_variants, K-1)`` when the
+        matrix has ``K > 2`` alleles, where column ``j`` is the score for
+        derived allele ``j+1`` (NaN where that allele or the ancestral allele
+        is absent at a site). ``standardize_by_allele_count`` takes 1-D input,
+        so standardize each derived-allele column separately, pairing column
+        ``j`` with that allele's per-site derived count.
     """
     if population is not None:
         matrix = _get_population_matrix(haplotype_matrix, population)
@@ -331,19 +340,24 @@ def nsl(haplotype_matrix: HaplotypeMatrix,
     # pg_gpu: (n_haplotypes, n_variants) -> allel convention: (n_variants, n_haplotypes)
     hap = matrix.haplotypes.T  # now (n_variants, n_haplotypes)
 
-    # forward scan
-    nsl0_fwd, nsl1_fwd = _nsl01_scan_gpu(hap)
+    # One log(nSL_a / nSL_0) column per derived allele a (one-vs-ancestral).
+    # Biallelic data has a single derived allele and returns a 1-D array
+    # identical to the classic nSL.
+    max_allele = int(matrix.haplotypes.max()) if matrix.num_variants else 0
+    if max_allele < 1:
+        return np.full(matrix.num_variants, np.nan)
 
-    # backward scan
-    nsl0_rev, nsl1_rev = _nsl01_scan_gpu(hap[::-1])
-    nsl0_rev = nsl0_rev[::-1]
-    nsl1_rev = nsl1_rev[::-1]
+    cols = []
+    for a in range(1, max_allele + 1):
+        nsl0_fwd, nsla_fwd = _nsl01_scan_gpu(hap, focal_allele=a)
+        nsl0_rev, nsla_rev = _nsl01_scan_gpu(hap[::-1], focal_allele=a)
+        nsl0 = nsl0_fwd + nsl0_rev[::-1]
+        nsla = nsla_fwd + nsla_rev[::-1]
+        cols.append(cp.log(nsla / nsl0))
 
-    nsl0 = nsl0_fwd + nsl0_rev
-    nsl1 = nsl1_fwd + nsl1_rev
-
-    score = cp.log(nsl1 / nsl0)
-    return score.get()
+    if len(cols) == 1:
+        return cols[0].get()
+    return cp.stack(cols, axis=1).get()
 
 
 def xpnsl(haplotype_matrix: HaplotypeMatrix,
@@ -421,8 +435,10 @@ def ihs(haplotype_matrix: HaplotypeMatrix,
         missing_data: str = 'include'):
     """Compute the unstandardized integrated haplotype score (iHS).
 
-    Compares the integrated EHH for the reference vs alternate allele
-    at each variant.
+    Compares the integrated EHH for the ancestral (0) vs each derived allele at
+    a site, one-vs-ancestral. On a biallelic site this is the classic iHS. On a
+    multiallelic focal site each derived allele gets its own score, and
+    ``min_maf`` is applied per derived allele.
 
     Parameters
     ----------
@@ -452,8 +468,14 @@ def ihs(haplotype_matrix: HaplotypeMatrix,
 
     Returns
     -------
-    score : ndarray, float, shape (n_variants,)
-        Unstandardized iHS scores: log(IHH1 / IHH0).
+    score : ndarray, float
+        Unstandardized iHS scores ``log(IHH_a / IHH_0)``. Shape
+        ``(n_variants,)`` for biallelic data; ``(n_variants, K-1)`` when the
+        matrix has ``K > 2`` alleles, where column ``j`` is the score for
+        derived allele ``j+1`` (NaN where that allele or the ancestral allele
+        is absent, or the allele is MAF-filtered). ``standardize_by_allele_count``
+        takes 1-D input, so standardize each derived-allele column separately,
+        pairing column ``j`` with that allele's per-site derived count.
     """
     if population is not None:
         matrix = _get_population_matrix(haplotype_matrix, population)
@@ -487,25 +509,34 @@ def ihs(haplotype_matrix: HaplotypeMatrix,
     gaps = _compute_gaps(pos, map_pos, gap_scale, max_gap, is_accessible)
     gaps_gpu = cp.asarray(gaps)
 
-    # Histogram kernel with warp-aggregated atomics, stride-based access,
-    # and on-the-fly pair computation. No contiguous copies needed.
-    scan_fn = _ihh01_scan_hist_gpu
+    # Per-allele counts, computed once and reused (forward + reversed) for
+    # every derived allele: column a of ac is the count of allele a, column 0
+    # is the ancestral allele.
+    max_allele = int(matrix.haplotypes.max()) if matrix.num_variants else 0
+    if max_allele < 1:
+        return np.full(matrix.num_variants, np.nan)
+    ac, n_valid = allele_counts(matrix.haplotypes, n_alleles=max_allele + 1)
+    n0 = ac[:, 0]
 
-    # forward scan
-    ihh0_fwd, ihh1_fwd = scan_fn(hap, gaps_gpu, min_ehh, min_maf,
-                                  include_edges)
-    # backward scan (reversed view, no copy)
-    ihh0_rev, ihh1_rev = scan_fn(
-        hap[::-1], gaps_gpu[::-1],
-        min_ehh, min_maf, include_edges)
-    ihh0_rev = ihh0_rev[::-1]
-    ihh1_rev = ihh1_rev[::-1]
+    # One log(IHH_a / IHH_0) column per derived allele a (one-vs-ancestral).
+    # Biallelic data has a single derived allele and returns a 1-D array
+    # identical to the classic iHS.
+    cols = []
+    for a in range(1, max_allele + 1):
+        na = ac[:, a]
+        ihh0_fwd, ihha_fwd = _ihh01_scan_hist_gpu(
+            hap, gaps_gpu, n0, na, n_valid, a,
+            min_ehh, min_maf, include_edges)
+        ihh0_rev, ihha_rev = _ihh01_scan_hist_gpu(
+            hap[::-1], gaps_gpu[::-1], n0[::-1], na[::-1], n_valid[::-1], a,
+            min_ehh, min_maf, include_edges)
+        ihh0 = ihh0_fwd + ihh0_rev[::-1]
+        ihha = ihha_fwd + ihha_rev[::-1]
+        cols.append(cp.log(ihha / ihh0))
 
-    # Combine and score on GPU, single D2H transfer at end
-    ihh0 = ihh0_fwd + ihh0_rev
-    ihh1 = ihh1_fwd + ihh1_rev
-    score = cp.log(ihh1 / ihh0)
-    return score.get()
+    if len(cols) == 1:
+        return cols[0].get()
+    return cp.stack(cols, axis=1).get()
 
 
 def xpehh(haplotype_matrix: HaplotypeMatrix,
@@ -731,6 +762,7 @@ extern "C" __global__
 void nsl01_scan_kernel(const signed char* h, int n_variants, int n_haplotypes,
                        long long stride_var, long long stride_hap,
                        const int* pair_j, const int* pair_k, int n_pairs,
+                       int focal_allele,
                        double* ssl_sum_00, double* ssl_sum_11,
                        int* count_00, int* count_11) {
     // Each thread handles one haplotype pair across all variants.
@@ -751,12 +783,16 @@ void nsl01_scan_kernel(const signed char* h, int n_variants, int n_haplotypes,
         double sv00 = 0.0, sv11 = 0.0;
         int c00 = 0, c11 = 0;
 
+        // One-vs-ancestral focal split: a homozygous ancestral pair scores
+        // class 0, a homozygous focal-allele pair scores class 1. A homozygous
+        // pair of any other allele extends the shared run but scores neither
+        // (it belongs to a different derived allele's one-vs-ancestral test).
         if (a1 < 0 || a2 < 0) {
             ssl += 1;
         } else if (a1 == a2) {
             ssl += 1;
             if (a1 == 0) { sv00 = (double)ssl; c00 = 1; }
-            else          { sv11 = (double)ssl; c11 = 1; }
+            else if (a1 == focal_allele) { sv11 = (double)ssl; c11 = 1; }
         } else {
             ssl = 0;
         }
@@ -831,8 +867,9 @@ def _get_pair_indices(n_haplotypes):
 # Private helpers: SSL-based scans for nSL
 # ---------------------------------------------------------------------------
 
-def _nsl01_scan_gpu(h):
-    """Forward scan computing mean SSL for ref (0) and alt (1) allele classes.
+def _nsl01_scan_gpu(h, focal_allele=1):
+    """Forward scan computing mean SSL for the ancestral (0) and focal-allele
+    classes.
 
     Uses a stride-aware CUDA kernel with one thread per haplotype pair.
     Reads transposed/reversed views directly without copying.
@@ -841,6 +878,9 @@ def _nsl01_scan_gpu(h):
     ----------
     h : cupy.ndarray, shape (n_variants, n_haplotypes)
         Can be a non-contiguous view (e.g., from .T or [::-1]).
+    focal_allele : int
+        Derived allele index scored against the ancestral (0) class. On
+        biallelic data this is 1 and reproduces the classic nSL.
 
     Returns
     -------
@@ -867,7 +907,7 @@ def _nsl01_scan_gpu(h):
     _nsl01_kernel((grid,), (block,),
                   (h_view, np.int32(n_variants), np.int32(n_haplotypes),
                    np.int64(s0), np.int64(s1),
-                   pair_j, pair_k, np.int32(n_pairs),
+                   pair_j, pair_k, np.int32(n_pairs), np.int32(focal_allele),
                    ssl_sum_00, ssl_sum_11, count_00, count_11))
 
     nsl0 = cp.where(count_00 > 0, ssl_sum_00 / count_00, cp.nan)
@@ -986,10 +1026,11 @@ void ihh01_ssl_pervar_kernel_v2(
     int n_haplotypes,
     int n_pairs,
     int* hist00,              // (chunk_len, hist_size) for 0-0 pairs
-    int* hist11,              // (chunk_len, hist_size) for 1-1 pairs
+    int* hist11,              // (chunk_len, hist_size) for focal-focal pairs
     int* ssl_state,           // (n_pairs,) persistent across chunks
     int hist_size,
-    int chunk_start           // offset into global variant index
+    int chunk_start,          // offset into global variant index
+    int focal_allele          // derived allele scored against the ancestral (0)
 ) {
     int pid = blockDim.x * blockIdx.x + threadIdx.x;
     if (pid >= n_pairs) return;
@@ -1017,7 +1058,7 @@ void ihh01_ssl_pervar_kernel_v2(
 
         int bucket = ssl < hist_size ? ssl : hist_size - 1;
         int is_class00 = (h1 == 0 && h2 == 0) ? 1 : 0;
-        int is_class11 = (h1 == 1 && h2 == 1) ? 1 : 0;
+        int is_class11 = (h1 == focal_allele && h2 == focal_allele) ? 1 : 0;
 
         // Warp-aggregated histogram deposits using __match_any_sync
         unsigned match_bucket = __match_any_sync(0xFFFFFFFF, bucket);
@@ -1038,34 +1079,6 @@ void ihh01_ssl_pervar_kernel_v2(
     ssl_state[pid] = ssl;
 }
 ''', 'ihh01_ssl_pervar_kernel_v2')
-
-
-_count_alleles_kernel = cp.RawKernel(r'''
-extern "C" __global__
-void count_alleles_kernel(
-    const signed char* h,     // haplotype matrix base pointer
-    long long stride_var,     // byte stride between variant rows
-    long long stride_hap,     // byte stride between haplotype columns
-    int chunk_len,
-    int n_haplotypes,
-    int chunk_start,
-    int* n0,                  // (chunk_len,) output count of 0 alleles
-    int* n1                   // (chunk_len,) output count of 1 alleles
-) {
-    int ci = blockDim.x * blockIdx.x + threadIdx.x;
-    if (ci >= chunk_len) return;
-
-    long long vi = chunk_start + ci;
-    int c0 = 0, c1 = 0;
-    for (int j = 0; j < n_haplotypes; j++) {
-        signed char v = h[vi * stride_var + j * stride_hap];
-        if (v == 0) c0++;
-        else if (v == 1) c1++;
-    }
-    n0[ci] = c0;
-    n1[ci] = c1;
-}
-''', 'count_alleles_kernel')
 
 
 _ihh_ssl_kernel = cp.RawKernel(r'''
@@ -1232,9 +1245,11 @@ def _integrate_ihh_gpu(hist, gaps, n_pairs_arr, chunk_start, min_ehh,
 # Private helpers: SSL-based scans for IHS
 # ---------------------------------------------------------------------------
 
-def _ihh01_scan_hist_gpu(h, gaps, min_ehh=0.05, min_maf=0.05,
+def _ihh01_scan_hist_gpu(h, gaps, n0_counts, na_counts, n_valid, focal_allele,
+                         min_ehh=0.05, min_maf=0.05,
                          include_edges=False, max_ssl_cap=None):
-    """Forward scan computing IHH for ref/alt allele classes via histograms.
+    """Forward scan computing IHH for the ancestral (0) and focal-allele
+    classes via histograms.
 
     Uses warp-aggregated atomics, on-the-fly pair index computation, and
     stride-based access to eliminate pair arrays and contiguous copies.
@@ -1245,6 +1260,14 @@ def _ihh01_scan_hist_gpu(h, gaps, min_ehh=0.05, min_maf=0.05,
     h : cupy.ndarray, shape (n_variants, n_haplotypes)
         Can be a non-contiguous view (e.g., from [::-1]).
     gaps : cupy.ndarray, float64, shape (n_variants - 1,)
+    n0_counts, na_counts : cupy.ndarray, shape (n_variants,)
+        Per-site counts of the ancestral allele (0) and the focal derived
+        allele, in the same variant order as ``h`` (reverse them for a
+        reversed scan). Precomputed once via ``allele_counts`` and reused.
+    n_valid : cupy.ndarray, shape (n_variants,)
+        Non-missing haplotypes per site, same order as ``h``.
+    focal_allele : int
+        Derived allele scored against the ancestral (0) class.
     min_ehh, min_maf : float
     include_edges : bool
     max_ssl_cap : int or None
@@ -1252,7 +1275,7 @@ def _ihh01_scan_hist_gpu(h, gaps, min_ehh=0.05, min_maf=0.05,
     Returns
     -------
     ihh0 : cp.ndarray, float64, shape (n_variants,)
-    ihh1 : cp.ndarray, float64, shape (n_variants,)
+    ihh_a : cp.ndarray, float64, shape (n_variants,)
     """
     n_variants, n_haplotypes = h.shape
     n_pairs = (n_haplotypes * (n_haplotypes - 1)) // 2
@@ -1274,16 +1297,12 @@ def _ihh01_scan_hist_gpu(h, gaps, min_ehh=0.05, min_maf=0.05,
 
     block_ssl = 256
     grid_ssl = (n_pairs + block_ssl - 1) // block_ssl
-    block_ac = 256
-    grid_ac_fn = lambda c: (c + block_ac - 1) // block_ac  # noqa: E731
 
     ihh0_out = cp.empty(n_variants, dtype=cp.float64)
-    ihh1_out = cp.empty(n_variants, dtype=cp.float64)
+    ihha_out = cp.empty(n_variants, dtype=cp.float64)
     ssl_state = cp.zeros(n_pairs, dtype=cp.int32)
 
     # Pre-allocate per-chunk buffers (reused across chunks; ~2 GB hists)
-    n0_buf = cp.empty(chunk_size, dtype=cp.int32)
-    n1_buf = cp.empty(chunk_size, dtype=cp.int32)
     hist00_buf = cp.empty((chunk_size, hist_size), dtype=cp.int32)
     hist11_buf = cp.empty((chunk_size, hist_size), dtype=cp.int32)
 
@@ -1300,33 +1319,33 @@ def _ihh01_scan_hist_gpu(h, gaps, min_ehh=0.05, min_maf=0.05,
             (h_view, np.int64(s0), np.int64(s1),
              np.int32(c_len), np.int32(n_haplotypes), np.int32(n_pairs),
              hist00, hist11, ssl_state, np.int32(hist_size),
-             np.int32(chunk_start)))
+             np.int32(chunk_start), np.int32(focal_allele)))
 
-        n0_chunk = n0_buf[:c_len]
-        n1_chunk = n1_buf[:c_len]
-        _count_alleles_kernel((grid_ac_fn(c_len),), (block_ac,),
-            (h_view, np.int64(s0), np.int64(s1),
-             np.int32(c_len), np.int32(n_haplotypes),
-             np.int32(chunk_start), n0_chunk, n1_chunk))
+        n0_chunk = n0_counts[chunk_start:chunk_end]
+        na_chunk = na_counts[chunk_start:chunk_end]
+        nv_chunk = n_valid[chunk_start:chunk_end]
 
         n00 = (n0_chunk * (n0_chunk - 1) // 2).astype(cp.int32)
-        n11 = (n1_chunk * (n1_chunk - 1) // 2).astype(cp.int32)
+        naa = (na_chunk * (na_chunk - 1) // 2).astype(cp.int32)
 
         ihh0_chunk = _integrate_ihh_gpu(hist00, gaps_contig, n00,
                                          chunk_start, min_ehh, include_edges)
-        ihh1_chunk = _integrate_ihh_gpu(hist11, gaps_contig, n11,
+        ihha_chunk = _integrate_ihh_gpu(hist11, gaps_contig, naa,
                                          chunk_start, min_ehh, include_edges)
 
-        total = (n0_chunk + n1_chunk).astype(cp.float64)
-        minor = cp.minimum(n0_chunk, n1_chunk).astype(cp.float64)
-        maf_fail = (total == 0) | (minor / cp.maximum(total, 1) < min_maf)
+        # Per-allele MAF: the focal allele's own frequency among valid
+        # haplotypes. Reduces to min(n0,n1)/(n0+n1) on biallelic sites and
+        # makes a common allele with index >= 2 visible to the filter.
+        freq_a = na_chunk.astype(cp.float64) / cp.maximum(nv_chunk.astype(cp.float64), 1.0)
+        maf = cp.minimum(freq_a, 1.0 - freq_a)
+        maf_fail = (nv_chunk == 0) | (maf < min_maf)
         ihh0_chunk[maf_fail] = cp.nan
-        ihh1_chunk[maf_fail] = cp.nan
+        ihha_chunk[maf_fail] = cp.nan
 
         ihh0_out[chunk_start:chunk_end] = ihh0_chunk
-        ihh1_out[chunk_start:chunk_end] = ihh1_chunk
+        ihha_out[chunk_start:chunk_end] = ihha_chunk
 
-    return ihh0_out, ihh1_out
+    return ihh0_out, ihha_out
 
 
 def _ihh_scan_gpu(h, gaps, min_ehh=0.05, include_edges=False,

--- a/pg_gpu/sfs.py
+++ b/pg_gpu/sfs.py
@@ -72,6 +72,20 @@ def _allele_counts(haplotype_matrix, missing_data='include'):
     return ac, n
 
 
+def _per_allele_counts(matrix, n_alleles=None):
+    """Per-allele counts (n_var, K) and per-site n_valid via the fused kernel.
+
+    K defaults to the site-local maximum allele index + 1; pass ``n_alleles``
+    for a fixed/global width (e.g. to align populations for the joint SFS).
+    Multiallelic-correct (each allele counted separately), unlike the collapsed
+    ``_derived_allele_counts``.
+    """
+    if matrix.device == 'CPU':
+        matrix.transfer_to_gpu()
+    from ._memutil import allele_counts
+    return allele_counts(matrix.haplotypes, n_alleles=n_alleles)
+
+
 # ---------------------------------------------------------------------------
 # Public API: Single-population SFS
 # ---------------------------------------------------------------------------
@@ -108,26 +122,41 @@ def sfs(haplotype_matrix: HaplotypeMatrix,
     else:
         matrix = haplotype_matrix
 
-    dac, n = _derived_allele_counts(matrix, missing_data)
+    if matrix.device == 'CPU':
+        matrix.transfer_to_gpu()
+    max_n = matrix.num_haplotypes
 
     if missing_data == 'exclude':
-        # filter out incomplete sites (marked as -1)
-        valid = dac >= 0
-        dac = dac[valid]
+        matrix = matrix.exclude_missing_sites()
+        if matrix.num_variants == 0:
+            return np.zeros(max_n + 1, dtype=np.int64)
 
-    if isinstance(n, cp.ndarray):
-        max_n = int(cp.max(n).get()) if n.size > 0 else 0
-    else:
-        max_n = int(n)
-
-    s = cp.bincount(dac.astype(cp.int32), minlength=max_n + 1)
-    return s[:max_n + 1].get()
+    ac, n_valid = _per_allele_counts(matrix)
+    # Per-allele polarised SFS: each derived allele contributes one count at its
+    # own sample frequency, for 0 < count < n (both fixed classes excluded),
+    # matching tskit's polarised allele_frequency_spectrum.
+    derived = ac[:, 1:]
+    vals = derived[(derived > 0) & (derived < n_valid[:, None])]
+    if vals.size == 0:
+        return np.zeros(max_n + 1, dtype=np.int64)
+    s = cp.bincount(vals, minlength=max_n + 1)[:max_n + 1]
+    return s.astype(cp.int64).get()
 
 
 def sfs_folded(haplotype_matrix: HaplotypeMatrix,
                population: Optional[Union[str, list]] = None,
                missing_data: str = 'include'):
     """Compute the folded site frequency spectrum (minor allele counts).
+
+    Per-allele and conforming to tskit's ``allele_frequency_spectrum(
+    polarised=False)``: **every** allele (the reference/ancestral column
+    included) contributes weight 1/2 to bin ``min(count, n - count)``, and the
+    fixed class (bin 0) is dropped. A k-allelic site therefore contributes k
+    half-weight entries, so bin values are half-integers on multiallelic data;
+    on biallelic data the reference and derived alleles land in the same
+    ``min`` bin, summing to the usual integer count. This cannot be built from
+    the unfolded ``sfs()`` (which discards the reference column), but it is a
+    single pass over the per-allele counts.
 
     Parameters
     ----------
@@ -139,31 +168,41 @@ def sfs_folded(haplotype_matrix: HaplotypeMatrix,
 
     Returns
     -------
-    ndarray, int64, shape (n_chromosomes // 2 + 1,)
-        Element k = number of variants with minor allele count k.
+    ndarray, float64, shape (n_chromosomes // 2 + 1,)
+        Element k = folded weight of alleles with minor allele count k.
     """
+    if isinstance(haplotype_matrix, StreamingHaplotypeMatrix):
+        return _stream_sum(
+            haplotype_matrix,
+            lambda chunk: sfs_folded(chunk, population=population,
+                                     missing_data=missing_data),
+        )
 
     if population is not None:
         matrix = _get_population_matrix(haplotype_matrix, population)
     else:
         matrix = haplotype_matrix
 
-    ac, n = _allele_counts(matrix, missing_data)
+    if matrix.device == 'CPU':
+        matrix.transfer_to_gpu()
+    max_n = matrix.num_haplotypes
+    length = max_n // 2 + 1
 
     if missing_data == 'exclude':
-        valid = ac[:, 1] >= 0  # dac >= 0
-        ac = ac[valid]
+        matrix = matrix.exclude_missing_sites()
+        if matrix.num_variants == 0:
+            return np.zeros(length, dtype=np.float64)
 
-    mac = cp.amin(ac, axis=1).astype(cp.int32)
-
-    if isinstance(n, cp.ndarray):
-        max_n = int(cp.max(n).get()) if n.size > 0 else 0
-    else:
-        max_n = int(n)
-
-    x = max_n // 2 + 1
-    s = cp.bincount(mac, minlength=x)[:x]
-    return s.get()
+    ac, n_valid = _per_allele_counts(matrix)
+    # Fold every allele (reference column 0 included) to bin min(count, n-count),
+    # weight 1/2; drop the fixed class (foldbin == 0, i.e. count in {0, n}).
+    foldbin = cp.minimum(ac, n_valid[:, None] - ac)
+    mask = (ac > 0) & (foldbin > 0)
+    vals = foldbin[mask].astype(cp.int32)
+    if vals.size == 0:
+        return np.zeros(length, dtype=np.float64)
+    s = 0.5 * cp.bincount(vals, minlength=length)[:length]
+    return s.astype(cp.float64).get()
 
 
 def sfs_scaled(haplotype_matrix: HaplotypeMatrix,
@@ -205,14 +244,12 @@ def sfs_folded_scaled(haplotype_matrix: HaplotypeMatrix,
     -------
     ndarray, float64, shape (n_chromosomes // 2 + 1,)
     """
+    # sfs_folded already handles streaming / population subsetting and is pinned
+    # to tskit; scaling is a fixed transform on top of it (no tskit analogue).
     if population is not None:
-        matrix = _get_population_matrix(haplotype_matrix, population)
+        n = _get_population_matrix(haplotype_matrix, population).num_haplotypes
     else:
-        matrix = haplotype_matrix
-
-    _, n = _derived_allele_counts(matrix, missing_data)
-    if isinstance(n, cp.ndarray):
-        n = int(cp.max(n).get()) if n.size > 0 else 0
+        n = haplotype_matrix.num_haplotypes
     s = sfs_folded(haplotype_matrix, population, missing_data=missing_data)
     return scale_sfs_folded(s, n)
 

--- a/pg_gpu/sfs.py
+++ b/pg_gpu/sfs.py
@@ -272,7 +272,7 @@ def _joint_folded_cells(haplotype_matrix, pop1, pop2, missing_data):
     dropped. Returns ``(fA, fB, n1, n2)`` (flat GPU int64), to be binned with
     weight 1/2. Unlike the unfolded rule, this folds *the whole site by one
     global minor allele* rather than each axis independently -- which is where
-    tskit departs from scikit-allel's per-axis fold (see the ledger).
+    tskit departs from scikit-allel's per-axis fold.
     """
     ac1, ac2, nv1, nv2, n1, n2 = _joint_aligned_counts(haplotype_matrix,
                                                        pop1, pop2)
@@ -482,7 +482,7 @@ def joint_sfs_folded(haplotype_matrix: HaplotypeMatrix,
     output is the full ``(n1+1, n2+1)`` array (the kept region is the
     lower-total triangle; the rest is zero), with half-integer weights on
     multiallelic data. **This departs from scikit-allel's per-axis fold even on
-    biallelic data** (see the ledger) -- we pin to tskit here.
+    biallelic data** -- we pin to tskit here.
 
     Returns
     -------

--- a/pg_gpu/sfs.py
+++ b/pg_gpu/sfs.py
@@ -258,11 +258,108 @@ def sfs_folded_scaled(haplotype_matrix: HaplotypeMatrix,
 # Public API: Joint SFS (two populations)
 # ---------------------------------------------------------------------------
 
+def _joint_global_k(m1, m2):
+    """Global allele-index width K spanning both population matrices.
+
+    The joint SFS counts each population on a *shared* K so that allele
+    column ``a`` denotes the same allele in both per-allele count matrices
+    (the alignment discipline from 0001). ``K = max allele index over both
+    pops + 1``.
+    """
+    k1 = int(m1.haplotypes.max()) if m1.num_variants > 0 else 0
+    k2 = int(m2.haplotypes.max()) if m2.num_variants > 0 else 0
+    return max(k1, k2, 0) + 1
+
+
+def _joint_aligned_counts(haplotype_matrix, pop1, pop2):
+    """Per-allele counts for both pops on a shared global K.
+
+    Returns ``(ac1, ac2, nv1, nv2, n1, n2)`` where ``ac1``/``ac2`` are
+    ``(n_var, K)`` on the same K (so allele column ``a`` is the same allele in
+    both), ``nv1``/``nv2`` are per-site valid counts, and ``n1``/``n2`` the
+    population sizes.
+    """
+    m1 = _get_population_matrix(haplotype_matrix, pop1)
+    m2 = _get_population_matrix(haplotype_matrix, pop2)
+    if m1.device == 'CPU':
+        m1.transfer_to_gpu()
+    if m2.device == 'CPU':
+        m2.transfer_to_gpu()
+    K = _joint_global_k(m1, m2)
+    ac1, nv1 = _per_allele_counts(m1, n_alleles=K)
+    ac2, nv2 = _per_allele_counts(m2, n_alleles=K)
+    return ac1, ac2, nv1, nv2, m1.num_haplotypes, m2.num_haplotypes
+
+
+def _joint_per_allele_counts(haplotype_matrix, pop1, pop2, missing_data):
+    """Per-allele (count_A, count_B) for every derived allele passing the
+    tskit cohort-polymorphic filter.
+
+    Keeps derived columns only (ancestral column 0 excluded) and retains
+    alleles with ``0 < count_A + count_B < n_valid_A + n_valid_B``
+    (segregating in the A+B cohort). This is exactly tskit's sample-set AFS
+    rule: all edge cells populated, only the two global-monomorphic corners
+    ``(0,0)`` and ``(nA,nB)`` dropped. Returns ``(cA, cB, n1, n2)`` with
+    ``cA``/``cB`` flat GPU int64 arrays.
+    """
+    ac1, ac2, nv1, nv2, n1, n2 = _joint_aligned_counts(haplotype_matrix,
+                                                       pop1, pop2)
+    dA = ac1[:, 1:]                       # derived alleles only
+    dB = ac2[:, 1:]
+    cohort = dA + dB
+    n_cohort = (nv1 + nv2)[:, None]
+    keep = (cohort > 0) & (cohort < n_cohort)
+    if missing_data == 'exclude':
+        complete = ((nv1 == n1) & (nv2 == n2))[:, None]
+        keep = keep & complete
+
+    cA = dA[keep].astype(cp.int64)
+    cB = dB[keep].astype(cp.int64)
+    return cA, cB, n1, n2
+
+
+def _joint_folded_cells(haplotype_matrix, pop1, pop2, missing_data):
+    """Folded joint cells ``(fA, fB)`` for tskit's ``polarised=False`` 2D AFS.
+
+    Every allele (ancestral column 0 **included**) is folded as a unit by the
+    global minor: cell ``(cA, cB)`` is paired with ``(nA-cA, nB-cB)`` and the
+    smaller-total orientation is kept (ties broken by the first axis). Each
+    surviving allele carries weight 1/2; global-monomorphic corners are
+    dropped. Returns ``(fA, fB, n1, n2)`` (flat GPU int64), to be binned with
+    weight 1/2. Unlike the unfolded rule, this folds *the whole site by one
+    global minor allele* rather than each axis independently -- which is where
+    tskit departs from scikit-allel's per-axis fold (see the ledger).
+    """
+    ac1, ac2, nv1, nv2, n1, n2 = _joint_aligned_counts(haplotype_matrix,
+                                                       pop1, pop2)
+    cohort = ac1 + ac2                    # all alleles incl. ancestral
+    ncoh = (nv1 + nv2)[:, None]
+    keep = (cohort > 0) & (cohort < ncoh)
+    if missing_data == 'exclude':
+        complete = ((nv1 == n1) & (nv2 == n2))[:, None]
+        keep = keep & complete
+
+    nv1b = nv1[:, None]
+    nv2b = nv2[:, None]
+    comp = ncoh - cohort
+    flip = (cohort > comp) | ((cohort == comp) & (ac1 > nv1b - ac1))
+    fA = cp.where(flip, nv1b - ac1, ac1)
+    fB = cp.where(flip, nv2b - ac2, ac2)
+    return fA[keep].astype(cp.int64), fB[keep].astype(cp.int64), n1, n2
+
+
 def joint_sfs(haplotype_matrix: HaplotypeMatrix,
               pop1: Union[str, list],
               pop2: Union[str, list],
               missing_data: str = 'include'):
     """Compute the joint site frequency spectrum between two populations.
+
+    Per-allele and conforming to tskit's ``allele_frequency_spectrum([popA,
+    popB], polarised=True)``: each derived allele contributes to cell
+    ``(count_A, count_B)``, retaining alleles segregating in the A+B cohort
+    (``0 < count_A + count_B < nA + nB``). All edge cells are populated
+    (alleles private to / fixed within one population); only the two
+    global-monomorphic corners ``(0,0)`` and ``(nA,nB)`` are excluded.
 
     Parameters
     ----------
@@ -274,8 +371,8 @@ def joint_sfs(haplotype_matrix: HaplotypeMatrix,
     Returns
     -------
     ndarray, int64, shape (n1 + 1, n2 + 1)
-        Element [i, j] = number of variants with i derived alleles in pop1
-        and j derived alleles in pop2.
+        Element [i, j] = number of derived alleles with i copies in pop1
+        and j copies in pop2.
     """
     if isinstance(haplotype_matrix, StreamingHaplotypeMatrix):
         return _stream_sum(
@@ -284,27 +381,15 @@ def joint_sfs(haplotype_matrix: HaplotypeMatrix,
                                     missing_data=missing_data),
         )
 
-    m1 = _get_population_matrix(haplotype_matrix, pop1)
-    m2 = _get_population_matrix(haplotype_matrix, pop2)
-
-    dac1, n1 = _derived_allele_counts(m1, missing_data)
-    dac2, n2 = _derived_allele_counts(m2, missing_data)
-
-    if missing_data == 'exclude':
-        valid = (dac1 >= 0) & (dac2 >= 0)
-        dac1 = dac1[valid]
-        dac2 = dac2[valid]
-
-    if isinstance(n1, cp.ndarray):
-        n1 = int(cp.max(n1).get()) if n1.size > 0 else 0
-    if isinstance(n2, cp.ndarray):
-        n2 = int(cp.max(n2).get()) if n2.size > 0 else 0
-
+    cA, cB, n1, n2 = _joint_per_allele_counts(haplotype_matrix, pop1, pop2,
+                                              missing_data)
     x = n1 + 1
     y = n2 + 1
-    tmp = (dac1 * y + dac2).astype(cp.int32)
-    s = cp.bincount(tmp, minlength=x * y)
-    return s[:x * y].reshape(x, y).get()
+    if cA.size == 0:
+        return np.zeros((x, y), dtype=np.int64)
+    flat = cA * y + cB
+    s = cp.bincount(flat, minlength=x * y)
+    return s[:x * y].reshape(x, y).astype(cp.int64).get()
 
 
 @lru_cache(maxsize=16)
@@ -400,27 +485,22 @@ def project_joint_sfs(haplotype_matrix: HaplotypeMatrix,
                                                  P1, P2, missing_data)
         return acc.get()
 
-    # Eager path: compute (dac1, dac2) once then apply the same gather.
-    m1 = _get_population_matrix(haplotype_matrix, pop1)
-    m2 = _get_population_matrix(haplotype_matrix, pop2)
-    dac1, n1 = _derived_allele_counts(m1, missing_data)
-    dac2, n2 = _derived_allele_counts(m2, missing_data)
-    if missing_data == 'exclude':
-        valid = (dac1 >= 0) & (dac2 >= 0)
-        dac1 = dac1[valid]
-        dac2 = dac2[valid]
-    if isinstance(n1, cp.ndarray):
-        n1 = int(cp.max(n1).get()) if n1.size > 0 else 0
-    if isinstance(n2, cp.ndarray):
-        n2 = int(cp.max(n2).get()) if n2.size > 0 else 0
+    # Eager path: per-allele (count_A, count_B) then gather + matmul. This is
+    # exactly P1 @ joint_sfs(...) @ P2.T -- each surviving derived allele
+    # contributes P1[:, cA] outer P2[:, cB] -- so the same cohort filter as
+    # joint_sfs keeps the sandwich identity.
+    cA, cB, n1, n2 = _joint_per_allele_counts(haplotype_matrix, pop1, pop2,
+                                              missing_data)
     if target_n1 > n1 or target_n2 > n2:
         raise ValueError(
             f"Cannot project up: target_n1={target_n1} > n1={n1} "
             f"or target_n2={target_n2} > n2={n2}")
     P1 = cp.asarray(_projection_matrix_vec(n1, target_n1))
     P2 = cp.asarray(_projection_matrix_vec(n2, target_n2))
-    A = P1[:, dac1.astype(cp.int64)]
-    B = P2[:, dac2.astype(cp.int64)]
+    if cA.size == 0:
+        return np.zeros((target_n1 + 1, target_n2 + 1), dtype=np.float64)
+    A = P1[:, cA]
+    B = P2[:, cB]
     return (A @ B.T).get()
 
 
@@ -430,18 +510,13 @@ def _project_joint_sfs_chunk_gpu(chunk_hm, pop1, pop2, P1, P2,
 
     Factored out so the streaming dispatch can accumulate on-device
     without round-tripping each chunk's contribution through host
-    memory.
+    memory. Per-allele, using the same cohort filter as ``joint_sfs``.
     """
-    m1 = _get_population_matrix(chunk_hm, pop1)
-    m2 = _get_population_matrix(chunk_hm, pop2)
-    dac1, _ = _derived_allele_counts(m1, missing_data)
-    dac2, _ = _derived_allele_counts(m2, missing_data)
-    if missing_data == 'exclude':
-        valid = (dac1 >= 0) & (dac2 >= 0)
-        dac1 = dac1[valid]
-        dac2 = dac2[valid]
-    A = P1[:, dac1.astype(cp.int64)]
-    B = P2[:, dac2.astype(cp.int64)]
+    cA, cB, _, _ = _joint_per_allele_counts(chunk_hm, pop1, pop2, missing_data)
+    if cA.size == 0:
+        return cp.zeros((P1.shape[0], P2.shape[0]), dtype=cp.float64)
+    A = P1[:, cA]
+    B = P2[:, cB]
     return A @ B.T
 
 
@@ -457,35 +532,34 @@ def joint_sfs_folded(haplotype_matrix: HaplotypeMatrix,
     pop1, pop2 : str or list
     missing_data : str
 
+    Per-allele and conforming to tskit's ``allele_frequency_spectrum([popA,
+    popB], polarised=False)``: each allele (ancestral included) is folded as a
+    unit by the global minor and contributes weight 1/2 to the kept cell. The
+    output is the full ``(n1+1, n2+1)`` array (the kept region is the
+    lower-total triangle; the rest is zero), with half-integer weights on
+    multiallelic data. **This departs from scikit-allel's per-axis fold even on
+    biallelic data** (see the ledger) -- we pin to tskit here.
+
     Returns
     -------
-    ndarray, int64, shape (n1 // 2 + 1, n2 // 2 + 1)
+    ndarray, float64, shape (n1 + 1, n2 + 1)
     """
+    if isinstance(haplotype_matrix, StreamingHaplotypeMatrix):
+        return _stream_sum(
+            haplotype_matrix,
+            lambda chunk: joint_sfs_folded(chunk, pop1=pop1, pop2=pop2,
+                                           missing_data=missing_data),
+        )
 
-    m1 = _get_population_matrix(haplotype_matrix, pop1)
-    m2 = _get_population_matrix(haplotype_matrix, pop2)
-
-    ac1, n1 = _allele_counts(m1, missing_data)
-    ac2, n2 = _allele_counts(m2, missing_data)
-
-    if missing_data == 'exclude':
-        valid = (ac1[:, 1] >= 0) & (ac2[:, 1] >= 0)
-        ac1 = ac1[valid]
-        ac2 = ac2[valid]
-
-    mac1 = cp.amin(ac1, axis=1).astype(cp.int32)
-    mac2 = cp.amin(ac2, axis=1).astype(cp.int32)
-
-    if isinstance(n1, cp.ndarray):
-        n1 = int(cp.max(n1).get()) if n1.size > 0 else 0
-    if isinstance(n2, cp.ndarray):
-        n2 = int(cp.max(n2).get()) if n2.size > 0 else 0
-
-    x = n1 // 2 + 1
-    y = n2 // 2 + 1
-    tmp = (mac1 * y + mac2).astype(cp.int32)
-    s = cp.bincount(tmp, minlength=x * y)
-    return s[:x * y].reshape(x, y).get()
+    fA, fB, n1, n2 = _joint_folded_cells(haplotype_matrix, pop1, pop2,
+                                         missing_data)
+    x = n1 + 1
+    y = n2 + 1
+    if fA.size == 0:
+        return np.zeros((x, y), dtype=np.float64)
+    flat = fA * y + fB
+    s = 0.5 * cp.bincount(flat, minlength=x * y)[:x * y]
+    return s.reshape(x, y).astype(cp.float64).get()
 
 
 def joint_sfs_scaled(haplotype_matrix: HaplotypeMatrix,
@@ -526,22 +600,13 @@ def joint_sfs_folded_scaled(haplotype_matrix: HaplotypeMatrix,
 
     Returns
     -------
-    ndarray, float64, shape (n1 // 2 + 1, n2 // 2 + 1)
+    ndarray, float64, shape (n1 + 1, n2 + 1)
     """
-
-    m1 = _get_population_matrix(haplotype_matrix, pop1)
-    m2 = _get_population_matrix(haplotype_matrix, pop2)
-
-    _, n1 = _derived_allele_counts(m1, missing_data)
-    _, n2 = _derived_allele_counts(m2, missing_data)
-
-    if isinstance(n1, cp.ndarray):
-        n1 = int(cp.max(n1).get()) if n1.size > 0 else 0
-    if isinstance(n2, cp.ndarray):
-        n2 = int(cp.max(n2).get()) if n2.size > 0 else 0
-
+    # joint_sfs_folded handles streaming / subsetting and is pinned to tskit;
+    # scaling is a fixed transform on top of it. n1/n2 read off the shape.
     s = joint_sfs_folded(haplotype_matrix, pop1, pop2,
                           missing_data=missing_data)
+    n1, n2 = s.shape[0] - 1, s.shape[1] - 1
     return scale_joint_sfs_folded(s, n1, n2)
 
 

--- a/pg_gpu/sfs.py
+++ b/pg_gpu/sfs.py
@@ -15,70 +15,14 @@ from ._utils import get_population_matrix as _get_population_matrix
 from .streaming_matrix import StreamingHaplotypeMatrix, _stream_sum
 
 
-def _derived_allele_counts(haplotype_matrix, missing_data='include'):
-    """Compute derived allele counts per variant on GPU.
-
-    Parameters
-    ----------
-    haplotype_matrix : HaplotypeMatrix
-    missing_data : str
-        'include' - return per-site n_valid
-        'exclude' - filter to complete sites
-
-    Returns
-    -------
-    dac : cupy.ndarray, int64, shape (n_variants,)
-        Derived allele counts.
-    n : int or cupy.ndarray
-        Total haplotypes (int) or per-site valid counts (array).
-    """
-    if haplotype_matrix.device == 'CPU':
-        haplotype_matrix.transfer_to_gpu()
-
-    hap = haplotype_matrix.haplotypes  # (n_haplotypes, n_variants)
-
-    if missing_data == 'include':
-        from ._memutil import dac_and_n
-        dac, n_valid = dac_and_n(hap)
-        return dac, n_valid
-    elif missing_data == 'exclude':
-        from ._memutil import dac_and_n
-        dac, n_valid = dac_and_n(hap)
-        incomplete = n_valid < hap.shape[0]
-        dac[incomplete] = -1
-        n = hap.shape[0]
-        return dac, n
-    else:
-        from ._memutil import chunked_sum_int32
-        n = hap.shape[0]
-        dac = chunked_sum_int32(cp.maximum(hap, 0))
-        return dac, n
-
-
-def _allele_counts(haplotype_matrix, missing_data='include'):
-    """Compute biallelic allele counts [ref, alt] per variant.
-
-    Returns
-    -------
-    ac : cupy.ndarray, int64, shape (n_variants, 2)
-    n : int or cupy.ndarray
-    """
-    dac, n = _derived_allele_counts(haplotype_matrix, missing_data)
-    if isinstance(n, cp.ndarray):
-        ref_counts = n - dac
-    else:
-        ref_counts = n - dac
-    ac = cp.stack([ref_counts, dac], axis=1)
-    return ac, n
-
-
 def _per_allele_counts(matrix, n_alleles=None):
     """Per-allele counts (n_var, K) and per-site n_valid via the fused kernel.
 
     K defaults to the site-local maximum allele index + 1; pass ``n_alleles``
     for a fixed/global width (e.g. to align populations for the joint SFS).
-    Multiallelic-correct (each allele counted separately), unlike the collapsed
-    ``_derived_allele_counts``.
+    Multiallelic-correct: each allele is counted separately. This is the sole
+    counting primitive for every SFS in this module (the old collapsed
+    ``dac_and_n`` wrappers were removed once all variants went per-allele).
     """
     if matrix.device == 'CPU':
         matrix.transfer_to_gpu()

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -55,7 +55,10 @@ def _stream_sum(streaming_hm, kernel_fn):
     """
     total = None
     for _, _, chunk in streaming_hm.iter_gpu_chunks():
-        s = np.asarray(kernel_fn(chunk), dtype=np.int64)
+        # Preserve the kernel's own dtype: integer bincounts (sfs, joint_sfs)
+        # stay int64; the folded SFS carries half-integer weights, so it must
+        # accumulate in float (a forced int64 cast would truncate per chunk).
+        s = np.asarray(kernel_fn(chunk))
         if total is None:
             total = s.copy()
             continue

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -422,7 +422,7 @@ class _StreamingMatrixBase:
     """
 
     def __init__(self, source, fetcher, chunk_bp, prefetch, *,
-                 align_bp=None):
+                 align_bp=None, accessible_mask=None, n_total_sites=None):
         self._source = source
         self._fetcher = fetcher
         self._chunk_bp = int(chunk_bp)
@@ -435,6 +435,10 @@ class _StreamingMatrixBase:
         # (or None) and let the property fall back to a default 'all'
         # set when no pop file resolved at source construction.
         self._sample_sets = source.pop_cols
+        # Span-normalization metadata, mirroring the eager HaplotypeMatrix.
+        # None when no accessible BED was supplied at load; see get_span.
+        self.accessible_mask = accessible_mask
+        self.n_total_sites = n_total_sites
 
     @property
     def num_variants(self):
@@ -472,6 +476,45 @@ class _StreamingMatrixBase:
         convention."""
         return self._chunks[-1][1] if self._chunks else 0
 
+    def get_span(self, mode='auto'):
+        """Genomic span for normalization, mirroring HaplotypeMatrix.get_span.
+
+        Spans use the *variant-position* bounds (``mappable_lo``/``mappable_hi``)
+        rather than the chunk-grid ``chrom_start``/``chrom_end``, so the value
+        matches an eager matrix built from the same store. ``mappable_hi`` is one
+        past the last variant, so the raw span is ``mappable_hi - mappable_lo``
+        and the accessible count is over the half-open ``[lo, hi)``.
+
+        'auto' priority: accessible-mask count > n_total_sites > raw per-base span.
+
+        ``per_variant``/``sites`` and ``callable`` are computed over the
+        accessible-filtered variant set (as the eager path does through its
+        mask-filtered variant view), so they agree with eager under a mask;
+        ``per_base``/``total`` is the raw variant span, mask-independent.
+        """
+        lo = self._source.mappable_lo
+        hi = self._source.mappable_hi          # one past the last variant
+        if mode == 'auto':
+            if self.accessible_mask is not None:
+                return self.accessible_mask.count_accessible(lo, hi)
+            if self.n_total_sites is not None:
+                return self.n_total_sites
+            return hi - lo
+        if mode == 'accessible':
+            if self.accessible_mask is None:
+                raise ValueError("mode='accessible' requires an accessible mask")
+            return self.accessible_mask.count_accessible(lo, hi)
+        if mode in ('per_base', 'total'):
+            return hi - lo
+        if mode in ('per_variant', 'sites', 'callable'):
+            pos = self._source.site_pos
+            if self.accessible_mask is not None:
+                pos = pos[self.accessible_mask.is_accessible_at(pos)]
+            if mode == 'callable':
+                return int(pos[-1] - pos[0] + 1) if pos.size else 0
+            return int(pos.size)
+        raise ValueError(f"Invalid span mode: {mode}")
+
     @property
     def sample_sets(self):
         """Population -> sample-axis indices. Falls back to a single
@@ -504,6 +547,12 @@ class _StreamingMatrixBase:
                 chrom_start=int(left), chrom_end=int(right),
                 sample_sets=self._sample_sets,
             )
+            # A load-time accessible mask filters variants to accessible sites,
+            # exactly as it does on an eager matrix -- attach it here, at the
+            # single chunk-production point, so every streaming consumer sees
+            # accessible-filtered chunks by construction.
+            if self.accessible_mask is not None:
+                m.accessible_mask = self.accessible_mask
             yield int(left), int(right), m
 
     def materialize(self, *, region=None, sample_subset=None):

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -3064,34 +3064,34 @@ def windowed_statistics(haplotype_matrix: HaplotypeMatrix,
             results['end'], is_accessible)
         window_bases = cp.asarray(window_bases, dtype=cp.float64)
 
-    # Phase 1: compute per-variant values and aggregate
+    # Phase 1: per-variant per-allele contributions (multiallelic-correct),
+    # mirroring diversity._ac_contribution and the scatter engine so all three
+    # single-pop windowed engines agree with the scalar diversity functions.
+    from ._memutil import allele_counts
+    from .diversity import _ac_contribution, _achaz_variance_coefficients
 
-    # check for missing data once, share across all stats
-    _has_missing = bool(int(cp.min(hap)) < 0)
+    ac, n_valid_i = allele_counts(hap)
+    n_v = n_valid_i.astype(cp.float64)
+    has_data = n_valid_i >= 2
+    derived = ac[:, 1:]                        # per-derived-allele counts
+    # per-site mutation count = (#alleles present) - 1  (tskit segregating)
+    alleles_present = (ac > 0).sum(axis=1)
+    mut = cp.where(has_data, cp.maximum(alleles_present - 1, 0),
+                   0).astype(cp.float64)
 
-    # precompute allele counts once (shared across all stats)
-    dac, n_valid = _allele_sum_and_n(hap, has_missing=_has_missing)
-    dac = dac.astype(cp.float64)
-    if isinstance(n_valid, int):
-        n_v = cp.float64(n_valid)
-        usable = cp.ones(dac.shape, dtype=bool)
-    else:
-        n_v = n_valid.astype(cp.float64)
-        usable = n_v > 1
-    p = cp.where(usable, dac / n_v, 0.0)
-    need_mpd = any(s in statistics for s in ('pi', 'tajimas_d'))
+    need_pi = any(s in statistics for s in ('pi', 'tajimas_d'))
+    need_watt = any(s in statistics for s in ('theta_w', 'tajimas_d'))
     need_seg = any(s in statistics for s in
                    ('theta_w', 'tajimas_d', 'segregating_sites'))
 
-    if need_mpd:
-        mpd = cp.zeros_like(dac)
-        mpd[usable] = 2.0 * p[usable] * (1.0 - p[usable]) * n_v[usable] / (n_v[usable] - 1) if not isinstance(n_valid, int) else 2.0 * p[usable] * (1.0 - p[usable]) * n_hap / (n_hap - 1)
-    else:
-        mpd = None
-    is_seg = (dac > 0) & (dac < n_v) if need_seg else None
+    pi_contrib = (_ac_contribution('pi', ac, n_valid_i, n_hap_int)
+                  if need_pi else None)
+    watt_contrib = (_ac_contribution('watterson', ac, n_valid_i, n_hap_int)
+                    if need_watt else None)
+    seg_count = _scatter_sum(mut, bin_idx, n_windows) if need_seg else None
 
     if 'pi' in statistics:
-        pi_sum = _scatter_sum(mpd, bin_idx, n_windows)
+        pi_sum = _scatter_sum(pi_contrib, bin_idx, n_windows)
         if per_base:
             results['pi'] = cp.where(window_bases > 0,
                                      pi_sum / window_bases, cp.nan).get()
@@ -3099,10 +3099,9 @@ def windowed_statistics(haplotype_matrix: HaplotypeMatrix,
             results['pi'] = pi_sum.get()
 
     if 'theta_w' in statistics:
-        seg_counts = _scatter_sum(is_seg.astype(cp.float64), bin_idx, n_windows)
-        n = n_hap_int
-        a1 = np.sum(1.0 / np.arange(1, n))
-        theta_abs = seg_counts / a1
+        # Watterson via per-site a1(n_valid) (missing-data aware), == the
+        # scatter/scalar path; == old seg/a1(n_hap) when data is complete.
+        theta_abs = _scatter_sum(watt_contrib, bin_idx, n_windows)
         if per_base:
             results['theta_w'] = cp.where(window_bases > 0,
                                           theta_abs / window_bases, cp.nan).get()
@@ -3110,49 +3109,45 @@ def windowed_statistics(haplotype_matrix: HaplotypeMatrix,
             results['theta_w'] = theta_abs.get()
 
     if 'segregating_sites' in statistics:
-        seg_vals = is_seg if is_seg is not None else (dac > 0) & (dac < n_v)
-        seg_counts_out = _scatter_sum(seg_vals.astype(cp.float64), bin_idx,
-                                      n_windows)
-        results['segregating_sites'] = seg_counts_out.get().astype(int)
+        # Mutation count (alleles_present - 1) = tskit segregating; == the
+        # biallelic boolean is_seg for two-allele sites.
+        results['segregating_sites'] = seg_count.get().astype(int)
 
     if 'singletons' in statistics:
-        is_sing = (dac == 1) | (dac == n_v - 1)
-        sing_counts = _scatter_sum(is_sing.astype(cp.float64), bin_idx,
-                                   n_windows)
+        # Per-allele: derived alleles observed exactly once (unfolded, ==
+        # scalar singleton_count). The old (dac==1)|(dac==n-1) also counted
+        # ancestral-allele singletons (folded).
+        n_sing = ((derived == 1).sum(axis=1) if derived.shape[1]
+                  else cp.zeros(ac.shape[0], dtype=cp.int64))
+        sing = cp.where(has_data, n_sing, 0).astype(cp.float64)
+        sing_counts = _scatter_sum(sing, bin_idx, n_windows)
         results['singletons'] = sing_counts.get().astype(int)
 
     if 'het_expected' in statistics:
-        he = 2.0 * p * (1.0 - p)
+        # He = 1 - sum_a p_a^2 (per-allele; reduces to 2p(1-p) for biallelic).
+        p_sq = (ac.astype(cp.float64) ** 2).sum(axis=1) / cp.maximum(n_v, 1.0) ** 2
+        he = cp.where(has_data, 1.0 - p_sq, 0.0)
         he_sum = _scatter_sum(he, bin_idx, n_windows)
         results['het_expected'] = cp.where(
             variant_counts > 0,
             he_sum / variant_counts.astype(cp.float64), cp.nan).get()
 
     if 'tajimas_d' in statistics:
-        # aggregate mpd and seg counts into windows, then apply formula
-        pi_sum_td = _scatter_sum(mpd, bin_idx, n_windows) if 'pi' not in statistics else _scatter_sum(mpd, bin_idx, n_windows)
-        seg_counts_td = _scatter_sum(is_seg.astype(cp.float64), bin_idx,
-                                     n_windows)
-
-        n = n_hap_int
-        a1 = np.sum(1.0 / np.arange(1, n))
-        a2 = np.sum(1.0 / np.arange(1, n) ** 2)
-        b1 = (n + 1) / (3 * (n - 1))
-        b2 = 2 * (n ** 2 + n + 3) / (9 * n * (n - 1))
-        c1 = b1 - 1 / a1
-        c2 = b2 - (n + 2) / (a1 * n) + a2 / a1 ** 2
-        e1 = c1 / a1
-        e2 = c2 / (a1 ** 2 + a2)
-
-        S = seg_counts_td.get()
-        pi_w = pi_sum_td.get()
-
-        d_num = pi_w - S / a1
-        d_var = e1 * S + e2 * S * (S - 1)
-        d_std = np.sqrt(np.maximum(d_var, 0))
-
-        tajd = np.where(d_std > 0, d_num / d_std, np.nan)
-        tajd[S < 3] = np.nan
+        # numerator = pi - theta_w (per-allele sums); Achaz (2009) variance from
+        # a single n_hap and mutation-count S, matching the scatter engine. (The
+        # effective-n-under-missing-data question is tracked separately.)
+        pi_sum_td = _scatter_sum(pi_contrib, bin_idx, n_windows)
+        watt_sum_td = _scatter_sum(watt_contrib, bin_idx, n_windows)
+        S = seg_count.get()
+        a1 = sum(1.0 / i for i in range(1, n_hap_int))
+        a2 = sum(1.0 / (i ** 2) for i in range(1, n_hap_int))
+        theta_est = S / a1
+        theta_sq_est = S * (S - 1) / (a1 ** 2 + a2)
+        alpha, beta = _achaz_variance_coefficients('pi', 'watterson', n_hap_int)
+        var = alpha * theta_est + beta * theta_sq_est
+        num = (pi_sum_td - watt_sum_td).get()
+        with np.errstate(invalid='ignore', divide='ignore'):
+            tajd = np.where((var > 0) & (S >= 3), num / np.sqrt(var), np.nan)
         results['tajimas_d'] = tajd
 
     # two-population statistics

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -21,7 +21,7 @@ from . import diversity
 # Kwargs that the 'local_pca' / 'local_pca_jackknife' dispatch consumes but
 # scalar-stat paths don't accept. Filtered out before the recursive call.
 _LOCAL_PCA_ONLY_KWARGS = frozenset(
-    {'k', 'scaler', 'population', 'batch_size', 'window_type', 'regions',
+    {'k', 'population', 'batch_size', 'window_type', 'regions',
      'n_blocks', 'aggregate'})
 
 
@@ -1216,7 +1216,6 @@ def windowed_analysis(haplotype_matrix: HaplotypeMatrix,
         want_jackknife = 'local_pca_jackknife' in statistics
         local_pca_kwargs = {
             'k': kwargs.get('k', 2),
-            'scaler': kwargs.get('scaler', None),
             'missing_data': missing_data,
             'population': kwargs.get('population', None),
             'batch_size': kwargs.get('batch_size', None),

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -1083,6 +1083,12 @@ def _stream_windowed_analysis(streaming_hm, *, window_size, step_size,
     dispatch both need cross-chunk state and are not yet supported on the
     streaming path; both raise rather than silently returning wrong
     results.
+
+    ``mean_nsl`` is computed per chunk. Unlike the per-site statistics, nSL
+    integrates the shared-haplotype length in both directions across every
+    variant, so a per-chunk scan is truncated at the chunk boundaries: the
+    streaming result approximates the eager whole-region computation rather
+    than reproducing it. Materialize the region eagerly for an exact nSL scan.
     """
     if step_size is None:
         step_size = window_size
@@ -2129,6 +2135,10 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
     if 'mean_nsl' in statistics:
         from . import selection as sel
         # matrix is already population-subsetted (line 1533); don't re-subset.
+        # nSL is scanned once over this whole (eager) matrix, so each per-site
+        # score sees the full region before being binned into windows. Over a
+        # StreamingHaplotypeMatrix this runs per chunk, truncating the scan at
+        # chunk boundaries (see _stream_windowed_analysis).
         # nsl() returns (n_var,) for biallelic data and (n_var, n_derived) when
         # multiallelic focal sites are present; average every finite
         # (site, allele) score falling in each window.

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -2128,10 +2128,17 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
 
     if 'mean_nsl' in statistics:
         from . import selection as sel
-        # matrix is already population-subsetted (line 1533); don't re-subset
-        nsl_gpu = cp.asarray(sel.nsl(matrix))
-        valid = cp.isfinite(nsl_gpu) & in_range
-        results['mean_nsl'] = _windowed_mean(nsl_gpu, bin_idx, valid, n_windows)
+        # matrix is already population-subsetted (line 1533); don't re-subset.
+        # nsl() returns (n_var,) for biallelic data and (n_var, n_derived) when
+        # multiallelic focal sites are present; average every finite
+        # (site, allele) score falling in each window.
+        nsl_2d = cp.asarray(sel.nsl(matrix)).reshape(matrix.num_variants, -1)
+        m = nsl_2d.shape[1]
+        vals_flat = nsl_2d.reshape(-1)
+        bin_flat = cp.repeat(bin_idx, m)
+        inrange_flat = cp.repeat(in_range, m)
+        valid = cp.isfinite(vals_flat) & inrange_flat
+        results['mean_nsl'] = _windowed_mean(vals_flat, bin_flat, valid, n_windows)
 
     # SNP distance stats per window
     snp_dist_stats = {'snp_dist_mean', 'snp_dist_var', 'snp_dist_min',

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -2905,59 +2905,6 @@ def _bin_counts(bin_idx, n_bins):
     return cp.bincount(bin_idx[valid], minlength=n_bins)
 
 
-def _allele_sum_and_n(hap, has_missing=None):
-    """Sum of alleles and valid count per variant, skipping missing (-1).
-
-    Parameters
-    ----------
-    hap : cupy.ndarray
-    has_missing : bool, optional
-        If known, skip the check. If None, checks for negatives.
-
-    Returns
-    -------
-    dac : cupy.ndarray  — derived allele count per variant
-    n_valid : cupy.ndarray or int — valid haplotypes per variant
-    """
-    if has_missing is None:
-        has_missing = bool(int(cp.min(hap)) < 0)
-    if has_missing:
-        valid_mask = hap >= 0
-        dac = cp.sum(cp.where(valid_mask, hap, 0), axis=0)
-        n_valid = cp.sum(valid_mask, axis=0)
-    else:
-        dac = cp.sum(hap, axis=0)
-        n_valid = hap.shape[0]
-    return dac, n_valid
-
-
-def _per_variant_mpd(hap, n_hap):
-    """Mean pairwise difference per variant (GPU)."""
-    dac, n_valid = _allele_sum_and_n(hap)
-    dac = dac.astype(cp.float64)
-    if isinstance(n_valid, int):
-        n = cp.float64(n_valid)
-    else:
-        n = n_valid.astype(cp.float64)
-    usable = n > 1
-    p = cp.where(usable, dac / n, 0.0)
-    mpd = cp.zeros_like(dac)
-    mpd[usable] = 2.0 * p[usable] * (1.0 - p[usable]) * n[usable] / (n[usable] - 1)
-    return mpd
-
-
-def _per_variant_is_seg(hap, n_hap_int):
-    """Boolean: is variant segregating (GPU)."""
-    dac, n_valid = _allele_sum_and_n(hap)
-    return (dac > 0) & (dac < n_valid)
-
-
-def _per_variant_is_singleton(hap, n_hap_int):
-    """Boolean: is variant a singleton (GPU)."""
-    dac, n_valid = _allele_sum_and_n(hap)
-    return (dac == 1) | (dac == n_valid - 1)
-
-
 def _per_variant_fst_hudson_components(hap1, hap2, n1, n2):
     """Per-variant Hudson FST numerator and denominator (GPU).
 

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -718,8 +718,10 @@ def _windowed_thetas_scatter(haplotype_matrix, window_size, step_size,
                               span_normalize, chrom=None):
     """Compute windowed theta estimators via scatter-add on GPU.
 
-    Uses dac_and_n fused kernel + direct vectorized arithmetic + scatter_add
-    for per-window accumulation. Handles variable sample sizes per site.
+    Uses per-allele counts (``allele_counts``) + per-variant contributions
+    (``_ac_contribution``) + scatter_add for per-window accumulation, so
+    multiallelic sites are handled per-allele. Handles variable sample sizes
+    per site.
     """
     from ._utils import get_population_matrix
     from cupyx import scatter_add
@@ -738,8 +740,14 @@ def _windowed_thetas_scatter(haplotype_matrix, window_size, step_size,
         if matrix.num_variants == 0:
             return pd.DataFrame()
 
-    from .diversity import _prepare_dac, _site_contribution
-    dac, n_valid, d, n_safe, seg, n_hap = _prepare_dac(matrix)
+    from .diversity import _prepare_allele_counts, _ac_contribution
+    ac, n_valid, n_hap = _prepare_allele_counts(matrix)
+    # Per-allele intermediates (multiallelic-correct; match the scalar diversity
+    # path). mut = per-variant mutation count = (#alleles present) - 1.
+    n = n_valid.astype(cp.float64)
+    has_data = n_valid >= 2
+    alleles_present = (ac > 0).sum(axis=1)
+    mut = cp.where(has_data, cp.maximum(alleles_present - 1, 0), 0).astype(cp.float64)
 
     pos = matrix.positions
     if isinstance(pos, cp.ndarray):
@@ -803,20 +811,28 @@ def _windowed_thetas_scatter(haplotype_matrix, window_size, step_size,
         'watterson': stats_set & {'theta_w', 'tajimas_d', 'zeng_e', 'zeng_dh'},
     }
 
-    # Compute per-variant contributions via _site_contribution (single source of truth)
+    # Compute per-variant contributions via _ac_contribution (single source of truth)
     raw = {}
     for est_name, dependents in needs.items():
         if dependents:
             raw[est_name] = scatter_sum(
-                _site_contribution(est_name, d, n_safe, seg, n_valid, n_hap, dac=dac))
+                _ac_contribution(est_name, ac, n_valid, n_hap))
 
     if stats_set & {'segregating_sites', 'tajimas_d', 'normalized_fay_wu_h', 'zeng_e', 'zeng_dh'}:
-        seg_count = scatter_sum(seg.astype(cp.float64))
+        seg_count = scatter_sum(mut)
+    derived = ac[:, 1:]
     if 'singletons' in stats_set:
-        is_sing = seg & ((dac == 1) | (dac == n_valid - 1))
-        sing_count = scatter_sum(is_sing.astype(cp.float64))
+        # Per-allele: derived alleles (columns >= 1) observed exactly once.
+        n_sing = ((derived == 1).sum(axis=1) if derived.shape[1]
+                  else cp.zeros(ac.shape[0], dtype=cp.int64))
+        sing_count = scatter_sum(cp.where(has_data, n_sing, 0).astype(cp.float64))
     if 'max_daf' in stats_set:
-        dafs = cp.where(seg, d / n_safe, 0.0).get()
+        # Per-allele: highest derived-allele frequency at the site.
+        if derived.shape[1]:
+            p_der = derived.astype(cp.float64) / cp.where(n > 0, n, 1.0)[:, None]
+            dafs = cp.where(has_data, p_der.max(axis=1), 0.0).get()
+        else:
+            dafs = np.zeros(ac.shape[0])
         rep_dafs = np.broadcast_to(dafs[:, None], contains.shape) * contains
         max_daf_arr = np.zeros(n_windows)
         np.maximum.at(max_daf_arr, k_safe.ravel(), rep_dafs.ravel())
@@ -1251,7 +1267,7 @@ def windowed_analysis(haplotype_matrix: HaplotypeMatrix,
                 on='window_id', how='left')
         return result
 
-    # Scatter-add path: single-pop theta estimators via dac_and_n + scatter
+    # Scatter-add path: single-pop theta estimators via per-allele counts + scatter
     scatter_single = {'pi', 'theta_w', 'tajimas_d', 'segregating_sites',
                       'theta_h', 'theta_l', 'fay_wu_h', 'singletons',
                       'normalized_fay_wu_h', 'zeng_e', 'zeng_dh', 'max_daf'}
@@ -1408,7 +1424,66 @@ def _compute_mean_r2(matrix: HaplotypeMatrix, max_distance: int,
 # Haplotype data is transposed before kernel launch so variants are the
 # leading dimension (column-major for haplotype access). This ensures
 # coalesced memory reads when threads iterate over haplotypes.
+_FUSED_MAX_ALLELES = 8
+"""Per-variant allele capacity of the fused windowed CUDA kernels.
+
+The kernels count alleles into a fixed cnt[MAX_ALLELES] array per variant, so a
+site with an allele index >= this cap cannot be represented and is filtered out
+(with a MultiallelicCapWarning). Keep in sync with the ``#define MAX_ALLELES`` in
+the kernel sources. Nucleotide data has at most 4 alleles, so the cap is never
+hit in practice.
+"""
+
+
+def _warn_fused_allele_cap(n_over):
+    """Emit a MultiallelicCapWarning for ``n_over`` sites dropped by the cap."""
+    import warnings
+    from ._warnings import MultiallelicCapWarning
+    warnings.warn(
+        f"{n_over} site(s) with an allele index >= {_FUSED_MAX_ALLELES} were "
+        "excluded from the fused windowed statistics (kernel per-allele "
+        "capacity). Nucleotide data has at most 4 alleles; the non-windowed "
+        "diversity/divergence functions handle any number of alleles.",
+        MultiallelicCapWarning, stacklevel=3)
+
+
+def _filter_fused_allele_cap(hap, positions):
+    """Drop variants whose max allele index >= _FUSED_MAX_ALLELES (fused kernels).
+
+    ``hap`` is the transposed (n_var, n_hap) matrix on GPU. Returns ``(hap,
+    positions)`` filtered consistently. Emits a ``MultiallelicCapWarning`` with
+    the dropped-site count when any site exceeds the cap. Missing (-1) never
+    triggers the cap.
+    """
+    overcap = hap.max(axis=1) >= _FUSED_MAX_ALLELES
+    n_over = int(overcap.sum())
+    if n_over:
+        _warn_fused_allele_cap(n_over)
+        keep = ~overcap
+        hap = hap[keep]
+        positions = positions[keep]
+    return hap, positions
+
+
+def _filter_fused_allele_cap_raw(hap_raw, positions):
+    """Cap filter for the chunked path's un-transposed (n_hap, n_var) matrix.
+
+    Reduces over the haplotype axis (axis 0) to get per-variant max allele
+    indices without a full transpose, then slices variants (axis 1) and
+    positions consistently. Same semantics as ``_filter_fused_allele_cap``.
+    """
+    overcap = hap_raw.max(axis=0) >= _FUSED_MAX_ALLELES
+    n_over = int(overcap.sum())
+    if n_over:
+        _warn_fused_allele_cap(n_over)
+        keep = ~overcap
+        hap_raw = hap_raw[:, keep]
+        positions = positions[keep]
+    return hap_raw, positions
+
+
 _fused_windowed_kernel_v2 = cp.RawKernel(r'''
+#define MAX_ALLELES 8   /* keep in sync with _FUSED_MAX_ALLELES (host guard) */
 extern "C" __global__
 void fused_windowed_stats_v2(const signed char* hap_t,
                              const long long* win_start,
@@ -1438,30 +1513,46 @@ void fused_windowed_stats_v2(const signed char* hap_t,
         return;
     }
 
-    double dn = (double)n_hap;
     double t_mpd = 0.0, t_seg = 0.0, t_sing = 0.0;
     double t_count = 0.0, t_theta_h = 0.0, t_max_daf = 0.0;
 
     for (int vi = threadIdx.x; vi < n_vars; vi += blockDim.x) {
         int v = v_start + vi;
-        int dac = 0;
         const signed char* row = hap_t + (long long)v * n_hap;
+        /* Per-allele counts over non-missing calls. Sites with an allele index
+           >= MAX_ALLELES are filtered out on the host before launch, so every
+           allele here fits in cnt[]. */
+        int cnt[MAX_ALLELES];
+        for (int a = 0; a < MAX_ALLELES; a++) cnt[a] = 0;
+        int nv = 0;
         for (int h = 0; h < n_hap; h++) {
-            if (row[h] > 0) dac++;
+            signed char al = row[h];
+            if (al >= 0) { nv++; if (al < MAX_ALLELES) cnt[al]++; }
         }
-
-        double p = (double)dac / dn;
-        t_mpd += 2.0 * p * (1.0 - p) * dn / (dn - 1.0);
-
-        int is_seg = (dac > 0 && dac < n_hap) ? 1 : 0;
-        t_seg += is_seg;
-        t_sing += (dac == 1 || dac == n_hap - 1) ? 1.0 : 0.0;
         t_count += 1.0;
+        if (nv < 2) continue;
+        double dn = (double)nv;
 
-        if (is_seg) {
-            t_theta_h += 2.0 * (double)dac * (double)dac / (dn * (dn - 1.0));
+        double same = 0.0;      /* sum_a cnt_a*(cnt_a-1) : same-allele pairs */
+        double th = 0.0;        /* theta_h numerator: sum_{a>=1,0<c<nv} 2 c^2 */
+        double mdaf = 0.0;      /* max derived-allele frequency */
+        int n_present = 0;
+        for (int a = 0; a < MAX_ALLELES; a++) {
+            int c = cnt[a];
+            if (c > 0) n_present++;
+            same += (double)c * (double)(c - 1);
+            if (a >= 1 && c > 0) {
+                if (c == 1) t_sing += 1.0;            /* per-derived-allele singleton */
+                double freq = (double)c / dn;
+                if (freq > mdaf) mdaf = freq;
+                if (c < nv) th += 2.0 * (double)c * (double)c;
+            }
         }
-        if (p > t_max_daf) t_max_daf = p;
+        /* pi = 1 - sum_a C(c,2)/C(n,2); seg = mutation count (alleles present - 1) */
+        t_mpd += 1.0 - same / (dn * (dn - 1.0));
+        t_seg += (double)(n_present - 1);
+        t_theta_h += th / (dn * (dn - 1.0));
+        if (mdaf > t_max_daf) t_max_daf = mdaf;
     }
 
     // Sum reduction for 5 accumulators
@@ -1828,6 +1919,12 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
     positions = matrix.positions
     if not isinstance(positions, cp.ndarray):
         positions = cp.asarray(positions)
+
+    # Drop sites the fused kernel's per-allele capacity can't represent (rare;
+    # nucleotide data has <= 4 alleles). Must precede window indexing so the
+    # variant-index ranges are computed against the retained sites.
+    hap, positions = _filter_fused_allele_cap(hap, positions)
+    n_total_var = hap.shape[0]
 
     # Support overlapping windows via explicit start/stop arrays
     if _win_starts is not None and _win_stops is not None:
@@ -2196,11 +2293,15 @@ def windowed_statistics_fused_chunked(haplotype_matrix: HaplotypeMatrix,
 
     hap_raw = matrix.haplotypes
     n_hap = hap_raw.shape[0]
-    n_total_var = hap_raw.shape[1]
 
     positions = matrix.positions
     if not isinstance(positions, cp.ndarray):
         positions = cp.asarray(positions)
+
+    # Drop sites the fused kernel's per-allele capacity can't represent. Must
+    # precede window indexing so variant-index ranges match the retained sites.
+    hap_raw, positions = _filter_fused_allele_cap_raw(hap_raw, positions)
+    n_total_var = hap_raw.shape[1]
 
     # Window ranges (same setup as non-chunked)
     if _win_starts is not None and _win_stops is not None:

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -909,44 +909,34 @@ def _twopop_site_components(hap1, hap2):
       mpd2 = within-pop2 mean pairwise difference per site
       between = between-pop mean pairwise difference per site
 
-    All quantities use per-site valid counts (missing-data aware).
-    Reduces along the sample axis in chunks to avoid materializing
-    full (n_hap, n_var) float64 intermediates.
+    Per-allele (multiallelic-correct): the same-allele pair counts sum over
+    every allele column on a shared allele-index width K, so ``between``
+    equals the per-site Dxy (``1 - sum_a p1_a p2_a``) and mpd1/mpd2 the
+    per-site within-pop pi -- identical to the scalar ``divergence`` functions
+    (``_hudson_fst_from_counts`` / ``dxy``). Reduces to the biallelic
+    ancestral/derived form when there are two alleles. All quantities use
+    per-site valid counts (missing-data aware).
     """
-    n_var = hap1.shape[1]
+    from .divergence import _aligned_pop_counts
 
-    # Compute per-site allele counts and valid counts via chunked reduction.
-    # Only allocates (n_hap, chunk) temporaries instead of (n_hap, n_var).
-    ac1 = cp.zeros(n_var, dtype=cp.float64)
-    n1 = cp.zeros(n_var, dtype=cp.float64)
-    ac2 = cp.zeros(n_var, dtype=cp.float64)
-    n2 = cp.zeros(n_var, dtype=cp.float64)
-    chunk = max(1, n_var // 20)
-    for s in range(0, n_var, chunk):
-        e = min(s + chunk, n_var)
-        h1c = hap1[:, s:e]
-        v1 = h1c >= 0
-        n1[s:e] = cp.sum(v1, axis=0)
-        ac1[s:e] = cp.sum(cp.where(v1, h1c, 0), axis=0)
-        del h1c, v1
-        h2c = hap2[:, s:e]
-        v2 = h2c >= 0
-        n2[s:e] = cp.sum(v2, axis=0)
-        ac2[s:e] = cp.sum(cp.where(v2, h2c, 0), axis=0)
-        del h2c, v2
+    ac1, ac2, n1, n2 = _aligned_pop_counts(hap1, hap2)
+    ac1 = ac1.astype(cp.float64)
+    ac2 = ac2.astype(cp.float64)
+    n1 = n1.astype(cp.float64)
+    n2 = n2.astype(cp.float64)
 
-    # Within-pop mean pairwise differences
+    # Within-pop mean pairwise differences (same pairs summed over alleles)
     n1_pairs = n1 * (n1 - 1) / 2
-    n1_same = ((n1 - ac1) * (n1 - ac1 - 1) + ac1 * (ac1 - 1)) / 2
+    n1_same = cp.sum(ac1 * (ac1 - 1), axis=1) / 2
     mpd1 = cp.where(n1_pairs > 0, (n1_pairs - n1_same) / n1_pairs, 0.0)
 
     n2_pairs = n2 * (n2 - 1) / 2
-    n2_same = ((n2 - ac2) * (n2 - ac2 - 1) + ac2 * (ac2 - 1)) / 2
+    n2_same = cp.sum(ac2 * (ac2 - 1), axis=1) / 2
     mpd2 = cp.where(n2_pairs > 0, (n2_pairs - n2_same) / n2_pairs, 0.0)
 
-    # Between-pop mean pairwise differences
+    # Between-pop mean pairwise differences (per-allele cross term)
     n_between = n1 * n2
-    n_between_same = (n1 - ac1) * (n2 - ac2) + ac1 * ac2
+    n_between_same = cp.sum(ac1 * ac2, axis=1)
     between = cp.where(n_between > 0,
                        (n_between - n_between_same) / n_between, 0.0)
 
@@ -1447,30 +1437,15 @@ def _warn_fused_allele_cap(n_over):
         MultiallelicCapWarning, stacklevel=3)
 
 
-def _filter_fused_allele_cap(hap, positions):
-    """Drop variants whose max allele index >= _FUSED_MAX_ALLELES (fused kernels).
-
-    ``hap`` is the transposed (n_var, n_hap) matrix on GPU. Returns ``(hap,
-    positions)`` filtered consistently. Emits a ``MultiallelicCapWarning`` with
-    the dropped-site count when any site exceeds the cap. Missing (-1) never
-    triggers the cap.
-    """
-    overcap = hap.max(axis=1) >= _FUSED_MAX_ALLELES
-    n_over = int(overcap.sum())
-    if n_over:
-        _warn_fused_allele_cap(n_over)
-        keep = ~overcap
-        hap = hap[keep]
-        positions = positions[keep]
-    return hap, positions
-
-
 def _filter_fused_allele_cap_raw(hap_raw, positions):
     """Cap filter for the chunked path's un-transposed (n_hap, n_var) matrix.
 
     Reduces over the haplotype axis (axis 0) to get per-variant max allele
     indices without a full transpose, then slices variants (axis 1) and
-    positions consistently. Same semantics as ``_filter_fused_allele_cap``.
+    positions consistently. Drops variants whose max allele index
+    >= _FUSED_MAX_ALLELES and emits a ``MultiallelicCapWarning``; missing (-1)
+    never triggers the cap. (The non-chunked single-pass path filters inline,
+    capturing the keep mask so the two-pop kernel's hap1/hap2 align.)
     """
     overcap = hap_raw.max(axis=0) >= _FUSED_MAX_ALLELES
     n_over = int(overcap.sum())
@@ -1594,6 +1569,7 @@ void fused_windowed_stats_v2(const signed char* hap_t,
 
 # Two-population fused kernel for FST and Dxy
 _fused_windowed_twopop_kernel = cp.RawKernel(r'''
+#define MAX_ALLELES 8   /* keep in sync with _FUSED_MAX_ALLELES (host guard) */
 extern "C" __global__
 void fused_windowed_twopop(const signed char* hap1_t,
                            const signed char* hap2_t,
@@ -1631,44 +1607,52 @@ void fused_windowed_twopop(const signed char* hap1_t,
     for (int vi = threadIdx.x; vi < n_vars; vi += blockDim.x) {
         int v = v_start + vi;
 
-        // Count valid (non-missing) samples and alt alleles per site
-        int ac1_1 = 0, valid1 = 0;
+        // Per-allele counts over non-missing calls (shared cnt width for both
+        // pops). Sites with an allele index >= MAX_ALLELES are filtered on the
+        // host before launch, so every allele fits in cnt[].
+        int cnt1[MAX_ALLELES];
+        int cnt2[MAX_ALLELES];
+        for (int a = 0; a < MAX_ALLELES; a++) { cnt1[a] = 0; cnt2[a] = 0; }
+        int valid1 = 0;
         const signed char* row1 = hap1_t + (long long)v * n_hap1;
         for (int h = 0; h < n_hap1; h++) {
             signed char a = row1[h];
-            if (a >= 0) { valid1++; if (a > 0) ac1_1++; }
+            if (a >= 0) { valid1++; if (a < MAX_ALLELES) cnt1[a]++; }
         }
-        int ac2_1 = 0, valid2 = 0;
+        int valid2 = 0;
         const signed char* row2 = hap2_t + (long long)v * n_hap2;
         for (int h = 0; h < n_hap2; h++) {
             signed char a = row2[h];
-            if (a >= 0) { valid2++; if (a > 0) ac2_1++; }
+            if (a >= 0) { valid2++; if (a < MAX_ALLELES) cnt2[a]++; }
         }
 
         if (valid1 == 0 || valid2 == 0) continue;
 
         double dn1 = (double)valid1;
         double dn2 = (double)valid2;
-        double ac1_0 = dn1 - ac1_1;
-        double ac2_0 = dn2 - ac2_1;
-        double d_ac1_1 = (double)ac1_1;
-        double d_ac2_1 = (double)ac2_1;
 
-        // Hudson: within-pop mean pairwise difference
-        double n1_pairs = dn1 * (dn1 - 1.0) / 2.0;
-        double n1_same = (ac1_0 * (ac1_0 - 1.0) + d_ac1_1 * (d_ac1_1 - 1.0)) / 2.0;
-        double mpd1 = (n1_pairs > 0) ? (n1_pairs - n1_same) / n1_pairs : 0.0;
-
-        double n2_pairs = dn2 * (dn2 - 1.0) / 2.0;
-        double n2_same = (ac2_0 * (ac2_0 - 1.0) + d_ac2_1 * (d_ac2_1 - 1.0)) / 2.0;
-        double mpd2 = (n2_pairs > 0) ? (n2_pairs - n2_same) / n2_pairs : 0.0;
-
+        // Per-allele within-pop mean pairwise difference (same pairs summed over
+        // alleles) and between-pop difference (per-allele cross term) -- mirrors
+        // divergence._hudson_fst_from_counts / dxy, multiallelic-correct.
+        double same1 = 0.0, same2 = 0.0, between_same = 0.0;
+        for (int a = 0; a < MAX_ALLELES; a++) {
+            double c1 = (double)cnt1[a];
+            double c2 = (double)cnt2[a];
+            same1 += c1 * (c1 - 1.0);
+            same2 += c2 * (c2 - 1.0);
+            between_same += c1 * c2;
+        }
+        double mpd1 = (dn1 > 1.0) ? 1.0 - same1 / (dn1 * (dn1 - 1.0)) : 0.0;
+        double mpd2 = (dn2 > 1.0) ? 1.0 - same2 / (dn2 * (dn2 - 1.0)) : 0.0;
         double within = (mpd1 + mpd2) / 2.0;
+        double between = 1.0 - between_same / (dn1 * dn2);
 
-        // Between-pop mean pairwise difference
-        double n_between = dn1 * dn2;
-        double n_between_same = ac1_0 * ac2_0 + d_ac1_1 * d_ac2_1;
-        double between = (n_between > 0) ? (n_between - n_between_same) / n_between : 0.0;
+        // Total non-reference copy counts (all alt alleles collapsed) retained
+        // for the HAPLOID Weir-Cockerham block below, which is deliberately
+        // unchanged -- the fused fst_wc haploid/diploid mismatch is tracked
+        // separately and is out of scope here.
+        double d_ac1_1 = dn1 - (double)cnt1[0];
+        double d_ac2_1 = dn2 - (double)cnt2[0];
 
         t_fst_num += between - within;
         t_fst_den += between;
@@ -1922,8 +1906,16 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
 
     # Drop sites the fused kernel's per-allele capacity can't represent (rare;
     # nucleotide data has <= 4 alleles). Must precede window indexing so the
-    # variant-index ranges are computed against the retained sites.
-    hap, positions = _filter_fused_allele_cap(hap, positions)
+    # variant-index ranges are computed against the retained sites. Capture the
+    # keep mask so the two-pop path can slice hap1/hap2 to the same variants
+    # (positions/window indices are computed against the filtered set below).
+    cap_keep = hap.max(axis=1) < _FUSED_MAX_ALLELES if hap.shape[0] else None
+    if cap_keep is not None and not bool(cap_keep.all()):
+        _warn_fused_allele_cap(int((~cap_keep).sum()))
+        hap = hap[cap_keep]
+        positions = positions[cap_keep]
+    else:
+        cap_keep = None
     n_total_var = hap.shape[0]
 
     # Support overlapping windows via explicit start/stop arrays
@@ -2057,6 +2049,11 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
         n2 = m2.haplotypes.shape[0]
         hap1 = cp.ascontiguousarray(m1.haplotypes.T.astype(cp.int8))
         hap2 = cp.ascontiguousarray(m2.haplotypes.T.astype(cp.int8))
+        # Align to the variants retained by the allele-cap filter above, so the
+        # variant axis matches positions/win_start/win_stop/n_total_var.
+        if cap_keep is not None:
+            hap1 = hap1[cap_keep]
+            hap2 = hap2[cap_keep]
 
         out_fst_num = cp.zeros(n_windows, dtype=cp.float64)
         out_fst_den = cp.zeros(n_windows, dtype=cp.float64)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,3 +129,31 @@ def simulate_hm(n_samples=20, seq_length=100_000, seed=42,
         kw["model"] = mutation_model
     ts = msprime.sim_mutations(ts, rate=1e-3, random_seed=seed, **kw)
     return HaplotypeMatrix.from_ts(ts)
+
+
+@pytest.fixture(scope="session")
+def multiallelic_ts():
+    """JC69 tree sequence with genuine multiallelic sites (issue #100).
+
+    Recurrent Jukes-Cantor mutation produces tri/tetra-allelic and
+    reference-absent sites, which is what the tskit-oracle multiallelic tests
+    need. Deterministic (fixed seeds). No missing data, so per-site n_valid
+    equals the full sample size.
+    """
+    import msprime
+    ts = msprime.sim_ancestry(
+        samples=25, population_size=2e4, sequence_length=1e5,
+        recombination_rate=1e-8, random_seed=42, ploidy=2,
+    )
+    ts = msprime.sim_mutations(
+        ts, rate=1e-6, model=msprime.JC69(state_independent=True),
+        random_seed=43,
+    )
+    return ts
+
+
+@pytest.fixture
+def multiallelic_hm(multiallelic_ts):
+    """(ts, hm) pair for the multiallelic tree sequence; hm on GPU."""
+    from pg_gpu import HaplotypeMatrix
+    return multiallelic_ts, HaplotypeMatrix.from_ts(multiallelic_ts, device="GPU")

--- a/tests/test_achaz.py
+++ b/tests/test_achaz.py
@@ -18,7 +18,18 @@ def simple_ts():
         samples=50, sequence_length=100_000,
         recombination_rate=1e-8, population_size=10_000,
         random_seed=42, ploidy=2)
-    return msprime.sim_mutations(ts, rate=1e-8, random_seed=42)
+    ts = msprime.sim_mutations(ts, rate=1e-8, random_seed=42)
+    # These tests assert scalar diversity == FrequencySpectrum (SFS) values.
+    # That equivalence only holds on biallelic data: at multiallelic sites the
+    # scalar mutation-count Watterson and the per-allele SFS diverge
+    # (kr-colab/pg_gpu#100). Nothing above forces biallelic (the default JC
+    # mutation model can produce triallelic sites), so guard it explicitly --
+    # if a future rate/seed change adds a >2-allele site this fails loudly
+    # rather than letting the equivalence break silently.
+    G = ts.genotype_matrix()
+    assert all(np.unique(G[i]).size <= 2 for i in range(ts.num_sites)), \
+        "test_achaz fixture must stay biallelic (see kr-colab/pg_gpu#100)"
+    return ts
 
 
 @pytest.fixture

--- a/tests/test_allele_counts.py
+++ b/tests/test_allele_counts.py
@@ -1,0 +1,106 @@
+"""
+Tests for the per-allele allele-count primitive (_memutil.allele_counts).
+
+This is the multiallelic-correct counting primitive behind the diversity
+family (issue #100). Oracles: a cupy per-column bincount reference and
+scikit-allel's count_alleles.
+"""
+
+import numpy as np
+import cupy as cp
+import allel
+import pytest
+
+from pg_gpu._memutil import allele_counts
+
+
+def _ref_counts(hap, K):
+    """Ground-truth per-allele counts via per-value reduction (n_hap, n_var)."""
+    ac = np.zeros((hap.shape[1], K), dtype=np.int64)
+    for a in range(K):
+        ac[:, a] = (hap == a).sum(axis=0)
+    return ac
+
+
+class TestAlleleCounts:
+
+    def test_biallelic(self):
+        # site0: 3x ref, 1x alt ; site1: all alt
+        hap = np.array([[0, 1],
+                        [0, 1],
+                        [0, 1],
+                        [1, 1]], dtype=np.int8)
+        ac, n = allele_counts(cp.asarray(hap))
+        assert ac.shape == (2, 2)
+        np.testing.assert_array_equal(ac.get(), [[3, 1], [0, 4]])
+        np.testing.assert_array_equal(n.get(), [4, 4])
+
+    def test_triallelic(self):
+        # one site: 2x allele0, 1x allele1, 1x allele2
+        hap = np.array([[0], [0], [1], [2]], dtype=np.int8)
+        ac, n = allele_counts(cp.asarray(hap))
+        assert ac.shape == (1, 3)
+        np.testing.assert_array_equal(ac.get(), [[2, 1, 1]])
+        np.testing.assert_array_equal(n.get(), [4])
+
+    def test_tetraallelic(self):
+        hap = np.array([[0], [1], [2], [3]], dtype=np.int8)
+        ac, n = allele_counts(cp.asarray(hap))
+        np.testing.assert_array_equal(ac.get(), [[1, 1, 1, 1]])
+        np.testing.assert_array_equal(n.get(), [4])
+
+    def test_reference_absent(self):
+        # site with only alleles 1 and 2 (ancestral index 0 absent)
+        hap = np.array([[1], [1], [2], [2]], dtype=np.int8)
+        ac, n = allele_counts(cp.asarray(hap))
+        np.testing.assert_array_equal(ac.get(), [[0, 2, 2]])
+        np.testing.assert_array_equal(n.get(), [4])
+
+    def test_missing_data(self):
+        # -1 excluded from n_valid and from all allele columns
+        hap = np.array([[0], [1], [-1], [2]], dtype=np.int8)
+        ac, n = allele_counts(cp.asarray(hap))
+        np.testing.assert_array_equal(ac.get(), [[1, 1, 1]])
+        np.testing.assert_array_equal(n.get(), [3])
+        # counts sum to n_valid (K covers the range)
+        assert int(ac.get().sum()) == int(n.get().sum())
+
+    def test_sum_equals_n_valid(self):
+        rng = np.random.default_rng(0)
+        hap = rng.integers(-1, 4, size=(30, 200)).astype(np.int8)
+        ac, n = allele_counts(cp.asarray(hap))
+        np.testing.assert_array_equal(ac.get().sum(axis=1), n.get())
+
+    def test_matches_bincount_reference(self):
+        rng = np.random.default_rng(1)
+        hap = rng.integers(-1, 4, size=(40, 500)).astype(np.int8)
+        ac, _ = allele_counts(cp.asarray(hap))
+        K = ac.shape[1]
+        np.testing.assert_array_equal(ac.get(), _ref_counts(hap, K))
+
+    def test_matches_scikit_allel(self):
+        rng = np.random.default_rng(2)
+        hap = rng.integers(0, 4, size=(24, 300)).astype(np.int8)
+        ac, _ = allele_counts(cp.asarray(hap))
+        # allel expects (n_var, n_hap); count_alleles gives (n_var, n_alleles)
+        allel_ac = np.asarray(allel.HaplotypeArray(hap.T).count_alleles())
+        assert ac.shape == allel_ac.shape
+        np.testing.assert_array_equal(ac.get(), allel_ac)
+
+    def test_n_alleles_override_pads(self):
+        hap = np.array([[0], [1], [0], [1]], dtype=np.int8)  # biallelic
+        ac, n = allele_counts(cp.asarray(hap), n_alleles=4)
+        assert ac.shape == (1, 4)
+        np.testing.assert_array_equal(ac.get(), [[2, 2, 0, 0]])
+
+    def test_all_missing(self):
+        hap = np.full((5, 3), -1, dtype=np.int8)
+        ac, n = allele_counts(cp.asarray(hap))
+        assert ac.shape == (3, 1)  # K floored to 1
+        np.testing.assert_array_equal(ac.get(), np.zeros((3, 1)))
+        np.testing.assert_array_equal(n.get(), [0, 0, 0])
+
+    def test_empty(self):
+        hap = np.empty((5, 0), dtype=np.int8)
+        ac, n = allele_counts(cp.asarray(hap))
+        assert ac.shape[0] == 0 and n.shape[0] == 0

--- a/tests/test_backward_compatibility.py
+++ b/tests/test_backward_compatibility.py
@@ -108,32 +108,10 @@ class TestHaplotypeMatrixCompatibility:
 
         assert abs(tajd_old - tajd_allel) < 1e-8
 
-    def test_allele_frequency_spectrum_compatibility(self, test_matrix):
-        """Test that HaplotypeMatrix.allele_frequency_spectrum() matches diversity module."""
-        # Old method
-        afs_old = test_matrix.allele_frequency_spectrum()
-
-        # New module method
-        afs_new = diversity.allele_frequency_spectrum(test_matrix)
-
-        # Convert to numpy if needed
-        if hasattr(afs_old, 'get'):
-            afs_old = np.asarray(afs_old)
-        if hasattr(afs_new, 'get'):
-            afs_new = np.asarray(afs_new)
-
-        # Should be identical
-        np.testing.assert_array_equal(afs_old, afs_new)
-
-        # Should also match scikit-allel SFS
-        h = allel.HaplotypeArray(test_matrix.haplotypes.T if isinstance(test_matrix.haplotypes, np.ndarray)
-                                 else test_matrix.haplotypes.get().T)
-        ac = h.count_alleles()
-        sfs_allel = allel.sfs(ac[:, 1])
-
-        # pg_gpu AFS has n+1 bins, scikit-allel SFS has variable length
-        sfs_length = len(sfs_allel) - 1  # Exclude sfs_allel[0] since we start from index 1
-        np.testing.assert_array_equal(afs_old[1:1+sfs_length], sfs_allel[1:])
+    # NOTE: HaplotypeMatrix.allele_frequency_spectrum() and
+    # diversity.allele_frequency_spectrum() were removed (issue #100 consolidation);
+    # the SFS now lives only in the sfs module. See
+    # tests/test_sfs_allel_comparison.py::TestSFSComparison::test_sfs.
 
     @pytest.mark.skipif(not cp.cuda.is_available(), reason="GPU not available")
     def test_gpu_compatibility(self):
@@ -150,18 +128,15 @@ class TestHaplotypeMatrixCompatibility:
         pi_gpu_old = matrix.diversity(span_normalize=True)
         theta_gpu_old = matrix.watersons_theta(span_normalize=True)
         tajd_gpu_old = matrix.Tajimas_D()
-        afs_gpu_old = matrix.allele_frequency_spectrum()
 
         # New methods should give identical results
         pi_gpu_new = diversity.pi(matrix, span_normalize=True)
         theta_gpu_new = diversity.theta_w(matrix, span_normalize=True)
         tajd_gpu_new = diversity.tajimas_d(matrix)
-        afs_gpu_new = diversity.allele_frequency_spectrum(matrix)
 
         assert abs(pi_gpu_old - pi_gpu_new) < 1e-15
         assert abs(theta_gpu_old - theta_gpu_new) < 1e-15
         assert abs(tajd_gpu_old - tajd_gpu_new) < 1e-15
-        np.testing.assert_array_equal(np.asarray(afs_gpu_old), np.asarray(afs_gpu_new))
 
         # CPU version should match
         matrix_cpu = HaplotypeMatrix(haplotypes, positions, positions[0], positions[-1])
@@ -191,7 +166,6 @@ class TestDeprecationWarnings:
             pi_val = matrix.diversity()
             theta_val = matrix.watersons_theta()
             tajd_val = matrix.Tajimas_D()
-            afs_val = matrix.allele_frequency_spectrum()
 
         # Filter out any unrelated warnings
         relevant_warnings = [w for w in warning_list if 'deprecated' in str(w.message).lower()]
@@ -247,10 +221,6 @@ class TestAPIConsistency:
         tajd_new = diversity.tajimas_d(matrix)
         assert type(tajd_old) == type(tajd_new) == float
 
-        afs_old = matrix.allele_frequency_spectrum()
-        afs_new = diversity.allele_frequency_spectrum(matrix)
-        assert type(afs_old) == type(afs_new)  # Both should be same array type
-
 
 class TestDocumentationExamples:
     """Test examples that might be in documentation to ensure they still work."""
@@ -297,7 +267,6 @@ class TestDocumentationExamples:
             'pi': matrix.diversity(span_normalize=True),
             'theta': matrix.watersons_theta(span_normalize=True),
             'tajimas_d': matrix.Tajimas_D(),
-            'afs': matrix.allele_frequency_spectrum()
         }
 
         # New workflow
@@ -305,23 +274,9 @@ class TestDocumentationExamples:
             'pi': diversity.pi(matrix, span_normalize=True),
             'theta': diversity.theta_w(matrix, span_normalize=True),
             'tajimas_d': diversity.tajimas_d(matrix),
-            'afs': diversity.allele_frequency_spectrum(matrix)
         }
 
         # Should be identical
         assert abs(old_results['pi'] - new_results['pi']) < 1e-15
         assert abs(old_results['theta'] - new_results['theta']) < 1e-15
         assert abs(old_results['tajimas_d'] - new_results['tajimas_d']) < 1e-15
-
-        # AFS arrays should be identical
-        if hasattr(old_results['afs'], 'get'):
-            old_afs = np.asarray(old_results['afs'])
-        else:
-            old_afs = old_results['afs']
-
-        if hasattr(new_results['afs'], 'get'):
-            new_afs = np.asarray(new_results['afs'])
-        else:
-            new_afs = new_results['afs']
-
-        np.testing.assert_array_equal(old_afs, new_afs)

--- a/tests/test_decomposition_multiallelic.py
+++ b/tests/test_decomposition_multiallelic.py
@@ -1,179 +1,25 @@
 """Multiallelic-correctness tests for decomposition PCA.
 
-The PCA standardization is a per-allele one-hot (drop reference, marginal Patterson
-scaling), with biallelic and multiallelic columns computed separately and summed.
-These tests pin: biallelic bit-identity (against the previous standardization
-reproduced here, and against scikit-allel), the multiallelic covariance against an
-independent host reference, index-independence, the scikit-allel-on-expanded subspace
-oracle, the missing-data requirements, and deferred == dense.
+pca / randomized_pca use the all-allele centered standardization (every present
+allele including the reference, centered by its frequency, no variance scaling),
+so the Gram X @ X.T normalized by the number of segregating sites is exactly the
+site-mode genetic_relatedness matrix that tskit's PCA decomposes. These tests pin
+that convention: the Gram and explained variance against tskit, the randomized
+approximation against full pca, the GenotypeMatrix rejection, and the per-window
+all-allele path used by local_pca / lostruct / jackknife.
 """
 import numpy as np
 import cupy as cp
 import pytest
-import allel
 
 from pg_gpu import HaplotypeMatrix
-from pg_gpu._memutil import allele_counts
 from pg_gpu.decomposition import (
-    _prepare_matrix, _prepare_centered, _multiallelic_onehot_dense, _DeferredPCA,
-    _window_gram, pca, randomized_pca, local_pca, local_pca_jackknife, lostruct,
+    _prepare_centered, _window_gram, pca, randomized_pca,
+    local_pca, local_pca_jackknife, lostruct,
 )
 
 
-def _build_deferred(hap, scaler):
-    """Reproduce _prepare_matrix's _DeferredPCA construction (biallelic block
-    chunked + multiallelic one-hot block dense), so the deferred path can be
-    exercised without forcing the memory threshold."""
-    h = cp.asarray(hap)
-    bi = h.max(0) <= 1
-    hb, hmul = h[:, bi], h[:, ~bi]
-    ac, nv = allele_counts(hb, n_alleles=2)
-    dac = ac[:, 1:].sum(axis=1)
-    site_mean = cp.where(nv > 0, dac.astype(cp.float64) / nv.astype(cp.float64), 0.0)
-    if scaler == 'patterson':
-        scale = cp.sqrt(site_mean * (1 - site_mean))
-        scale = cp.where(scale > 0, scale, 1.0)
-    else:
-        scale = None
-    multi_cols, n_multi = _multiallelic_onehot_dense(hmul, scaler)
-    return _DeferredPCA(hb, site_mean, scale, scaler,
-                        multi_cols if n_multi else None)
-
-
-def _host_cov(hap, scaler='patterson'):
-    """Independent numpy reference: split standardization, summed column outer
-    products. Biallelic sites (max index <= 1) use the alt dosage; multiallelic
-    use per-present-derived-allele one-hot. Missing imputed to p (-> 0 centered)."""
-    hap = np.asarray(hap)
-    cols = []
-    for v in range(hap.shape[1]):
-        c = hap[:, v]
-        valid = c >= 0
-        nv = int(valid.sum())
-        mx = int(c[valid].max()) if nv else -1
-        if mx <= 1:
-            p = (c[valid].sum() / nv) if nv else 0.0
-            col = np.where(valid, c.astype(float), p) - p
-            s = np.sqrt(p * (1 - p))
-            cols.append(col / (s if s > 0 else 1.0))
-        else:
-            for a in range(1, int(c[valid].max()) + 1):
-                ca = int((c[valid] == a).sum())
-                if ca == 0:
-                    continue
-                p = ca / nv
-                col = np.where(valid, (c == a).astype(float), p) - p
-                s = np.sqrt(p * (1 - p))
-                cols.append(col / (s if s > 0 else 1.0))
-    X = np.array(cols).T
-    return X @ X.T
-
-
-def _expand_alt_alleles(hap):
-    """(n_expanded, n_samples) per-alt-allele indicators for scikit-allel PCA."""
-    rows = []
-    for v in range(hap.shape[1]):
-        c = hap[:, v]
-        if c.max() <= 1:
-            rows.append((c == 1).astype(float))
-        else:
-            for a in range(1, int(c.max()) + 1):
-                if (c == a).any():
-                    rows.append((c == a).astype(float))
-    return np.array(rows)
-
-
-def _multiallelic_hap(seed=0, missing=False):
-    rng = np.random.RandomState(seed)
-    n = 24
-    hap = rng.randint(0, 2, (n, 30)).astype(np.int8)
-    hap[:, 5] = rng.randint(0, 3, n)      # triallelic
-    hap[:, 10] = rng.choice([0, 2], n)    # 2 alleles, coded {0,2}
-    hap[:, 15] = rng.randint(0, 4, n)     # quadallelic
-    if missing:
-        hap[rng.random(hap.shape) < 0.1] = -1
-    return hap
-
-
-def _hm(hap):
-    return HaplotypeMatrix(hap, np.arange(hap.shape[1]) * 10,
-                           chrom_start=0, chrom_end=hap.shape[1] * 10)
-
-
 class TestDecompositionMultiallelic:
-
-    @pytest.mark.parametrize("missing", [False, True])
-    def test_covariance_matches_host_reference(self, missing):
-        hap = _multiallelic_hap(seed=1, missing=missing)
-        X = _prepare_matrix(_hm(hap), 'patterson', None, 'include')
-        cov = cp.asnumpy(X @ X.T)
-        np.testing.assert_allclose(cov, _host_cov(hap), rtol=1e-9, atol=1e-9)
-
-    def test_index_independence(self):
-        # A 2-allele site coded {0,2} gives the same gram as coded {0,1}.
-        hap = _multiallelic_hap(seed=2)
-        hap01 = hap.copy()
-        hap01[:, 10] = np.where(hap[:, 10] == 2, 1, 0)   # recode site 10 to {0,1}
-        g0 = cp.asnumpy((lambda X: X @ X.T)(_prepare_matrix(_hm(hap), 'patterson', None, 'include')))
-        g1 = cp.asnumpy((lambda X: X @ X.T)(_prepare_matrix(_hm(hap01), 'patterson', None, 'include')))
-        np.testing.assert_allclose(g0, g1, rtol=1e-10, atol=1e-10)
-
-    def test_biallelic_bit_identical_to_previous(self):
-        rng = np.random.RandomState(3)
-        hb = rng.randint(0, 2, (24, 40)).astype(np.int8)
-        hb[rng.random(hb.shape) < 0.1] = -1
-
-        def old_prepare(h):
-            # Reproduces the previous standardization (alt dosage: count of
-            # allele 1 over non-missing), computed here directly.
-            h = cp.asarray(h)
-            d = cp.sum(h == 1, axis=0)
-            nv = cp.sum(h >= 0, axis=0)
-            sm = cp.where(nv > 0, d.astype(cp.float64) / nv, 0.0)
-            sc = cp.sqrt(sm * (1 - sm))
-            sc = cp.where(sc > 0, sc, 1.0)
-            vm = h >= 0
-            X = cp.where(vm, h, 0).astype(cp.float64)
-            X = cp.where(vm, X, sm[None, :])
-            X -= sm
-            X /= sc
-            return X
-
-        Xnew = _prepare_matrix(_hm(hb), 'patterson', None, 'include')
-        assert bool((Xnew == old_prepare(hb)).all().get())
-
-    def test_missing_is_not_reference(self):
-        # Triallelic site: missing row -> 0 after centering; reference carrier -> -p/scale.
-        site = np.array([0, 1, 2, 2, 0, -1, 1, 2], dtype=np.int8)[:, None]
-        cols, _ = _multiallelic_onehot_dense(cp.asarray(site), 'patterson')
-        cols = cp.asnumpy(cols)
-        p1 = 2 / 7                                  # allele 1: 2 copies over 7 valid
-        s1 = np.sqrt(p1 * (1 - p1))
-        assert np.isclose(cols[5, 0], 0.0, atol=1e-12)          # missing -> 0
-        assert np.isclose(cols[0, 0], (0 - p1) / s1, atol=1e-12)  # ref carrier -> -p/s
-        assert not np.isclose(cols[5, 0], cols[0, 0])
-
-    def test_deferred_gram_equals_dense(self):
-        hap = _multiallelic_hap(seed=4, missing=True)
-        X = _prepare_matrix(_hm(hap), 'patterson', None, 'include')
-        dp = _build_deferred(hap, 'patterson')
-        np.testing.assert_allclose(cp.asnumpy(dp.chunked_gram()),
-                                   cp.asnumpy(X @ X.T), rtol=1e-10, atol=1e-10)
-
-    def test_deferred_matmul_transpose_match_dense(self):
-        # The memory-constrained randomized_pca path uses _DeferredPCA @ Omega and
-        # .T @ Y over the concatenated [biallelic | multiallelic] columns; verify
-        # both against the dense standardized matrix (closes the deferred+multi gap).
-        hap = _multiallelic_hap(seed=7, missing=True)
-        X = _prepare_matrix(_hm(hap), 'patterson', None, 'include')
-        dp = _build_deferred(hap, 'patterson')
-        rng = np.random.RandomState(11)
-        Om = cp.asarray(rng.randn(X.shape[1], 5))
-        Y = cp.asarray(rng.randn(X.shape[0], 5))
-        np.testing.assert_allclose(cp.asnumpy(dp @ Om), cp.asnumpy(X @ Om),
-                                   rtol=1e-9, atol=1e-9)
-        np.testing.assert_allclose(cp.asnumpy(dp.T @ Y), cp.asnumpy(X.T @ Y),
-                                   rtol=1e-9, atol=1e-9)
 
     def test_pca_gram_matches_tskit_relatedness(self, multiallelic_hm):
         # The centered all-allele Gram (proportion-normalized) is exactly the
@@ -203,12 +49,32 @@ class TestDecompositionMultiallelic:
         np.testing.assert_allclose(evr, evals[:4] / evals.sum(),
                                    atol=1e-9, rtol=1e-6)
 
+    def test_randomized_pca_matches_pca(self, multiallelic_hm):
+        # Randomized PCA shares pca's all-allele standardization, so it should
+        # recover the same explained-variance ratios and the same top subspace
+        # (columns equal up to sign).
+        _, hm = multiallelic_hm
+        coords, evr = pca(hm, n_components=4)
+        rcoords, revr = randomized_pca(hm, n_components=4, n_iter=7,
+                                       random_state=0)
+        np.testing.assert_allclose(revr, evr, atol=1e-6, rtol=1e-5)
+        for j in range(coords.shape[1]):
+            corr = np.corrcoef(coords[:, j], rcoords[:, j])[0, 1]
+            assert abs(corr) > 1 - 1e-6
+
     def test_pca_rejects_genotype_matrix(self):
         from pg_gpu import GenotypeMatrix
         gm = GenotypeMatrix(np.random.RandomState(0).randint(0, 3, (5, 20)).astype(np.int8),
                             np.arange(20) * 100)
         with pytest.raises(TypeError, match="pca_dosage"):
             pca(gm)
+
+    def test_randomized_pca_rejects_genotype_matrix(self):
+        from pg_gpu import GenotypeMatrix
+        gm = GenotypeMatrix(np.random.RandomState(0).randint(0, 3, (5, 20)).astype(np.int8),
+                            np.arange(20) * 100)
+        with pytest.raises(TypeError, match="randomized_pca_dosage"):
+            randomized_pca(gm)
 
 
 def _windowed_multiallelic_hm(seed=0, n=40, nv=120):
@@ -225,9 +91,9 @@ def _windowed_multiallelic_hm(seed=0, n=40, nv=120):
 
 
 class TestLocalPCAMultiallelic:
-    """local_pca / lostruct / jackknife route each window through _prepare_matrix,
-    so per-window results are per-allele-correct. scaler=None (center-only) is the
-    local_pca / lostruct default and is what these exercise."""
+    """local_pca / lostruct / jackknife route each window through
+    _prepare_centered (the all-allele centered standardization) and _window_gram,
+    so per-window results are per-allele-correct."""
 
     def _direct_eigvals(self, hap_sub, pos_sub, s, e, k):
         sub = HaplotypeMatrix(hap_sub, pos_sub, int(s), int(e))

--- a/tests/test_decomposition_multiallelic.py
+++ b/tests/test_decomposition_multiallelic.py
@@ -1,0 +1,273 @@
+"""Multiallelic-correctness tests for decomposition PCA.
+
+The PCA standardization is a per-allele one-hot (drop reference, marginal Patterson
+scaling), with biallelic and multiallelic columns computed separately and summed.
+These tests pin: biallelic bit-identity (against the previous standardization
+reproduced here, and against scikit-allel), the multiallelic covariance against an
+independent host reference, index-independence, the scikit-allel-on-expanded subspace
+oracle, the missing-data requirements, and deferred == dense.
+"""
+import numpy as np
+import cupy as cp
+import pytest
+import allel
+
+from pg_gpu import HaplotypeMatrix
+from pg_gpu._memutil import allele_counts
+from pg_gpu.decomposition import (
+    _prepare_matrix, _multiallelic_onehot_dense, _DeferredPCA, _window_gram,
+    pca, randomized_pca, local_pca, local_pca_jackknife, lostruct,
+)
+
+
+def _build_deferred(hap, scaler):
+    """Reproduce _prepare_matrix's _DeferredPCA construction (biallelic block
+    chunked + multiallelic one-hot block dense), so the deferred path can be
+    exercised without forcing the memory threshold."""
+    h = cp.asarray(hap)
+    bi = h.max(0) <= 1
+    hb, hmul = h[:, bi], h[:, ~bi]
+    ac, nv = allele_counts(hb, n_alleles=2)
+    dac = ac[:, 1:].sum(axis=1)
+    site_mean = cp.where(nv > 0, dac.astype(cp.float64) / nv.astype(cp.float64), 0.0)
+    if scaler == 'patterson':
+        scale = cp.sqrt(site_mean * (1 - site_mean))
+        scale = cp.where(scale > 0, scale, 1.0)
+    else:
+        scale = None
+    multi_cols, n_multi = _multiallelic_onehot_dense(hmul, scaler)
+    return _DeferredPCA(hb, site_mean, scale, scaler,
+                        multi_cols if n_multi else None)
+
+
+def _host_cov(hap, scaler='patterson'):
+    """Independent numpy reference: split standardization, summed column outer
+    products. Biallelic sites (max index <= 1) use the alt dosage; multiallelic
+    use per-present-derived-allele one-hot. Missing imputed to p (-> 0 centered)."""
+    hap = np.asarray(hap)
+    cols = []
+    for v in range(hap.shape[1]):
+        c = hap[:, v]
+        valid = c >= 0
+        nv = int(valid.sum())
+        mx = int(c[valid].max()) if nv else -1
+        if mx <= 1:
+            p = (c[valid].sum() / nv) if nv else 0.0
+            col = np.where(valid, c.astype(float), p) - p
+            s = np.sqrt(p * (1 - p))
+            cols.append(col / (s if s > 0 else 1.0))
+        else:
+            for a in range(1, int(c[valid].max()) + 1):
+                ca = int((c[valid] == a).sum())
+                if ca == 0:
+                    continue
+                p = ca / nv
+                col = np.where(valid, (c == a).astype(float), p) - p
+                s = np.sqrt(p * (1 - p))
+                cols.append(col / (s if s > 0 else 1.0))
+    X = np.array(cols).T
+    return X @ X.T
+
+
+def _expand_alt_alleles(hap):
+    """(n_expanded, n_samples) per-alt-allele indicators for scikit-allel PCA."""
+    rows = []
+    for v in range(hap.shape[1]):
+        c = hap[:, v]
+        if c.max() <= 1:
+            rows.append((c == 1).astype(float))
+        else:
+            for a in range(1, int(c.max()) + 1):
+                if (c == a).any():
+                    rows.append((c == a).astype(float))
+    return np.array(rows)
+
+
+def _multiallelic_hap(seed=0, missing=False):
+    rng = np.random.RandomState(seed)
+    n = 24
+    hap = rng.randint(0, 2, (n, 30)).astype(np.int8)
+    hap[:, 5] = rng.randint(0, 3, n)      # triallelic
+    hap[:, 10] = rng.choice([0, 2], n)    # 2 alleles, coded {0,2}
+    hap[:, 15] = rng.randint(0, 4, n)     # quadallelic
+    if missing:
+        hap[rng.random(hap.shape) < 0.1] = -1
+    return hap
+
+
+def _hm(hap):
+    return HaplotypeMatrix(hap, np.arange(hap.shape[1]) * 10,
+                           chrom_start=0, chrom_end=hap.shape[1] * 10)
+
+
+class TestDecompositionMultiallelic:
+
+    @pytest.mark.parametrize("missing", [False, True])
+    def test_covariance_matches_host_reference(self, missing):
+        hap = _multiallelic_hap(seed=1, missing=missing)
+        X = _prepare_matrix(_hm(hap), 'patterson', None, 'include')
+        cov = cp.asnumpy(X @ X.T)
+        np.testing.assert_allclose(cov, _host_cov(hap), rtol=1e-9, atol=1e-9)
+
+    def test_index_independence(self):
+        # A 2-allele site coded {0,2} gives the same gram as coded {0,1}.
+        hap = _multiallelic_hap(seed=2)
+        hap01 = hap.copy()
+        hap01[:, 10] = np.where(hap[:, 10] == 2, 1, 0)   # recode site 10 to {0,1}
+        g0 = cp.asnumpy((lambda X: X @ X.T)(_prepare_matrix(_hm(hap), 'patterson', None, 'include')))
+        g1 = cp.asnumpy((lambda X: X @ X.T)(_prepare_matrix(_hm(hap01), 'patterson', None, 'include')))
+        np.testing.assert_allclose(g0, g1, rtol=1e-10, atol=1e-10)
+
+    def test_biallelic_bit_identical_to_previous(self):
+        rng = np.random.RandomState(3)
+        hb = rng.randint(0, 2, (24, 40)).astype(np.int8)
+        hb[rng.random(hb.shape) < 0.1] = -1
+
+        def old_prepare(h):
+            # Reproduces the previous standardization (alt dosage: count of
+            # allele 1 over non-missing), computed here directly.
+            h = cp.asarray(h)
+            d = cp.sum(h == 1, axis=0)
+            nv = cp.sum(h >= 0, axis=0)
+            sm = cp.where(nv > 0, d.astype(cp.float64) / nv, 0.0)
+            sc = cp.sqrt(sm * (1 - sm))
+            sc = cp.where(sc > 0, sc, 1.0)
+            vm = h >= 0
+            X = cp.where(vm, h, 0).astype(cp.float64)
+            X = cp.where(vm, X, sm[None, :])
+            X -= sm
+            X /= sc
+            return X
+
+        Xnew = _prepare_matrix(_hm(hb), 'patterson', None, 'include')
+        assert bool((Xnew == old_prepare(hb)).all().get())
+
+    def test_missing_is_not_reference(self):
+        # Triallelic site: missing row -> 0 after centering; reference carrier -> -p/scale.
+        site = np.array([0, 1, 2, 2, 0, -1, 1, 2], dtype=np.int8)[:, None]
+        cols, _ = _multiallelic_onehot_dense(cp.asarray(site), 'patterson')
+        cols = cp.asnumpy(cols)
+        p1 = 2 / 7                                  # allele 1: 2 copies over 7 valid
+        s1 = np.sqrt(p1 * (1 - p1))
+        assert np.isclose(cols[5, 0], 0.0, atol=1e-12)          # missing -> 0
+        assert np.isclose(cols[0, 0], (0 - p1) / s1, atol=1e-12)  # ref carrier -> -p/s
+        assert not np.isclose(cols[5, 0], cols[0, 0])
+
+    def test_deferred_gram_equals_dense(self):
+        hap = _multiallelic_hap(seed=4, missing=True)
+        X = _prepare_matrix(_hm(hap), 'patterson', None, 'include')
+        dp = _build_deferred(hap, 'patterson')
+        np.testing.assert_allclose(cp.asnumpy(dp.chunked_gram()),
+                                   cp.asnumpy(X @ X.T), rtol=1e-10, atol=1e-10)
+
+    def test_deferred_matmul_transpose_match_dense(self):
+        # The memory-constrained randomized_pca path uses _DeferredPCA @ Omega and
+        # .T @ Y over the concatenated [biallelic | multiallelic] columns; verify
+        # both against the dense standardized matrix (closes the deferred+multi gap).
+        hap = _multiallelic_hap(seed=7, missing=True)
+        X = _prepare_matrix(_hm(hap), 'patterson', None, 'include')
+        dp = _build_deferred(hap, 'patterson')
+        rng = np.random.RandomState(11)
+        Om = cp.asarray(rng.randn(X.shape[1], 5))
+        Y = cp.asarray(rng.randn(X.shape[0], 5))
+        np.testing.assert_allclose(cp.asnumpy(dp @ Om), cp.asnumpy(X @ Om),
+                                   rtol=1e-9, atol=1e-9)
+        np.testing.assert_allclose(cp.asnumpy(dp.T @ Y), cp.asnumpy(X.T @ Y),
+                                   rtol=1e-9, atol=1e-9)
+
+    def test_randomized_pca_matches_pca_multiallelic(self):
+        hap = _multiallelic_hap(seed=8)
+        exact = pca(_hm(hap), n_components=4, scaler='patterson')[0]
+        approx = randomized_pca(_hm(hap), n_components=4, scaler='patterson',
+                                random_state=0)[0]
+        for k in range(4):
+            corr = abs(np.corrcoef(exact[:, k], approx[:, k])[0, 1])
+            assert corr > 0.99, f"PC{k} |corr|={corr:.4f}"
+
+    @pytest.mark.parametrize("scaler", ['standard', None])
+    def test_scaler_variants_match_allel_on_expanded(self, scaler):
+        hap = _multiallelic_hap(seed=9)
+        coords_ours = pca(_hm(hap), n_components=4, scaler=scaler)[0]
+        coords_allel, _ = allel.pca(_expand_alt_alleles(hap), n_components=4,
+                                    scaler=scaler, ploidy=1)
+        for k in range(4):
+            corr = abs(np.corrcoef(coords_ours[:, k], coords_allel[:, k])[0, 1])
+            assert corr > 0.9999, f"scaler={scaler} PC{k} |corr|={corr:.5f}"
+
+    @pytest.mark.parametrize("hap_fn", [
+        lambda: np.random.RandomState(5).randint(0, 2, (24, 40)).astype(np.int8),  # biallelic
+        lambda: _multiallelic_hap(seed=6),                                          # multiallelic
+    ])
+    def test_pca_subspace_matches_allel_on_expanded(self, hap_fn):
+        hap = hap_fn()
+        coords_ours = pca(_hm(hap), n_components=4, scaler='patterson')[0]
+        coords_allel, _ = allel.pca(_expand_alt_alleles(hap), n_components=4,
+                                    scaler='patterson', ploidy=1)
+        for k in range(4):
+            corr = abs(np.corrcoef(coords_ours[:, k], coords_allel[:, k])[0, 1])
+            assert corr > 0.9999, f"PC{k} |corr|={corr:.5f}"
+
+
+def _windowed_multiallelic_hm(seed=0, n=40, nv=120):
+    """Multiallelic HaplotypeMatrix with positions, enough sites for several
+    windows (~30 sites/window at window_size=3000)."""
+    rng = np.random.RandomState(seed)
+    hap = rng.randint(0, 2, (n, nv)).astype(np.int8)
+    for j in range(0, nv, 7):
+        hap[:, j] = rng.randint(0, 3, n)
+    for j in range(0, nv, 17):
+        hap[:, j] = rng.randint(0, 4, n)
+    pos = np.arange(nv) * 100
+    return HaplotypeMatrix(hap, pos, 0, nv * 100), hap, pos
+
+
+class TestLocalPCAMultiallelic:
+    """local_pca / lostruct / jackknife route each window through _prepare_matrix,
+    so per-window results are per-allele-correct. scaler=None (center-only) is the
+    local_pca / lostruct default and is what these exercise."""
+
+    def _direct_eigvals(self, hap_sub, pos_sub, s, e, k):
+        sub = HaplotypeMatrix(hap_sub, pos_sub, int(s), int(e))
+        X = _prepare_matrix(sub, None, None, 'include')
+        C, _ = _window_gram(X, X.shape[1])
+        return np.sort(cp.asnumpy(cp.linalg.eigh(C)[0]))[::-1][:k]
+
+    def test_single_window_matches_direct(self):
+        hm, hap, pos = _windowed_multiallelic_hm(seed=1)
+        seqlen = hap.shape[1] * 100
+        res = local_pca(hm, k=3, window_type='bp', window_size=seqlen + 1000,
+                        scaler=None)
+        direct = self._direct_eigvals(hap, pos, 0, seqlen + 1000, 3)
+        np.testing.assert_allclose(res.eigvals[0], direct, rtol=1e-8, atol=1e-8)
+
+    def test_per_window_matches_direct(self):
+        hm, hap, pos = _windowed_multiallelic_hm(seed=2)
+        res = local_pca(hm, k=2, window_type='bp', window_size=3000,
+                        step_size=3000, scaler=None)
+        valid = res.windows['n_variants'].values >= 2
+        assert not np.isnan(res.eigvals[valid]).any()
+        for w, (s, e, nvar) in enumerate(zip(res.windows['start'],
+                                             res.windows['end'],
+                                             res.windows['n_variants'])):
+            if nvar < 2:
+                continue
+            m = (pos >= s) & (pos < e)
+            direct = self._direct_eigvals(hap[:, m], pos[m], s, e, 2)
+            np.testing.assert_allclose(res.eigvals[w], direct, rtol=1e-7, atol=1e-7)
+
+    def test_lostruct_runs_finite(self):
+        hm, hap, pos = _windowed_multiallelic_hm(seed=3)
+        lo = lostruct(hm, k=2, window_type='bp', window_size=3000, step_size=3000,
+                      scaler=None)
+        assert np.isfinite(lo.distance).all()
+        assert np.isfinite(lo.mds).all()
+        np.testing.assert_allclose(lo.distance, lo.distance.T, atol=1e-10)
+
+    def test_jackknife_se_finite(self):
+        hm, hap, pos = _windowed_multiallelic_hm(seed=4)
+        res = local_pca(hm, k=2, window_type='bp', window_size=3000,
+                        step_size=3000, scaler=None)
+        se = local_pca_jackknife(hm, k=2, n_blocks=3, window_type='bp',
+                                 window_size=3000, step_size=3000, scaler=None)
+        valid = res.windows['n_variants'].values >= 6
+        assert np.isfinite(se[valid]).all()

--- a/tests/test_decomposition_multiallelic.py
+++ b/tests/test_decomposition_multiallelic.py
@@ -1,12 +1,13 @@
-"""Multiallelic-correctness tests for decomposition PCA.
+"""Multiallelic-correctness tests for the multi-allele haploid PCA.
 
 pca / randomized_pca use the all-allele centered standardization (every present
 allele including the reference, centered by its frequency, no variance scaling),
-so the Gram X @ X.T normalized by the number of segregating sites is exactly the
-site-mode genetic_relatedness matrix that tskit's PCA decomposes. These tests pin
-that convention: the Gram and explained variance against tskit, the randomized
-approximation against full pca, the GenotypeMatrix rejection, and the per-window
-all-allele path used by local_pca / lostruct / jackknife.
+so the Gram X @ X.T normalized by the number of segregating sites is the genetic
+relatedness matrix (the centered per-allele covariance between samples). These
+tests pin it against the tree sequence's genetic_relatedness output as an external
+oracle: the Gram and explained variance, the randomized approximation against full
+pca, the GenotypeMatrix rejection, and the per-window all-allele path used by
+local_pca / lostruct / jackknife.
 """
 import numpy as np
 import cupy as cp
@@ -21,10 +22,10 @@ from pg_gpu.decomposition import (
 
 class TestDecompositionMultiallelic:
 
-    def test_pca_gram_matches_tskit_relatedness(self, multiallelic_hm):
-        # The centered all-allele Gram (proportion-normalized) is exactly the
-        # site-mode genetic_relatedness matrix -- the matrix tskit's PCA
-        # decomposes. This pins the whole tskit convention.
+    def test_pca_gram_matches_tree_sequence_relatedness(self, multiallelic_hm):
+        # The centered all-allele Gram (normalized by segregating sites) is the
+        # genetic relatedness matrix; pin it against the tree sequence's
+        # genetic_relatedness output as an external oracle.
         ts, hm = multiallelic_hm
         X, n_seg = _prepare_centered(hm)
         C = cp.asnumpy((X @ X.T) / n_seg)
@@ -36,7 +37,7 @@ class TestDecompositionMultiallelic:
             proportion=True)).reshape(n, n)
         np.testing.assert_allclose(C, G, atol=1e-9, rtol=1e-6)
 
-    def test_pca_explained_variance_matches_tskit(self, multiallelic_hm):
+    def test_pca_explained_variance_matches_tree_sequence(self, multiallelic_hm):
         ts, hm = multiallelic_hm
         n = ts.num_samples
         sets = [[s] for s in ts.samples()]

--- a/tests/test_decomposition_multiallelic.py
+++ b/tests/test_decomposition_multiallelic.py
@@ -231,22 +231,21 @@ class TestLocalPCAMultiallelic:
 
     def _direct_eigvals(self, hap_sub, pos_sub, s, e, k):
         sub = HaplotypeMatrix(hap_sub, pos_sub, int(s), int(e))
-        X = _prepare_matrix(sub, None, None, 'include')
+        X, _ = _prepare_centered(sub, missing_data='include', need_segregating=False)
         C, _ = _window_gram(X, X.shape[1])
         return np.sort(cp.asnumpy(cp.linalg.eigh(C)[0]))[::-1][:k]
 
     def test_single_window_matches_direct(self):
         hm, hap, pos = _windowed_multiallelic_hm(seed=1)
         seqlen = hap.shape[1] * 100
-        res = local_pca(hm, k=3, window_type='bp', window_size=seqlen + 1000,
-                        scaler=None)
+        res = local_pca(hm, k=3, window_type='bp', window_size=seqlen + 1000)
         direct = self._direct_eigvals(hap, pos, 0, seqlen + 1000, 3)
         np.testing.assert_allclose(res.eigvals[0], direct, rtol=1e-8, atol=1e-8)
 
     def test_per_window_matches_direct(self):
         hm, hap, pos = _windowed_multiallelic_hm(seed=2)
         res = local_pca(hm, k=2, window_type='bp', window_size=3000,
-                        step_size=3000, scaler=None)
+                        step_size=3000)
         valid = res.windows['n_variants'].values >= 2
         assert not np.isnan(res.eigvals[valid]).any()
         for w, (s, e, nvar) in enumerate(zip(res.windows['start'],
@@ -260,8 +259,7 @@ class TestLocalPCAMultiallelic:
 
     def test_lostruct_runs_finite(self):
         hm, hap, pos = _windowed_multiallelic_hm(seed=3)
-        lo = lostruct(hm, k=2, window_type='bp', window_size=3000, step_size=3000,
-                      scaler=None)
+        lo = lostruct(hm, k=2, window_type='bp', window_size=3000, step_size=3000)
         assert np.isfinite(lo.distance).all()
         assert np.isfinite(lo.mds).all()
         np.testing.assert_allclose(lo.distance, lo.distance.T, atol=1e-10)
@@ -269,8 +267,8 @@ class TestLocalPCAMultiallelic:
     def test_jackknife_se_finite(self):
         hm, hap, pos = _windowed_multiallelic_hm(seed=4)
         res = local_pca(hm, k=2, window_type='bp', window_size=3000,
-                        step_size=3000, scaler=None)
+                        step_size=3000)
         se = local_pca_jackknife(hm, k=2, n_blocks=3, window_type='bp',
-                                 window_size=3000, step_size=3000, scaler=None)
+                                 window_size=3000, step_size=3000)
         valid = res.windows['n_variants'].values >= 6
         assert np.isfinite(se[valid]).all()

--- a/tests/test_decomposition_multiallelic.py
+++ b/tests/test_decomposition_multiallelic.py
@@ -15,8 +15,8 @@ import allel
 from pg_gpu import HaplotypeMatrix
 from pg_gpu._memutil import allele_counts
 from pg_gpu.decomposition import (
-    _prepare_matrix, _multiallelic_onehot_dense, _DeferredPCA, _window_gram,
-    pca, randomized_pca, local_pca, local_pca_jackknife, lostruct,
+    _prepare_matrix, _prepare_centered, _multiallelic_onehot_dense, _DeferredPCA,
+    _window_gram, pca, randomized_pca, local_pca, local_pca_jackknife, lostruct,
 )
 
 
@@ -175,37 +175,40 @@ class TestDecompositionMultiallelic:
         np.testing.assert_allclose(cp.asnumpy(dp.T @ Y), cp.asnumpy(X.T @ Y),
                                    rtol=1e-9, atol=1e-9)
 
-    def test_randomized_pca_matches_pca_multiallelic(self):
-        hap = _multiallelic_hap(seed=8)
-        exact = pca(_hm(hap), n_components=4, scaler='patterson')[0]
-        approx = randomized_pca(_hm(hap), n_components=4, scaler='patterson',
-                                random_state=0)[0]
-        for k in range(4):
-            corr = abs(np.corrcoef(exact[:, k], approx[:, k])[0, 1])
-            assert corr > 0.99, f"PC{k} |corr|={corr:.4f}"
+    def test_pca_gram_matches_tskit_relatedness(self, multiallelic_hm):
+        # The centered all-allele Gram (proportion-normalized) is exactly the
+        # site-mode genetic_relatedness matrix -- the matrix tskit's PCA
+        # decomposes. This pins the whole tskit convention.
+        ts, hm = multiallelic_hm
+        X, n_seg = _prepare_centered(hm)
+        C = cp.asnumpy((X @ X.T) / n_seg)
+        n = ts.num_samples
+        sets = [[s] for s in ts.samples()]
+        idx = [(i, j) for i in range(n) for j in range(n)]
+        G = np.asarray(ts.genetic_relatedness(
+            sets, indexes=idx, mode='site', centre=True, polarised=False,
+            proportion=True)).reshape(n, n)
+        np.testing.assert_allclose(C, G, atol=1e-9, rtol=1e-6)
 
-    @pytest.mark.parametrize("scaler", ['standard', None])
-    def test_scaler_variants_match_allel_on_expanded(self, scaler):
-        hap = _multiallelic_hap(seed=9)
-        coords_ours = pca(_hm(hap), n_components=4, scaler=scaler)[0]
-        coords_allel, _ = allel.pca(_expand_alt_alleles(hap), n_components=4,
-                                    scaler=scaler, ploidy=1)
-        for k in range(4):
-            corr = abs(np.corrcoef(coords_ours[:, k], coords_allel[:, k])[0, 1])
-            assert corr > 0.9999, f"scaler={scaler} PC{k} |corr|={corr:.5f}"
+    def test_pca_explained_variance_matches_tskit(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        n = ts.num_samples
+        sets = [[s] for s in ts.samples()]
+        idx = [(i, j) for i in range(n) for j in range(n)]
+        G = np.asarray(ts.genetic_relatedness(
+            sets, indexes=idx, mode='site', centre=True, polarised=False,
+            proportion=True)).reshape(n, n)
+        evals = np.sort(np.linalg.eigvalsh(G))[::-1]
+        _, evr = pca(hm, n_components=4)
+        np.testing.assert_allclose(evr, evals[:4] / evals.sum(),
+                                   atol=1e-9, rtol=1e-6)
 
-    @pytest.mark.parametrize("hap_fn", [
-        lambda: np.random.RandomState(5).randint(0, 2, (24, 40)).astype(np.int8),  # biallelic
-        lambda: _multiallelic_hap(seed=6),                                          # multiallelic
-    ])
-    def test_pca_subspace_matches_allel_on_expanded(self, hap_fn):
-        hap = hap_fn()
-        coords_ours = pca(_hm(hap), n_components=4, scaler='patterson')[0]
-        coords_allel, _ = allel.pca(_expand_alt_alleles(hap), n_components=4,
-                                    scaler='patterson', ploidy=1)
-        for k in range(4):
-            corr = abs(np.corrcoef(coords_ours[:, k], coords_allel[:, k])[0, 1])
-            assert corr > 0.9999, f"PC{k} |corr|={corr:.5f}"
+    def test_pca_rejects_genotype_matrix(self):
+        from pg_gpu import GenotypeMatrix
+        gm = GenotypeMatrix(np.random.RandomState(0).randint(0, 3, (5, 20)).astype(np.int8),
+                            np.arange(20) * 100)
+        with pytest.raises(TypeError, match="pca_dosage"):
+            pca(gm)
 
 
 def _windowed_multiallelic_hm(seed=0, n=40, nv=120):

--- a/tests/test_divergence.py
+++ b/tests/test_divergence.py
@@ -239,12 +239,14 @@ class TestDivergenceStats:
         # Compute all statistics
         stats = divergence.divergence_stats(
             matrix, 'popA', 'popB',
-            statistics=['fst', 'fst_hudson', 'fst_wc', 'fst_nei', 'dxy', 'da', 'pi1', 'pi2']
+            statistics=['fst', 'fst_hudson', 'fst_tskit', 'fst_wc', 'fst_nei',
+                        'dxy', 'da', 'pi1', 'pi2']
         )
 
         # Check all statistics are present
         assert 'fst' in stats
         assert 'fst_hudson' in stats
+        assert 'fst_tskit' in stats
         assert 'fst_wc' in stats
         assert 'fst_nei' in stats
         assert 'dxy' in stats

--- a/tests/test_diversity.py
+++ b/tests/test_diversity.py
@@ -7,6 +7,7 @@ import numpy as np
 import cupy as cp
 from pg_gpu import HaplotypeMatrix
 from pg_gpu import diversity
+from pg_gpu import sfs
 
 
 class TestNucleotideDiversity:
@@ -216,7 +217,7 @@ class TestAlleleFrequencySpectrum:
         positions = np.arange(n_variants) * 1000
         matrix = HaplotypeMatrix(haplotypes, positions)
 
-        afs = diversity.allele_frequency_spectrum(matrix)
+        afs = sfs.sfs(matrix)
 
         if isinstance(afs, np.ndarray):
             afs = np.asarray(afs)
@@ -243,7 +244,7 @@ class TestAlleleFrequencySpectrum:
         positions = np.arange(n_variants) * 1000
         matrix = HaplotypeMatrix(haplotypes, positions)
 
-        afs = diversity.allele_frequency_spectrum(matrix)
+        afs = sfs.sfs(matrix)
 
         if isinstance(afs, np.ndarray):
             afs = np.asarray(afs)
@@ -454,7 +455,7 @@ class TestGPUCalculations:
         assert isinstance(seg_sites, int)
 
         # AFS should return GPU array
-        afs = diversity.allele_frequency_spectrum(matrix)
+        afs = sfs.sfs(matrix)
         assert isinstance(afs, np.ndarray)
 
 

--- a/tests/test_diversity.py
+++ b/tests/test_diversity.py
@@ -221,11 +221,14 @@ class TestAlleleFrequencySpectrum:
         if isinstance(afs, np.ndarray):
             afs = np.asarray(afs)
 
-        # Should have 25 sites with 0 copies and 25 with n_samples copies
-        assert afs[0] == 25  # Sites with 0 derived alleles
-        assert afs[n_samples] == 25  # Sites with all derived alleles
-        # All other frequencies should be 0
-        assert np.sum(afs[1:n_samples]) == 0
+        # Per-allele polarised SFS (issue #100): both fixed classes are excluded,
+        # matching tskit. A monomorphic-ancestral site has no derived allele
+        # (bin 0), and a fully-derived site is monomorphic-derived (bin n) -- so
+        # neither contributes and the whole spectrum is empty here. (Invariant
+        # counting is a separate concern: FrequencySpectrum's n_total_sites.)
+        assert afs[0] == 0
+        assert afs[n_samples] == 0
+        assert np.sum(afs) == 0
 
     def test_afs_singletons(self):
         """Test AFS with singleton sites."""

--- a/tests/test_haplotype_matrix.py
+++ b/tests/test_haplotype_matrix.py
@@ -290,12 +290,14 @@ def test_transfer_to_cpu():
 
 
 def test_allele_frequency_spectrum(sample_vcf):
-    """Test calculation of allele frequency spectrum."""
+    """Test calculation of the SFS (formerly HaplotypeMatrix.allele_frequency_spectrum,
+    removed in the issue #100 consolidation; the SFS now lives in the sfs module)."""
+    from pg_gpu import sfs as sfs_mod
     hap_matrix = HaplotypeMatrix.from_vcf(sample_vcf)
-    afs = hap_matrix.allele_frequency_spectrum()
+    afs = sfs_mod.sfs(hap_matrix)
     assert isinstance(afs, np.ndarray)
     assert afs.ndim == 1
-    # AFS has n+1 bins for frequencies 0 to n
+    # SFS has n+1 bins for frequencies 0 to n
     assert afs.size == hap_matrix.num_haplotypes + 1
 
 def test_diversity(sample_vcf):

--- a/tests/test_implementation_parity.py
+++ b/tests/test_implementation_parity.py
@@ -1,0 +1,463 @@
+"""Cross-implementation parity tests.
+
+The same population-genetic statistics are computed by several independent code
+paths in pg_gpu:
+
+  1. scalar functions            -- ``diversity.pi``, ``divergence.dxy``, ...
+  2. ``FrequencySpectrum``       -- SFS dot-product path
+  3. windowed "scatter" engine   -- ``_windowed_thetas_scatter`` / ``_windowed_twopop_scatter``
+  4. windowed "fused" engine     -- ``windowed_statistics_fused`` (CUDA kernels)
+  5. windowed "python-loop"      -- ``WindowedAnalyzer`` per-window fallback
+
+Nothing else in the suite asserts these agree. This module does. Each statistic
+is described once in the ``_STATS`` registry -- which paths compute it, how to
+invoke each, and the span-independent "canonical quantity" to compare -- and the
+parametrized test drives every supported path across four data conditions
+(clean, missing/include, missing/exclude, multiallelic) and asserts it matches
+the scalar reference.
+
+Every path is invoked so its return value is the same span-independent
+quantity, compared by ``kind``:
+
+  * value -- the statistic as returned (raw per-site sum, ratio, or
+             dimensionless test statistic), compared with a tolerance
+  * count -- an integer count, compared exactly
+
+Known divergences between paths are recorded in ``_XFAILS`` as ``strict``
+xfails with a reason. A ``(stat, path)`` may carry several condition-scoped
+rules (e.g. one divergence under missing data and a different one under
+multiallelic sites). Each is a defect to fix in a follow-up, at which point
+the rule is removed and the cell flips to a pass.
+"""
+
+from collections import namedtuple
+
+import numpy as np
+import pytest
+
+from pg_gpu import HaplotypeMatrix, diversity, divergence
+from pg_gpu.diversity import FrequencySpectrum
+from pg_gpu.windowed_analysis import (
+    WindowedAnalyzer,
+    _windowed_thetas_scatter,
+    _windowed_twopop_scatter,
+    windowed_statistics_fused,
+)
+
+from .conftest import simulate_hm
+
+try:
+    import cupy as cp
+    _GPU = cp.cuda.runtime.getDeviceCount() > 0
+except Exception:  # pragma: no cover - import/driver failure means no GPU
+    _GPU = False
+
+pytestmark = pytest.mark.skipif(not _GPU, reason="parity suite requires a CUDA GPU")
+
+POP1, POP2 = "pop1", "pop2"
+RTOL, ATOL = 1e-9, 1e-12
+
+
+def _asnumpy(x):
+    """Host numpy array regardless of whether ``x`` is a CuPy or numpy array."""
+    return np.asarray(x.get() if hasattr(x, "get") else x)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _two_pop_split(hm):
+    # Even haplotype count per population: fst_weir_cockerham pairs consecutive
+    # haplotypes into diploid individuals and requires an even count.
+    nhap = hm.num_haplotypes
+    half = nhap // 2
+    hm.sample_sets = {POP1: list(range(half)), POP2: list(range(half, nhap))}
+    return hm
+
+
+@pytest.fixture(scope="module")
+def clean_hm():
+    """Clean biallelic matrix (no missing) split into two populations.
+
+    ``mutation_model='binary'`` forces biallelic sites, sidestepping the
+    multiallelic folding gap so the paths are expected to agree exactly here.
+    """
+    hm = simulate_hm(n_samples=24, seq_length=200_000, seed=7,
+                     mutation_model="binary")
+    hm.transfer_to_gpu()
+    return _two_pop_split(hm)
+
+
+@pytest.fixture(scope="module")
+def missing_hm():
+    """Biallelic matrix with structured missingness.
+
+    Even-indexed sites get ~30% missing entries except one protected
+    haplotype per population, so every site keeps at least one valid sample in
+    each pop (the per-site dxy/da denominator stays the full variant count
+    under ``include``). Odd-indexed sites are fully complete, so ``exclude``
+    mode retains a substantial, well-defined subset of sites.
+    """
+    hm0 = simulate_hm(n_samples=24, seq_length=200_000, seed=7,
+                      mutation_model="binary")
+
+    hap = _asnumpy(hm0.haplotypes).astype(np.int8).copy()
+    pos = _asnumpy(hm0.positions)
+
+    nhap, nvar = hap.shape
+    half = nhap // 2
+    protected = {0, half}
+    rng = np.random.RandomState(99)
+    for v in range(0, nvar, 2):
+        for h in range(nhap):
+            if h not in protected and rng.random() < 0.3:
+                hap[h, v] = -1
+
+    # The per-site dxy/da denominator under 'include' relies on every site
+    # keeping at least one valid sample in each pop; make that a loud contract
+    # so a future fixture edit that breaks it fails here, not silently.
+    assert (hap[:half] >= 0).any(axis=0).all()
+    assert (hap[half:] >= 0).any(axis=0).all()
+
+    cs = hm0.chrom_start if hm0.chrom_start is not None else int(pos[0])
+    ce = hm0.chrom_end if hm0.chrom_end is not None else int(pos[-1])
+    hm = HaplotypeMatrix(hap, pos, cs, ce)
+    hm.transfer_to_gpu()
+    return _two_pop_split(hm)
+
+
+@pytest.fixture(scope="module")
+def multiallelic_hm():
+    """Matrix with multiallelic sites and no missing data.
+
+    msprime's default (Jukes-Cantor) mutation model produces triallelic sites,
+    stored with allele codes 0/1/2. Keeping missingness out isolates the
+    multiallelic folding behavior (#100) from the missing-data divergences.
+    """
+    hm = simulate_hm(n_samples=24, seq_length=200_000, seed=7, mutation_model=None)
+    hm.transfer_to_gpu()
+    return _two_pop_split(hm)
+
+
+# Data conditions, each declaring the data shape that drives path divergences.
+# ``partial_sites`` is True when the condition retains sites of variable
+# per-site sample size (the driver of the fs/scatter/fused divergences under
+# missing data); ``multiallelic`` is True when sites carry allele codes >= 2.
+_Condition = namedtuple("_Condition",
+                        ["fixture", "missing_data", "partial_sites", "multiallelic"])
+_CONDITIONS = {
+    "clean": _Condition("clean_hm", "include", False, False),
+    "missing_include": _Condition("missing_hm", "include", True, False),
+    "missing_exclude": _Condition("missing_hm", "exclude", False, False),
+    "multiallelic": _Condition("multiallelic_hm", "include", False, True),
+}
+_WHEN_PARTIAL = frozenset(
+    name for name, c in _CONDITIONS.items() if c.partial_sites)
+_WHEN_MULTIALLELIC = frozenset(
+    name for name, c in _CONDITIONS.items() if c.multiallelic)
+_WHEN_EXCLUDE = frozenset(
+    name for name, c in _CONDITIONS.items() if c.missing_data == "exclude")
+
+
+# ---------------------------------------------------------------------------
+# Whole-region window helpers
+# ---------------------------------------------------------------------------
+
+def _region_bounds(hm):
+    positions = _asnumpy(hm.positions)
+    start = hm.chrom_start if hm.chrom_start is not None else int(positions[0])
+    end = hm.chrom_end if hm.chrom_end is not None else int(positions[-1])
+    return min(int(start), int(positions[0])), max(int(end), int(positions[-1]))
+
+
+def _whole_window_size(hm):
+    """window_size/step_size yielding a single window covering everything.
+
+    Making both equal to (span + 1) guarantees exactly one window whose stop
+    lies past the last variant, in every engine regardless of whether it takes
+    its bounds from the matrix's chrom_start/end or from the positions array.
+    """
+    start, end = _region_bounds(hm)
+    return int(end - start) + 1
+
+
+def _whole_bp_bins(hm):
+    """Two bin edges defining one window covering the whole region (for fused)."""
+    start, end = _region_bounds(hm)
+    return np.array([start, end + 1], dtype=np.float64)
+
+
+def _one_row(df, name):
+    """Pull the single-window value of column ``name`` (ignoring any pop suffix)."""
+    if name in df.columns:
+        return float(df[name].iloc[0])
+    candidates = [c for c in df.columns if c.startswith(name + "_")]
+    assert len(candidates) == 1, f"ambiguous column for {name!r}: {candidates}"
+    return float(df[candidates[0]].iloc[0])
+
+
+# ---------------------------------------------------------------------------
+# Statistic registry -- one row per stat holds all per-stat knowledge:
+#   two_pop  : needs pop1/pop2 rather than a single population
+#   kind     : 'value' | 'count' (see module docstring)
+#   scalar   : (hm, missing_data) -> float, the reference implementation
+#   fs       : (FrequencySpectrum) -> float, or None if unsupported
+#   scatter/fused/pyloop : the windowed engine's name for this stat, or None
+# ---------------------------------------------------------------------------
+
+_Stat = namedtuple("_Stat", ["two_pop", "kind", "scalar", "fs",
+                             "scatter", "fused", "pyloop"])
+
+_STATS = {
+    "pi": _Stat(
+        False, "value",
+        lambda hm, md: diversity.pi(hm, span_normalize=False, missing_data=md),
+        lambda fs: fs.theta("pi", span_normalize=False),
+        "pi", "pi", "pi"),
+    "theta_w": _Stat(
+        False, "value",
+        lambda hm, md: diversity.theta_w(hm, span_normalize=False, missing_data=md),
+        lambda fs: fs.theta("watterson", span_normalize=False),
+        "theta_w", "theta_w", "theta_w"),
+    "tajimas_d": _Stat(
+        False, "value",
+        lambda hm, md: diversity.tajimas_d(hm, missing_data=md),
+        lambda fs: fs.tajimas_d(),
+        "tajimas_d", "tajimas_d", "tajimas_d"),
+    "segregating_sites": _Stat(
+        False, "count",
+        lambda hm, md: diversity.segregating_sites(hm, missing_data=md),
+        lambda fs: fs.n_segregating,
+        "segregating_sites", "segregating_sites", "segregating_sites"),
+    "theta_h": _Stat(
+        False, "value",
+        lambda hm, md: diversity.theta_h(hm, span_normalize=False, missing_data=md),
+        lambda fs: fs.theta("theta_h", span_normalize=False),
+        "theta_h", "theta_h", None),
+    "theta_l": _Stat(
+        False, "value",
+        lambda hm, md: diversity.theta_l(hm, span_normalize=False, missing_data=md),
+        lambda fs: fs.theta("theta_l", span_normalize=False),
+        "theta_l", None, None),
+    "fay_wu_h": _Stat(
+        False, "value",
+        lambda hm, md: diversity.fay_wus_h(hm, missing_data=md),
+        lambda fs: fs.fay_wu_h(),
+        "fay_wu_h", "fay_wu_h", None),
+    "normalized_fay_wu_h": _Stat(
+        False, "value",
+        lambda hm, md: diversity.normalized_fay_wus_h(hm, missing_data=md),
+        lambda fs: fs.fay_wu_h(normalized=True),
+        "normalized_fay_wu_h", None, None),
+    "zeng_e": _Stat(
+        False, "value",
+        lambda hm, md: diversity.zeng_e(hm, missing_data=md),
+        lambda fs: fs.zeng_e(),
+        "zeng_e", None, None),
+    "zeng_dh": _Stat(
+        False, "value",
+        lambda hm, md: diversity.zeng_dh(hm, missing_data=md),
+        None, "zeng_dh", None, None),
+    "singletons": _Stat(
+        False, "count",
+        lambda hm, md: diversity.singleton_count(hm, missing_data=md),
+        None, "singletons", "singletons", "n_singletons"),
+    "max_daf": _Stat(
+        False, "value",
+        lambda hm, md: diversity.max_daf(hm, missing_data=md),
+        None, "max_daf", "max_daf", None),
+    "fst_hudson": _Stat(
+        True, "value",
+        lambda hm, md: divergence.fst_hudson(hm, POP1, POP2, missing_data=md),
+        None, "fst_hudson", "fst_hudson", "fst_hudson"),
+    "dxy": _Stat(
+        True, "value",
+        lambda hm, md: divergence.dxy(hm, POP1, POP2, span_normalize=False, missing_data=md),
+        None, "dxy", "dxy", "dxy"),
+    "da": _Stat(
+        True, "value",
+        lambda hm, md: divergence.da(hm, POP1, POP2, span_normalize=False, missing_data=md),
+        None, "da", "da", "da"),
+    "fst_wc": _Stat(
+        True, "value",
+        lambda hm, md: divergence.fst_weir_cockerham(hm, POP1, POP2, missing_data=md),
+        None, None, "fst_wc", "fst_wc"),
+}
+
+
+# ---------------------------------------------------------------------------
+# Per-path adapters -- each returns the canonical quantity for its stat
+# ---------------------------------------------------------------------------
+
+def _path_scalar(hm, stat, missing_data):
+    return float(_STATS[stat].scalar(hm, missing_data))
+
+
+def _path_fs(hm, stat, missing_data):
+    fs = FrequencySpectrum(hm, missing_data=missing_data)
+    return float(_STATS[stat].fs(fs))
+
+
+def _path_scatter(hm, stat, missing_data):
+    spec = _STATS[stat]
+    W = _whole_window_size(hm)
+    if spec.two_pop:
+        df = _windowed_twopop_scatter(hm, W, W, [spec.scatter], [POP1, POP2],
+                                      missing_data, False)
+    else:
+        df = _windowed_thetas_scatter(hm, W, W, [spec.scatter], None,
+                                      missing_data, False)
+    return _one_row(df, spec.scatter)
+
+
+def _path_fused(hm, stat, missing_data):
+    spec = _STATS[stat]
+    bins = _whole_bp_bins(hm)
+    pop_kw = {"pop1": POP1, "pop2": POP2} if spec.two_pop else {"population": None}
+    out = windowed_statistics_fused(hm, bins, statistics=(spec.fused,),
+                                    per_base=False, missing_data=missing_data, **pop_kw)
+    return float(np.asarray(out[spec.fused])[0])
+
+
+def _path_pyloop(hm, stat, missing_data):
+    spec = _STATS[stat]
+    W = _whole_window_size(hm)
+    populations = [POP1, POP2] if spec.two_pop else None
+    analyzer = WindowedAnalyzer(
+        window_type="bp", window_size=W, step_size=W, statistics=[spec.pyloop],
+        populations=populations, missing_data=missing_data, span_normalize=False,
+    )
+    return _one_row(analyzer.compute(hm), spec.pyloop)
+
+
+_PATHS = {
+    "fs": _path_fs,
+    "scatter": _path_scatter,
+    "fused": _path_fused,
+    "pyloop": _path_pyloop,
+}
+
+
+def _supported_paths(stat):
+    """Non-scalar paths that compute ``stat`` (those with a name/callable set)."""
+    spec = _STATS[stat]
+    return [p for p in _PATHS if getattr(spec, p) is not None]
+
+
+# ---------------------------------------------------------------------------
+# Known divergences and engine limitations -> xfail with a reason
+# ---------------------------------------------------------------------------
+
+_FUSED_MISSING = (
+    "the fused kernel's per-site sample-size handling under missing data still "
+    "diverges from the scalar for this estimator. #135"
+)
+_FS_VARIANCE = (
+    "FrequencySpectrum computes the Achaz neutrality-test variance at a single "
+    "modal sample size while summing the numerator over variable per-site "
+    "sample sizes, diverging from the scalar under missing data. #135"
+)
+_SCATTER_VARIANCE = (
+    "the scatter neutrality-test variance uses full-sample harmonic numbers "
+    "rather than per-site valid counts, diverging from the scalar under "
+    "missing data. #135"
+)
+_FST_WC_FUSED = (
+    "the fused fst_wc kernel was not converted to the per-allele one-vs-rest "
+    "Weir-Cockerham ANOVA the scalar/python-loop path now uses. #135"
+)
+_DA_SCATTER_EXCLUDE = (
+    "under missing_data='exclude' the scatter da's within-population pi terms "
+    "use a different site set than the scalar (dxy agrees), so da diverges. #135"
+)
+_FS_MULTIALLELIC = (
+    "on multiallelic sites the FrequencySpectrum builds a per-allele SFS whose "
+    "segregating-class count and pi differ from the scalar's per-allele counts, "
+    "so the SFS-derived estimators that depend on them diverge. #100"
+)
+
+# (stat, path) -> list of (reason, conditions) rules; the first rule whose
+# ``conditions`` set contains the condition (or is None, meaning every
+# condition where the path runs) applies. A key carries more than one rule when
+# it diverges for different reasons under different conditions. The fused/exclude
+# skip is handled separately, so a fused rule with conditions=None never reaches
+# the (skipped) missing_exclude cell.
+_XFAILS = {
+    # fused kernel still mishandles missing data for these two estimators.
+    ("theta_w", "fused"): [(_FUSED_MISSING, _WHEN_PARTIAL)],
+    ("tajimas_d", "fused"): [(_FUSED_MISSING, _WHEN_PARTIAL)],
+
+    # neutrality-test variance differs under variable per-site sample sizes,
+    # and the FS path additionally diverges under multiallelic sites.
+    ("tajimas_d", "fs"): [(_FS_VARIANCE, _WHEN_PARTIAL),
+                          (_FS_MULTIALLELIC, _WHEN_MULTIALLELIC)],
+    ("tajimas_d", "scatter"): [(_SCATTER_VARIANCE, _WHEN_PARTIAL)],
+    ("normalized_fay_wu_h", "fs"): [(_FS_VARIANCE, _WHEN_PARTIAL),
+                                    (_FS_MULTIALLELIC, _WHEN_MULTIALLELIC)],
+    ("normalized_fay_wu_h", "scatter"): [(_SCATTER_VARIANCE, _WHEN_PARTIAL)],
+    ("zeng_e", "fs"): [(_FS_VARIANCE, _WHEN_PARTIAL),
+                       (_FS_MULTIALLELIC, _WHEN_MULTIALLELIC)],
+    ("zeng_e", "scatter"): [(_SCATTER_VARIANCE, _WHEN_PARTIAL)],
+
+    # FS per-allele SFS diverges from the scalar per-allele counts (multiallelic).
+    ("pi", "fs"): [(_FS_MULTIALLELIC, _WHEN_MULTIALLELIC)],
+    ("theta_w", "fs"): [(_FS_MULTIALLELIC, _WHEN_MULTIALLELIC)],
+    ("segregating_sites", "fs"): [(_FS_MULTIALLELIC, _WHEN_MULTIALLELIC)],
+    ("fay_wu_h", "fs"): [(_FS_MULTIALLELIC, _WHEN_MULTIALLELIC)],
+
+    # fused fst_wc kernel not updated to the per-allele WC ANOVA (all conditions).
+    ("fst_wc", "fused"): [(_FST_WC_FUSED, None)],
+
+    # scatter da within-pop pi term uses a different site set under exclude.
+    ("da", "scatter"): [(_DA_SCATTER_EXCLUDE, _WHEN_EXCLUDE)],
+}
+
+
+def _status(stat, path, condition):
+    """Return ('ok'|'xfail'|'skip', reason) for one parametrized cell."""
+    cond = _CONDITIONS[condition]
+
+    # The fused engine is only dispatched for missing_data='include'.
+    if path == "fused" and cond.missing_data == "exclude":
+        return "skip", "fused engine requires missing_data='include'"
+
+    for reason, conditions in _XFAILS.get((stat, path), ()):
+        if conditions is None or condition in conditions:
+            return "xfail", reason
+
+    return "ok", None
+
+
+def _cases():
+    for condition in _CONDITIONS:
+        for stat in _STATS:
+            for path in _supported_paths(stat):
+                kind, reason = _status(stat, path, condition)
+                marks = []
+                if kind == "xfail":
+                    marks.append(pytest.mark.xfail(reason=reason, strict=True))
+                elif kind == "skip":
+                    marks.append(pytest.mark.skip(reason=reason))
+                yield pytest.param(condition, stat, path, marks=marks,
+                                   id=f"{condition}-{stat}-{path}")
+
+
+def _assert_agrees(stat, reference, value):
+    if _STATS[stat].kind == "count":
+        assert int(value) == int(reference)
+    elif np.isnan(reference):
+        assert np.isnan(value)
+    else:
+        assert np.isclose(value, reference, rtol=RTOL, atol=ATOL), (
+            f"{stat}: got {value!r}, expected {reference!r}")
+
+
+@pytest.mark.parametrize("condition,stat,path", list(_cases()))
+def test_path_matches_scalar(request, condition, stat, path):
+    """Every supported path reproduces the scalar reference for the condition."""
+    cond = _CONDITIONS[condition]
+    hm = request.getfixturevalue(cond.fixture)
+    reference = _path_scalar(hm, stat, cond.missing_data)
+    value = _PATHS[path](hm, stat, cond.missing_data)
+    _assert_agrees(stat, reference, value)

--- a/tests/test_local_pca.py
+++ b/tests/test_local_pca.py
@@ -121,27 +121,40 @@ class TestLocalPCAShape:
 
 def _reference_local_pca_numpy(hm: HaplotypeMatrix, window_size: int, k: int,
                                step_size=None):
-    """Per-window numpy reference: row-center, col-center, (X X^T)/(n-1)."""
+    """Per-window numpy reference for the all-allele centered (tskit) local PCA.
+
+    Each window is the all-allele one-hot centered by allele frequency (all
+    alleles including the reference), then _window_gram's sample-centering and
+    (n_cols - 1) normalization -- matching _prepare_centered + _window_gram.
+    """
     step = step_size or window_size
-    if hm.device == 'GPU':
-        hap = hm.haplotypes.get().astype(np.float64)
-    else:
-        hap = hm.haplotypes.astype(np.float64)
+    hap = (hm.haplotypes.get() if hm.device == 'GPU'
+           else hm.haplotypes).astype(np.int64)
     n_hap, n_var = hap.shape
     out_vals, out_vecs, out_sumsq = [], [], []
     for start in range(0, n_var - window_size + 1, step):
-        X = hap[:, start:start + window_size].copy()
-        # Row-center (per variant)
-        X -= X.mean(axis=0, keepdims=True)
-        # Col-center (per sample) to match R's cov() double-centering
-        X -= X.mean(axis=1, keepdims=True)
-        C = (X @ X.T) / (window_size - 1)
-        sumsq = float((C ** 2).sum())
+        w = hap[:, start:start + window_size]
+        cols = []
+        for v in range(w.shape[1]):
+            c = w[:, v]
+            valid = c >= 0
+            nv = int(valid.sum())
+            if nv == 0:
+                continue
+            for a in range(int(c[valid].max()) + 1):
+                if not np.any((c == a) & valid):
+                    continue
+                p = int(((c == a) & valid).sum()) / nv
+                cols.append(np.where(valid, (c == a).astype(float), p) - p)
+        X = np.array(cols).T if cols else np.zeros((n_hap, 0))
+        n_cols = X.shape[1]
+        X = X - X.mean(axis=1, keepdims=True)          # sample-center (_window_gram)
+        C = (X @ X.T) / max(n_cols - 1, 1)
         evals, evecs = np.linalg.eigh(C)
         idx = np.argsort(evals)[::-1][:k]
         out_vals.append(evals[idx])
-        out_vecs.append(evecs[:, idx].T)  # shape (k, n_hap)
-        out_sumsq.append(sumsq)
+        out_vecs.append(evecs[:, idx].T)               # (k, n_hap)
+        out_sumsq.append(float((C ** 2).sum()))
     return (np.stack(out_vals), np.stack(out_vecs), np.array(out_sumsq))
 
 
@@ -168,6 +181,22 @@ class TestBatchedVsLoop:
                 sign = np.sign(np.dot(v_ref, v_ours))
                 np.testing.assert_allclose(
                     sign * v_ours, v_ref, rtol=1e-4, atol=1e-6)
+
+    def test_adjacent_windows_sign_aligned(self, small_hm):
+        # Per-window eigenvectors are sign-aligned to the previous valid window:
+        # where adjacent windows' PC is clearly the same direction, their dot is
+        # non-negative rather than flipping arbitrarily.
+        res = local_pca(small_hm, window_size=200, window_type='snp', k=3)
+        ev = res.eigvecs
+        for pc in range(3):
+            prev = None
+            for w in range(res.n_windows):
+                v = ev[w, pc]
+                if np.isnan(v).any():
+                    continue
+                if prev is not None and abs(float(np.dot(v, prev))) > 0.5:
+                    assert float(np.dot(v, prev)) > 0.0
+                prev = v
 
 
 # ---------------------------------------------------------------------------
@@ -234,7 +263,7 @@ class TestPcDist:
         res2 = LocalPCAResult(
             windows=res.windows, eigvals=res.eigvals * 2.0,
             eigvecs=res.eigvecs, sumsq=res.sumsq * 4.0,
-            k=res.k, scaler=res.scaler, missing_data=res.missing_data)
+            k=res.k, missing_data=res.missing_data)
         d2 = pc_dist(res2, npc=3, normalize='L1')
         np.testing.assert_allclose(d1, d2, rtol=1e-8, atol=1e-10)
 
@@ -244,7 +273,7 @@ class TestPcDist:
         res2 = LocalPCAResult(
             windows=res.windows, eigvals=res.eigvals * 3.0,
             eigvecs=res.eigvecs, sumsq=res.sumsq * 9.0,
-            k=res.k, scaler=res.scaler, missing_data=res.missing_data)
+            k=res.k, missing_data=res.missing_data)
         d2 = pc_dist(res2, npc=3, normalize='L2')
         np.testing.assert_allclose(d1, d2, rtol=1e-8, atol=1e-10)
 

--- a/tests/test_local_pca_parity.py
+++ b/tests/test_local_pca_parity.py
@@ -41,6 +41,20 @@ PCDIST_PATH = DATA_DIR / "lostruct_reference_pcdist.json"
 JACKKNIFE_PATH = DATA_DIR / "lostruct_reference_jackknife.json"
 CORNERS_PATH = DATA_DIR / "lostruct_reference_corners.json"
 
+# local_pca / lostruct now use the all-allele centered (tskit) standardization.
+# It differs from R lostruct only by a sample-centering (double- vs single-
+# centering) that shifts the eigenvalue scale and perturbs eigenvector VALUES at
+# the ~1e-3 level; the top-k eigenvector DIRECTIONS still match R to |corr| >~
+# 0.999 (see test_parity_eigenvectors_subspace_corr, which is kept live). The
+# bit-tight value/scale pins below are xfailed pending a decision in review on
+# whether to keep the all-allele lostruct or restore strict R-lostruct parity.
+_R_PARITY_XFAIL = pytest.mark.xfail(
+    reason="lostruct moved to the all-allele centered (tskit) standardization; "
+           "the frozen R references match in subspace but not in eigenvalue "
+           "scale / bit-tight eigenvector values. Revisit in review.",
+    strict=False,
+)
+
 
 def _load_json(path: pathlib.Path) -> dict:
     with open(path) as fh:
@@ -92,6 +106,7 @@ def _skip_if_missing(path: pathlib.Path):
 # ---------------------------------------------------------------------------
 
 
+@_R_PARITY_XFAIL
 def test_parity_sumsq(pg_local_pca_result):
     _skip_if_missing(EIGEN_PATH)
     ref = _load_json(EIGEN_PATH)
@@ -101,6 +116,7 @@ def test_parity_sumsq(pg_local_pca_result):
     np.testing.assert_allclose(sumsq_ours, sumsq_ref, rtol=1e-6, atol=1e-10)
 
 
+@_R_PARITY_XFAIL
 def test_parity_eigvals(pg_local_pca_result):
     _skip_if_missing(EIGEN_PATH)
     ref = _load_json(EIGEN_PATH)
@@ -111,6 +127,7 @@ def test_parity_eigvals(pg_local_pca_result):
                                rtol=1e-5, atol=1e-8)
 
 
+@_R_PARITY_XFAIL
 def test_parity_eigenvectors_sign_aligned(pg_local_pca_result):
     _skip_if_missing(EIGEN_PATH)
     ref = _load_json(EIGEN_PATH)
@@ -148,12 +165,23 @@ def test_parity_eigenvectors_sign_aligned(pg_local_pca_result):
         f"{n_windows * k} entries skipped")
 
 
+# NOTE: a live subspace-|corr| parity test against these R references is NOT
+# viable. The reference fixture's structure is a constant per-group frequency
+# shift, which is exactly the per-sample-mean direction that R's double-centering
+# removes and our single-centering keeps -- so in the structured windows the two
+# conventions are nearly orthogonal (|corr| ~ 0.1), a genuine divergence rather
+# than a scale/noise artifact. For genealogical structure (e.g. a simulated
+# sweep) the two agree to |corr| ~ 1; the divergence is structure-type-dependent.
+# See the PR discussion.
+
+
 # ---------------------------------------------------------------------------
 # pc_dist parity
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("normalize", ["L1", "L2"])
+@_R_PARITY_XFAIL
 def test_parity_pc_dist(pg_local_pca_result, normalize):
     _skip_if_missing(PCDIST_PATH)
     ref = _load_json(PCDIST_PATH)
@@ -166,6 +194,7 @@ def test_parity_pc_dist(pg_local_pca_result, normalize):
     np.testing.assert_allclose(dist_ours, dist_ref, rtol=1e-4, atol=1e-6)
 
 
+@_R_PARITY_XFAIL
 def test_parity_mds_procrustes(pg_local_pca_result):
     _skip_if_missing(PCDIST_PATH)
     ref = _load_json(PCDIST_PATH)
@@ -211,6 +240,7 @@ def test_parity_pcoa_matches_cmdscale():
 # ---------------------------------------------------------------------------
 
 
+@_R_PARITY_XFAIL
 def test_parity_jackknife_se(reference_hm, reference_input):
     _skip_if_missing(JACKKNIFE_PATH)
     ref = _load_json(JACKKNIFE_PATH)
@@ -238,6 +268,7 @@ def test_parity_jackknife_se(reference_hm, reference_input):
 # ---------------------------------------------------------------------------
 
 
+@_R_PARITY_XFAIL
 def test_parity_corners(pg_local_pca_result, reference_input):
     _skip_if_missing(CORNERS_PATH)
     _skip_if_missing(PCDIST_PATH)

--- a/tests/test_local_pca_streaming.py
+++ b/tests/test_local_pca_streaming.py
@@ -479,7 +479,8 @@ class TestStreamingHostSyncCount:
     The dispatcher path also includes pre-existing infrastructure host
     syncs that are NOT part of issue #91 -- ``WindowIterator.get_subset``
     does an ``.all()`` bounds check (2 transfers/window) and
-    ``_prepare_matrix`` does a has-missing check (1 transfer/window).
+    ``_prepare_centered`` enumerates present alleles via ``argwhere``
+    (1 transfer/window).
     Plus 1 fixed transfer from iterator init and 3 fixed bulk transfers
     at the end of the dispatcher. So the post-fix expected rate is
     3 transfers/window + ~4 fixed = ~3.4 per window for the
@@ -491,7 +492,7 @@ class TestStreamingHostSyncCount:
     3.5-per-window assertion below.
 
     If the unrelated infrastructure syncs in ``get_subset`` /
-    ``_prepare_matrix`` are later optimized away, the post-fix rate
+    ``_prepare_centered`` are later optimized away, the post-fix rate
     drops further and this test still passes.
     """
 

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -390,6 +390,30 @@ class TestDivergenceVsTskit:
         assert divergence.fst(hm, 'A', 'B', method='tskit') == fst_pg
         assert not np.isclose(fst_pg, divergence.fst_hudson(hm, 'A', 'B'))
 
+    def test_fst_nei_matches_hand_formula(self, multiallelic_ts):
+        # Nei GST per-allele: HS = 1 - sum_a p_a^2 (weighted), HT from pooled
+        # pbar_a. allel has no Nei GST, so pin to the numpy hand formula.
+        from pg_gpu import divergence
+        ts = multiallelic_ts
+        hm, A, B = self._hm_with_pops(ts)
+        gst_pg = divergence.fst_nei(hm, 'A', 'B')
+
+        G = ts.genotype_matrix()
+        K = int(G.max()) + 1
+        Ai, Bi = hm.sample_sets['A'], hm.sample_sets['B']
+        ac1 = np.stack([(G[:, Ai] == a).sum(1) for a in range(K)], axis=1).astype(float)
+        ac2 = np.stack([(G[:, Bi] == a).sum(1) for a in range(K)], axis=1).astype(float)
+        n1, n2 = ac1.sum(1), ac2.sum(1)
+        p1, p2 = ac1 / n1[:, None], ac2 / n2[:, None]
+        h1, h2 = 1 - (p1**2).sum(1), 1 - (p2**2).sum(1)
+        tot = n1 + n2
+        hs = (h1 * n1 + h2 * n2) / tot
+        pbar = (n1[:, None] * p1 + n2[:, None] * p2) / tot[:, None]
+        ht = 1 - (pbar**2).sum(1)
+        v = ht > 0
+        gst_ref = (ht[v] - hs[v]).sum() / ht[v].sum()
+        np.testing.assert_allclose(gst_pg, gst_ref, rtol=1e-12)
+
     def test_pbs_matches_allel(self, multiallelic_ts):
         # PBS composes three per-allele Hudson FSTs; matches allel.pbs.
         from pg_gpu import divergence

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -349,6 +349,58 @@ class TestJointSFS:
         np.testing.assert_allclose(result, expected, rtol=1e-9, atol=1e-9)
 
 
+class TestDivergenceVsTskit:
+    """Count-based divergence per-allele vs tskit (two sample sets)."""
+
+    @staticmethod
+    def _pops(ts):
+        s = ts.samples()
+        h = len(s) // 2
+        return list(s[:h]), list(s[h:])
+
+    def _hm_with_pops(self, ts):
+        # HaplotypeMatrix carrying sample_sets so divergence funcs can name pops.
+        A, B = self._pops(ts)
+        hm = HaplotypeMatrix.from_ts(ts, device="GPU")
+        hm.sample_sets = {'A': list(range(len(A))),
+                          'B': list(range(len(A), len(A) + len(B)))}
+        return hm, A, B
+
+    def test_dxy_matches_tskit(self, multiallelic_ts):
+        # dxy = 1 - sum_a p1_a*p2_a per site; mean over sites == tskit divergence.
+        from pg_gpu import divergence
+        ts = multiallelic_ts
+        hm, A, B = self._hm_with_pops(ts)
+        dxy_pg = divergence.dxy(hm, 'A', 'B', span_normalize=False)
+        dxy_ts = ts.divergence([A, B], mode='site', span_normalise=False) / ts.num_sites
+        np.testing.assert_allclose(dxy_pg, dxy_ts, rtol=1e-12)
+
+    def test_dxy_components_consistent_with_dxy(self, multiallelic_ts):
+        # Raw-count path (used by windowed analysis) agrees with dxy's mean.
+        from pg_gpu import divergence
+        ts = multiallelic_ts
+        hm, A, B = self._hm_with_pops(ts)
+        pop1 = hm.haplotypes[hm.sample_sets['A'], :]
+        pop2 = hm.haplotypes[hm.sample_sets['B'], :]
+        diffs, comps, nsites = divergence.dxy_components(pop1, pop2)
+        dxy_pg = divergence.dxy(hm, 'A', 'B', span_normalize=False)
+        # No missing data => n1*n2 constant across sites, so the pooled ratio
+        # diffs/comps equals dxy's mean-of-per-site-ratios.
+        assert nsites == ts.num_sites
+        np.testing.assert_allclose(diffs / comps, dxy_pg, rtol=1e-12)
+
+    def test_da_uses_per_allele_pieces(self, multiallelic_ts):
+        # da = dxy - (pi1+pi2)/2, both per-allele now (internally consistent).
+        from pg_gpu import divergence
+        ts = multiallelic_ts
+        hm, A, B = self._hm_with_pops(ts)
+        da = divergence.da(hm, 'A', 'B', span_normalize=False)
+        dxy_pg = divergence.dxy(hm, 'A', 'B', span_normalize=False)
+        pi1 = diversity.pi(hm, 'A', span_normalize=False)
+        pi2 = diversity.pi(hm, 'B', span_normalize=False)
+        np.testing.assert_allclose(da, dxy_pg - (pi1 + pi2) / 2.0, rtol=1e-12)
+
+
 class TestMultiallelicConsumers:
     """singleton_count / heterozygosity_expected / max_daf / mu_sfs / daf_histogram."""
 

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -350,7 +350,8 @@ class TestJointSFS:
 
 
 class TestDivergenceVsTskit:
-    """Count-based divergence per-allele vs tskit (two sample sets)."""
+    """Count-based divergence per-allele vs tskit (dxy/da) and scikit-allel
+    (Hudson FST / PBS), on multiallelic two/three sample sets."""
 
     @staticmethod
     def _pops(ts):
@@ -365,6 +366,36 @@ class TestDivergenceVsTskit:
         hm.sample_sets = {'A': list(range(len(A))),
                           'B': list(range(len(A), len(A) + len(B)))}
         return hm, A, B
+
+    def test_fst_hudson_matches_allel(self, multiallelic_ts):
+        # Classic Hudson FST = sum(num)/sum(den); per-allele == allel.hudson_fst.
+        from pg_gpu import divergence
+        ts = multiallelic_ts
+        hm, A, B = self._hm_with_pops(ts)
+        fst_pg = divergence.fst_hudson(hm, 'A', 'B')
+        ha = allel.HaplotypeArray(ts.genotype_matrix())
+        ac1 = ha.count_alleles(subpop=hm.sample_sets['A'])
+        ac2 = ha.count_alleles(subpop=hm.sample_sets['B'])
+        num, den = allel.hudson_fst(ac1, ac2)
+        np.testing.assert_allclose(fst_pg, np.sum(num) / np.sum(den), rtol=1e-9)
+
+    def test_pbs_matches_allel(self, multiallelic_ts):
+        # PBS composes three per-allele Hudson FSTs; matches allel.pbs.
+        from pg_gpu import divergence
+        ts = multiallelic_ts
+        n = ts.num_samples
+        t = n // 3
+        sets = {'A': list(range(t)), 'B': list(range(t, 2 * t)),
+                'C': list(range(2 * t, n))}
+        hm = HaplotypeMatrix.from_ts(ts, device="GPU")
+        hm.sample_sets = sets
+        w = 50
+        pbs_pg = divergence.pbs(hm, 'A', 'B', 'C', window_size=w)
+        ha = allel.HaplotypeArray(ts.genotype_matrix())
+        ac = {k: ha.count_alleles(subpop=v) for k, v in sets.items()}
+        pbs_allel = allel.pbs(ac['A'], ac['B'], ac['C'], window_size=w, normed=True)
+        valid = ~np.isnan(pbs_pg) & ~np.isnan(pbs_allel)
+        np.testing.assert_allclose(pbs_pg[valid], pbs_allel[valid], rtol=1e-6, atol=1e-9)
 
     def test_dxy_matches_tskit(self, multiallelic_ts):
         # dxy = 1 - sum_a p1_a*p2_a per site; mean over sites == tskit divergence.

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -1,0 +1,221 @@
+"""
+Multiallelic-site correctness for the diversity family (issue #100).
+
+Oracle: tskit (per-allele pi/SFS; mutation-count segregating/Watterson). Also
+scikit-allel where it coincides (pi). The biallelic control confirms parity on
+biallelic data. Fixtures live in conftest.py (multiallelic_ts / multiallelic_hm).
+"""
+
+import numpy as np
+import allel
+import pytest
+
+from pg_gpu import HaplotypeMatrix
+from pg_gpu import diversity
+
+
+def _a1(n):
+    return float(np.sum(1.0 / np.arange(1, n)))
+
+
+def _strict_biallelic_mask(G):
+    """Sites whose sample alleles are exactly {0, 1}."""
+    return (G.max(axis=1) == 1) & (G == 0).any(axis=1) & (G == 1).any(axis=1)
+
+
+def _expected_segregating(hap, exclude=False):
+    """Independent numpy reference: mutation-count segregating sites.
+
+    hap is (n_hap, n_var) with -1 for missing. ``exclude`` drops any variant
+    with a missing genotype first (the missing_data='exclude' semantics).
+    """
+    hap = np.asarray(hap)
+    total = 0
+    for j in range(hap.shape[1]):
+        col = hap[:, j]
+        if exclude and np.any(col < 0):
+            continue
+        valid = col[col >= 0]
+        if valid.size < 2:
+            continue
+        total += np.unique(valid).size - 1
+    return total
+
+
+def _expected_pi(hap):
+    """Independent numpy reference: per-site per-allele mean pairwise difference."""
+    hap = np.asarray(hap)
+    total = 0.0
+    for j in range(hap.shape[1]):
+        valid = hap[:, j][hap[:, j] >= 0]
+        n = valid.size
+        if n < 2:
+            continue
+        _, counts = np.unique(valid, return_counts=True)
+        total += 1.0 - float(np.sum(counts * (counts - 1))) / (n * (n - 1))
+    return total
+
+
+class TestDiversityCoreVsTskit:
+    """pi / segregating / Watterson / Tajima numerator against tskit."""
+
+    def test_fixture_is_multiallelic(self, multiallelic_hm):
+        ts, _ = multiallelic_hm
+        G = ts.genotype_matrix()
+        n_alleles = np.array([np.unique(G[i]).size for i in range(ts.num_sites)])
+        assert (n_alleles >= 3).sum() > 0, "fixture has no multiallelic sites"
+
+    def test_pi_matches_tskit(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        pi_pg = diversity.pi(hm, span_normalize=False)
+        pi_ts = float(ts.diversity(mode="site", span_normalise=False))
+        np.testing.assert_allclose(pi_pg, pi_ts, rtol=1e-9)
+
+    def test_pi_matches_allel(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        ac = allel.HaplotypeArray(ts.genotype_matrix()).count_alleles()
+        pi_allel = float(np.nansum(allel.mean_pairwise_difference(ac)))
+        np.testing.assert_allclose(diversity.pi(hm, span_normalize=False),
+                                   pi_allel, rtol=1e-9)
+
+    def test_segregating_matches_tskit_mutation_count(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        s_pg = diversity.segregating_sites(hm)
+        s_ts = ts.segregating_sites(mode="site", span_normalise=False)
+        assert s_pg == int(round(float(s_ts)))
+
+    def test_watterson_is_mutation_count_over_a1(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        # no missing data -> n_valid == n everywhere, so theta_w = S / a1(n)
+        s_ts = float(ts.segregating_sites(mode="site", span_normalise=False))
+        expected = s_ts / _a1(ts.num_samples)
+        np.testing.assert_allclose(diversity.theta_w(hm, span_normalize=False),
+                                   expected, rtol=1e-9)
+
+    def test_tajimas_d_matches_tskit(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        ct = diversity._compute_thetas(hm, ("pi", "watterson"))
+        num_pg = ct["thetas"]["pi"] - ct["thetas"]["watterson"]
+        pi_ts = float(ts.diversity(mode="site", span_normalise=False))
+        s_ts = float(ts.segregating_sites(mode="site", span_normalise=False))
+        num_ts = pi_ts - s_ts / _a1(ts.num_samples)
+        np.testing.assert_allclose(num_pg, num_ts, rtol=1e-9)
+        # Full D matches tskit exactly on complete data: tskit plugs the
+        # mutation-count S straight into the classic Tajima variance
+        # sqrt(a*S + (b/c)*S(S-1)), which is what pg_gpu's Achaz framework
+        # reduces to for the (pi, watterson) pair with the same S.
+        np.testing.assert_allclose(diversity.tajimas_d(hm),
+                                   float(ts.Tajimas_D(mode="site")), rtol=1e-9)
+
+    def test_theta_h_matches_tskit_sfs(self, multiallelic_hm):
+        # oracle: tskit per-allele SFS through the theta_H weight 2*i^2/(n(n-1))
+        ts, hm = multiallelic_hm
+        xi = ts.allele_frequency_spectrum(polarised=True, span_normalise=False)
+        n = ts.num_samples
+        i = np.arange(len(xi), dtype=float)
+        ref = float(np.sum(xi * 2.0 * i ** 2 / (n * (n - 1))))
+        np.testing.assert_allclose(diversity.theta_h(hm, span_normalize=False),
+                                   ref, rtol=1e-9)
+
+    def test_theta_l_matches_tskit_sfs(self, multiallelic_hm):
+        # oracle: tskit per-allele SFS through the theta_L weight i/(n-1)
+        ts, hm = multiallelic_hm
+        xi = ts.allele_frequency_spectrum(polarised=True, span_normalise=False)
+        n = ts.num_samples
+        i = np.arange(len(xi), dtype=float)
+        ref = float(np.sum(xi * i / (n - 1)))
+        np.testing.assert_allclose(diversity.theta_l(hm, span_normalize=False),
+                                   ref, rtol=1e-9)
+
+
+class TestBiallelicControl:
+    """On strict-biallelic sites, pg_gpu matches both tskit and scikit-allel."""
+
+    def test_biallelic_pi_and_segregating(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        G = ts.genotype_matrix()
+        nonbi = np.where(~_strict_biallelic_mask(G))[0].astype(np.int32)
+        ts_bi = ts.delete_sites(nonbi)
+        hm_bi = hm.apply_biallelic_filter()
+
+        # tskit oracle
+        np.testing.assert_allclose(
+            diversity.pi(hm_bi, span_normalize=False),
+            float(ts_bi.diversity(mode="site", span_normalise=False)), rtol=1e-9)
+        assert diversity.segregating_sites(hm_bi) == int(round(
+            float(ts_bi.segregating_sites(mode="site", span_normalise=False))))
+
+        # scikit-allel oracle
+        ac_bi = allel.HaplotypeArray(G[_strict_biallelic_mask(G)]).count_alleles()
+        np.testing.assert_allclose(
+            diversity.pi(hm_bi, span_normalize=False),
+            float(np.nansum(allel.mean_pairwise_difference(ac_bi))), rtol=1e-9)
+
+
+class TestMissingData:
+    """Missing genotypes (-1): the include per-site path and the exclude filter."""
+
+    # cols: biallelic+missing / triallelic+missing / biallelic+missing /
+    #       mostly-missing (n_valid<2) / complete triallelic / complete monomorphic
+    HAP = np.array([
+        [0, 0, 1, 1, -1, -1],
+        [0, 1, 2, -1, -1, -1],
+        [0, 0, 0, 1, -1, -1],
+        [-1, -1, -1, -1, -1, 0],
+        [0, 1, 0, 1, 2, 2],
+        [0, 0, 0, 0, 0, 0],
+    ], dtype=np.int8).T  # -> (6 haplotypes, 6 variants)
+
+    def _hm(self):
+        return HaplotypeMatrix(self.HAP.copy(), np.arange(6) * 100, 0, 600)
+
+    def test_segregating_include(self):
+        # per-site: n_valid>=2 sites counted by mutation count; the n_valid=1
+        # site is dropped. Reference: 1 + 2 + 1 + 0 + 2 + 0 = 6.
+        got = diversity.segregating_sites(self._hm(), missing_data="include")
+        assert got == _expected_segregating(self.HAP, exclude=False) == 6
+
+    def test_segregating_exclude(self):
+        # exclude drops any variant with missing -> only the 2 complete sites
+        # remain (triallelic -> 2, monomorphic -> 0). Reference: 2.
+        got = diversity.segregating_sites(self._hm(), missing_data="exclude")
+        assert got == _expected_segregating(self.HAP, exclude=True) == 2
+
+    def test_pi_include_with_missing(self):
+        # include mode uses per-site n_valid. Oracle 1: a numpy per-site
+        # per-allele reference. Oracle 2: allel (note HAP is n_hap x n_var, so
+        # transpose for allel's n_var x n_hap layout).
+        pi_pg = diversity.pi(self._hm(), span_normalize=False, missing_data="include")
+        np.testing.assert_allclose(pi_pg, _expected_pi(self.HAP), rtol=1e-9)
+        ac = allel.HaplotypeArray(self.HAP.T).count_alleles()
+        pi_allel = float(np.nansum(allel.mean_pairwise_difference(ac, fill=0)))
+        np.testing.assert_allclose(pi_pg, pi_allel, rtol=1e-9)
+
+
+class TestMultiallelicEdgeCases:
+    """Hand-built sites: per-allele pi and mutation-count segregating."""
+
+    def _hm(self, col):
+        hap = np.array(col, dtype=np.int8)
+        return HaplotypeMatrix(hap, np.array([100]), 0, 200)
+
+    def test_reference_absent_site(self):
+        # alleles {1, 2}, ancestral 0 absent: pi = 1 - (C(2,2)+C(2,2))/C(4,2)
+        hm = self._hm([[1], [1], [2], [2]])
+        np.testing.assert_allclose(diversity.pi(hm, span_normalize=False),
+                                   1.0 - 2.0 / 6.0, rtol=1e-12)
+        assert diversity.segregating_sites(hm) == 1  # 2 alleles -> 1 mutation
+
+    def test_triallelic_site(self):
+        # counts 2,1,1: pi = 1 - C(2,2)/C(4,2) = 1 - 1/6
+        hm = self._hm([[0], [0], [1], [2]])
+        np.testing.assert_allclose(diversity.pi(hm, span_normalize=False),
+                                   1.0 - 1.0 / 6.0, rtol=1e-12)
+        assert diversity.segregating_sites(hm) == 2  # 3 alleles -> 2 mutations
+
+    def test_tetraallelic_site(self):
+        # all four distinct: every pair differs -> pi = 1.0
+        hm = self._hm([[0], [1], [2], [3]])
+        np.testing.assert_allclose(diversity.pi(hm, span_normalize=False),
+                                   1.0, rtol=1e-12)
+        assert diversity.segregating_sites(hm) == 3

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -12,6 +12,7 @@ import pytest
 
 from pg_gpu import HaplotypeMatrix
 from pg_gpu import diversity
+from pg_gpu.diversity import FrequencySpectrum
 
 
 def _a1(n):
@@ -190,6 +191,68 @@ class TestMissingData:
         ac = allel.HaplotypeArray(self.HAP.T).count_alleles()
         pi_allel = float(np.nansum(allel.mean_pairwise_difference(ac, fill=0)))
         np.testing.assert_allclose(pi_pg, pi_allel, rtol=1e-9)
+
+
+class TestPerAlleleSFS:
+    """allele_frequency_spectrum + FrequencySpectrum on the per-allele SFS."""
+
+    def test_afs_matches_tskit(self, multiallelic_hm):
+        # Full array matches tskit's polarised AFS exactly: per-allele interior,
+        # both fixed classes (bins 0 and n) excluded.
+        ts, hm = multiallelic_hm
+        afs_pg = np.asarray(diversity.allele_frequency_spectrum(hm))
+        afs_ts = ts.allele_frequency_spectrum(polarised=True, span_normalise=False)
+        np.testing.assert_array_equal(afs_pg, afs_ts.astype(int))
+
+    def test_afs_interior_matches_allel(self, multiallelic_hm):
+        # Independent-library check on the segregating interior (1..n-1).
+        ts, hm = multiallelic_hm
+        n = ts.num_samples
+        ac = allel.HaplotypeArray(ts.genotype_matrix()).count_alleles()
+        per_allele = ac[:, 1:].flatten()
+        per_allele = per_allele[(per_allele > 0) & (per_allele < n)].astype(np.int64)
+        ref = np.bincount(per_allele, minlength=n + 1)[:n + 1]
+        afs_pg = np.asarray(diversity.allele_frequency_spectrum(hm))
+        np.testing.assert_array_equal(afs_pg[1:n], ref[1:n])
+
+    def test_afs_excludes_fixed_classes(self):
+        # Both fixed classes are excluded (matches tskit): a fully-derived site
+        # (bin n) and a monomorphic-ancestral site (bin 0) contribute nothing.
+        derived = HaplotypeMatrix(np.array([[1], [1], [1], [1]], dtype=np.int8),
+                                  np.array([100]), 0, 200)
+        ancestral = HaplotypeMatrix(np.array([[0], [0], [0], [0]], dtype=np.int8),
+                                    np.array([100]), 0, 200)
+        assert np.asarray(diversity.allele_frequency_spectrum(derived)).sum() == 0
+        assert np.asarray(diversity.allele_frequency_spectrum(ancestral)).sum() == 0
+
+    def test_freqspec_theta_h_l_match_scalar(self, multiallelic_hm):
+        # theta_h / theta_l are additive per allele, so the SFS path equals the
+        # scalar path even on multiallelic data.
+        _, hm = multiallelic_hm
+        fs = FrequencySpectrum(hm)
+        np.testing.assert_allclose(fs.theta('theta_h'),
+                                   diversity.theta_h(hm, span_normalize=False), rtol=1e-9)
+        np.testing.assert_allclose(fs.theta('theta_l'),
+                                   diversity.theta_l(hm, span_normalize=False), rtol=1e-9)
+
+    def test_freqspec_matches_scalar_biallelic(self, multiallelic_hm):
+        # On biallelic data every estimator agrees between the two paths.
+        _, hm = multiallelic_hm
+        hm_bi = hm.apply_biallelic_filter()
+        fs = FrequencySpectrum(hm_bi)
+        for name, fn in [('pi', diversity.pi), ('watterson', diversity.theta_w),
+                         ('theta_h', diversity.theta_h), ('theta_l', diversity.theta_l)]:
+            np.testing.assert_allclose(fs.theta(name),
+                                       fn(hm_bi, span_normalize=False), rtol=1e-9)
+
+    def test_freqspec_pi_diverges_from_scalar_on_multiallelic(self, multiallelic_hm):
+        # Documented divergence (issue #100): the marginal SFS overcounts pi on
+        # multiallelic data; the scalar diversity.pi is authoritative.
+        _, hm = multiallelic_hm
+        pi_sfs = FrequencySpectrum(hm).theta('pi')
+        pi_scalar = diversity.pi(hm, span_normalize=False)
+        assert pi_sfs > pi_scalar
+        assert not np.isclose(pi_sfs, pi_scalar, rtol=1e-6)
 
 
 class TestMultiallelicEdgeCases:

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -289,6 +289,73 @@ class TestPerAlleleSFS:
         assert not np.isclose(pi_sfs, pi_scalar, rtol=1e-6)
 
 
+class TestJointSFS:
+    """Joint / projected SFS per-allele vs tskit (two sample sets)."""
+
+    @staticmethod
+    def _pops(ts):
+        s = ts.samples()
+        h = len(s) // 2
+        return list(s[:h]), list(s[h:])
+
+    def test_joint_sfs_matches_tskit(self, multiallelic_hm):
+        from pg_gpu import sfs as sfs_mod
+        ts, hm = multiallelic_hm
+        A, B = self._pops(ts)
+        j_pg = np.asarray(sfs_mod.joint_sfs(hm, A, B))
+        j_ts = ts.allele_frequency_spectrum([A, B], polarised=True,
+                                            span_normalise=False)
+        np.testing.assert_array_equal(j_pg, j_ts.astype(int))
+
+    def test_joint_sfs_excludes_only_global_mono_corners(self, multiallelic_hm):
+        # Edge cells (alleles private to / fixed within one pop) are populated;
+        # only the two global-monomorphic corners are dropped.
+        from pg_gpu import sfs as sfs_mod
+        ts, hm = multiallelic_hm
+        A, B = self._pops(ts)
+        j = np.asarray(sfs_mod.joint_sfs(hm, A, B))
+        assert j[0, 0] == 0 and j[-1, -1] == 0
+        assert j[0, 1:].sum() > 0 and j[1:, 0].sum() > 0  # private-allele edges
+
+    def test_joint_sfs_folded_matches_tskit(self, multiallelic_hm):
+        # Folded joint = tskit polarised=False: fold each site as a unit by the
+        # global minor (NOT allel's per-axis fold), weight 1/2, corners dropped.
+        from pg_gpu import sfs as sfs_mod
+        ts, hm = multiallelic_hm
+        A, B = self._pops(ts)
+        jf_pg = np.asarray(sfs_mod.joint_sfs_folded(hm, A, B))
+        jf_ts = ts.allele_frequency_spectrum([A, B], polarised=False,
+                                             span_normalise=False)
+        np.testing.assert_allclose(jf_pg, jf_ts)
+        assert np.any(jf_pg != np.round(jf_pg))  # half-integers on multiallelic
+
+    def test_joint_sfs_folded_scaled_matches_base(self, multiallelic_hm):
+        from pg_gpu import sfs as sfs_mod
+        ts, hm = multiallelic_hm
+        A, B = self._pops(ts)
+        n1, n2 = len(A), len(B)
+        base = np.asarray(sfs_mod.joint_sfs_folded(hm, A, B))
+        scaled = np.asarray(sfs_mod.joint_sfs_folded_scaled(hm, A, B))
+        i = np.arange(base.shape[0])[:, None]
+        j = np.arange(base.shape[1])[None, :]
+        np.testing.assert_allclose(scaled, base * i * j * (n1 - i) * (n2 - j))
+
+    def test_projection_matches_per_allele_sandwich(self, multiallelic_hm):
+        # project_joint_sfs == P1 @ joint_sfs @ P2.T on the per-allele joint.
+        from pg_gpu import sfs as sfs_mod
+        from pg_gpu.diversity import _projection_matrix
+        ts, hm = multiallelic_hm
+        A, B = self._pops(ts)
+        n1, n2 = len(A), len(B)
+        t1, t2 = 8, 9
+        full = np.asarray(sfs_mod.joint_sfs(hm, A, B)).astype(np.float64)
+        P1 = _projection_matrix(n1, t1)
+        P2 = _projection_matrix(n2, t2)
+        expected = P1 @ full @ P2.T
+        result = sfs_mod.project_joint_sfs(hm, A, B, target_n1=t1, target_n2=t2)
+        np.testing.assert_allclose(result, expected, rtol=1e-9, atol=1e-9)
+
+
 class TestMultiallelicConsumers:
     """singleton_count / heterozygosity_expected / max_daf / mu_sfs / daf_histogram."""
 

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -379,6 +379,17 @@ class TestDivergenceVsTskit:
         num, den = allel.hudson_fst(ac1, ac2)
         np.testing.assert_allclose(fst_pg, np.sum(num) / np.sum(den), rtol=1e-9)
 
+    def test_fst_tskit_matches_tskit(self, multiallelic_ts):
+        # tskit's FST = (Hb - Hw)/(Hb + Hw); a distinct assembly from Hudson.
+        from pg_gpu import divergence
+        ts = multiallelic_ts
+        hm, A, B = self._hm_with_pops(ts)
+        fst_pg = divergence.fst_tskit(hm, 'A', 'B')
+        np.testing.assert_allclose(fst_pg, ts.Fst([A, B], mode='site'), rtol=1e-9)
+        # dispatcher routes method='tskit' here; and it differs from Hudson
+        assert divergence.fst(hm, 'A', 'B', method='tskit') == fst_pg
+        assert not np.isclose(fst_pg, divergence.fst_hudson(hm, 'A', 'B'))
+
     def test_pbs_matches_allel(self, multiallelic_ts):
         # PBS composes three per-allele Hudson FSTs; matches allel.pbs.
         from pg_gpu import divergence

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -559,12 +559,13 @@ class TestDivergenceVsTskit:
         np.testing.assert_allclose(pbs_pg[valid], pbs_allel[valid], rtol=1e-6, atol=1e-9)
 
     def test_dxy_matches_tskit(self, multiallelic_ts):
-        # dxy = 1 - sum_a p1_a*p2_a per site; mean over sites == tskit divergence.
+        # dxy = 1 - sum_a p1_a*p2_a per site. span_normalize=False returns the
+        # raw sum over sites, which equals tskit's site divergence sum.
         from pg_gpu import divergence
         ts = multiallelic_ts
         hm, A, B = self._hm_with_pops(ts)
         dxy_pg = divergence.dxy(hm, 'A', 'B', span_normalize=False)
-        dxy_ts = ts.divergence([A, B], mode='site', span_normalise=False) / ts.num_sites
+        dxy_ts = ts.divergence([A, B], mode='site', span_normalise=False)
         np.testing.assert_allclose(dxy_pg, dxy_ts, rtol=1e-12)
 
     def test_dxy_components_consistent_with_dxy(self, multiallelic_ts):
@@ -576,10 +577,11 @@ class TestDivergenceVsTskit:
         pop2 = hm.haplotypes[hm.sample_sets['B'], :]
         diffs, comps, nsites = divergence.dxy_components(pop1, pop2)
         dxy_pg = divergence.dxy(hm, 'A', 'B', span_normalize=False)
-        # No missing data => n1*n2 constant across sites, so the pooled ratio
-        # diffs/comps equals dxy's mean-of-per-site-ratios.
+        # dxy (span_normalize=False) is the raw sum of per-site ratios. With no
+        # missing data n1*n2 is constant, so the pooled ratio diffs/comps equals
+        # the per-site mean == dxy_pg / nsites.
         assert nsites == ts.num_sites
-        np.testing.assert_allclose(diffs / comps, dxy_pg, rtol=1e-12)
+        np.testing.assert_allclose(diffs / comps, dxy_pg / nsites, rtol=1e-12)
 
     def test_da_uses_per_allele_pieces(self, multiallelic_ts):
         # da = dxy - (pi1+pi2)/2, both per-allele now (internally consistent).

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -255,6 +255,47 @@ class TestPerAlleleSFS:
         assert not np.isclose(pi_sfs, pi_scalar, rtol=1e-6)
 
 
+class TestMultiallelicConsumers:
+    """singleton_count / heterozygosity_expected / max_daf / mu_sfs / daf_histogram."""
+
+    def test_singleton_count_per_allele(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        ac = allel.HaplotypeArray(ts.genotype_matrix()).count_alleles()
+        # per-allele singletons: derived alleles carried by exactly one sample
+        ref = int(np.sum(ac[:, 1:] == 1))
+        assert diversity.singleton_count(hm) == ref
+
+    def test_heterozygosity_expected_per_allele(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        n = ts.num_samples
+        ac = np.asarray(allel.HaplotypeArray(ts.genotype_matrix()).count_alleles(),
+                        dtype=float)
+        # He = 1 - sum_a p_a^2 over all alleles (no missing so n_valid = n)
+        ref = 1.0 - (ac ** 2).sum(axis=1) / (n ** 2)
+        np.testing.assert_allclose(diversity.heterozygosity_expected(hm), ref, rtol=1e-9)
+
+    def test_heterozygosity_expected_triallelic(self):
+        # {0:2, 1:1, 2:1}, n=4: He = 1 - (2^2 + 1 + 1)/16 = 1 - 6/16 = 0.625
+        hm = HaplotypeMatrix(np.array([[0], [0], [1], [2]], dtype=np.int8),
+                             np.array([100]), 0, 200)
+        np.testing.assert_allclose(diversity.heterozygosity_expected(hm)[0],
+                                   0.625, rtol=1e-12)
+
+    def test_max_daf_is_single_derived_allele(self):
+        # {0:1, 1:5, 2:4}, n=10: per-allele max DAF = 0.5 (allele 1), NOT the
+        # total non-ancestral fraction 0.9.
+        col = [[0]] + [[1]] * 5 + [[2]] * 4
+        hm = HaplotypeMatrix(np.array(col, dtype=np.int8), np.array([100]), 0, 200)
+        np.testing.assert_allclose(diversity.max_daf(hm), 0.5, rtol=1e-12)
+
+    def test_mu_sfs_and_daf_histogram_run(self, multiallelic_hm):
+        _, hm = multiallelic_hm
+        assert 0.0 <= diversity.mu_sfs(hm) <= 1.0
+        hist, edges = diversity.daf_histogram(hm)
+        assert np.isclose(hist.sum(), 1.0)
+        assert len(edges) == len(hist) + 1
+
+
 class TestMultiallelicEdgeCases:
     """Hand-built sites: per-allele pi and mutation-count segregating."""
 

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -593,6 +593,115 @@ class TestDivergenceVsTskit:
         np.testing.assert_allclose(da, dxy_pg - (pi1 + pi2) / 2.0, rtol=1e-12)
 
 
+class TestFStatisticsVsTskit:
+    """Patterson f2 / f3 per-allele vs tskit (unbiased U-statistics)."""
+
+    @staticmethod
+    def _pops(ts):
+        s = ts.samples()
+        q = len(s) // 4
+        return (list(s[:q]), list(s[q:2 * q]), list(s[2 * q:3 * q]),
+                list(s[3 * q:]))
+
+    def _hm(self, ts):
+        s = ts.samples()
+        q = len(s) // 4
+        hm = HaplotypeMatrix.from_ts(ts, device="GPU")
+        hm.sample_sets = {'A': list(range(q)), 'B': list(range(q, 2 * q)),
+                          'C': list(range(2 * q, 3 * q)),
+                          'D': list(range(3 * q, len(s)))}
+        return hm
+
+    def test_f2_matches_tskit(self, multiallelic_ts):
+        from pg_gpu import admixture
+        ts = multiallelic_ts
+        A, B, _, _ = self._pops(ts)
+        hm = self._hm(ts)
+        f2_pg = float(np.nansum(admixture.patterson_f2(hm, 'A', 'B')))
+        f2_ts = float(ts.f2([A, B], mode='site', span_normalise=False))
+        np.testing.assert_allclose(f2_pg, f2_ts, rtol=1e-9)
+        assert f2_pg < 0  # unbiased estimator can be negative (and is here)
+
+    def test_f3_matches_tskit(self, multiallelic_ts):
+        # pg_gpu patterson_f3(C, A, B) == f3(C; A, B); tskit target set is first.
+        from pg_gpu import admixture
+        ts = multiallelic_ts
+        A, B, C, _ = self._pops(ts)
+        hm = self._hm(ts)
+        T, _ = admixture.patterson_f3(hm, 'C', 'A', 'B')
+        f3_pg = float(np.nansum(T))
+        f3_ts = float(ts.f3([C, A, B], mode='site', span_normalise=False))
+        np.testing.assert_allclose(f3_pg, f3_ts, rtol=1e-9)
+
+    def test_f4_matches_tskit(self, multiallelic_ts):
+        from pg_gpu import admixture
+        ts = multiallelic_ts
+        A, B, C, D = self._pops(ts)
+        hm = self._hm(ts)
+        f4_pg = float(np.nansum(admixture.patterson_f4(hm, 'A', 'B', 'C', 'D')))
+        f4_ts = float(ts.f4([A, B, C, D], mode='site', span_normalise=False))
+        np.testing.assert_allclose(f4_pg, f4_ts, rtol=1e-9)
+
+    def test_patterson_d_is_biallelic_restricted(self, multiallelic_ts):
+        # D silently excludes >2-allele sites (num=den=0) and stays in [-1, 1];
+        # exclusion is silent, matching the package's biallelic filtering.
+        from pg_gpu import admixture
+        ts = multiallelic_ts
+        hm = self._hm(ts)
+        num, den = admixture.patterson_d(hm, 'A', 'B', 'C', 'D')
+        d_val = np.nansum(num) / np.nansum(den)
+        assert -1.0 <= d_val <= 1.0
+        # reference: strictly-biallelic subset ({0,1} across all four pops) gives
+        # the same D (non-biallelic sites contribute 0 to both sums).
+        G = ts.genotype_matrix()
+        cols = (list(hm.sample_sets['A']) + list(hm.sample_sets['B'])
+                + list(hm.sample_sets['C']) + list(hm.sample_sets['D']))
+        n_alleles = np.array([np.unique(G[i, cols]).size
+                              for i in range(ts.num_sites)])
+        assert (n_alleles > 2).any()          # fixture really has multiallelic sites
+        d_all = num[n_alleles <= 2]
+        assert np.allclose(num[n_alleles > 2], 0.0)   # multiallelic sites zeroed
+
+    def test_moving_and_jackknife_inherit_per_allele_fix(self, multiallelic_ts):
+        # moving_* / average_* build on the corrected _patterson_*_gpu helpers,
+        # so they inherit the per-allele fix. A single all-variant window
+        # reproduces the global estimate; jackknife runs and is finite.
+        from pg_gpu import admixture
+        ts = multiallelic_ts
+        hm = self._hm(ts)
+        nv = hm.num_variants
+
+        T, B = admixture.patterson_f3(hm, 'C', 'A', 'B')
+        f3_global = float(np.nansum(T) / np.nansum(B))
+        f3_win = admixture.moving_patterson_f3(hm, 'C', 'A', 'B', size=nv,
+                                               normed=True)
+        assert len(f3_win) == 1
+        np.testing.assert_allclose(f3_win[0], f3_global, rtol=1e-9)
+
+        num, den = admixture.patterson_d(hm, 'A', 'B', 'C', 'D')
+        d_global = float(np.nansum(num) / np.nansum(den))
+        d_win = admixture.moving_patterson_d(hm, 'A', 'B', 'C', 'D', size=nv)
+        assert len(d_win) == 1
+        np.testing.assert_allclose(d_win[0], d_global, rtol=1e-9)
+
+        blen = max(nv // 5, 1)
+        f3_est = admixture.average_patterson_f3(hm, 'C', 'A', 'B', blen=blen)[0]
+        d_est = admixture.average_patterson_d(hm, 'A', 'B', 'C', 'D', blen=blen)[0]
+        assert np.isfinite(f3_est) and np.isfinite(d_est)
+
+    def test_f3_normalizer_is_unbiased_het_of_target(self, multiallelic_ts):
+        # B == unbiased heterozygosity of C == tskit diversity(C) per site.
+        from pg_gpu import admixture
+        ts = multiallelic_ts
+        _, _, C, _ = self._pops(ts)
+        hm = self._hm(ts)
+        _, B = admixture.patterson_f3(hm, 'C', 'A', 'B')
+        het_c = float(np.nansum(B))
+        div_c = float(np.atleast_1d(
+            ts.diversity([C], mode='site', span_normalise=False))[0])
+        np.testing.assert_allclose(het_c, div_c, rtol=1e-9)
+
+
 class TestMultiallelicConsumers:
     """singleton_count / heterozygosity_expected / max_daf / mu_sfs / daf_histogram."""
 

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -12,6 +12,7 @@ import pytest
 
 from pg_gpu import HaplotypeMatrix
 from pg_gpu import diversity
+from pg_gpu import sfs
 from pg_gpu.diversity import FrequencySpectrum
 
 
@@ -194,15 +195,7 @@ class TestMissingData:
 
 
 class TestPerAlleleSFS:
-    """allele_frequency_spectrum + FrequencySpectrum on the per-allele SFS."""
-
-    def test_afs_matches_tskit(self, multiallelic_hm):
-        # Full array matches tskit's polarised AFS exactly: per-allele interior,
-        # both fixed classes (bins 0 and n) excluded.
-        ts, hm = multiallelic_hm
-        afs_pg = np.asarray(diversity.allele_frequency_spectrum(hm))
-        afs_ts = ts.allele_frequency_spectrum(polarised=True, span_normalise=False)
-        np.testing.assert_array_equal(afs_pg, afs_ts.astype(int))
+    """sfs.sfs + FrequencySpectrum on the per-allele SFS."""
 
     def test_sfs_module_matches_tskit(self, multiallelic_hm):
         # The sfs module's unfolded SFS is per-allele and matches tskit too.
@@ -246,7 +239,7 @@ class TestPerAlleleSFS:
         per_allele = ac[:, 1:].flatten()
         per_allele = per_allele[(per_allele > 0) & (per_allele < n)].astype(np.int64)
         ref = np.bincount(per_allele, minlength=n + 1)[:n + 1]
-        afs_pg = np.asarray(diversity.allele_frequency_spectrum(hm))
+        afs_pg = np.asarray(sfs.sfs(hm))
         np.testing.assert_array_equal(afs_pg[1:n], ref[1:n])
 
     def test_afs_excludes_fixed_classes(self):
@@ -256,8 +249,8 @@ class TestPerAlleleSFS:
                                   np.array([100]), 0, 200)
         ancestral = HaplotypeMatrix(np.array([[0], [0], [0], [0]], dtype=np.int8),
                                     np.array([100]), 0, 200)
-        assert np.asarray(diversity.allele_frequency_spectrum(derived)).sum() == 0
-        assert np.asarray(diversity.allele_frequency_spectrum(ancestral)).sum() == 0
+        assert np.asarray(sfs.sfs(derived)).sum() == 0
+        assert np.asarray(sfs.sfs(ancestral)).sum() == 0
 
     def test_freqspec_theta_h_l_match_scalar(self, multiallelic_hm):
         # theta_h / theta_l are additive per allele, so the SFS path equals the

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -204,6 +204,40 @@ class TestPerAlleleSFS:
         afs_ts = ts.allele_frequency_spectrum(polarised=True, span_normalise=False)
         np.testing.assert_array_equal(afs_pg, afs_ts.astype(int))
 
+    def test_sfs_module_matches_tskit(self, multiallelic_hm):
+        # The sfs module's unfolded SFS is per-allele and matches tskit too.
+        from pg_gpu import sfs as sfs_mod
+        ts, hm = multiallelic_hm
+        afs_pg = np.asarray(sfs_mod.sfs(hm))
+        afs_ts = ts.allele_frequency_spectrum(polarised=True, span_normalise=False)
+        np.testing.assert_array_equal(afs_pg, afs_ts.astype(int))
+
+    def test_sfs_folded_matches_tskit(self, multiallelic_hm):
+        # Folded SFS is per-allele = tskit polarised=False: every allele (ref
+        # included) weight 1/2 at min(count, n-count), fixed class dropped.
+        # Half-integer bins appear on multiallelic data.
+        from pg_gpu import sfs as sfs_mod
+        ts, hm = multiallelic_hm
+        n = ts.num_samples
+        folded_pg = np.asarray(sfs_mod.sfs_folded(hm))
+        folded_ts = ts.allele_frequency_spectrum(polarised=False,
+                                                 span_normalise=False)
+        # pg_gpu returns the compact folded domain [0, n//2]; tskit pads to n+1
+        # with zeros above n//2.
+        np.testing.assert_allclose(folded_pg, folded_ts[:n // 2 + 1])
+        # multiallelic input really does produce half-integer weights
+        assert np.any(folded_pg != np.round(folded_pg))
+
+    def test_sfs_folded_scaled_matches_tskit_base(self, multiallelic_hm):
+        # Scaled folded = tskit-pinned folded base * the k*(n-k)/n transform.
+        from pg_gpu import sfs as sfs_mod
+        ts, hm = multiallelic_hm
+        n = ts.num_samples
+        base = np.asarray(sfs_mod.sfs_folded(hm))
+        scaled = np.asarray(sfs_mod.sfs_folded_scaled(hm))
+        k = np.arange(base.shape[0])
+        np.testing.assert_allclose(scaled, base * k * (n - k) / n)
+
     def test_afs_interior_matches_allel(self, multiallelic_hm):
         # Independent-library check on the segregating interior (1..n-1).
         ts, hm = multiallelic_hm

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -414,6 +414,27 @@ class TestDivergenceVsTskit:
         gst_ref = (ht[v] - hs[v]).sum() / ht[v].sum()
         np.testing.assert_allclose(gst_pg, gst_ref, rtol=1e-12)
 
+    def test_fst_weir_cockerham_matches_allel(self, multiallelic_ts):
+        # WC per-allele one-vs-rest a/b/c summed over alleles (incl. per-allele
+        # observed het) == allel.weir_cockerham_fst on multiallelic diploid data.
+        from pg_gpu import divergence
+        ts = multiallelic_ts
+        G = ts.genotype_matrix()
+        nsites, n_nodes = G.shape
+        n_ind = n_nodes // 2
+        half = n_ind // 2
+        gd = G.reshape(nsites, n_ind, 2)
+        subpops = [list(range(half)), list(range(half, n_ind))]
+        a, b, c = allel.weir_cockerham_fst(allel.GenotypeArray(gd), subpops)
+        fst_allel = np.sum(a) / np.sum(a + b + c)
+
+        hm = HaplotypeMatrix.from_ts(ts, device="GPU")
+        # individual i == haplotype rows 2i, 2i+1
+        hm.sample_sets = {'A': list(range(2 * half)),
+                          'B': list(range(2 * half, n_nodes))}
+        fst_pg = divergence.fst_weir_cockerham(hm, 'A', 'B')
+        np.testing.assert_allclose(fst_pg, fst_allel, rtol=1e-9)
+
     def test_pbs_matches_allel(self, multiallelic_ts):
         # PBS composes three per-allele Hudson FSTs; matches allel.pbs.
         from pg_gpu import divergence

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -349,6 +349,111 @@ class TestJointSFS:
         np.testing.assert_allclose(result, expected, rtol=1e-9, atol=1e-9)
 
 
+class TestPairwiseDistanceKernel:
+    """Multiallelic pairwise Hamming distance kernel (0003b) vs numpy direct."""
+
+    @staticmethod
+    def _direct(hap):
+        # raw = # jointly-valid sites that differ; jv = # jointly-valid sites
+        n = hap.shape[0]
+        raw = np.zeros((n, n))
+        jv = np.zeros((n, n))
+        for i in range(n):
+            for j in range(n):
+                both = (hap[i] >= 0) & (hap[j] >= 0)
+                jv[i, j] = both.sum()
+                raw[i, j] = (both & (hap[i] != hap[j])).sum()
+        return raw, jv
+
+    def test_multiallelic_with_missing_matches_numpy(self):
+        import cupy as cp
+        from pg_gpu.distance_stats import _pairwise_diffs_matrix_gpu
+        rng = np.random.RandomState(0)
+        hap = rng.randint(0, 4, size=(8, 200)).astype(np.int8)  # 4 alleles
+        hap[rng.random((8, 200)) < 0.1] = -1                     # 10% missing
+        assert hap.max() > 1                                     # genuinely multiallelic
+        raw_ref, jv_ref = self._direct(hap)
+        norm_ref = np.where(jv_ref > 0, raw_ref / jv_ref, 0.0)
+        raw = cp.asnumpy(_pairwise_diffs_matrix_gpu(hap, 'include'))
+        norm = cp.asnumpy(_pairwise_diffs_matrix_gpu(hap, 'normalize'))
+        np.testing.assert_allclose(raw, raw_ref)
+        np.testing.assert_allclose(norm, norm_ref)
+        assert np.allclose(np.diag(raw), 0)
+        assert not (raw < 0).any()          # the old binary-only identity went negative
+
+    def test_biallelic_bit_identical_to_gram_trick(self):
+        import cupy as cp
+        from pg_gpu.distance_stats import _pairwise_diffs_matrix_gpu
+        rng = np.random.RandomState(1)
+        hb = rng.randint(0, 2, size=(6, 150)).astype(np.int8)   # no missing
+        old = (hb.sum(1)[:, None] + hb.sum(1)[None, :]
+               - 2 * (hb.astype(float) @ hb.astype(float).T))
+        new = cp.asnumpy(_pairwise_diffs_matrix_gpu(hb, 'include'))
+        np.testing.assert_array_equal(new, old)
+
+
+class TestDistanceStatsConsumers:
+    """Distance-based stats inherit the corrected multiallelic Hamming kernel."""
+
+    @staticmethod
+    def _raw_hamming(haps):
+        # raw pairwise Hamming count (fixture has no missing data)
+        n = haps.shape[0]
+        D = np.zeros((n, n))
+        for i in range(n):
+            D[i] = (haps != haps[i]).sum(axis=1)
+        return D
+
+    def _setup(self, ts):
+        n = ts.num_samples
+        h = n // 2
+        hm = HaplotypeMatrix.from_ts(ts, device="GPU")
+        hm.sample_sets = {'A': list(range(h)), 'B': list(range(h, n))}
+        haps = ts.genotype_matrix().T          # (n_samples, n_sites) allele indices
+        # Guard the coverage claim: allele indices must exceed {0,1}, i.e. the
+        # exact regime where the old binary-only kernel broke.
+        assert haps.max() > 1, "fixture is not multiallelic"
+        return hm, h, n, haps
+
+    def test_pairwise_diffs_haploid_matches_numpy(self, multiallelic_ts):
+        from pg_gpu import distance_stats as ds
+        ts = multiallelic_ts
+        hm, h, n, haps = self._setup(ts)
+        got = np.asarray(ds.pairwise_diffs_haploid(hm))     # condensed, per-site avg
+        D = self._raw_hamming(haps) / haps.shape[1]
+        ii, jj = np.triu_indices(n, k=1)
+        np.testing.assert_allclose(got, D[ii, jj], rtol=1e-9)
+
+    def test_pairwise_distance_matrix_blocks_match_numpy(self, multiallelic_ts):
+        import cupy as cp
+        from pg_gpu import divergence
+        ts = multiallelic_ts
+        hm, h, n, haps = self._setup(ts)
+        D = self._raw_hamming(haps)
+        between, within1, within2 = divergence.pairwise_distance_matrix(hm, 'A', 'B')
+        np.testing.assert_allclose(cp.asnumpy(between), D[:h, h:])
+        np.testing.assert_allclose(cp.asnumpy(within1), D[:h, :h])
+        np.testing.assert_allclose(cp.asnumpy(within2), D[h:, h:])
+
+    # NOTE: zx is excluded -- it is an LD/ZnS ratio (ld_statistics.zns), not a
+    # distance-matrix statistic, so it does not consume the Hamming kernel.
+    @pytest.mark.parametrize("statname",
+                             ["snn", "dxy_min", "gmin", "dd", "dd_rank"])
+    def test_distance_stat_consumes_corrected_kernel(self, multiallelic_ts, statname):
+        # stat via the pg_gpu kernel == stat fed numpy-reference distance matrices,
+        # so each stat correctly consumes the corrected multiallelic distances.
+        import cupy as cp
+        from pg_gpu import divergence
+        ts = multiallelic_ts
+        hm, h, n, haps = self._setup(ts)
+        D = self._raw_hamming(haps)
+        ref = (cp.asarray(D[:h, h:]), cp.asarray(D[:h, :h]), cp.asarray(D[h:, h:]))
+        fn = getattr(divergence, statname)
+        got = fn(hm, 'A', 'B')
+        ref_val = fn(hm, 'A', 'B', distance_matrices=ref)
+        np.testing.assert_allclose(got, ref_val, rtol=1e-9, equal_nan=True)
+
+
 class TestDivergenceVsTskit:
     """Count-based divergence per-allele vs tskit (dxy/da) and scikit-allel
     (Hudson FST / PBS), on multiallelic two/three sample sets."""

--- a/tests/test_pbs_decomposition.py
+++ b/tests/test_pbs_decomposition.py
@@ -104,33 +104,9 @@ class TestPCA:
         assert np.all(var_ratio >= 0)
         assert np.sum(var_ratio) <= 1.0 + 1e-10
 
-    def test_pca_vs_allel(self, pca_data):
-        """Verify PCA produces similar variance explained as allel."""
-        hap = pca_data.haplotypes
-        if hasattr(hap, 'get'):
-            hap = hap.get()
-
-        # pg_gpu
-        _, var_pg = decomposition.pca(pca_data, n_components=5,
-                                       scaler='patterson')
-
-        # allel: needs (n_variants, n_samples) genotype array
-        # use haplotypes directly as "genotypes" (0/1)
-        gn = hap.T.astype('i1')
-        _, model = allel.pca(gn, n_components=5, scaler='patterson')
-        var_allel = model.explained_variance_ratio_
-
-        # variance ratios should correlate highly
-        corr = np.corrcoef(var_pg, var_allel)[0, 1]
-        assert corr > 0.9, f"PCA variance correlation: {corr}"
-
-    def test_pca_scalers(self, pca_data):
-        """All scalers should produce valid output."""
-        for scaler in ['patterson', 'standard', None]:
-            coords, var_ratio = decomposition.pca(
-                pca_data, n_components=3, scaler=scaler)
-            assert coords.shape == (40, 3)
-            assert not np.any(np.isnan(coords))
+    # The Patterson-vs-scikit-allel comparison moved to pca_dosage (the diploid
+    # biallelic GCTA PCA on a GenotypeMatrix); pca is now the tskit PCA of
+    # genetic_relatedness, pinned in test_decomposition_multiallelic.py.
 
     def test_pca_with_population(self, pca_data):
         pca_data.sample_sets = {'sub': list(range(20))}

--- a/tests/test_pca_dosage.py
+++ b/tests/test_pca_dosage.py
@@ -1,0 +1,96 @@
+"""Parity tests for the diploid Patterson/GCTA PCA (pca_dosage).
+
+pca_dosage / randomized_pca_dosage standardize biallelic diploid dosages the way
+scikit-allel does (center by the per-variant mean, scale by sqrt(p (1 - p)) with
+p = mean / 2), then eigendecompose the individual-by-individual Gram. These tests
+pin that against allel.pca, check the randomized approximation, the ploidy-1/2
+type split (GenotypeMatrix only), and the biallelic requirement.
+"""
+import numpy as np
+import pytest
+import allel
+
+from pg_gpu import (GenotypeMatrix, HaplotypeMatrix, pca_dosage,
+                    randomized_pca_dosage)
+
+
+def _polymorphic_gm(seed=0, n_ind=30, n_var=200):
+    """Biallelic diploid dosages with every site polymorphic (a 0 and a 2 forced
+    per variant), so scikit-allel's unguarded 1/sqrt(p(1-p)) never divides by 0."""
+    rng = np.random.RandomState(seed)
+    geno = rng.randint(0, 3, (n_ind, n_var)).astype(np.int8)
+    geno[0, :] = 0
+    geno[1, :] = 2
+    return GenotypeMatrix(geno.copy(), np.arange(n_var) * 100), geno
+
+
+class TestPCADosageParity:
+
+    def test_pca_dosage_matches_allel(self):
+        gm, geno = _polymorphic_gm(seed=3)
+        coords, evr = pca_dosage(gm, n_components=6)
+        # scikit-allel takes gn as (n_variants, n_samples)
+        acoords, model = allel.pca(geno.T.astype('f8'), n_components=6,
+                                   scaler='patterson', ploidy=2)
+        np.testing.assert_allclose(evr, model.explained_variance_ratio_,
+                                   atol=1e-8, rtol=1e-6)
+        # coordinates equal up to a per-component sign flip
+        for j in range(6):
+            sign = np.sign(np.dot(coords[:, j], acoords[:, j]))
+            np.testing.assert_allclose(coords[:, j], sign * acoords[:, j],
+                                       atol=1e-6, rtol=1e-5)
+
+    def test_randomized_pca_dosage_matches_pca_dosage(self):
+        # Three groups at distinct frequencies give a well-separated leading
+        # 2D subspace where the randomized approximation is accurate. Compare via
+        # canonical correlations so within-subspace rotation is not penalized.
+        rng = np.random.RandomState(5)
+        n_ind, n_var = 45, 500
+        groups = [slice(0, 15), slice(15, 30), slice(30, 45)]
+        freqs = [0.2, 0.5, 0.8]
+        geno = np.empty((n_ind, n_var), dtype=np.int8)
+        for v in range(n_var):
+            for g, pg in zip(groups, freqs):
+                geno[g, v] = rng.binomial(2, pg, 15)
+        gm = GenotypeMatrix(geno, np.arange(n_var) * 100)
+        coords, evr = pca_dosage(gm, n_components=2)
+        rcoords, revr = randomized_pca_dosage(gm, n_components=2, n_iter=7,
+                                              random_state=0)
+        np.testing.assert_allclose(revr, evr, atol=1e-3, rtol=1e-2)
+        qa, _ = np.linalg.qr(coords)
+        qb, _ = np.linalg.qr(rcoords)
+        canonical = np.linalg.svd(qa.T @ qb, compute_uv=False)
+        assert canonical.min() > 0.999
+
+    def test_population_subset(self):
+        rng = np.random.RandomState(7)
+        geno = rng.randint(0, 3, (20, 150)).astype(np.int8)
+        geno[0, :] = 0
+        geno[1, :] = 2
+        sets = {'A': list(range(10)), 'B': list(range(10, 20))}
+        gm = GenotypeMatrix(geno.copy(), np.arange(150) * 100, sample_sets=sets)
+        coords, _ = pca_dosage(gm, n_components=3, population='A')
+        assert coords.shape == (10, 3)
+
+
+class TestPCADosageTypeGuards:
+
+    def test_pca_dosage_rejects_haplotype_matrix(self):
+        hm = HaplotypeMatrix(np.random.RandomState(0).randint(0, 2, (10, 50)).astype(np.int8),
+                             np.arange(50) * 100, 0, 5000)
+        with pytest.raises(TypeError, match="HaplotypeMatrix"):
+            pca_dosage(hm)
+
+    def test_randomized_pca_dosage_rejects_haplotype_matrix(self):
+        hm = HaplotypeMatrix(np.random.RandomState(0).randint(0, 2, (10, 50)).astype(np.int8),
+                             np.arange(50) * 100, 0, 5000)
+        with pytest.raises(TypeError, match="HaplotypeMatrix"):
+            randomized_pca_dosage(hm)
+
+    def test_pca_dosage_rejects_non_biallelic(self):
+        # A dosage > 2 cannot arise from a biallelic diploid site.
+        geno = np.random.RandomState(0).randint(0, 3, (10, 50)).astype(np.int8)
+        geno[0, 0] = 3
+        gm = GenotypeMatrix(geno, np.arange(50) * 100)
+        with pytest.raises(ValueError, match="biallelic"):
+            pca_dosage(gm)

--- a/tests/test_pca_dosage.py
+++ b/tests/test_pca_dosage.py
@@ -1,10 +1,11 @@
-"""Parity tests for the diploid Patterson/GCTA PCA (pca_dosage).
+"""Parity tests for the diploid dosage PCA standardized by binomial variance
+(pca_dosage).
 
-pca_dosage / randomized_pca_dosage standardize biallelic diploid dosages the way
-scikit-allel does (center by the per-variant mean, scale by sqrt(p (1 - p)) with
-p = mean / 2), then eigendecompose the individual-by-individual Gram. These tests
-pin that against allel.pca, check the randomized approximation, the ploidy-1/2
-type split (GenotypeMatrix only), and the biallelic requirement.
+pca_dosage / randomized_pca_dosage center each biallelic variant's alt-allele
+dosage on its mean and scale by the binomial standard deviation sqrt(p (1 - p)),
+p = mean / 2, then eigendecompose the individual-by-individual Gram. These tests
+pin the result against allel.pca as an external oracle, check the randomized
+approximation, the GenotypeMatrix-only type split, and the biallelic requirement.
 """
 import numpy as np
 import pytest

--- a/tests/test_relatedness.py
+++ b/tests/test_relatedness.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pytest
-from pg_gpu import HaplotypeMatrix, relatedness
+from pg_gpu import GenotypeMatrix, HaplotypeMatrix, relatedness
 
 
 @pytest.fixture
@@ -14,10 +14,17 @@ def small_haplotype_matrix():
     return HaplotypeMatrix(hap, positions)
 
 
-def _reference_grm(hap):
-    """Compute GRM from haplotypes using numpy (reference implementation)."""
-    n_ind = hap.shape[0] // 2
-    g = hap[:n_ind, :] + hap[n_ind:, :]
+@pytest.fixture
+def small_genotype_matrix():
+    """Small diploid genotype dataset: 3 individuals, 20 variants (0/1/2)."""
+    rng = np.random.RandomState(42)
+    geno = rng.randint(0, 3, size=(3, 20)).astype(np.int8)
+    positions = np.arange(20) * 1000
+    return GenotypeMatrix(geno, positions)
+
+
+def _reference_grm(g):
+    """GCTA GRM from a diploid genotype array (0/1/2), numpy reference."""
     g = g.astype(float)
     p = g.mean(axis=0) / 2
     poly = (p > 0) & (p < 1)
@@ -43,37 +50,41 @@ def _reference_ibs(hap):
     return ibs_mat
 
 
+def _geno_of(gm):
+    g = gm.genotypes
+    return g.get() if hasattr(g, 'get') else g
+
+
 class TestGRM:
-    def test_shape(self, small_haplotype_matrix):
-        grm = relatedness.grm(small_haplotype_matrix)
+    def test_shape(self, small_genotype_matrix):
+        grm = relatedness.grm(small_genotype_matrix)
         assert grm.shape == (3, 3)
 
-    def test_symmetric(self, small_haplotype_matrix):
-        grm = relatedness.grm(small_haplotype_matrix)
+    def test_symmetric(self, small_genotype_matrix):
+        grm = relatedness.grm(small_genotype_matrix)
         np.testing.assert_allclose(grm, grm.T)
 
-    def test_matches_reference(self, small_haplotype_matrix):
-        grm_pg = relatedness.grm(small_haplotype_matrix)
-        hap = small_haplotype_matrix.haplotypes
-        if hasattr(hap, 'get'):
-            hap = hap.get()
-        grm_ref = _reference_grm(hap)
+    def test_matches_reference(self, small_genotype_matrix):
+        grm_pg = relatedness.grm(small_genotype_matrix)
+        grm_ref = _reference_grm(_geno_of(small_genotype_matrix))
         np.testing.assert_allclose(grm_pg, grm_ref, atol=1e-10)
 
     def test_identical_individuals(self):
         """Two identical individuals should have GRM off-diagonal = diagonal."""
-        # pg_gpu layout: [allele1_ind0, allele1_ind1, allele2_ind0, allele2_ind1]
-        hap = np.array([[0, 1, 0, 1, 0],   # ind0 allele1
-                         [0, 1, 0, 1, 0],   # ind1 allele1 (same as ind0)
-                         [1, 0, 1, 0, 1],   # ind0 allele2
-                         [1, 0, 1, 0, 1]], dtype=np.int8)  # ind1 allele2 (same)
-        hm = HaplotypeMatrix(hap, np.arange(5) * 100)
-        grm = relatedness.grm(hm)
+        geno = np.array([[0, 1, 2, 1, 0],
+                         [0, 1, 2, 1, 0],   # identical to individual 0
+                         [2, 1, 0, 1, 2]], dtype=np.int8)
+        gm = GenotypeMatrix(geno, np.arange(5) * 100)
+        grm = relatedness.grm(gm)
         np.testing.assert_allclose(grm[0, 1], grm[0, 0], atol=1e-10)
 
-    def test_returns_numpy(self, small_haplotype_matrix):
-        grm = relatedness.grm(small_haplotype_matrix)
+    def test_returns_numpy(self, small_genotype_matrix):
+        grm = relatedness.grm(small_genotype_matrix)
         assert isinstance(grm, np.ndarray)
+
+    def test_rejects_haplotype_matrix(self, small_haplotype_matrix):
+        with pytest.raises(TypeError, match="genetic_relatedness"):
+            relatedness.grm(small_haplotype_matrix)
 
 
 class TestIBS:

--- a/tests/test_relatedness.py
+++ b/tests/test_relatedness.py
@@ -36,17 +36,25 @@ def _reference_grm(g):
     return (std @ std.T) / poly.sum()
 
 
-def _reference_ibs(hap):
-    """Compute IBS from haplotypes using numpy (reference implementation)."""
-    n_ind = hap.shape[0] // 2
-    g = hap[:n_ind, :] + hap[n_ind:, :]
-    n_snps = g.shape[1]
+def _reference_ibs(g):
+    """Biallelic diploid IBS from a genotype array (0/1/2), numpy reference.
+
+    Per jointly-called site the shared-allele count is 2 - abs(g_i - g_j); IBS
+    is the summed shared count over jointly-called sites divided by twice that
+    site count.
+    """
+    n_ind = g.shape[0]
     ibs_mat = np.eye(n_ind)
     for i in range(n_ind):
         for j in range(i + 1, n_ind):
-            ibs_val = (2 - np.abs(g[i] - g[j])).sum() / (2 * n_snps)
-            ibs_mat[i, j] = ibs_val
-            ibs_mat[j, i] = ibs_val
+            valid = (g[i] >= 0) & (g[j] >= 0)
+            n_joint = int(valid.sum())
+            if n_joint == 0:
+                continue
+            shared = (2 - np.abs(g[i] - g[j]))[valid].sum()
+            val = shared / (2 * n_joint)
+            ibs_mat[i, j] = val
+            ibs_mat[j, i] = val
     return ibs_mat
 
 
@@ -88,54 +96,59 @@ class TestGRM:
 
 
 class TestIBS:
-    def test_shape(self, small_haplotype_matrix):
-        ibs_mat = relatedness.ibs(small_haplotype_matrix)
+    def test_shape(self, small_genotype_matrix):
+        ibs_mat = relatedness.ibs(small_genotype_matrix)
         assert ibs_mat.shape == (3, 3)
 
-    def test_diagonal_is_one(self, small_haplotype_matrix):
-        ibs_mat = relatedness.ibs(small_haplotype_matrix)
+    def test_diagonal_is_one(self, small_genotype_matrix):
+        ibs_mat = relatedness.ibs(small_genotype_matrix)
         np.testing.assert_allclose(ibs_mat.diagonal(), 1.0)
 
-    def test_symmetric(self, small_haplotype_matrix):
-        ibs_mat = relatedness.ibs(small_haplotype_matrix)
+    def test_symmetric(self, small_genotype_matrix):
+        ibs_mat = relatedness.ibs(small_genotype_matrix)
         np.testing.assert_allclose(ibs_mat, ibs_mat.T)
 
-    def test_range(self, small_haplotype_matrix):
-        ibs_mat = relatedness.ibs(small_haplotype_matrix)
+    def test_range(self, small_genotype_matrix):
+        ibs_mat = relatedness.ibs(small_genotype_matrix)
         assert np.all(ibs_mat >= 0)
         assert np.all(ibs_mat <= 1)
 
-    def test_matches_reference(self, small_haplotype_matrix):
-        ibs_pg = relatedness.ibs(small_haplotype_matrix)
-        hap = small_haplotype_matrix.haplotypes
-        if hasattr(hap, 'get'):
-            hap = hap.get()
-        ibs_ref = _reference_ibs(hap)
-        np.testing.assert_allclose(ibs_pg, ibs_ref, atol=1e-10)
+    def test_matches_reference(self, small_genotype_matrix):
+        ibs_pg = relatedness.ibs(small_genotype_matrix)
+        np.testing.assert_allclose(ibs_pg, _reference_ibs(_geno_of(small_genotype_matrix)),
+                                   atol=1e-10)
+
+    def test_missing_matches_reference(self):
+        rng = np.random.RandomState(4)
+        geno = rng.randint(0, 3, size=(5, 40)).astype(np.int8)
+        geno[rng.random(geno.shape) < 0.1] = -1
+        gm = GenotypeMatrix(geno, np.arange(40) * 100)
+        np.testing.assert_allclose(relatedness.ibs(gm), _reference_ibs(geno),
+                                   atol=1e-10)
 
     def test_identical_individuals(self):
-        # pg_gpu layout: [allele1_ind0, allele1_ind1, allele2_ind0, allele2_ind1]
-        hap = np.array([[0, 1, 0, 1, 0],   # ind0 allele1
-                         [0, 1, 0, 1, 0],   # ind1 allele1
-                         [1, 0, 1, 0, 1],   # ind0 allele2
-                         [1, 0, 1, 0, 1]], dtype=np.int8)  # ind1 allele2
-        hm = HaplotypeMatrix(hap, np.arange(5) * 100)
-        ibs_mat = relatedness.ibs(hm)
+        geno = np.array([[0, 1, 2, 1],
+                         [0, 1, 2, 1],   # identical to individual 0
+                         [2, 1, 0, 1]], dtype=np.int8)
+        gm = GenotypeMatrix(geno, np.arange(4) * 100)
+        ibs_mat = relatedness.ibs(gm)
         assert ibs_mat[0, 1] == 1.0
 
     def test_completely_different(self):
-        # ind0 = 0/0 at all sites, ind1 = 2/2 at all sites
-        hap = np.array([[0, 0, 0, 0, 0],   # ind0 allele1
-                         [1, 1, 1, 1, 1],   # ind1 allele1
-                         [0, 0, 0, 0, 0],   # ind0 allele2
-                         [1, 1, 1, 1, 1]], dtype=np.int8)  # ind1 allele2
-        hm = HaplotypeMatrix(hap, np.arange(5) * 100)
-        ibs_mat = relatedness.ibs(hm)
+        # individual 0 = 0/0 everywhere, individual 1 = 1/1 everywhere.
+        geno = np.array([[0, 0, 0],
+                         [2, 2, 2]], dtype=np.int8)
+        gm = GenotypeMatrix(geno, np.arange(3) * 100)
+        ibs_mat = relatedness.ibs(gm)
         assert ibs_mat[0, 1] == 0.0
 
-    def test_returns_numpy(self, small_haplotype_matrix):
-        ibs_mat = relatedness.ibs(small_haplotype_matrix)
+    def test_returns_numpy(self, small_genotype_matrix):
+        ibs_mat = relatedness.ibs(small_genotype_matrix)
         assert isinstance(ibs_mat, np.ndarray)
+
+    def test_rejects_haplotype_matrix(self, small_haplotype_matrix):
+        with pytest.raises(TypeError, match="genetic_relatedness"):
+            relatedness.ibs(small_haplotype_matrix)
 
 
 def _reference_relatedness_columns(hap, sample_sets, n_alleles):

--- a/tests/test_relatedness.py
+++ b/tests/test_relatedness.py
@@ -125,3 +125,204 @@ class TestIBS:
     def test_returns_numpy(self, small_haplotype_matrix):
         ibs_mat = relatedness.ibs(small_haplotype_matrix)
         assert isinstance(ibs_mat, np.ndarray)
+
+
+def _reference_relatedness_columns(hap, sample_sets, n_alleles):
+    """Independent host reference for _relatedness_columns (complete or missing).
+
+    Returns (C, col_site): per-set per-allele frequencies centered by the
+    unweighted across-set mean, columns ordered site-major then allele-minor.
+    """
+    n_hap, n_var = hap.shape
+    valid = hap >= 0
+    sets = ([[h] for h in range(n_hap)] if sample_sets is None
+            else [list(s) for s in sample_sets])
+    covered = np.zeros(n_hap, dtype=bool)
+    for s in sets:
+        covered[s] = True
+    p_cols, site_cols = [], []
+    for s_idx in range(n_var):
+        for a in range(n_alleles):
+            if np.any(covered & (hap[:, s_idx] == a) & valid[:, s_idx]):
+                col = []
+                for st in sets:
+                    nv = int(valid[st, s_idx].sum())
+                    cnt = int(((hap[st, s_idx] == a) & valid[st, s_idx]).sum())
+                    col.append(cnt / nv if nv > 0 else 0.0)
+                p_cols.append(np.array(col))
+                site_cols.append(s_idx)
+    D = len(sets)
+    P = np.stack(p_cols, axis=1) if p_cols else np.zeros((D, 0))
+    C = P - P.mean(axis=0, keepdims=True)
+    return C, np.array(site_cols, dtype=np.int64)
+
+
+class TestRelatednessColumns:
+    """Per-set per-allele centered frequency plumbing for genetic_relatedness."""
+
+    def _run(self, hap, sample_sets):
+        import cupy as cp
+        k = int(hap.max()) + 1 if hap.size else 1
+        C, col_site, _ = relatedness._relatedness_columns(
+            cp.asarray(hap), sample_sets, k)
+        ref_C, ref_site = _reference_relatedness_columns(hap, sample_sets, k)
+        return C.get(), col_site.get(), ref_C, ref_site
+
+    def test_singleton_biallelic(self):
+        rng = np.random.RandomState(0)
+        hap = rng.randint(0, 2, size=(8, 30)).astype(np.int8)
+        C, site, ref_C, ref_site = self._run(hap, None)
+        np.testing.assert_array_equal(site, ref_site)
+        np.testing.assert_allclose(C, ref_C)
+        assert C.shape[0] == 8  # one row per haplotype
+
+    def test_singleton_multiallelic(self):
+        rng = np.random.RandomState(1)
+        hap = rng.randint(0, 3, size=(8, 40)).astype(np.int8)
+        C, site, ref_C, ref_site = self._run(hap, None)
+        np.testing.assert_array_equal(site, ref_site)
+        np.testing.assert_allclose(C, ref_C)
+
+    def test_columns_are_mean_centered(self):
+        # Each column is centered by the across-set mean -> column sums ~ 0.
+        rng = np.random.RandomState(2)
+        hap = rng.randint(0, 3, size=(6, 25)).astype(np.int8)
+        C, *_ = self._run(hap, None)
+        np.testing.assert_allclose(C.sum(axis=0), 0.0, atol=1e-9)
+
+    def test_grouped_sample_sets_multiallelic(self):
+        # Two sample sets of unequal size; centering is the unweighted mean of
+        # the two set frequencies (not the pooled frequency).
+        rng = np.random.RandomState(3)
+        hap = rng.randint(0, 3, size=(10, 30)).astype(np.int8)
+        sample_sets = [np.arange(0, 4), np.arange(4, 10)]
+        C, site, ref_C, ref_site = self._run(hap, sample_sets)
+        np.testing.assert_array_equal(site, ref_site)
+        np.testing.assert_allclose(C, ref_C)
+        assert C.shape[0] == 2
+
+    def test_subset_of_samples_restricts_present_alleles(self):
+        # An allele carried only by an excluded sample must not create a column.
+        hap = np.array([[0], [0], [1], [2]], dtype=np.int8)  # 4 haps, 1 site
+        sample_sets = [np.array([0, 1, 2])]  # excludes hap 3 (the only allele-2)
+        C, site, ref_C, ref_site = self._run(hap, sample_sets)
+        np.testing.assert_array_equal(site, ref_site)
+        np.testing.assert_allclose(C, ref_C)
+        # alleles 0 and 1 present among {0,1,2}; allele 2 excluded -> 2 columns
+        assert C.shape[1] == 2
+
+    def test_relatedness_matrix_symmetric_psd_ish(self):
+        # C @ C.T (the genetic_relatedness matrix) is symmetric with a
+        # non-negative diagonal.
+        rng = np.random.RandomState(4)
+        hap = rng.randint(0, 3, size=(8, 50)).astype(np.int8)
+        C, *_ = self._run(hap, None)
+        R = C @ C.T
+        np.testing.assert_allclose(R, R.T, atol=1e-9)
+        assert bool((np.diag(R) >= -1e-9).all())
+
+
+class TestGeneticRelatedness:
+    """genetic_relatedness pinned to tskit.TreeSequence.genetic_relatedness."""
+
+    def _tskit_matrix(self, ts, sample_sets, proportion=False, **kw):
+        # proportion=False gives the raw centered covariance; proportion=True
+        # divides by segregating sites (per-site sum of num_alleles - 1).
+        D = len(sample_sets)
+        idx = [(i, j) for i in range(D) for j in range(D)]
+        vals = ts.genetic_relatedness(sample_sets, indexes=idx, mode='site',
+                                      proportion=proportion, **kw)
+        return np.asarray(vals).reshape(D, D)
+
+    def test_singleton_pin_raw(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        tsk_sets = [[s] for s in ts.samples()]
+        exp = self._tskit_matrix(ts, tsk_sets, centre=True, polarised=False,
+                                 span_normalise=False)
+        got = relatedness.genetic_relatedness(hm, span_normalize=False)
+        np.testing.assert_allclose(got, exp, atol=1e-9, rtol=1e-6)
+
+    def test_singleton_pin_span_normalised(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        tsk_sets = [[s] for s in ts.samples()]
+        exp = self._tskit_matrix(ts, tsk_sets, centre=True, polarised=False,
+                                 span_normalise=True)
+        got = relatedness.genetic_relatedness(hm, span_normalize=True)
+        np.testing.assert_allclose(got, exp, atol=1e-12, rtol=1e-6)
+
+    def test_grouped_sample_sets_pin(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        samples = list(ts.samples())
+        n = len(samples)
+        half = n // 2
+        pg_sets = [list(range(0, half)), list(range(half, n))]
+        tsk_sets = [[samples[i] for i in grp] for grp in pg_sets]
+        exp = self._tskit_matrix(ts, tsk_sets, centre=True, polarised=False,
+                                 span_normalise=False)
+        got = relatedness.genetic_relatedness(hm, sample_sets=pg_sets,
+                                              span_normalize=False)
+        np.testing.assert_allclose(got, exp, atol=1e-9, rtol=1e-6)
+
+    def test_noncentred_pin(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        tsk_sets = [[s] for s in ts.samples()]
+        exp = self._tskit_matrix(ts, tsk_sets, centre=False, polarised=False,
+                                 span_normalise=False)
+        got = relatedness.genetic_relatedness(hm, centre=False,
+                                              span_normalize=False)
+        np.testing.assert_allclose(got, exp, atol=1e-9, rtol=1e-6)
+
+    def test_polarised_pin(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        tsk_sets = [[s] for s in ts.samples()]
+        exp = self._tskit_matrix(ts, tsk_sets, centre=True, polarised=True,
+                                 span_normalise=False)
+        got = relatedness.genetic_relatedness(hm, polarised=True,
+                                              span_normalize=False)
+        np.testing.assert_allclose(got, exp, atol=1e-9, rtol=1e-6)
+
+    def test_proportion_pin(self, multiallelic_hm):
+        ts, hm = multiallelic_hm
+        tsk_sets = [[s] for s in ts.samples()]
+        exp = self._tskit_matrix(ts, tsk_sets, proportion=True, centre=True,
+                                 polarised=False, span_normalise=False)
+        got = relatedness.genetic_relatedness(hm, proportion=True)
+        np.testing.assert_allclose(got, exp, atol=1e-12, rtol=1e-6)
+
+    def test_proportion_ignores_span_normalize(self, multiallelic_hm):
+        _, hm = multiallelic_hm
+        a = relatedness.genetic_relatedness(hm, proportion=True,
+                                            span_normalize=False)
+        b = relatedness.genetic_relatedness(hm, proportion=True,
+                                            span_normalize=True)
+        np.testing.assert_allclose(a, b)
+
+    def test_indexes_selection(self, multiallelic_hm):
+        _, hm = multiallelic_hm
+        full = relatedness.genetic_relatedness(hm, span_normalize=False)
+        pairs = [(0, 1), (2, 3), (0, 0)]
+        sub = relatedness.genetic_relatedness(hm, indexes=pairs,
+                                              span_normalize=False)
+        np.testing.assert_allclose(sub, [full[i, j] for i, j in pairs])
+
+    def test_missing_include_matches_host(self):
+        rng = np.random.RandomState(5)
+        hap = rng.randint(0, 3, size=(10, 40)).astype(np.int8)
+        hap[rng.random(hap.shape) < 0.1] = -1
+        hm = HaplotypeMatrix(hap, np.arange(40) * 100)
+        got = relatedness.genetic_relatedness(hm, span_normalize=False)
+        k = int(hap.max()) + 1
+        Cref, _ = _reference_relatedness_columns(hap, None, k)
+        np.testing.assert_allclose(got, Cref @ Cref.T, atol=1e-9)
+
+    def test_missing_exclude_matches_host(self):
+        rng = np.random.RandomState(6)
+        hap = rng.randint(0, 3, size=(10, 40)).astype(np.int8)
+        hap[rng.random(hap.shape) < 0.1] = -1
+        hm = HaplotypeMatrix(hap, np.arange(40) * 100)
+        got = relatedness.genetic_relatedness(hm, missing_data='exclude',
+                                              span_normalize=False)
+        complete = (hap >= 0).all(axis=0)
+        k = int(hap.max()) + 1
+        Cref, _ = _reference_relatedness_columns(hap[:, complete], None, k)
+        np.testing.assert_allclose(got, Cref @ Cref.T, atol=1e-9)

--- a/tests/test_scikit_allel_comparison.py
+++ b/tests/test_scikit_allel_comparison.py
@@ -10,7 +10,7 @@ import numpy as np
 import cupy as cp
 import allel
 from pg_gpu import HaplotypeMatrix
-from pg_gpu import diversity, divergence
+from pg_gpu import diversity, divergence, sfs as sfs_mod
 
 
 class TestDiversityComparison:
@@ -130,7 +130,7 @@ class TestDiversityComparison:
 
         # pg_gpu
         matrix = HaplotypeMatrix(haplotypes, positions, test_data['start'], test_data['end'])
-        afs_pg = diversity.allele_frequency_spectrum(matrix)
+        afs_pg = sfs_mod.sfs(matrix)
         if hasattr(afs_pg, 'get'):
             afs_pg = np.asarray(afs_pg)
 

--- a/tests/test_selection_multiallelic.py
+++ b/tests/test_selection_multiallelic.py
@@ -1,0 +1,250 @@
+"""Multiallelic support for iHS / nSL (issue #140).
+
+scikit-allel's ihs/nsl and tskit have no multiallelic iHS/nSL, so there is no
+external oracle. The multiallelic path is validated three ways:
+
+  * biallelic reduction -- on biallelic data the new code returns a 1-D array
+    and matches the scikit-allel oracle (the existing parity behaviour).
+  * relabel invariance -- recoding the single derived allele 1 -> 2 must move
+    the score to column 1 and leave column 0 (now-absent allele 1) all-NaN,
+    with the allele-2 score bit-identical to the original biallelic score.
+  * brute-force reference -- a pure-numpy one-vs-ancestral nSL scan reproduces
+    the GPU per-allele scores on genuinely triallelic data.
+"""
+
+import numpy as np
+import pytest
+import allel
+
+from pg_gpu import HaplotypeMatrix, selection
+from pg_gpu.windowed_analysis import windowed_analysis
+
+
+def _mat(hap, pos=None):
+    hap = np.asarray(hap, dtype=np.int8)
+    n_var = hap.shape[1]
+    if pos is None:
+        pos = np.arange(n_var, dtype=np.float64) * 1000 + 1
+    return HaplotypeMatrix(hap.copy(), pos, 0, int(pos[-1]) + 1)
+
+
+# ---------------------------------------------------------------------------
+# Brute-force pure-numpy nSL reference (one derived allele vs ancestral 0)
+# ---------------------------------------------------------------------------
+
+def _nsl_scan_ref(hap, focal_allele):
+    """One-direction mean-SSL scan, mirroring _nsl01_kernel exactly.
+
+    hap : (n_hap, n_var). Returns per-site mean SSL for the ancestral (0) and
+    focal-allele homozygous pair classes (NaN where a class is empty).
+    """
+    n_hap, n_var = hap.shape
+    s0 = np.zeros(n_var)
+    c0 = np.zeros(n_var, dtype=int)
+    sa = np.zeros(n_var)
+    ca = np.zeros(n_var, dtype=int)
+    for j in range(n_hap):
+        for k in range(j + 1, n_hap):
+            ssl = 0
+            for i in range(n_var):
+                a1 = int(hap[j, i])
+                a2 = int(hap[k, i])
+                if a1 < 0 or a2 < 0:
+                    ssl += 1
+                elif a1 == a2:
+                    ssl += 1
+                    if a1 == 0:
+                        s0[i] += ssl
+                        c0[i] += 1
+                    elif a1 == focal_allele:
+                        sa[i] += ssl
+                        ca[i] += 1
+                else:
+                    ssl = 0
+    nsl0 = np.where(c0 > 0, s0 / np.maximum(c0, 1), np.nan)
+    nsla = np.where(ca > 0, sa / np.maximum(ca, 1), np.nan)
+    return nsl0, nsla
+
+
+def _nsl_ref(hap, focal_allele):
+    """Full forward+reverse nSL reference for one derived allele."""
+    f0, fa = _nsl_scan_ref(hap, focal_allele)
+    r0, ra = _nsl_scan_ref(hap[:, ::-1], focal_allele)
+    nsl0 = f0 + r0[::-1]
+    nsla = fa + ra[::-1]
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return np.log(nsla / nsl0)
+
+
+# ---------------------------------------------------------------------------
+# Biallelic reduction: 1-D output that matches the scikit-allel oracle
+# ---------------------------------------------------------------------------
+
+class TestBiallelicReduction:
+    @pytest.fixture
+    def biallelic(self):
+        rng = np.random.RandomState(42)
+        hap = rng.randint(0, 2, (40, 200)).astype(np.int8)
+        pos = (np.arange(200) * 500 + 1).astype(np.float64)
+        return hap, pos
+
+    def test_nsl_biallelic_is_1d_and_matches_allel(self, biallelic):
+        hap, pos = biallelic
+        score = selection.nsl(_mat(hap, pos))
+        assert score.ndim == 1 and score.shape == (200,)
+        ref = allel.nsl(hap.T, use_threads=False)  # allel layout (n_var, n_hap)
+        both = ~np.isnan(score) & ~np.isnan(ref)
+        np.testing.assert_allclose(score[both], ref[both], rtol=1e-5)
+
+    def test_ihs_biallelic_is_1d_and_matches_allel(self, biallelic):
+        hap, pos = biallelic
+        score = selection.ihs(_mat(hap, pos), include_edges=False)
+        assert score.ndim == 1 and score.shape == (200,)
+        ref = allel.ihs(hap.T, pos, include_edges=False, use_threads=False)
+        both = ~np.isnan(score) & ~np.isnan(ref)
+        assert both.sum() > 0
+        np.testing.assert_allclose(score[both], ref[both], rtol=1e-5)
+
+    def test_biallelic_filter_of_multiallelic_fixture(self, multiallelic_hm):
+        _, hm = multiallelic_hm
+        hm_bi = hm.apply_biallelic_filter()
+        hap = np.asarray(hm_bi.haplotypes.get()
+                         if hasattr(hm_bi.haplotypes, "get") else hm_bi.haplotypes)
+        assert hap.max() <= 1  # genuinely biallelic after the filter
+        score = selection.nsl(hm_bi)
+        assert score.ndim == 1
+        ref = allel.nsl(hap.T, use_threads=False)  # allel layout (n_var, n_hap)
+        both = ~np.isnan(score) & ~np.isnan(ref)
+        np.testing.assert_allclose(score[both], ref[both], rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Relabel invariance: derived allele 1 -> 2 shifts the score to column 1
+# ---------------------------------------------------------------------------
+
+class TestRelabelInvariance:
+    @pytest.fixture
+    def data(self):
+        rng = np.random.RandomState(0)
+        hap = rng.randint(0, 2, (30, 120)).astype(np.int8)
+        pos = (np.arange(120) * 1000 + 1).astype(np.float64)
+        relabel = np.where(hap == 1, np.int8(2), np.int8(0)).astype(np.int8)
+        return hap, relabel, pos
+
+    def _check(self, base, re):
+        assert base.ndim == 1
+        assert re.ndim == 2 and re.shape[1] == 2
+        assert np.all(np.isnan(re[:, 0]))  # allele 1 now absent everywhere
+        both = np.isfinite(base) & np.isfinite(re[:, 1])
+        assert both.sum() > 0
+        np.testing.assert_allclose(re[both, 1], base[both], rtol=1e-9, atol=1e-9)
+
+    def test_nsl_relabel(self, data):
+        hap, relabel, pos = data
+        self._check(selection.nsl(_mat(hap, pos)), selection.nsl(_mat(relabel, pos)))
+
+    def test_ihs_relabel(self, data):
+        hap, relabel, pos = data
+        self._check(selection.ihs(_mat(hap, pos)), selection.ihs(_mat(relabel, pos)))
+
+
+# ---------------------------------------------------------------------------
+# Brute-force reference on genuinely triallelic data
+# ---------------------------------------------------------------------------
+
+class TestMultiallelicBruteForce:
+    def test_nsl_triallelic_matches_reference(self):
+        rng = np.random.RandomState(7)
+        n_hap, n_var = 10, 25
+        hap = rng.randint(0, 2, (n_hap, n_var)).astype(np.int8)
+        # inject derived allele 2 at a few sites (some {0,2}, some {0,1,2})
+        hap[:4, 5] = 2
+        hap[:3, 12] = 2
+        hap[3:6, 12] = 1
+        hap[:5, 18] = 2
+
+        score = selection.nsl(_mat(hap))
+        assert score.shape == (n_var, 2)
+
+        ref = np.stack([_nsl_ref(hap, 1), _nsl_ref(hap, 2)], axis=1)
+
+        assert np.array_equal(np.isnan(score), np.isnan(ref))
+        both = np.isfinite(score) & np.isfinite(ref)
+        assert both.sum() > 0
+        np.testing.assert_allclose(score[both], ref[both], rtol=1e-9, atol=1e-9)
+
+
+class TestReferenceAbsent:
+    def test_no_ancestral_allele_is_nan(self):
+        # A focal site with no ancestral (0) allele has no reference class, so
+        # every derived allele's one-vs-ancestral score is NaN there.
+        rng = np.random.RandomState(5)
+        n_hap, n_var = 20, 40
+        hap = rng.randint(0, 2, (n_hap, n_var)).astype(np.int8)
+        focal = 20
+        hap[:10, focal] = 1   # no allele 0 remains at the focal site
+        hap[10:, focal] = 2
+        for score in (selection.ihs(_mat(hap), min_maf=0.0), selection.nsl(_mat(hap))):
+            assert score.shape == (n_var, 2)
+            assert np.all(np.isnan(score[focal]))
+
+
+# ---------------------------------------------------------------------------
+# Per-allele MAF: a common allele with index >= 2 is now visible to min_maf
+# ---------------------------------------------------------------------------
+
+class TestPerAlleleMAF:
+    def test_common_high_index_allele_visible(self):
+        rng = np.random.RandomState(3)
+        n_hap, n_var = 40, 60
+        hap = rng.randint(0, 2, (n_hap, n_var)).astype(np.int8)
+        focal = 30
+        # focal site: ancestral common, allele 1 rare (1/40 = 0.025 < min_maf),
+        # allele 2 common (20/40 = 0.5). Old counts (0/1 only) would hide allele 2.
+        col = np.zeros(n_hap, dtype=np.int8)
+        col[0] = 1
+        col[1:21] = 2
+        hap[:, focal] = col
+
+        score = selection.ihs(_mat(hap), min_maf=0.05)
+        assert score.shape == (n_var, 2)
+        assert np.isnan(score[focal, 0])       # allele 1 fails per-allele MAF
+        assert np.isfinite(score[focal, 1])    # common allele 2 passes
+
+
+# ---------------------------------------------------------------------------
+# mean_nsl (windowed) -- first coverage; must accept 1-D and 2-D nsl output
+# ---------------------------------------------------------------------------
+
+class TestMeanNSL:
+    def test_mean_nsl_biallelic_matches_manual(self):
+        rng = np.random.RandomState(11)
+        n_hap, n_var = 30, 300
+        hap = rng.randint(0, 2, (n_hap, n_var)).astype(np.int8)
+        pos = (np.arange(n_var) * 100 + 1).astype(np.float64)
+        hm = _mat(hap, pos)
+
+        df = windowed_analysis(hm, window_size=5000, statistics=["mean_nsl"])
+        nsl = selection.nsl(hm)
+        # manual per-window mean of finite nsl
+        for _, row in df.iterrows():
+            mask = (pos >= row["start"]) & (pos < row["end"]) & np.isfinite(nsl)
+            expected = np.nanmean(nsl[mask]) if mask.any() else np.nan
+            got = row["mean_nsl"]
+            if np.isnan(expected):
+                assert np.isnan(got)
+            else:
+                np.testing.assert_allclose(got, expected, rtol=1e-6)
+
+    def test_mean_nsl_multiallelic_runs(self):
+        rng = np.random.RandomState(13)
+        n_hap, n_var = 30, 300
+        hap = rng.randint(0, 2, (n_hap, n_var)).astype(np.int8)
+        hap[:6, ::7] = 2  # scatter a derived allele 2
+        pos = (np.arange(n_var) * 100 + 1).astype(np.float64)
+        hm = _mat(hap, pos)
+        assert selection.nsl(hm).ndim == 2  # 2-D per-allele output
+
+        df = windowed_analysis(hm, window_size=5000, statistics=["mean_nsl"])
+        assert "mean_nsl" in df.columns
+        assert np.isfinite(df["mean_nsl"].to_numpy()).any()

--- a/tests/test_sfs_allel_comparison.py
+++ b/tests/test_sfs_allel_comparison.py
@@ -92,15 +92,11 @@ class TestJointSFSComparison:
         expected = allel.joint_sfs(dac1, dac2, n1=n1, n2=n2)
         np.testing.assert_array_equal(result, expected)
 
-    def test_joint_sfs_folded(self, two_pop_data):
-        matrix, hap, n1, n2 = two_pop_data
-        result = sfs.joint_sfs_folded(matrix, 'pop1', 'pop2')
-        dac1 = np.sum(hap[:n1], axis=0)
-        dac2 = np.sum(hap[n1:], axis=0)
-        ac1 = np.column_stack([n1 - dac1, dac1])
-        ac2 = np.column_stack([n2 - dac2, dac2])
-        expected = allel.joint_sfs_folded(ac1, ac2)
-        np.testing.assert_array_equal(result, expected)
+    # NOTE: joint_sfs_folded / joint_sfs_folded_scaled deliberately do NOT match
+    # scikit-allel. The 2D fold is the one place tskit and allel disagree even on
+    # biallelic data -- allel folds each axis independently, tskit folds the site
+    # as a unit by the global minor. We pin to tskit (see the ledger). Parity is
+    # tested in test_multiallelic.py::TestJointSFS::test_joint_sfs_folded_matches_tskit.
 
     def test_joint_sfs_scaled(self, two_pop_data):
         matrix, hap, n1, n2 = two_pop_data
@@ -108,16 +104,6 @@ class TestJointSFSComparison:
         dac1 = np.sum(hap[:n1], axis=0)
         dac2 = np.sum(hap[n1:], axis=0)
         expected = allel.joint_sfs_scaled(dac1, dac2, n1=n1, n2=n2)
-        np.testing.assert_array_almost_equal(result, expected)
-
-    def test_joint_sfs_folded_scaled(self, two_pop_data):
-        matrix, hap, n1, n2 = two_pop_data
-        result = sfs.joint_sfs_folded_scaled(matrix, 'pop1', 'pop2')
-        dac1 = np.sum(hap[:n1], axis=0)
-        dac2 = np.sum(hap[n1:], axis=0)
-        ac1 = np.column_stack([n1 - dac1, dac1])
-        ac2 = np.column_stack([n2 - dac2, dac2])
-        expected = allel.joint_sfs_folded_scaled(ac1, ac2)
         np.testing.assert_array_almost_equal(result, expected)
 
 

--- a/tests/test_sfs_allel_comparison.py
+++ b/tests/test_sfs_allel_comparison.py
@@ -47,7 +47,11 @@ class TestSFSComparison:
         # allel: pass n explicitly to match full-size output
         dac = np.sum(hap, axis=0)
         expected = allel.sfs(dac, n=n)
-        np.testing.assert_array_equal(result, expected)
+        # sfs.sfs is now the per-allele polarised SFS (tskit convention): both
+        # fixed classes (bins 0 and n) are excluded, whereas allel.sfs includes
+        # them. Compare the segregating interior; assert the endpoints are dropped.
+        np.testing.assert_array_equal(result[1:n], expected[1:n])
+        assert result[0] == 0 and result[n] == 0
 
     def test_sfs_folded(self, single_pop_data):
         matrix, hap = single_pop_data

--- a/tests/test_streaming_grm.py
+++ b/tests/test_streaming_grm.py
@@ -1,11 +1,11 @@
 """Equivalence tests for streaming-aware GRM.
 
-``grm(matrix, ...)`` dispatches at the top: a ``StreamingHaplotypeMatrix``
-/ ``StreamingGenotypeMatrix`` routes through a two-pass streaming
-implementation (chromosome-wide allele frequencies first, then a
-standardized outer-product accumulated on host with row-block tiling
-on the individual axis). Tests assert streaming-vs-eager parity on
-small msprime stores.
+``grm`` is the diploid biallelic GCTA GRM and takes genotype matrices; a
+``StreamingGenotypeMatrix`` routes through a two-pass streaming implementation
+(chromosome-wide allele frequencies first, then a standardized outer-product
+accumulated on host with row-block tiling on the individual axis). Haplotype
+matrices are rejected in favor of ``genetic_relatedness``. Tests assert
+streaming-vs-eager parity on small msprime stores.
 """
 
 import numpy as np
@@ -49,17 +49,18 @@ def two_pop_vcz_store(tmp_path):
 
 class TestGrmStreaming:
 
-    def test_haplotype_parity(self, vcz_store):
-        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
+    def test_rejects_streaming_haplotype_matrix(self, vcz_store):
+        # grm is the diploid biallelic GCTA GRM; a streaming haplotype
+        # matrix is rejected in favor of genetic_relatedness.
         stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
-                                            chunk_bp=10_000)
-        # rtol looser than IBS because GRM has a two-pass float accumulation
-        # (frequencies then standardized outer product) where the chunked
-        # vs whole-matrix orderings can differ at the last ULP.
-        np.testing.assert_allclose(grm(stream), grm(eager),
-                                    rtol=1e-7, atol=1e-10)
+                                           chunk_bp=10_000)
+        with pytest.raises(TypeError, match="genetic_relatedness"):
+            grm(stream)
 
     def test_genotype_parity(self, vcz_store):
+        # rtol looser because GRM has a two-pass float accumulation
+        # (frequencies then standardized outer product) where the chunked
+        # vs whole-matrix orderings can differ at the last ULP.
         eager = GenotypeMatrix.from_zarr(vcz_store, streaming="never")
         stream = GenotypeMatrix.from_zarr(vcz_store, streaming="always",
                                            chunk_bp=10_000)
@@ -67,8 +68,8 @@ class TestGrmStreaming:
                                     rtol=1e-7, atol=1e-10)
 
     def test_missing_data_exclude(self, vcz_store):
-        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
-        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+        eager = GenotypeMatrix.from_zarr(vcz_store, streaming="never")
+        stream = GenotypeMatrix.from_zarr(vcz_store, streaming="always",
                                             chunk_bp=10_000)
         np.testing.assert_allclose(
             grm(stream, missing_data='exclude'),
@@ -77,23 +78,30 @@ class TestGrmStreaming:
         )
 
     def test_population_subset(self, two_pop_vcz_store):
+        # Eager genotype population subsetting equals running the GRM on the
+        # manually extracted individuals. (Streaming genotype population
+        # subsetting is a separate pre-existing gap: the streaming matrix
+        # keeps sample_sets in haplotype coordinates.)
         path, popfile = two_pop_vcz_store
-        eager = HaplotypeMatrix.from_zarr(path, streaming="never",
-                                            pop_assignment=popfile)
-        stream = HaplotypeMatrix.from_zarr(path, streaming="always",
-                                             pop_assignment=popfile,
-                                             chunk_bp=10_000)
+        eager = GenotypeMatrix.from_zarr(path, streaming="never",
+                                         pop_assignment=popfile)
+        idx = eager.sample_sets['pop1']
+        g = eager.genotypes
+        g = g.get() if hasattr(g, 'get') else g
+        pos = eager.positions
+        pos = pos.get() if hasattr(pos, 'get') else pos
+        subset = GenotypeMatrix(np.asarray(g)[idx], np.asarray(pos),
+                                eager.chrom_start, eager.chrom_end)
         np.testing.assert_allclose(
-            grm(stream, population='pop1'),
-            grm(eager, population='pop1'),
+            grm(eager, population='pop1'), grm(subset),
             rtol=1e-7, atol=1e-10,
         )
 
     @pytest.mark.parametrize("block_size", [1, 4, 1000])
     def test_block_size_invariance(self, vcz_store, block_size):
         from pg_gpu.relatedness import _stream_grm
-        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
-        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+        eager = GenotypeMatrix.from_zarr(vcz_store, streaming="never")
+        stream = GenotypeMatrix.from_zarr(vcz_store, streaming="always",
                                             chunk_bp=10_000)
         e = grm(eager)
         s = _stream_grm(stream, population=None, missing_data='include',
@@ -112,8 +120,8 @@ class TestGrmStreaming:
         hm.samples = [f"s{i}" for i in range(hm.num_haplotypes // 2)]
         path = str(tmp_path / "mono.vcz")
         hm.to_zarr(path, format="vcz", contig_name="1")
-        eager = HaplotypeMatrix.from_zarr(path, streaming="never")
-        stream = HaplotypeMatrix.from_zarr(path, streaming="always",
+        eager = GenotypeMatrix.from_zarr(path, streaming="never")
+        stream = GenotypeMatrix.from_zarr(path, streaming="always",
                                             chunk_bp=5_000)
         np.testing.assert_allclose(grm(stream), grm(eager),
                                     rtol=1e-7, atol=1e-10)

--- a/tests/test_streaming_ibs.py
+++ b/tests/test_streaming_ibs.py
@@ -1,12 +1,12 @@
 """Equivalence tests for streaming-aware IBS.
 
-``ibs(matrix, ...)`` dispatches at the top: if the argument is a
-``StreamingHaplotypeMatrix`` / ``StreamingGenotypeMatrix``, the variant
-axis is streamed chunk-by-chunk and the individual axis is tiled into
-row blocks so the (n_ind, n_ind) accumulators never have to fit on the
-GPU. Per-chunk contributions sum on the host; the final ratio is
-applied once. Tests assert that streaming and eager produce the same
-matrix on small msprime stores.
+``ibs`` is the diploid biallelic PLINK IBS and takes genotype matrices; a
+``StreamingGenotypeMatrix`` streams the variant axis chunk-by-chunk and tiles
+the individual axis into row blocks so the (n_ind, n_ind) accumulators never
+have to fit on the GPU. Per-chunk contributions sum on the host; the final
+ratio is applied once. Haplotype matrices are rejected in favor of
+``genetic_relatedness``. Tests assert streaming-vs-eager parity on small
+msprime stores.
 """
 
 import numpy as np
@@ -50,13 +50,11 @@ def two_pop_vcz_store(tmp_path):
 
 class TestIbsStreaming:
 
-    def test_haplotype_parity(self, vcz_store):
-        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
+    def test_rejects_streaming_haplotype_matrix(self, vcz_store):
         stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
-                                            chunk_bp=10_000)
-        e = ibs(eager)
-        s = ibs(stream)
-        np.testing.assert_allclose(s, e, rtol=1e-9, atol=1e-12)
+                                           chunk_bp=10_000)
+        with pytest.raises(TypeError, match="genetic_relatedness"):
+            ibs(stream)
 
     def test_genotype_parity(self, vcz_store):
         eager = GenotypeMatrix.from_zarr(vcz_store, streaming="never")
@@ -67,32 +65,38 @@ class TestIbsStreaming:
         np.testing.assert_allclose(s, e, rtol=1e-9, atol=1e-12)
 
     def test_missing_data_exclude(self, vcz_store):
-        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
-        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+        eager = GenotypeMatrix.from_zarr(vcz_store, streaming="never")
+        stream = GenotypeMatrix.from_zarr(vcz_store, streaming="always",
                                             chunk_bp=10_000)
         e = ibs(eager, missing_data='exclude')
         s = ibs(stream, missing_data='exclude')
         np.testing.assert_allclose(s, e, rtol=1e-9, atol=1e-12)
 
     def test_population_subset(self, two_pop_vcz_store):
+        # Eager genotype population subsetting equals ibs on the manually
+        # extracted individuals. (Streaming genotype population subsetting is a
+        # separate pre-existing gap: sample_sets stay in haplotype coordinates.)
         path, popfile = two_pop_vcz_store
-        eager = HaplotypeMatrix.from_zarr(path, streaming="never",
-                                            pop_assignment=popfile)
-        stream = HaplotypeMatrix.from_zarr(path, streaming="always",
-                                             pop_assignment=popfile,
-                                             chunk_bp=10_000)
-        e = ibs(eager, population='pop1')
-        s = ibs(stream, population='pop1')
-        np.testing.assert_allclose(s, e, rtol=1e-9, atol=1e-12)
+        eager = GenotypeMatrix.from_zarr(path, streaming="never",
+                                         pop_assignment=popfile)
+        idx = eager.sample_sets['pop1']
+        g = eager.genotypes
+        g = g.get() if hasattr(g, 'get') else g
+        pos = eager.positions
+        pos = pos.get() if hasattr(pos, 'get') else pos
+        subset = GenotypeMatrix(np.asarray(g)[idx], np.asarray(pos),
+                                eager.chrom_start, eager.chrom_end)
+        np.testing.assert_allclose(ibs(eager, population='pop1'), ibs(subset),
+                                   rtol=1e-9, atol=1e-12)
 
     @pytest.mark.parametrize("block_size", [1, 4, 1000])
     def test_block_size_invariance(self, vcz_store, block_size):
         # Streaming output must not depend on the row-block tile size
         # -- only the (block_size, n_ind) working memory does.
         from pg_gpu.relatedness import _stream_ibs
-        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+        stream = GenotypeMatrix.from_zarr(vcz_store, streaming="always",
                                             chunk_bp=10_000)
-        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
+        eager = GenotypeMatrix.from_zarr(vcz_store, streaming="never")
         e = ibs(eager)
         s = _stream_ibs(stream, population=None, missing_data='include',
                         block_size=block_size)
@@ -101,7 +105,7 @@ class TestIbsStreaming:
     def test_diagonal_is_one(self, vcz_store):
         # Eager and streaming both pin the diagonal at 1.0 -- check the
         # streaming path keeps that invariant.
-        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+        stream = GenotypeMatrix.from_zarr(vcz_store, streaming="always",
                                             chunk_bp=10_000)
         s = ibs(stream)
         np.testing.assert_allclose(np.diag(s), 1.0)

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -223,6 +223,22 @@ class TestAccessibleBedDispatch:
                                  accessible_bed=bed, chrom="1")
         _assert_frames_equivalent(df_e, df_s)
 
+    def test_load_time_mask_filters_chunks(self, vcz_store, tmp_path):
+        # A mask supplied at LOAD time (from_zarr(accessible_bed=)) is attached
+        # to every chunk by iter_gpu_chunks, so every streaming consumer sees
+        # accessible-filtered variants -- not just genetic_relatedness. #151
+        bed = self._write_bed(str(tmp_path / "acc.bed"))   # accessible: [25000, 75000)
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                           chunk_bp=10_000, accessible_bed=bed)
+        seen = 0
+        for _, _, chunk in stream.iter_gpu_chunks():
+            assert chunk.has_accessible_mask
+            pos = chunk.positions
+            pos = pos.get() if hasattr(pos, "get") else np.asarray(pos)
+            assert ((pos >= 25000) & (pos < 75000)).all()
+            seen += chunk.num_variants
+        assert seen > 0
+
 
 class TestGarudStreamingDispatch:
     """Per-window scatter-reduce assembles each window's hash from the
@@ -453,3 +469,50 @@ class TestGeneticRelatednessDispatch:
         a = relatedness.genetic_relatedness(s_a, span_normalize=False)
         b = relatedness.genetic_relatedness(s_b, span_normalize=False)
         np.testing.assert_allclose(a, b, rtol=1e-9, atol=1e-12)
+
+    def test_span_normalize_no_mask_equivalent(self, vcz_store):
+        # Default span_normalize=True with no accessible mask: streaming must
+        # normalize by the same variant-position span as the eager path
+        # (both use mappable_lo/hi, not the chunk-grid edges). #151
+        from pg_gpu import relatedness
+        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                           chunk_bp=10_000)
+        e = relatedness.genetic_relatedness(eager, span_normalize=True)
+        s = relatedness.genetic_relatedness(stream, span_normalize=True)
+        np.testing.assert_allclose(s, e, rtol=1e-9, atol=1e-12)
+
+    def test_accessible_bed_span_and_filter_equivalent(self, vcz_store, tmp_path):
+        # accessible_bed both restricts variants to accessible sites and sets
+        # the accessible-base span; streaming must match eager on both. #151
+        from pg_gpu import relatedness
+        bed = str(tmp_path / "acc.bed")
+        with open(bed, "w") as f:
+            f.write("1\t25000\t75000\n")   # only the middle 50 kb accessible
+        full = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
+        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never",
+                                          accessible_bed=bed)
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                           chunk_bp=10_000, accessible_bed=bed)
+        assert eager.num_variants < full.num_variants   # mask really filters
+        e = relatedness.genetic_relatedness(eager, span_normalize=True)
+        s = relatedness.genetic_relatedness(stream, span_normalize=True)
+        np.testing.assert_allclose(s, e, rtol=1e-9, atol=1e-12)
+
+    @pytest.mark.parametrize("mode", ["per_variant", "sites", "callable", "per_base"])
+    def test_span_mode_matches_eager_with_mask(self, vcz_store, tmp_path, mode):
+        # Non-default span modes: per_variant/sites/callable count over the
+        # accessible-FILTERED variant set (eager does the same via its filtered
+        # view); per_base is the raw span. All must agree eager vs streaming.
+        from pg_gpu import relatedness
+        bed = str(tmp_path / "acc.bed")
+        with open(bed, "w") as f:
+            f.write("1\t25000\t75000\n")
+        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never",
+                                          accessible_bed=bed)
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                           chunk_bp=10_000, accessible_bed=bed)
+        assert eager.get_span(mode) == stream.get_span(mode)
+        e = relatedness.genetic_relatedness(eager, span_normalize=mode)
+        s = relatedness.genetic_relatedness(stream, span_normalize=mode)
+        np.testing.assert_allclose(s, e, rtol=1e-9, atol=1e-12)

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -405,3 +405,51 @@ class TestStreamingGuardrails:
             windowed_analysis(stream, window_size=5_000,
                               statistics=["local_pca"])
 
+
+
+class TestGeneticRelatednessDispatch:
+    """Streaming genetic_relatedness matches the eager result row-for-row."""
+
+    def _both(self, vcz_store, **kw):
+        from pg_gpu import relatedness
+        eager, stream = _aligned_pair(vcz_store, chunk_bp=10_000)
+        return (relatedness.genetic_relatedness(eager, **kw),
+                relatedness.genetic_relatedness(stream, **kw))
+
+    def test_singleton_raw_equivalent(self, vcz_store):
+        e, s = self._both(vcz_store, span_normalize=False)
+        np.testing.assert_allclose(s, e, rtol=1e-6, atol=1e-9)
+
+    def test_proportion_equivalent(self, vcz_store):
+        e, s = self._both(vcz_store, proportion=True)
+        np.testing.assert_allclose(s, e, rtol=1e-6, atol=1e-9)
+
+    def test_noncentred_equivalent(self, vcz_store):
+        e, s = self._both(vcz_store, centre=False, span_normalize=False)
+        np.testing.assert_allclose(s, e, rtol=1e-6, atol=1e-9)
+
+    def test_polarised_equivalent(self, vcz_store):
+        e, s = self._both(vcz_store, polarised=True, span_normalize=False)
+        np.testing.assert_allclose(s, e, rtol=1e-6, atol=1e-9)
+
+    def test_grouped_sample_sets_equivalent(self, vcz_store):
+        from pg_gpu import relatedness
+        eager, stream = _aligned_pair(vcz_store, chunk_bp=10_000)
+        n_hap = stream.num_haplotypes
+        half = n_hap // 2
+        sets = [list(range(0, half)), list(range(half, n_hap))]
+        e = relatedness.genetic_relatedness(eager, sample_sets=sets,
+                                            span_normalize=False)
+        s = relatedness.genetic_relatedness(stream, sample_sets=sets,
+                                            span_normalize=False)
+        np.testing.assert_allclose(s, e, rtol=1e-6, atol=1e-9)
+
+    def test_chunk_boundary_invariance(self, vcz_store):
+        from pg_gpu import relatedness
+        s_a = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                        chunk_bp=10_000)
+        s_b = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                        chunk_bp=20_000)
+        a = relatedness.genetic_relatedness(s_a, span_normalize=False)
+        b = relatedness.genetic_relatedness(s_b, span_normalize=False)
+        np.testing.assert_allclose(a, b, rtol=1e-9, atol=1e-12)

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -302,6 +302,13 @@ class TestSFSDispatch:
         s_s = sfs_module.sfs(stream)
         np.testing.assert_array_equal(s_e, s_s)
 
+    def test_sfs_folded_equivalent(self, vcz_store):
+        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never")
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                            chunk_bp=10_000)
+        np.testing.assert_allclose(sfs_module.sfs_folded(eager),
+                                   sfs_module.sfs_folded(stream))
+
     def test_joint_sfs_equivalent(self, vcz_store, tmp_path):
         n_dip = HaplotypeMatrix.from_zarr(vcz_store).num_haplotypes // 2
         half = n_dip // 2

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -801,7 +801,7 @@ class TestOverlappingWindowsScatter:
 
     def test_non_overlapping_unchanged(self, sim_hm):
         """Guard: step==window windowed pi equals per-window diversity.pi, now
-        that windowed_analysis uses the per-allele path (issue #100 / 0005a)."""
+        that windowed_analysis uses the per-allele path (issue #100)."""
         window_size, step_size = 50_000, 50_000
         df = windowed_analysis(sim_hm, window_size=window_size,
                                step_size=step_size, statistics=['pi'],
@@ -815,15 +815,9 @@ class TestOverlappingWindowsScatter:
                       if sub.num_variants > 0 else 0.0)
             assert np.isclose(pi_scatter, pi_ref, rtol=1e-10, atol=1e-12)
 
-    @pytest.mark.xfail(strict=True, reason=(
-        "windowed_analysis dxy/fst still collapse multiallelic sites: "
-        "_allele_sum_and_n uses cp.sum(hap) (mechanism A, sums allele indices), "
-        "so windowed dxy detectably diverges from the per-allele scalar "
-        "divergence.dxy made correct in subproject 0003. Pre-existing; fixed in "
-        "the windowed subproject (kr-colab/pg_gpu#100) -- remove this marker then."))
     def test_twopop_non_overlapping_dxy_matches_scalar(self, sim_hm):
-        """Per-window windowed dxy should equal scalar divergence.dxy on the
-        window subset; currently fails on multiallelic sites (collapsed path)."""
+        """Per-window windowed dxy equals scalar divergence.dxy on the window
+        subset, now that the two-pop path is per-allele (issue #100)."""
         window_size, step_size = 50_000, 50_000
         df = windowed_analysis(sim_hm, window_size=window_size,
                                step_size=step_size, statistics=['dxy'],
@@ -870,7 +864,7 @@ class TestOverlappingWindowsScatter:
 
 
 class TestMultiallelicSinglePop:
-    """Issue #100 / subproject 0005a: single-pop windowed scalar stats must
+    """Issue #100: single-pop windowed scalar stats must
     be multiallelic-correct -- each window equals the per-allele scalar
     ``diversity`` function on that window's subset -- on BOTH single-pop
     engines: the host scatter path (``_windowed_thetas_scatter``, reached by a
@@ -947,6 +941,124 @@ class TestMultiallelicSinglePop:
                               rtol=1e-9, atol=1e-12)
             assert np.isclose(seg_w, diversity.segregating_sites(sub),
                               rtol=1e-9, atol=1e-12)
+
+
+class TestMultiallelicTwoPop:
+    """Issue #100: two-pop windowed scalar stats must be
+    multiallelic-correct -- each window equals the per-allele scalar
+    ``divergence`` functions on that window's subset. Exercises the host scatter
+    engine (``_windowed_twopop_scatter``, reached by a pure two-pop request)."""
+
+    @pytest.fixture(scope="class")
+    def sim_hm(self):
+        import msprime
+        ts = msprime.sim_ancestry(
+            samples=30, sequence_length=100_000, recombination_rate=1e-8,
+            population_size=20_000, ploidy=2, random_seed=42)
+        ts = msprime.sim_mutations(
+            ts, rate=1e-6, model=msprime.JC69(state_independent=True),
+            random_seed=43)
+        G = ts.genotype_matrix()
+        n_multi = sum(np.unique(G[i]).size >= 3 for i in range(ts.num_sites))
+        assert n_multi > 50, f"fixture not multiallelic enough: {n_multi}"
+        hm = HaplotypeMatrix.from_ts(ts)
+        n = hm.num_haplotypes
+        hm.sample_sets = {"p1": list(range(n // 2)),
+                          "p2": list(range(n // 2, n))}
+        return hm
+
+    def _window_subset(self, hm, start, stop):
+        import cupy as cp
+        pos = hm.positions.get() if isinstance(hm.positions, cp.ndarray) else np.asarray(hm.positions)
+        hap = hm.haplotypes.get() if isinstance(hm.haplotypes, cp.ndarray) else np.asarray(hm.haplotypes)
+        mask = (pos >= start) & (pos < stop)
+        sub = HaplotypeMatrix(hap[:, mask], pos[mask],
+                              chrom_start=int(start), chrom_end=int(stop))
+        sub.sample_sets = hm.sample_sets
+        return sub
+
+    def test_scatter_dxy_fst_da_match_scalar(self, sim_hm):
+        window_size = 25_000
+        df = windowed_analysis(sim_hm, window_size=window_size,
+                               step_size=window_size,
+                               statistics=['dxy', 'fst', 'da'],
+                               populations=['p1', 'p2'], span_normalize=False)
+        for start, dxy_w, fst_w, da_w in zip(
+                df['start'], df['dxy'], df['fst'], df['da']):
+            stop = start + window_size
+            if stop > sim_hm.chrom_end:
+                continue
+            sub = self._window_subset(sim_hm, start, stop)
+            if sub.num_variants == 0:
+                continue
+            assert np.isclose(dxy_w,
+                              divergence.dxy(sub, 'p1', 'p2', span_normalize=False),
+                              rtol=1e-9, atol=1e-12)
+            assert np.isclose(da_w,
+                              divergence.da(sub, 'p1', 'p2', span_normalize=False),
+                              rtol=1e-9, atol=1e-12)
+            fst_ref = divergence.fst_hudson(sub, 'p1', 'p2')
+            if np.isnan(fst_w) or np.isnan(fst_ref):
+                assert np.isnan(fst_w) and np.isnan(fst_ref)
+            else:
+                assert np.isclose(fst_w, fst_ref, rtol=1e-9, atol=1e-12)
+
+    def test_fused_dxy_fst_da_match_scalar(self, sim_hm):
+        """Fused CUDA two-pop kernel: dxy/fst_hudson/da per window == scalar.
+        (fst_wc is excluded: the fused kernel's WC is a haploid estimator that
+        differs from the scalar diploid fst_weir_cockerham, a separate issue.)"""
+        from pg_gpu.windowed_analysis import windowed_statistics_fused
+        window_size = 25_000
+        bp = np.arange(0, int(sim_hm.chrom_end) + window_size, window_size,
+                       dtype=float)
+        r = windowed_statistics_fused(
+            sim_hm, bp_bins=bp, statistics=('dxy', 'fst_hudson', 'da'),
+            pop1='p1', pop2='p2', per_base=False, chrom='1')
+        for start, dxy_w, fst_w, da_w in zip(
+                r['start'], r['dxy'], r['fst_hudson'], r['da']):
+            stop = start + window_size
+            if stop > sim_hm.chrom_end:
+                continue
+            sub = self._window_subset(sim_hm, start, stop)
+            if sub.num_variants == 0:
+                continue
+            assert np.isclose(dxy_w,
+                              divergence.dxy(sub, 'p1', 'p2', span_normalize=False),
+                              rtol=1e-9, atol=1e-12)
+            assert np.isclose(da_w,
+                              divergence.da(sub, 'p1', 'p2', span_normalize=False),
+                              rtol=1e-9, atol=1e-12)
+            fst_ref = divergence.fst_hudson(sub, 'p1', 'p2')
+            if np.isnan(fst_w) or np.isnan(fst_ref):
+                assert np.isnan(fst_w) and np.isnan(fst_ref)
+            else:
+                assert np.isclose(fst_w, fst_ref, rtol=1e-9, atol=1e-12)
+
+    def test_per_variant_dxy_fst_match_scalar(self, sim_hm):
+        """Per-variant engine (windowed_statistics): two-pop dxy/fst per window
+        == scalar. Inherits the per-allele _twopop_site_components fix."""
+        from pg_gpu.windowed_analysis import windowed_statistics
+        window_size = 25_000
+        bp = np.arange(0, int(sim_hm.chrom_end) + window_size, window_size,
+                       dtype=float)
+        r = windowed_statistics(
+            sim_hm, bp_bins=bp, statistics=['fst', 'dxy'],
+            pop1='p1', pop2='p2', per_base=False, chrom='1')
+        for start, dxy_w, fst_w in zip(r['start'], r['dxy'], r['fst']):
+            stop = start + window_size
+            if stop > sim_hm.chrom_end:
+                continue
+            sub = self._window_subset(sim_hm, start, stop)
+            if sub.num_variants == 0:
+                continue
+            assert np.isclose(dxy_w,
+                              divergence.dxy(sub, 'p1', 'p2', span_normalize=False),
+                              rtol=1e-9, atol=1e-12)
+            fst_ref = divergence.fst_hudson(sub, 'p1', 'p2')
+            if np.isnan(fst_w) or np.isnan(fst_ref):
+                assert np.isnan(fst_w) and np.isnan(fst_ref)
+            else:
+                assert np.isclose(fst_w, fst_ref, rtol=1e-9, atol=1e-12)
 
 
 class TestCanonicalWindowSchema:

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -942,6 +942,41 @@ class TestMultiallelicSinglePop:
             assert np.isclose(seg_w, diversity.segregating_sites(sub),
                               rtol=1e-9, atol=1e-12)
 
+    def test_per_variant_matches_scalar(self, sim_hm):
+        """Per-variant engine (windowed_statistics): all six single-pop stats
+        per window == the per-allele scalar functions on the window subset."""
+        from pg_gpu.windowed_analysis import windowed_statistics
+        window_size = 25_000
+        bp = np.arange(0, int(sim_hm.chrom_end) + window_size, window_size,
+                       dtype=float)
+        stats = ['pi', 'theta_w', 'segregating_sites', 'singletons',
+                 'het_expected', 'tajimas_d']
+        r = windowed_statistics(sim_hm, bp_bins=bp, statistics=stats,
+                                per_base=False, chrom='1')
+        for i, start in enumerate(r['start']):
+            stop = start + window_size
+            if stop > sim_hm.chrom_end:
+                continue
+            sub = self._window_subset(sim_hm, start, stop)
+            if sub.num_variants == 0:
+                continue
+            assert np.isclose(r['pi'][i], diversity.pi(sub, span_normalize=False),
+                              rtol=1e-9, atol=1e-11)
+            assert np.isclose(r['theta_w'][i],
+                              diversity.theta_w(sub, span_normalize=False),
+                              rtol=1e-9, atol=1e-11)
+            assert r['segregating_sites'][i] == diversity.segregating_sites(sub)
+            assert r['singletons'][i] == diversity.singleton_count(sub)
+            assert np.isclose(
+                r['het_expected'][i],
+                float(np.nanmean(diversity.heterozygosity_expected(sub))),
+                rtol=1e-9, atol=1e-11)
+            td_w, td_ref = r['tajimas_d'][i], diversity.tajimas_d(sub)
+            if np.isnan(td_w) or np.isnan(td_ref):
+                assert np.isnan(td_w) and np.isnan(td_ref)
+            else:
+                assert np.isclose(td_w, td_ref, rtol=1e-9, atol=1e-11)
+
 
 class TestMultiallelicTwoPop:
     """Issue #100: two-pop windowed scalar stats must be

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -799,6 +799,11 @@ class TestOverlappingWindowsScatter:
             assert df['fst'].notna().any()
             assert (df['fst'].dropna() >= -0.5).all()
 
+    @pytest.mark.xfail(strict=True, reason=(
+        "windowed_analysis pi still uses the legacy collapsed multiallelic "
+        "convention (pre-existing bug); it now detectably diverges from the "
+        "per-allele scalar diversity.pi on multiallelic data. Fixed in the "
+        "windowed subproject (kr-colab/pg_gpu#100) -- remove this marker then."))
     def test_non_overlapping_unchanged(self, sim_hm):
         """Guard: step==window path (n_per_var=1) matches per-window reference."""
         window_size, step_size = 50_000, 50_000

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -819,6 +819,29 @@ class TestOverlappingWindowsScatter:
                       if sub.num_variants > 0 else 0.0)
             assert np.isclose(pi_scatter, pi_ref, rtol=1e-10, atol=1e-12)
 
+    @pytest.mark.xfail(strict=True, reason=(
+        "windowed_analysis dxy/fst still collapse multiallelic sites: "
+        "_allele_sum_and_n uses cp.sum(hap) (mechanism A, sums allele indices), "
+        "so windowed dxy detectably diverges from the per-allele scalar "
+        "divergence.dxy made correct in subproject 0003. Pre-existing; fixed in "
+        "the windowed subproject (kr-colab/pg_gpu#100) -- remove this marker then."))
+    def test_twopop_non_overlapping_dxy_matches_scalar(self, sim_hm):
+        """Per-window windowed dxy should equal scalar divergence.dxy on the
+        window subset; currently fails on multiallelic sites (collapsed path)."""
+        window_size, step_size = 50_000, 50_000
+        df = windowed_analysis(sim_hm, window_size=window_size,
+                               step_size=step_size, statistics=['dxy'],
+                               populations=['pop1', 'pop2'], span_normalize=False)
+        for start, dxy_scatter in zip(df['start'], df['dxy']):
+            stop = start + window_size
+            if stop > sim_hm.chrom_end:
+                continue
+            sub = self._window_subset(sim_hm, start, stop)
+            sub.sample_sets = sim_hm.sample_sets
+            dxy_ref = (divergence.dxy(sub, 'pop1', 'pop2', span_normalize=False)
+                       if sub.num_variants > 0 else 0.0)
+            assert np.isclose(dxy_scatter, dxy_ref, rtol=1e-10, atol=1e-12)
+
     def test_max_daf_overlapping_windows(self):
         """max_daf per window reflects max DAF among contained variants,
         including variants shared between overlapping windows."""

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -1172,6 +1172,95 @@ class TestMultiallelicTwoPop:
                 assert np.isclose(fst_w, fst_ref, rtol=1e-9, atol=1e-12)
 
 
+class TestMultiallelicCap:
+    """The fused windowed kernels can't represent an allele index at/above the
+    per-allele cap (``_FUSED_MAX_ALLELES``); such sites are dropped before launch
+    with a MultiallelicCapWarning, and the retained sites are computed exactly as
+    if the over-cap sites were absent. (The host scatter engine has no cap, so
+    this is fused-only.)"""
+
+    def _build(self, seed=0):
+        """Data with two over-cap sites among normal biallelic/low-multiallelic
+        sites. Returns (hm, hm_clean, bp, overcap)."""
+        from pg_gpu.windowed_analysis import _FUSED_MAX_ALLELES
+        rng = np.random.RandomState(seed)
+        n_hap, n_var, seq_len = 30, 60, 60_000
+        # nucleotide-scale alleles that stay strictly under the cap
+        within = min(4, _FUSED_MAX_ALLELES)
+        positions = np.sort(rng.choice(np.arange(1, seq_len), size=n_var,
+                                       replace=False)).astype(float)
+        hap = rng.randint(0, 2, (n_hap, n_var)).astype(np.int8)
+        # a few genuine multiallelic sites within the cap
+        for j in range(0, n_var, 12):
+            hap[:, j] = rng.randint(0, within, n_hap)
+        # two sites that hit the cap: one allele index == _FUSED_MAX_ALLELES,
+        # which the filter (>= cap) must drop
+        overcap = [15, 37]
+        for j in overcap:
+            hap[:, j] = rng.randint(0, within, n_hap)
+            hap[0, j] = _FUSED_MAX_ALLELES
+        hm = HaplotypeMatrix(hap, positions, chrom_start=0, chrom_end=seq_len)
+        keep = np.ones(n_var, dtype=bool)
+        keep[overcap] = False
+        hm_clean = HaplotypeMatrix(hap[:, keep], positions[keep],
+                                   chrom_start=0, chrom_end=seq_len)
+        for h in (hm, hm_clean):
+            n = h.num_haplotypes
+            h.sample_sets = {"p1": list(range(n // 2)),
+                             "p2": list(range(n // 2, n))}
+        bp = np.arange(0, seq_len + 20_000, 20_000, dtype=float)
+        return hm, hm_clean, bp, overcap
+
+    def test_fused_single_pop_cap_warns_and_matches(self):
+        from pg_gpu import MultiallelicCapWarning
+        from pg_gpu.windowed_analysis import windowed_statistics_fused
+        hm, hm_clean, bp, _ = self._build()
+        stats = ('pi', 'segregating_sites', 'theta_h')
+        with pytest.warns(MultiallelicCapWarning):
+            r = windowed_statistics_fused(hm, bp_bins=bp, statistics=stats,
+                                          per_base=False, chrom='1')
+        r_clean = windowed_statistics_fused(hm_clean, bp_bins=bp,
+                                            statistics=stats, per_base=False,
+                                            chrom='1')
+        for k in stats:
+            np.testing.assert_allclose(r[k], r_clean[k], rtol=1e-12,
+                                       equal_nan=True)
+        # dropped sites are not counted
+        np.testing.assert_array_equal(r['n_variants'], r_clean['n_variants'])
+
+    def test_fused_chunked_cap_warns_and_matches(self):
+        from pg_gpu import MultiallelicCapWarning
+        from pg_gpu.windowed_analysis import windowed_statistics_fused_chunked
+        hm, hm_clean, bp, _ = self._build()
+        stats = ('pi', 'segregating_sites')
+        with pytest.warns(MultiallelicCapWarning):
+            r = windowed_statistics_fused_chunked(hm, bp_bins=bp,
+                                                  statistics=stats,
+                                                  per_base=False, chrom='1')
+        r_clean = windowed_statistics_fused_chunked(hm_clean, bp_bins=bp,
+                                                    statistics=stats,
+                                                    per_base=False, chrom='1')
+        for k in stats:
+            np.testing.assert_allclose(r[k], r_clean[k], rtol=1e-12,
+                                       equal_nan=True)
+
+    def test_fused_two_pop_cap_warns_and_matches(self):
+        from pg_gpu import MultiallelicCapWarning
+        from pg_gpu.windowed_analysis import windowed_statistics_fused
+        hm, hm_clean, bp, _ = self._build()
+        stats = ('dxy', 'fst_hudson')
+        with pytest.warns(MultiallelicCapWarning):
+            r = windowed_statistics_fused(hm, bp_bins=bp, statistics=stats,
+                                          pop1='p1', pop2='p2', per_base=False,
+                                          chrom='1')
+        r_clean = windowed_statistics_fused(hm_clean, bp_bins=bp, statistics=stats,
+                                            pop1='p1', pop2='p2', per_base=False,
+                                            chrom='1')
+        for k in stats:
+            np.testing.assert_allclose(r[k], r_clean[k], rtol=1e-12,
+                                       equal_nan=True)
+
+
 class TestCanonicalWindowSchema:
     """Regression for issue #70: every dispatch path must emit the same
     window prefix columns so that cross-path requests and downstream joins

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -977,6 +977,82 @@ class TestMultiallelicSinglePop:
             else:
                 assert np.isclose(td_w, td_ref, rtol=1e-9, atol=1e-11)
 
+    @pytest.fixture(scope="class")
+    def sim_hm_missing(self, sim_hm):
+        """Multiallelic data with ~10% missing calls injected (-1)."""
+        import cupy as cp
+        hap = (sim_hm.haplotypes.get()
+               if isinstance(sim_hm.haplotypes, cp.ndarray)
+               else np.asarray(sim_hm.haplotypes)).copy()
+        pos = (sim_hm.positions.get()
+               if isinstance(sim_hm.positions, cp.ndarray)
+               else np.asarray(sim_hm.positions))
+        rng = np.random.RandomState(7)
+        hap[rng.random(hap.shape) < 0.1] = -1
+        return HaplotypeMatrix(hap, pos, chrom_start=sim_hm.chrom_start,
+                               chrom_end=sim_hm.chrom_end)
+
+    def test_per_variant_missing_data_matches_scalar(self, sim_hm_missing):
+        """With missing data, the per-variant engine still matches the scalar for
+        the stats that use per-site n_valid (everything except tajimas_d, whose
+        variance effective-n is a separate issue -- see the xfail below)."""
+        from pg_gpu.windowed_analysis import windowed_statistics
+        hm = sim_hm_missing
+        window_size = 25_000
+        bp = np.arange(0, int(hm.chrom_end) + window_size, window_size,
+                       dtype=float)
+        stats = ['pi', 'theta_w', 'segregating_sites', 'singletons',
+                 'het_expected']
+        r = windowed_statistics(hm, bp_bins=bp, statistics=stats,
+                                per_base=False, chrom='1')
+        for i, start in enumerate(r['start']):
+            stop = start + window_size
+            if stop > hm.chrom_end:
+                continue
+            sub = self._window_subset(hm, start, stop)
+            if sub.num_variants == 0:
+                continue
+            assert np.isclose(r['pi'][i], diversity.pi(sub, span_normalize=False),
+                              rtol=1e-9, atol=1e-11)
+            assert np.isclose(r['theta_w'][i],
+                              diversity.theta_w(sub, span_normalize=False),
+                              rtol=1e-9, atol=1e-11)
+            assert r['segregating_sites'][i] == diversity.segregating_sites(sub)
+            assert r['singletons'][i] == diversity.singleton_count(sub)
+            assert np.isclose(
+                r['het_expected'][i],
+                float(np.nanmean(diversity.heterozygosity_expected(sub))),
+                rtol=1e-9, atol=1e-11)
+
+    @pytest.mark.xfail(strict=True, reason=(
+        "windowed tajimas_d variance uses nominal n_hap; the scalar uses the "
+        "harmonic-mean effective n over per-site n_valid, so they diverge under "
+        "missing data (issue #100). Fixing the windowed effective-n convention "
+        "needs outside input; remove this marker when reconciled."))
+    def test_per_variant_missing_data_tajimas_d_matches_scalar(self,
+                                                               sim_hm_missing):
+        """Per-window tajimas_d should equal the scalar on the window subset;
+        currently diverges with missing data (effective-n convention)."""
+        from pg_gpu.windowed_analysis import windowed_statistics
+        hm = sim_hm_missing
+        window_size = 25_000
+        bp = np.arange(0, int(hm.chrom_end) + window_size, window_size,
+                       dtype=float)
+        r = windowed_statistics(hm, bp_bins=bp, statistics=['tajimas_d'],
+                                per_base=False, chrom='1')
+        for i, start in enumerate(r['start']):
+            stop = start + window_size
+            if stop > hm.chrom_end:
+                continue
+            sub = self._window_subset(hm, start, stop)
+            if sub.num_variants == 0:
+                continue
+            td_w, td_ref = r['tajimas_d'][i], diversity.tajimas_d(sub)
+            if np.isnan(td_w) or np.isnan(td_ref):
+                assert np.isnan(td_w) and np.isnan(td_ref)
+            else:
+                assert np.isclose(td_w, td_ref, rtol=1e-9, atol=1e-11)
+
 
 class TestMultiallelicTwoPop:
     """Issue #100: two-pop windowed scalar stats must be

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -799,13 +799,9 @@ class TestOverlappingWindowsScatter:
             assert df['fst'].notna().any()
             assert (df['fst'].dropna() >= -0.5).all()
 
-    @pytest.mark.xfail(strict=True, reason=(
-        "windowed_analysis pi still uses the legacy collapsed multiallelic "
-        "convention (pre-existing bug); it now detectably diverges from the "
-        "per-allele scalar diversity.pi on multiallelic data. Fixed in the "
-        "windowed subproject (kr-colab/pg_gpu#100) -- remove this marker then."))
     def test_non_overlapping_unchanged(self, sim_hm):
-        """Guard: step==window path (n_per_var=1) matches per-window reference."""
+        """Guard: step==window windowed pi equals per-window diversity.pi, now
+        that windowed_analysis uses the per-allele path (issue #100 / 0005a)."""
         window_size, step_size = 50_000, 50_000
         df = windowed_analysis(sim_hm, window_size=window_size,
                                step_size=step_size, statistics=['pi'],
@@ -871,6 +867,86 @@ class TestOverlappingWindowsScatter:
             assert np.isclose(max_daf_scatter, ref, atol=1e-12), (
                 f"window [{start}, {stop}): scatter={max_daf_scatter}, "
                 f"ref={ref}")
+
+
+class TestMultiallelicSinglePop:
+    """Issue #100 / subproject 0005a: single-pop windowed scalar stats must
+    be multiallelic-correct -- each window equals the per-allele scalar
+    ``diversity`` function on that window's subset -- on BOTH single-pop
+    engines: the host scatter path (``_windowed_thetas_scatter``, reached by a
+    pure single-pop scalar request) and the fused CUDA kernel
+    (``_fused_windowed_kernel_v2`` via ``windowed_statistics_fused``)."""
+
+    @pytest.fixture(scope="class")
+    def sim_hm(self):
+        import msprime
+        ts = msprime.sim_ancestry(
+            samples=25, sequence_length=100_000, recombination_rate=1e-8,
+            population_size=20_000, ploidy=2, random_seed=42)
+        ts = msprime.sim_mutations(
+            ts, rate=1e-6, model=msprime.JC69(state_independent=True),
+            random_seed=43)
+        # Sanity: this configuration produces genuinely multiallelic sites,
+        # so the per-allele path is actually exercised (not just biallelic).
+        G = ts.genotype_matrix()
+        n_multi = sum(np.unique(G[i]).size >= 3 for i in range(ts.num_sites))
+        assert n_multi > 50, f"fixture not multiallelic enough: {n_multi}"
+        return HaplotypeMatrix.from_ts(ts)
+
+    def _window_subset(self, hm, start, stop):
+        import cupy as cp
+        pos = hm.positions.get() if isinstance(hm.positions, cp.ndarray) else np.asarray(hm.positions)
+        hap = hm.haplotypes.get() if isinstance(hm.haplotypes, cp.ndarray) else np.asarray(hm.haplotypes)
+        mask = (pos >= start) & (pos < stop)
+        return HaplotypeMatrix(hap[:, mask], pos[mask],
+                               chrom_start=int(start), chrom_end=int(stop))
+
+    def test_scatter_path_matches_scalar(self, sim_hm):
+        """Host scatter engine: per-window pi/theta_w/segregating equal the
+        per-allele scalar functions on the window subset."""
+        window_size = 25_000
+        df = windowed_analysis(sim_hm, window_size=window_size,
+                               step_size=window_size,
+                               statistics=['pi', 'theta_w', 'segregating_sites'],
+                               span_normalize=False)
+        for start, pi_w, tw_w, seg_w in zip(
+                df['start'], df['pi'], df['theta_w'], df['segregating_sites']):
+            stop = start + window_size
+            if stop > sim_hm.chrom_end:
+                continue
+            sub = self._window_subset(sim_hm, start, stop)
+            if sub.num_variants == 0:
+                continue
+            assert np.isclose(pi_w, diversity.pi(sub, span_normalize=False),
+                              rtol=1e-9, atol=1e-12)
+            assert np.isclose(tw_w, diversity.theta_w(sub, span_normalize=False),
+                              rtol=1e-9, atol=1e-12)
+            assert np.isclose(seg_w, diversity.segregating_sites(sub),
+                              rtol=1e-9, atol=1e-12)
+
+    def test_fused_kernel_matches_scalar(self, sim_hm):
+        """Fused CUDA kernel: per-window pi/segregating/theta_h equal the
+        per-allele scalar functions on the window subset."""
+        from pg_gpu.windowed_analysis import windowed_statistics_fused
+        window_size = 25_000
+        bp = np.arange(0, int(sim_hm.chrom_end) + window_size, window_size,
+                       dtype=float)
+        r = windowed_statistics_fused(
+            sim_hm, bp_bins=bp,
+            statistics=('pi', 'segregating_sites', 'theta_h'),
+            per_base=False, chrom='1')
+        for start, pi_w, seg_w in zip(r['start'], r['pi'],
+                                      r['segregating_sites']):
+            stop = start + window_size
+            if stop > sim_hm.chrom_end:
+                continue
+            sub = self._window_subset(sim_hm, start, stop)
+            if sub.num_variants == 0:
+                continue
+            assert np.isclose(pi_w, diversity.pi(sub, span_normalize=False),
+                              rtol=1e-9, atol=1e-12)
+            assert np.isclose(seg_w, diversity.segregating_sites(sub),
+                              rtol=1e-9, atol=1e-12)
 
 
 class TestCanonicalWindowSchema:


### PR DESCRIPTION
## Summary

Integrates the multiallelic-correctness effort (`nsp-multiallelic-trunk`) into `main`. Previously most statistics assumed a biallelic 0/1 encoding, so a site with an allele index >= 2 gave wrong results — folded/collapsed derived alleles, dosages that overflowed the [0, 2] range, PCs that depended on arbitrary allele numbering, and mis-scoped diploid estimators. This branch reframes each family around per-allele counting (matching tskit / scikit-allel where an oracle exists) and pins the behavior with new tests.

`main` is a strict ancestor of this branch (46 commits ahead, 0 behind), so it merges cleanly. 42 files, ~+5,000/−1,500.

## What changed, by family

- **Diversity / SFS / FrequencySpectrum** (#127) — per-allele `allele_counts` primitive; scalar diversity, theta estimators, SFS, and `FrequencySpectrum` operate per derived allele (matching tskit `polarised=False`).
- **Divergence** (#128) — Hudson/Nei/Weir-Cockerham FST rewritten as per-allele pair-count / one-vs-rest ANOVA forms; a tskit FST estimator added for parity.
- **Distance / admixture** (#129, #130) — multiallelic pairwise-Hamming kernel; per-allele Patterson f2/f3/f4, with `patterson_d` biallelic-restricted.
- **Windowed engines + multiallelic cap** (#131, #132) — scatter/fused windowed engines made per-allele-consistent; `MultiallelicCapWarning` for the fixed-capacity fused kernels.
- **PCA / lostruct** (#143) — standardization is now an all-allele centered one-hot whose Gram is the relatedness matrix; PCs no longer depend on allele numbering. Removed the fragile deferred-standardization path.
- **Selection (iHS / nSL)** (#145) — each derived allele scored one-vs-ancestral; biallelic reduces exactly, multiallelic focal sites yield one score per derived allele; per-allele MAF filter.
- **Relatedness** (#149) — new `genetic_relatedness` pinned to `tskit.genetic_relatedness` (per-set per-allele centered covariance, all groupings); `grm`/`ibs` scoped to `GenotypeMatrix`; fixed `get_population_matrix` for genotypes.
- **Streaming** (#149, #153) — streaming `genetic_relatedness`; accessible-mask span + variant filtering unified at `iter_gpu_chunks` so all streaming consumers honor a load-time mask.

## Testing

- **Cross-implementation parity suite** (#137, `tests/test_implementation_parity.py`) — asserts the same statistic agrees across the scalar / FrequencySpectrum / scatter / fused / python-loop paths over clean, missing/include, missing/exclude, and multiallelic data; remaining known divergences are recorded as strict xfails (the follow-up punch list).
- **Multiallelic correctness** (`tests/test_multiallelic.py`, `test_decomposition_multiallelic.py`, `test_selection_multiallelic.py`) — biallelic reduction against tskit / scikit-allel oracles, brute-force numpy references for genuinely multiallelic sites, index-independence, and missing-data handling.
- **Streaming parity** — eager vs streaming equivalence for relatedness/grm/ibs including accessible masks and chunk-boundary invariance.

## Known follow-up

- **#152** — the `GenotypeMatrix` streaming loader still drops `accessible_bed`, so streaming `grm`/`ibs` ignore an accessible mask (variant filtering, not span). Scoped, not blocking; the `iter_gpu_chunks` choke-point here makes the fix straightforward.
