### PR TITLE
Multiallelic support for decomposition.pairwise_distance

### DIFF
--- a/pg_gpu/decomposition.py
+++ b/pg_gpu/decomposition.py
@@ -394,18 +394,27 @@ def pairwise_distance(haplotype_matrix: HaplotypeMatrix,
                       missing_data: str = 'include'):
     """Compute pairwise distances between samples.
 
+    Distances are built from the allele-mismatch count m: the number of sites at
+    which two haplotypes carry different alleles (over jointly non-missing sites).
+    This is label-independent, so it does not depend on how alleles are numbered
+    and is correct at multiallelic sites. cityblock and sqeuclidean are both m;
+    euclidean is sqrt(m). On categorical data these coincide up to that transform,
+    and on biallelic data m equals the usual per-site difference count, so the
+    values match the standard distances there.
+
     Parameters
     ----------
     haplotype_matrix : HaplotypeMatrix
         Haplotype data.
     metric : str
-        Distance metric. Supported on GPU: 'euclidean', 'cityblock',
-        'sqeuclidean'. Falls back to scipy for other metrics.
+        Distance metric: 'euclidean' (default), 'cityblock', or 'sqeuclidean'.
+        Other metrics raise NotImplementedError.
     population : str or list, optional
         Population subset.
     missing_data : str
-        'include' - mask missing, normalize per pair
-        'exclude' - filter sites with any missing
+        'include' - count mismatches over jointly non-missing sites, scaled to
+        the full variant span per pair
+        'exclude' - filter sites with any missing first
 
     Returns
     -------
@@ -421,6 +430,14 @@ def pairwise_distance(haplotype_matrix: HaplotypeMatrix,
     if matrix.device == 'CPU':
         matrix.transfer_to_gpu()
 
+    if metric not in ('euclidean', 'sqeuclidean', 'cityblock'):
+        raise NotImplementedError(
+            "pairwise_distance supports metric in "
+            "{'euclidean', 'sqeuclidean', 'cityblock'}; got %r" % (metric,))
+
+    from .distance_stats import (_pairwise_diffs_matrix_gpu,
+                                 _extract_upper_triangle)
+
     hap = matrix.haplotypes
 
     if missing_data == 'exclude':
@@ -428,55 +445,21 @@ def pairwise_distance(haplotype_matrix: HaplotypeMatrix,
         complete = missing_per_var == 0
         hap = hap[:, complete]
 
-    X = cp.where(hap >= 0, hap, 0).astype(cp.float64)
-    valid_mask = (hap >= 0).astype(cp.float64)
-    has_missing = cp.any(hap < 0)
-    n = X.shape[0]
+    n_var = hap.shape[1]
+    # m = number of differing jointly-valid sites per pair (multiallelic-correct,
+    # label-independent one-hot Hamming); joint_valid = jointly non-missing site
+    # count per pair. cityblock and sqeuclidean are both m; euclidean is sqrt(m).
+    m, joint_valid = _pairwise_diffs_matrix_gpu(
+        hap, missing_data='include', return_joint_valid=True)
 
-    if metric in ('euclidean', 'sqeuclidean', 'cityblock'):
-        idx_i, idx_j = cp.triu_indices(n, k=1)
-        n_pairs = len(idx_i)
-
-        # Estimate batch size from available GPU memory
-        n_variants = X.shape[1]
-        free_mem = cp.cuda.Device().mem_info[0]
-        # Each pair needs ~3 float64 arrays of n_variants (diff, joint, result)
-        bytes_per_pair = n_variants * 8 * 3
-        batch_size = max(1, min(n_pairs, int(free_mem * 0.3 / bytes_per_pair)))
-        dist_parts = []
-
-        for start in range(0, n_pairs, batch_size):
-            end = min(start + batch_size, n_pairs)
-            bi = idx_i[start:end]
-            bj = idx_j[start:end]
-
-            if has_missing:
-                # only compare at jointly-valid sites
-                joint = valid_mask[bi] * valid_mask[bj]
-                n_joint = cp.sum(joint, axis=1)
-            else:
-                n_joint = cp.float64(X.shape[1])
-
-            if metric == 'cityblock':
-                raw = cp.sum(cp.abs(X[bi] - X[bj]) * (joint if has_missing else 1.0), axis=1)
-            else:
-                raw = cp.sum(((X[bi] - X[bj]) ** 2) * (joint if has_missing else 1.0), axis=1)
-
-            # normalize by jointly-valid sites
-            if has_missing:
-                d = cp.where(n_joint > 0, raw * X.shape[1] / n_joint, 0.0)
-            else:
-                d = raw
-
-            if metric == 'euclidean':
-                d = cp.sqrt(d)
-            dist_parts.append(d)
-
-        return cp.concatenate(dist_parts).get()
-    else:
-        from scipy.spatial.distance import pdist
-        X_cpu = X.get()
-        return pdist(X_cpu, metric=metric)
+    # Scale the mismatch count to the full variant span when missing sites reduce
+    # the jointly-valid count (raw * n_var / n_joint). With no missing data
+    # joint_valid == n_var, so d == m. On biallelic {0,1} data m equals the old
+    # raw sum, so this is bit-identical to the previous per-metric formula.
+    d = cp.where(joint_valid > 0, m * n_var / joint_valid, 0.0)
+    if metric == 'euclidean':
+        d = cp.sqrt(d)
+    return _extract_upper_triangle(d)
 
 
 def pcoa(dist, n_components: Optional[int] = None):

--- a/pg_gpu/decomposition.py
+++ b/pg_gpu/decomposition.py
@@ -421,6 +421,14 @@ def pairwise_distance(haplotype_matrix: HaplotypeMatrix,
     dist : ndarray, float64, shape (n_samples * (n_samples - 1) // 2,)
         Condensed distance matrix.
     """
+    from .genotype_matrix import GenotypeMatrix
+    if isinstance(haplotype_matrix, GenotypeMatrix):
+        raise TypeError(
+            "pairwise_distance is an allele-mismatch distance over haplotypes and "
+            "requires a HaplotypeMatrix; a GenotypeMatrix holds 0/1/2 dosages, for "
+            "which allele mismatch is not the right distance. Use "
+            "distance_stats.pairwise_diffs_diploid for a diploid genotype distance, "
+            "or to_haplotype_matrix() first.")
 
     if population is not None:
         matrix = _get_population_matrix(haplotype_matrix, population)

--- a/pg_gpu/distance_stats.py
+++ b/pg_gpu/distance_stats.py
@@ -21,7 +21,8 @@ def _extract_upper_triangle(mat):
     return result.get() if hasattr(result, 'get') else result
 
 
-def _pairwise_diffs_matrix_gpu(hap, missing_data='include'):
+def _pairwise_diffs_matrix_gpu(hap, missing_data='include',
+                               return_joint_valid=False):
     """Compute full pairwise Hamming distance matrix on GPU.
 
     Internal helper returning the raw cupy distance matrix. Used by
@@ -48,11 +49,17 @@ def _pairwise_diffs_matrix_gpu(hap, missing_data='include'):
     missing_data : str
         'include' - raw counts at jointly non-missing sites
         'normalize' - per-site average (divide by jointly valid count)
+    return_joint_valid : bool
+        When True, also return the (n_hap, n_hap) count of jointly non-missing
+        sites per pair, so a caller can apply its own normalization with the
+        same counts. Default False (existing callers are unchanged).
 
     Returns
     -------
     diffs_mat : cupy.ndarray, float64, shape (n_hap, n_hap)
         Pairwise distance matrix on GPU.
+    joint_valid : cupy.ndarray, float64, shape (n_hap, n_hap)
+        Only returned when ``return_joint_valid`` is True.
     """
     from ._memutil import estimate_variant_chunk_size
 
@@ -86,6 +93,8 @@ def _pairwise_diffs_matrix_gpu(hap, missing_data='include'):
     if missing_data == 'normalize':
         diffs_mat = cp.where(joint_valid > 0, diffs_mat / joint_valid, 0.0)
 
+    if return_joint_valid:
+        return diffs_mat, joint_valid
     return diffs_mat
 
 

--- a/tests/test_pbs_decomposition.py
+++ b/tests/test_pbs_decomposition.py
@@ -5,6 +5,7 @@ Validates against scikit-allel where applicable.
 
 import pytest
 import numpy as np
+import cupy as cp
 import allel
 from pg_gpu import HaplotypeMatrix
 from pg_gpu import divergence, decomposition
@@ -189,6 +190,116 @@ class TestPairwiseDistance:
             dist_scipy = pdist(hap.astype(float), metric=metric)
             np.testing.assert_allclose(dist_pg, dist_scipy, rtol=1e-10,
                                       err_msg=f"{metric} mismatch")
+
+    @pytest.mark.parametrize("metric", ['euclidean', 'cityblock', 'sqeuclidean'])
+    @pytest.mark.parametrize("missing_data", ['include', 'exclude'])
+    def test_biallelic_bit_identical_to_premultiallelic(self, metric, missing_data):
+        # The mismatch-count rewrite must not change biallelic output, including
+        # the missing-data normalization path (which scipy cannot oracle since it
+        # treats -1 as a value). Pin bit-for-bit against the pre-multiallelic
+        # per-pair formula reproduced here.
+        def premultiallelic(hap):
+            hap = cp.asarray(hap)
+            if missing_data == 'exclude':
+                hap = hap[:, cp.sum(hap < 0, axis=0) == 0]
+            X = cp.where(hap >= 0, hap, 0).astype(cp.float64)
+            valid = (hap >= 0).astype(cp.float64)
+            has_missing = bool(cp.any(hap < 0))
+            n, nv = X.shape
+            ii, jj = cp.triu_indices(n, k=1)
+            if has_missing:
+                joint = valid[ii] * valid[jj]
+                njoint = cp.sum(joint, axis=1)
+            if metric == 'cityblock':
+                raw = cp.sum(cp.abs(X[ii] - X[jj]) * (joint if has_missing else 1.0), axis=1)
+            else:
+                raw = cp.sum(((X[ii] - X[jj]) ** 2) * (joint if has_missing else 1.0), axis=1)
+            d = cp.where(njoint > 0, raw * nv / njoint, 0.0) if has_missing else raw
+            if metric == 'euclidean':
+                d = cp.sqrt(d)
+            return d.get()
+
+        rng = np.random.RandomState(7)
+        hap = rng.randint(0, 2, (16, 60)).astype(np.int8)
+        hap[rng.random(hap.shape) < 0.15] = -1
+        matrix = HaplotypeMatrix(hap, np.arange(60) * 10, 0, 600)
+        new = decomposition.pairwise_distance(
+            matrix, metric=metric, missing_data=missing_data)
+        np.testing.assert_array_equal(new, premultiallelic(hap))
+
+
+def _host_pairwise(hap, metric, missing_data='include'):
+    """Independent host reference: the allele-mismatch count m per pair, scaled to
+    the full variant span over jointly non-missing sites. euclidean = sqrt(m)."""
+    hap = np.asarray(hap)
+    if missing_data == 'exclude':
+        hap = hap[:, (hap >= 0).all(axis=0)]
+    n, nv = hap.shape
+    out = []
+    for i in range(n):
+        for j in range(i + 1, n):
+            valid = (hap[i] >= 0) & (hap[j] >= 0)
+            njoint = int(valid.sum())
+            m = int(((hap[i] != hap[j]) & valid).sum())
+            d = (m * nv / njoint) if njoint > 0 else 0.0
+            out.append(np.sqrt(d) if metric == 'euclidean' else d)
+    return np.array(out)
+
+
+class TestPairwiseDistanceMultiallelic:
+    """pairwise_distance is a label-independent allele-mismatch distance, correct
+    on multiallelic sites and unchanged on biallelic data."""
+
+    def _hm(self, hap):
+        return HaplotypeMatrix(hap, np.arange(hap.shape[1]) * 10, 0,
+                               hap.shape[1] * 10)
+
+    @pytest.mark.parametrize("metric", ['euclidean', 'cityblock', 'sqeuclidean'])
+    @pytest.mark.parametrize("missing_data", ['include', 'exclude'])
+    def test_matches_host_reference(self, metric, missing_data):
+        rng = np.random.RandomState(1)
+        hap = rng.randint(0, 4, (14, 50)).astype(np.int8)
+        hap[rng.random(hap.shape) < 0.12] = -1
+        dist = decomposition.pairwise_distance(
+            self._hm(hap), metric=metric, missing_data=missing_data)
+        np.testing.assert_allclose(
+            dist, _host_pairwise(hap, metric, missing_data), rtol=1e-12)
+
+    @pytest.mark.parametrize("metric", ['euclidean', 'cityblock', 'sqeuclidean'])
+    def test_label_independence(self, metric):
+        rng = np.random.RandomState(2)
+        hap = rng.randint(0, 4, (12, 40)).astype(np.int8)
+        perm = np.array([2, 0, 3, 1], dtype=np.int8)   # relabel alleles 0..3
+        d0 = decomposition.pairwise_distance(self._hm(hap), metric=metric)
+        d1 = decomposition.pairwise_distance(self._hm(perm[hap]), metric=metric)
+        np.testing.assert_array_equal(d0, d1)
+
+    @pytest.mark.parametrize("metric", ['euclidean', 'cityblock', 'sqeuclidean'])
+    def test_biallelic_index_reduction(self, metric):
+        # A 2-allele site coded {0,2} gives the same distances as {0,1}.
+        rng = np.random.RandomState(3)
+        h2 = rng.choice([0, 2], (10, 30)).astype(np.int8)
+        h1 = np.where(h2 == 2, 1, 0).astype(np.int8)
+        d2 = decomposition.pairwise_distance(self._hm(h2), metric=metric)
+        d1 = decomposition.pairwise_distance(self._hm(h1), metric=metric)
+        np.testing.assert_array_equal(d2, d1)
+
+    def test_metrics_collapse_on_categorical(self):
+        # On allele-index data cityblock == sqeuclidean == m and euclidean == sqrt(m).
+        rng = np.random.RandomState(4)
+        hap = rng.randint(0, 4, (10, 45)).astype(np.int8)
+        hm = self._hm(hap)
+        cb = decomposition.pairwise_distance(hm, metric='cityblock')
+        sq = decomposition.pairwise_distance(hm, metric='sqeuclidean')
+        eu = decomposition.pairwise_distance(hm, metric='euclidean')
+        np.testing.assert_array_equal(cb, sq)
+        np.testing.assert_allclose(eu, np.sqrt(sq), rtol=1e-12)
+
+    def test_unsupported_metric_raises(self):
+        rng = np.random.RandomState(5)
+        hm = self._hm(rng.randint(0, 3, (6, 20)).astype(np.int8))
+        with pytest.raises(NotImplementedError, match="euclidean"):
+            decomposition.pairwise_distance(hm, metric='correlation')
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pbs_decomposition.py
+++ b/tests/test_pbs_decomposition.py
@@ -301,6 +301,14 @@ class TestPairwiseDistanceMultiallelic:
         with pytest.raises(NotImplementedError, match="euclidean"):
             decomposition.pairwise_distance(hm, metric='correlation')
 
+    def test_rejects_genotype_matrix(self):
+        from pg_gpu import GenotypeMatrix
+        gm = GenotypeMatrix(
+            np.random.RandomState(6).randint(0, 3, (6, 20)).astype(np.int8),
+            np.arange(20) * 10)
+        with pytest.raises(TypeError, match="HaplotypeMatrix"):
+            decomposition.pairwise_distance(gm)
+
 
 # ---------------------------------------------------------------------------
 # PCoA tests


### PR DESCRIPTION
#### Background

decomposition.pairwise_distance built its euclidean / sqeuclidean / cityblock distances from the raw allele-index matrix, using the allele index as a magnitude. On a multiallelic site that makes the distance depend on arbitrary allele numbering (|allele 3 - allele 0| = 3 but |allele 2 - allele 1| = 1), the same index-inflation class of bug as the old PCA path. It feeds pcoa (classical MDS). GenotypeMatrix input previous errored out with an obscure message (no attribute "haplotypes"), and now raises a TypeError.

#### What changed

The three supported metrics are now built from the allele-mismatch count m: the number of jointly non-missing sites at which two haplotypes carry different alleles. cityblock and sqeuclidean are m; euclidean is sqrt(m). m is label-independent, so the distance no longer depends on how alleles are numbered, and it is correct at multiallelic sites. On categorical (allele-index) data the three metrics are all functions of the single quantity m, so they coincide up to that transform.

pairwise_distance now routes its mismatch count through the shared one-hot Hamming kernel distance_stats._pairwise_diffs_matrix_gpu (the multiallelic-correct kernel already used by pairwise_diffs_haploid and the divergence two-population distances), rather than carrying its own per-metric computation. The kernel gains an additive return_joint_valid flag (default off, so existing callers are byte-for-byte unchanged) so pairwise_distance can apply the exact prior normalization m * n_var / n_joint (multiply-before-divide) over the jointly non-missing site count from a single pass.

The scipy fallback for other metrics is removed. It was unused (no caller or test exercised it) and ran on the raw allele-index matrix. Most scipy metrics are magnitude-based (euclidean-like, chebyshev, correlation, ...) and index-inflate on multiallelic input; a few (hamming, matching) are label-independent and would be correct as-is, and the boolean metrics collapse multiallelic to presence/absence. Rather than generalize twenty metrics case-by-case for a dead path, an unsupported metric now raises NotImplementedError.

Passing GenotypeMatrix would previously have results in an ambiguous error, now it raises a TypeError that explicitly points to HaplotypeMatrix.

#### Behaviour

Biallelic output is unchanged, bit-for-bit, including the missing-data normalization path. On multiallelic data the distances are now label-independent instead of index-inflated. pcoa is unaffected: when it is called on pairwise_distance output the input distances change on multiallelic data (correctly), and its other consumer, lostruct, feeds it pc_dist output rather than pairwise_distance, so that path is untouched. The memory profile of pairwise_distance changes from pair-batching to the kernel's variant-chunked (n_hap, n_hap) accumulation, matching pairwise_diffs_haploid at the same sample count.

#### Verification

- Biallelic bit-identity, bit-for-bit (array_equal) against a reconstruction of the pre-multiallelic per-pair formula, across clean and both missing-data modes for all three metrics -- this covers the missing-data normalization path, which scipy cannot oracle since it treats missing (-1) as a value. The pre-existing biallelic-vs-scipy tests (clean, rtol) still pass.
- Multiallelic parity against an independent host mismatch-count reference, clean and missing, all three metrics.
- Label-independence: permuting allele labels leaves the distances unchanged.
- Reduction: a 2-allele site coded {0,2} gives the same distances as {0,1}.
- Metric collapse: cityblock == sqeuclidean, euclidean == sqrt, on categorical data.
- Unsupported metric raises.
- The shared kernel's existing callers (pairwise_diffs_haploid, the divergence two-population distances, the diploSHIC distance features) are unchanged.
- Passing a GenotypeMatrix raises a type error.