### PR TITLE
Streaming GenotypeMatrix honors accessible_bed for grm/ibs (#152)

### DIFF
--- a/pg_gpu/accessible.py
+++ b/pg_gpu/accessible.py
@@ -246,3 +246,34 @@ def resolve_accessible_mask(mask_or_path, chrom_start, chrom_end, chrom=None):
         raise ValueError(
             "Could not determine mask range from BED and chromosome bounds")
     return bed_to_mask(mask_or_path, chrom=chrom, length=length, offset=offset)
+
+
+def resolve_streaming_accessible_mask(accessible_bed, source, region=None):
+    """Resolve an accessible BED over a streaming source's variant bounds.
+
+    Both streaming loaders (haplotype and genotype) resolve the same mask
+    once over the source's position span and hand it to the streaming
+    matrix, so per-chunk variant filtering -- and, for span-normalized
+    reductions, the accessible-base denominator -- matches the eager path.
+    ``mappable_hi`` is one past the last variant, so the inclusive last
+    position is ``mappable_hi - 1``.
+
+    Parameters
+    ----------
+    accessible_bed : str, path-like, numpy.ndarray, AccessibleMask, or None
+        Passthrough to ``resolve_accessible_mask``. ``None`` returns ``None``.
+    source : ZarrGenotypeSource
+        Streaming source; supplies ``mappable_lo``/``mappable_hi``/``chrom``.
+    region : str, optional
+        ``"chrom:start-end"`` region string; its contig overrides
+        ``source.chrom`` for matching a BED file's contig name.
+
+    Returns
+    -------
+    AccessibleMask or None
+    """
+    if accessible_bed is None:
+        return None
+    chrom = region.split(':')[0] if region else source.chrom
+    return resolve_accessible_mask(
+        accessible_bed, source.mappable_lo, source.mappable_hi - 1, chrom)

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -482,7 +482,7 @@ class GenotypeMatrix:
             return cls._build_streaming(
                 path, region=region, pop_assignment=pop_assignment,
                 chunk_bp=chunk_bp, prefetch=prefetch,
-                backend=backend,
+                backend=backend, accessible_bed=accessible_bed,
             )
 
         # 'auto' and 'never' both want eager when the matrix fits;
@@ -504,7 +504,7 @@ class GenotypeMatrix:
             return cls._build_streaming(
                 path, region=region, pop_assignment=pop_assignment,
                 chunk_bp=chunk_bp, prefetch=prefetch,
-                backend=backend, source=source,
+                backend=backend, source=source, accessible_bed=accessible_bed,
             )
         return cls._build_eager(path, region=region,
                                 accessible_bed=accessible_bed,
@@ -564,7 +564,8 @@ class GenotypeMatrix:
 
     @classmethod
     def _build_streaming(cls, path, *, region, pop_assignment, chunk_bp,
-                         prefetch, backend="auto", source=None):
+                         prefetch, backend="auto", source=None,
+                         accessible_bed=None):
         from .streaming_matrix import (
             StreamingGenotypeMatrix, _pick_chunk_fetcher,
         )
@@ -576,9 +577,19 @@ class GenotypeMatrix:
         else:
             source.pop_cols = source._resolve_pop_assignment(pop_assignment)
         fetcher = _pick_chunk_fetcher(source, backend=backend)
+
+        # Resolve the accessible BED once over the source's variant-position
+        # bounds so every chunk is filtered to accessible variants, matching
+        # the eager path's mask-filtered .genotypes view (grm/ibs read that
+        # view, so streaming and eager see the same variant set).
+        from .accessible import resolve_streaming_accessible_mask
+        accessible_mask = resolve_streaming_accessible_mask(
+            accessible_bed, source, region)
+
         return StreamingGenotypeMatrix(
             source, fetcher,
             chunk_bp=chunk_bp, prefetch=prefetch,
+            accessible_mask=accessible_mask,
         )
 
     def filter(self, variants=None, genotypes=None,

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -738,15 +738,11 @@ class HaplotypeMatrix:
         # Resolve an accessible BED once over the source's variant-position
         # bounds and hand it to the streaming matrix, so span-normalized
         # reductions (genetic_relatedness) divide by accessible bases the same
-        # way the eager path does. ``mappable_hi`` is one past the last variant,
-        # so the inclusive last position is ``mappable_hi - 1``.
-        accessible_mask = None
-        if accessible_bed is not None:
-            from .accessible import resolve_accessible_mask
-            chrom = region.split(':')[0] if region else source.chrom
-            lo, hi = source.mappable_lo, source.mappable_hi
-            accessible_mask = resolve_accessible_mask(
-                accessible_bed, lo, hi - 1, chrom)
+        # way the eager path does, and every chunk is filtered to accessible
+        # variants.
+        from .accessible import resolve_streaming_accessible_mask
+        accessible_mask = resolve_streaming_accessible_mask(
+            accessible_bed, source, region)
 
         return StreamingHaplotypeMatrix(
             source, fetcher,

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -713,9 +713,10 @@ class StreamingGenotypeMatrix(_StreamingMatrixBase):
 
     Returned by ``GenotypeMatrix.from_zarr`` when the requested matrix
     does not fit eagerly on the GPU. Sample sets index the diploid
-    axis (``0..num_individuals-1``), not the haplotype axis. ``ibs``
-    accepts this class directly; ``grm`` still needs an eager
-    sub-region via ``.materialize(region=...)``.
+    axis (``0..num_individuals-1``), not the haplotype axis. ``grm`` and
+    ``ibs`` accept this class directly, streaming variant chunks; kernels
+    that need every variant in scope at once call
+    ``.materialize(region=(lo, hi))`` for an eager sub-region.
     """
 
     @property
@@ -728,11 +729,11 @@ class StreamingGenotypeMatrix(_StreamingMatrixBase):
             "StreamingGenotypeMatrix has no materialized .genotypes "
             "array; the matrix is too big to fit eagerly, which is why "
             "from_zarr returned this class instead of GenotypeMatrix. "
-            "For grm or any other kernel that needs every variant in "
-            "scope at once, call .materialize(region=(lo, hi)) to get "
-            "an eager GenotypeMatrix over a sub-region. For per-window "
-            "streaming stats and ibs, pass this object directly to the "
-            "kernel."
+            "For per-window streaming stats, grm, and ibs, pass this "
+            "object directly to the kernel. For a kernel that needs "
+            "every variant in scope at once, call "
+            ".materialize(region=(lo, hi)) to get an eager "
+            "GenotypeMatrix over a sub-region."
         )
 
     def _sample_axis_size(self):

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -239,6 +239,35 @@ class TestAccessibleBedDispatch:
             seen += chunk.num_variants
         assert seen > 0
 
+    def test_load_time_mask_windowed_equivalent(self, vcz_store, tmp_path):
+        # A LOAD-TIME mask must reach windowed_analysis without re-passing
+        # accessible_bed: iter_gpu_chunks attaches it, and the per-chunk
+        # eager call honors the already-attached mask. This is a distinct
+        # path from test_accessible_bed_equivalent, which passes the BED as
+        # an argument. Both eager and streaming carry the mask from load.
+        bed = self._write_bed(str(tmp_path / "acc.bed"))
+        eager = HaplotypeMatrix.from_zarr(vcz_store, streaming="never",
+                                          accessible_bed=bed)
+        stream = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                           chunk_bp=10_000, accessible_bed=bed)
+        eager.chrom_start = stream.chrom_start
+        eager.chrom_end = stream.chrom_end
+        stats = ["pi", "theta_w", "segregating_sites"]
+        df_e = windowed_analysis(eager, window_size=5_000, statistics=stats)
+        df_s = windowed_analysis(stream, window_size=5_000, statistics=stats)
+        _assert_frames_equivalent(df_e, df_s)
+
+        # Guard that the mask actually bit: an unmasked streaming run must
+        # differ, else the test would pass even if the mask were dropped.
+        unmasked = HaplotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                             chunk_bp=10_000)
+        df_u = windowed_analysis(unmasked, window_size=5_000,
+                                 statistics=["segregating_sites"])
+        df_u = df_u.sort_values("start").reset_index(drop=True)
+        df_s2 = df_s.sort_values("start").reset_index(drop=True)
+        assert not np.allclose(df_u["segregating_sites"].to_numpy(),
+                               df_s2["segregating_sites"].to_numpy())
+
 
 class TestGarudStreamingDispatch:
     """Per-window scatter-reduce assembles each window's hash from the

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from pg_gpu import HaplotypeMatrix, windowed_analysis
+from pg_gpu import GenotypeMatrix, HaplotypeMatrix, windowed_analysis
 from pg_gpu import sfs as sfs_module
 
 from .conftest import simulate_hm
@@ -516,3 +516,71 @@ class TestGeneticRelatednessDispatch:
         e = relatedness.genetic_relatedness(eager, span_normalize=mode)
         s = relatedness.genetic_relatedness(stream, span_normalize=mode)
         np.testing.assert_allclose(s, e, rtol=1e-9, atol=1e-12)
+
+
+class TestGrmIbsAccessibleBed:
+    """Streaming grm/ibs match eager row-for-row, and a load-time
+    accessible_bed filters variants identically on both paths. grm/ibs are
+    per-site averages (not span-normalized), so the mask matters here purely
+    as variant filtering. #152"""
+
+    # Accessible: [25000, 75000). Excluding the flanks forces the mask to be
+    # applied at chunk boundaries, not just the matrix edges.
+    def _write_bed(self, path):
+        with open(path, "w") as f:
+            f.write("1\t25000\t75000\n")
+        return path
+
+    @pytest.mark.parametrize("stat", ["grm", "ibs"])
+    def test_no_mask_equivalent(self, vcz_store, stat):
+        from pg_gpu import relatedness
+        fn = getattr(relatedness, stat)
+        eager = GenotypeMatrix.from_zarr(vcz_store, streaming="never")
+        stream = GenotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                          chunk_bp=10_000)
+        np.testing.assert_allclose(fn(stream), fn(eager),
+                                   rtol=1e-6, atol=1e-9)
+
+    @pytest.mark.parametrize("stat", ["grm", "ibs"])
+    def test_accessible_bed_equivalent(self, vcz_store, tmp_path, stat):
+        from pg_gpu import relatedness
+        fn = getattr(relatedness, stat)
+        bed = self._write_bed(str(tmp_path / "acc.bed"))
+        full = GenotypeMatrix.from_zarr(vcz_store, streaming="never")
+        eager = GenotypeMatrix.from_zarr(vcz_store, streaming="never",
+                                         accessible_bed=bed)
+        stream = GenotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                          chunk_bp=10_000, accessible_bed=bed)
+        assert eager.num_variants < full.num_variants   # mask really filters
+        np.testing.assert_allclose(fn(stream), fn(eager),
+                                   rtol=1e-6, atol=1e-9)
+
+    @pytest.mark.parametrize("stat", ["grm", "ibs"])
+    def test_load_time_mask_changes_streaming_result(self, vcz_store, tmp_path,
+                                                     stat):
+        # Guard against a no-op mask trivially "matching" eager: the masked
+        # streaming result must differ from the unmasked one. Without the
+        # #152 fix the streaming matrix carries no mask and these are equal.
+        from pg_gpu import relatedness
+        fn = getattr(relatedness, stat)
+        bed = self._write_bed(str(tmp_path / "acc.bed"))
+        unmasked = GenotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                            chunk_bp=10_000)
+        masked = GenotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                          chunk_bp=10_000, accessible_bed=bed)
+        assert not np.allclose(fn(masked), fn(unmasked))
+
+    def test_load_time_mask_filters_chunks(self, vcz_store, tmp_path):
+        # The mask is attached to every chunk iter_gpu_chunks yields, so each
+        # chunk's genotypes are restricted to accessible positions.
+        bed = self._write_bed(str(tmp_path / "acc.bed"))
+        stream = GenotypeMatrix.from_zarr(vcz_store, streaming="always",
+                                          chunk_bp=10_000, accessible_bed=bed)
+        seen = 0
+        for _, _, chunk in stream.iter_gpu_chunks():
+            assert chunk.has_accessible_mask
+            pos = chunk.positions
+            pos = pos.get() if hasattr(pos, "get") else np.asarray(pos)
+            assert ((pos >= 25000) & (pos < 75000)).all()
+            seen += chunk.num_variants
+        assert seen > 0


### PR DESCRIPTION
Closes #152.

## Problem

`GenotypeMatrix.from_zarr(..., streaming=..., accessible_bed=bed)` accepted `accessible_bed` but both streaming branches dropped it, so a `StreamingGenotypeMatrix` carried no accessible mask. `grm`/`ibs` then streamed over **all** variants while the eager path filtered to accessible sites via the mask-filtered `.genotypes` view -- a silent eager-vs-streaming divergence under an `accessible_bed`, with no error raised. This is the sibling of #151, which fixed the same drop for `HaplotypeMatrix`.

## Fix

- Forward `accessible_bed` from both `GenotypeMatrix.from_zarr` streaming branches into `_build_streaming`, resolve the mask once over the source's variant bounds, and hand it to `StreamingGenotypeMatrix`. `iter_gpu_chunks` already attaches the mask to every chunk, so per-chunk variant filtering happens for free and streaming `grm`/`ibs` match eager.
- Factor the shared "resolve mask over source bounds" block into `resolve_streaming_accessible_mask`, now used by both the haplotype and genotype streaming loaders.
- Correct the stale `StreamingGenotypeMatrix` docs/error text, which still claimed `grm` needs `.materialize()` -- it streams directly.

## Audit

Swept the whole streaming surface for this bug class (mask honored on eager, dropped on streaming):

- **Loaders**: only `from_zarr` streams; both `HaplotypeMatrix` (#151) and `GenotypeMatrix` (this PR) now forward the mask. `from_vcf`/`from_ts` are eager-only.
- **Consumers**: no stats module reads raw arrays -- all go through the accessible-filtered `.haplotypes`/`.genotypes`/`.positions` properties. Verified per streaming consumer: `sfs`, `genetic_relatedness` (#153), `grm`/`ibs`, `windowed_analysis`, and `ld_statistics` all honor the mask. `selection`, `admixture`, `diversity`, `divergence`, `distance_stats`, `ld_statistics_genotype`, and `local_pca` have no streaming-matrix input path (eager-only or raise).

Conclusion: no other statistic carried a live instance of this bug. The one residual was a test-coverage gap for the load-time-mask -> streaming `windowed_analysis` path, closed here with a regression test.

## Tests

- Eager-vs-streaming `grm`/`ibs` parity with and without an `accessible_bed`, plus a guard that the mask actually changes the streaming result and a chunk-level check that each streaming chunk is restricted to accessible positions.
- Pin the load-time mask through streaming `windowed_analysis`.
- Full suite green (`test_streaming_kernels`, `test_accessible_mask`, `test_relatedness`, matrix/streaming loaders); `ruff` clean.