### PR TITLE
Multiallelic-correct windowed daf_hist / mu_sfs

### DIFF
--- a/pg_gpu/diversity.py
+++ b/pg_gpu/diversity.py
@@ -1693,10 +1693,26 @@ def diplotype_frequency_spectrum(genotype_matrix,
     return freqs, len(counts)
 
 
+def _daf_bin_index(dafs, n_bins):
+    """Bin index in [0, n_bins - 1] for derived-allele frequencies in [0, 1].
+
+    Left-closed bins of width 1/n_bins; a frequency of 1.0 falls in the top bin.
+    Shared by daf_histogram and the windowed daf_hist so the two assign bins
+    identically (the windowed path scatters these indices into per-window
+    histograms; here they feed a single bincount).
+    """
+    idx = cp.floor(dafs * n_bins).astype(cp.int32)
+    return cp.clip(idx, 0, n_bins - 1)
+
+
 def _histogram_from_dafs(dafs, n_bins):
     """Shared: compute normalized histogram from DAF CuPy array."""
     bin_edges = cp.linspace(0, 1, n_bins + 1)
-    hist = cp.histogram(dafs, bins=bin_edges)[0].astype(cp.float64)
+    if dafs.size:
+        idx = _daf_bin_index(dafs, n_bins)
+        hist = cp.bincount(idx, minlength=n_bins)[:n_bins].astype(cp.float64)
+    else:
+        hist = cp.zeros(n_bins, dtype=cp.float64)
     total = cp.sum(hist)
     if total > 0:
         hist = hist / total

--- a/pg_gpu/sfs.py
+++ b/pg_gpu/sfs.py
@@ -206,9 +206,8 @@ def _joint_global_k(m1, m2):
     """Global allele-index width K spanning both population matrices.
 
     The joint SFS counts each population on a *shared* K so that allele
-    column ``a`` denotes the same allele in both per-allele count matrices
-    (the alignment discipline from 0001). ``K = max allele index over both
-    pops + 1``.
+    column ``a`` denotes the same allele in both per-allele count matrices.
+    ``K = max allele index over both pops + 1``.
     """
     k1 = int(m1.haplotypes.max()) if m1.num_variants > 0 else 0
     k2 = int(m2.haplotypes.max()) if m2.num_variants > 0 else 0

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -63,8 +63,8 @@ CANONICAL_WINDOW_PREFIX = (
     'chrom', 'start', 'end', 'center', 'n_variants', 'window_id')
 
 # Number of bins in the windowed daf_hist feature (columns daf_bin_0 ..
-# daf_bin_{_DAF_N_BINS - 1}). Fixed for now, shared by the fused engine and the
-# fallback so they emit the same columns; making it a caller parameter is deferred.
+# daf_bin_{_DAF_N_BINS - 1}) emitted by the fused engine. Fixed for now; making
+# it a caller parameter is deferred.
 _DAF_N_BINS = 20
 
 
@@ -233,16 +233,9 @@ class StatisticsComputer:
                                                 span_normalize=sn),
         }
 
-        # Frequency-spectrum features computed here (the exclude-mode path) by
-        # deferring to the scalar diversity functions per window; the fused engine
-        # handles the include-mode fast path. daf_hist is vector-valued and expands
-        # into daf_bin_0 .. daf_bin_{n-1} columns.
-        self.FREQ_STATS = {'daf_hist', 'mu_sfs'}
-
         self.single_pop_stats = []
         self.two_pop_stats = []
         self.ld_stats = []
-        self.freq_stats = []
         self.custom_stats = []
 
         for stat in self.statistics:
@@ -253,8 +246,6 @@ class StatisticsComputer:
                     self.two_pop_stats.append(stat)
                 elif stat in self.LD_STATS:
                     self.ld_stats.append(stat)
-                elif stat in self.FREQ_STATS:
-                    self.freq_stats.append(stat)
                 else:
                     raise ValueError(f"Unknown statistic: {stat}")
             else:
@@ -274,17 +265,12 @@ class StatisticsComputer:
 
         # Skip if no variants
         if window.n_variants == 0:
-            # Empty window: scalar stats are undefined -> NaN. The frequency-
-            # spectrum features are vector-valued (their own daf_bin_* / mu_sfs
-            # columns) and must still emit those columns, filled with the value
-            # the scalar and fused paths give for no data (0.0 / all-zero
-            # histogram) -- handled below by _freq_stat_results.
+            # Fill with NaN for all statistics
             for stat in self.statistics:
-                name = stat if isinstance(stat, str) else stat.__name__
-                if name in self.FREQ_STATS:
-                    continue  # emitted as their own columns below
-                results[name] = np.nan
-            results.update(self._freq_stat_results(window.matrix, 0))
+                if isinstance(stat, str):
+                    results[stat] = np.nan
+                else:
+                    results[stat.__name__] = np.nan
             return results
 
         # Single population statistics
@@ -321,43 +307,12 @@ class StatisticsComputer:
                 kwargs['bins'] = self.ld_bins
             results[stat] = self.LD_STATS[stat](window, **kwargs)
 
-        # Frequency-spectrum features (daf_hist / mu_sfs), computed on the first
-        # population if any, matching the fused engine's population handling.
-        if self.freq_stats:
-            fmatrix = (self._get_population_matrix(window.matrix, self.populations[0])
-                       if self.populations else window.matrix)
-            results.update(self._freq_stat_results(fmatrix, window.n_variants))
-
         # Custom statistics
         for stat in self.custom_stats:
             kwargs = self.custom_stat_kwargs.get(stat.__name__, {})
             results[stat.__name__] = stat(window, **kwargs)
 
         return results
-
-    def _freq_stat_results(self, matrix, n_variants):
-        """daf_hist (as daf_bin_0 .. daf_bin_{_DAF_N_BINS - 1}) and mu_sfs columns.
-
-        Defers to diversity.mu_sfs / diversity.daf_histogram (the include/exclude
-        scalar reference), so the windowed value equals the scalar over the same
-        variants. An empty window yields 0.0 / an all-zero histogram, matching the
-        scalar on an empty slice and the fused engine's empty-window output.
-        """
-        res = {}
-        n_bins = _DAF_N_BINS
-        if 'mu_sfs' in self.freq_stats:
-            res['mu_sfs'] = (0.0 if n_variants == 0 else
-                             float(diversity.mu_sfs(matrix, missing_data=self.missing_data)))
-        if 'daf_hist' in self.freq_stats:
-            if n_variants == 0:
-                hist = np.zeros(n_bins)
-            else:
-                hist, _ = diversity.daf_histogram(matrix, n_bins=n_bins,
-                                                  missing_data=self.missing_data)
-                hist = np.asarray(hist)
-            for b in range(n_bins):
-                res[f'daf_bin_{b}'] = float(hist[b])
-        return res
 
     @staticmethod
     def _store_result(results: Dict, key: str, val):
@@ -2172,16 +2127,9 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
                                win_start, win_stop, n_windows, statistics,
                                results)
 
-    # Per-site stats binned into windows via scatter_add. Assign each variant to
-    # the window whose right-open [start, end) contains it, matching win_start /
-    # win_stop, n_variants and the dedicated scatter engines: pick the last window
-    # whose start is <= pos, then require pos < that window's end. Searching the
-    # window ENDS instead would put a variant sitting exactly on a boundary
-    # (pos == a window end == the next window's start) in the lower window,
-    # disagreeing with n_variants.
-    bin_idx = cp.searchsorted(ws_gpu, positions, side='right') - 1
-    safe = cp.clip(bin_idx, 0, n_windows - 1)
-    in_range = (bin_idx >= 0) & (bin_idx < n_windows) & (positions < we_gpu[safe])
+    # Per-site stats binned into windows via scatter_add
+    bin_idx = cp.searchsorted(we_gpu, positions)
+    in_range = (bin_idx >= 0) & (bin_idx < n_windows)
 
     # Shared per-allele counts (used by daf_hist and mu_sfs). Per-derived-allele,
     # per-site n_valid -- the same convention as diversity.daf_histogram / mu_sfs,

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -2126,10 +2126,13 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
     bin_idx = cp.searchsorted(we_gpu, positions)
     in_range = (bin_idx >= 0) & (bin_idx < n_windows)
 
-    # Shared DAC computation (used by daf_hist and mu_sfs)
-    dac_gpu = None
+    # Shared per-allele counts (used by daf_hist and mu_sfs). Per-derived-allele,
+    # per-site n_valid -- the same convention as diversity.daf_histogram / mu_sfs,
+    # so the windowed values equal the scalar over each window (include mode).
+    ac_daf = nv_daf = None
     if any(s in statistics for s in ('daf_hist', 'mu_sfs')):
-        dac_gpu = cp.sum(cp.maximum(matrix.haplotypes, 0).astype(cp.int32), axis=0)
+        from ._memutil import allele_counts
+        ac_daf, nv_daf = allele_counts(matrix.haplotypes)   # (n_var, K), (n_var,)
 
     if 'mean_nsl' in statistics:
         from . import selection as sel
@@ -2189,29 +2192,51 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
             if stat in statistics:
                 results[stat] = arr
 
-    # DAF histogram per window (GPU scatter)
+    # DAF histogram per window (GPU scatter). One entry per present derived
+    # allele (freq = count / n_valid), scattered into (window, bin) and
+    # normalized per window -- matching diversity.daf_histogram.
     if 'daf_hist' in statistics:
+        from .diversity import _daf_bin_index
         n_daf_bins = 20
-        daf = dac_gpu.astype(cp.float64) / n_hap
-        daf_bin = cp.minimum((daf * n_daf_bins).astype(cp.int32), n_daf_bins - 1)
-        # Composite index: window * n_daf_bins + daf_bin
-        composite = bin_idx * n_daf_bins + daf_bin
-        valid_daf = in_range
-        flat = _scatter_sum(cp.ones_like(composite[valid_daf], dtype=cp.float64),
-                            composite[valid_daf], n_windows * n_daf_bins)
+        derived = ac_daf[:, 1:]                                  # (n_var, K-1)
+        n_der = derived.shape[1]
+        nv = cp.maximum(nv_daf.astype(cp.float64), 1.0)[:, None]
+        freq = (derived.astype(cp.float64) / nv).reshape(-1)     # per (site, allele)
+        # keep present derived alleles at in-range, non-missing sites
+        keep = ((derived > 0) & (nv_daf[:, None] > 0)
+                & in_range[:, None]).reshape(-1)
+        bin_rep = cp.repeat(bin_idx, n_der)                      # site's window
+        composite = cp.where(keep, bin_rep * n_daf_bins
+                             + _daf_bin_index(freq, n_daf_bins), 0)
+        flat = _scatter_sum(keep.astype(cp.float64), composite,
+                            n_windows * n_daf_bins)
         hist_matrix = flat.get().reshape(n_windows, n_daf_bins)
+        row_sum = hist_matrix.sum(axis=1, keepdims=True)
+        hist_matrix = np.divide(hist_matrix, row_sum,
+                                out=np.zeros_like(hist_matrix),
+                                where=row_sum > 0)
         for b in range(n_daf_bins):
             results[f'daf_bin_{b}'] = hist_matrix[:, b]
 
-    # muSFS: fraction of SNPs at SFS edges
+    # muSFS: fraction of segregating (site, allele) entries at the SFS edges
+    # (singleton or n_valid-1), per-site n_valid -- matching diversity.mu_sfs.
     if 'mu_sfs' in statistics:
-        is_edge = ((dac_gpu == 1) | (dac_gpu == n_hap - 1)).astype(cp.float64)
-        edge_sum = _scatter_sum(is_edge[in_range], bin_idx[in_range], n_windows)
-        total_count = _bin_counts(bin_idx[in_range], n_windows)
-        edge_cpu = edge_sum.get()
-        count_cpu = total_count.get()
-        mu_sfs = np.where(count_cpu > 0, edge_cpu / count_cpu, np.nan)
-        results['mu_sfs'] = mu_sfs
+        derived = ac_daf[:, 1:]
+        n_der = derived.shape[1]
+        nvc = nv_daf[:, None]
+        is_seg = (derived > 0) & (derived < nvc) & in_range[:, None]
+        is_edge = is_seg & ((derived == 1) | (derived == nvc - 1))
+        keep = cp.repeat(in_range, n_der)
+        bin_safe = cp.where(keep, cp.repeat(bin_idx, n_der), 0)
+        seg_sum = _scatter_sum(is_seg.reshape(-1).astype(cp.float64),
+                               bin_safe, n_windows).get()
+        edge_sum = _scatter_sum(is_edge.reshape(-1).astype(cp.float64),
+                                bin_safe, n_windows).get()
+        # matches diversity.mu_sfs, which returns 0.0 when a window has no
+        # segregating (site, allele) entries (rather than NaN)
+        results['mu_sfs'] = np.divide(edge_sum, seg_sum,
+                                      out=np.zeros_like(edge_sum),
+                                      where=seg_sum > 0)
 
     # Per-window pairwise stats (LD, distance moments)
     ld_pairwise = {'zns', 'omega', 'mu_ld'}

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -2201,7 +2201,6 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
     # allele (freq = count / n_valid), scattered into (window, bin) and
     # normalized per window -- matching diversity.daf_histogram.
     if 'daf_hist' in statistics:
-        from .diversity import _daf_bin_index
         n_daf_bins = _DAF_N_BINS
         derived = ac_daf[:, 1:]                                  # (n_var, K-1)
         n_der = derived.shape[1]
@@ -2212,7 +2211,7 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
                 & in_range[:, None]).reshape(-1)
         bin_rep = cp.repeat(bin_idx, n_der)                      # site's window
         composite = cp.where(keep, bin_rep * n_daf_bins
-                             + _daf_bin_index(freq, n_daf_bins), 0)
+                             + diversity._daf_bin_index(freq, n_daf_bins), 0)
         flat = _scatter_sum(keep.astype(cp.float64), composite,
                             n_windows * n_daf_bins)
         hist_matrix = flat.get().reshape(n_windows, n_daf_bins)

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -274,7 +274,11 @@ class StatisticsComputer:
 
         # Skip if no variants
         if window.n_variants == 0:
-            # Fill with NaN for all statistics
+            # Empty window: scalar stats are undefined -> NaN. The frequency-
+            # spectrum features are vector-valued (their own daf_bin_* / mu_sfs
+            # columns) and must still emit those columns, filled with the value
+            # the scalar and fused paths give for no data (0.0 / all-zero
+            # histogram) -- handled below by _freq_stat_results.
             for stat in self.statistics:
                 name = stat if isinstance(stat, str) else stat.__name__
                 if name in self.FREQ_STATS:

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -228,9 +228,16 @@ class StatisticsComputer:
                                                 span_normalize=sn),
         }
 
+        # Frequency-spectrum features computed here (the exclude-mode path) by
+        # deferring to the scalar diversity functions per window; the fused engine
+        # handles the include-mode fast path. daf_hist is vector-valued and expands
+        # into daf_bin_0 .. daf_bin_{n-1} columns.
+        self.FREQ_STATS = {'daf_hist', 'mu_sfs'}
+
         self.single_pop_stats = []
         self.two_pop_stats = []
         self.ld_stats = []
+        self.freq_stats = []
         self.custom_stats = []
 
         for stat in self.statistics:
@@ -241,6 +248,8 @@ class StatisticsComputer:
                     self.two_pop_stats.append(stat)
                 elif stat in self.LD_STATS:
                     self.ld_stats.append(stat)
+                elif stat in self.FREQ_STATS:
+                    self.freq_stats.append(stat)
                 else:
                     raise ValueError(f"Unknown statistic: {stat}")
             else:
@@ -262,10 +271,11 @@ class StatisticsComputer:
         if window.n_variants == 0:
             # Fill with NaN for all statistics
             for stat in self.statistics:
-                if isinstance(stat, str):
-                    results[stat] = np.nan
-                else:
-                    results[stat.__name__] = np.nan
+                name = stat if isinstance(stat, str) else stat.__name__
+                if name in self.FREQ_STATS:
+                    continue  # emitted as their own columns below
+                results[name] = np.nan
+            results.update(self._freq_stat_results(window.matrix, 0))
             return results
 
         # Single population statistics
@@ -302,12 +312,43 @@ class StatisticsComputer:
                 kwargs['bins'] = self.ld_bins
             results[stat] = self.LD_STATS[stat](window, **kwargs)
 
+        # Frequency-spectrum features (daf_hist / mu_sfs), computed on the first
+        # population if any, matching the fused engine's population handling.
+        if self.freq_stats:
+            fmatrix = (self._get_population_matrix(window.matrix, self.populations[0])
+                       if self.populations else window.matrix)
+            results.update(self._freq_stat_results(fmatrix, window.n_variants))
+
         # Custom statistics
         for stat in self.custom_stats:
             kwargs = self.custom_stat_kwargs.get(stat.__name__, {})
             results[stat.__name__] = stat(window, **kwargs)
 
         return results
+
+    def _freq_stat_results(self, matrix, n_variants):
+        """daf_hist (as daf_bin_0 .. daf_bin_19) and mu_sfs columns for one window.
+
+        Defers to diversity.mu_sfs / diversity.daf_histogram (the include/exclude
+        scalar reference), so the windowed value equals the scalar over the same
+        variants. An empty window yields 0.0 / an all-zero histogram, matching the
+        scalar on an empty slice and the fused engine's empty-window output.
+        """
+        res = {}
+        n_bins = 20
+        if 'mu_sfs' in self.freq_stats:
+            res['mu_sfs'] = (0.0 if n_variants == 0 else
+                             float(diversity.mu_sfs(matrix, missing_data=self.missing_data)))
+        if 'daf_hist' in self.freq_stats:
+            if n_variants == 0:
+                hist = np.zeros(n_bins)
+            else:
+                hist, _ = diversity.daf_histogram(matrix, n_bins=n_bins,
+                                                  missing_data=self.missing_data)
+                hist = np.asarray(hist)
+            for b in range(n_bins):
+                res[f'daf_bin_{b}'] = float(hist[b])
+        return res
 
     @staticmethod
     def _store_result(results: Dict, key: str, val):

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -62,6 +62,11 @@ def _compute_window_bases(haplotype_matrix, win_starts, win_stops,
 CANONICAL_WINDOW_PREFIX = (
     'chrom', 'start', 'end', 'center', 'n_variants', 'window_id')
 
+# Number of bins in the windowed daf_hist feature (columns daf_bin_0 ..
+# daf_bin_{_DAF_N_BINS - 1}). Fixed for now, shared by the fused engine and the
+# fallback so they emit the same columns; making it a caller parameter is deferred.
+_DAF_N_BINS = 20
+
 
 def _init_window_results(chrom, win_starts_bp, win_stops_bp, n_variants):
     """Canonical window prefix columns, shared by every dispatch path.
@@ -327,7 +332,7 @@ class StatisticsComputer:
         return results
 
     def _freq_stat_results(self, matrix, n_variants):
-        """daf_hist (as daf_bin_0 .. daf_bin_19) and mu_sfs columns for one window.
+        """daf_hist (as daf_bin_0 .. daf_bin_{_DAF_N_BINS - 1}) and mu_sfs columns.
 
         Defers to diversity.mu_sfs / diversity.daf_histogram (the include/exclude
         scalar reference), so the windowed value equals the scalar over the same
@@ -335,7 +340,7 @@ class StatisticsComputer:
         scalar on an empty slice and the fused engine's empty-window output.
         """
         res = {}
-        n_bins = 20
+        n_bins = _DAF_N_BINS
         if 'mu_sfs' in self.freq_stats:
             res['mu_sfs'] = (0.0 if n_variants == 0 else
                              float(diversity.mu_sfs(matrix, missing_data=self.missing_data)))
@@ -2245,7 +2250,7 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
     # normalized per window -- matching diversity.daf_histogram.
     if 'daf_hist' in statistics:
         from .diversity import _daf_bin_index
-        n_daf_bins = 20
+        n_daf_bins = _DAF_N_BINS
         derived = ac_daf[:, 1:]                                  # (n_var, K-1)
         n_der = derived.shape[1]
         nv = cp.maximum(nv_daf.astype(cp.float64), 1.0)[:, None]

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -2122,9 +2122,16 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
                                win_start, win_stop, n_windows, statistics,
                                results)
 
-    # Per-site stats binned into windows via scatter_add
-    bin_idx = cp.searchsorted(we_gpu, positions)
-    in_range = (bin_idx >= 0) & (bin_idx < n_windows)
+    # Per-site stats binned into windows via scatter_add. Assign each variant to
+    # the window whose right-open [start, end) contains it, matching win_start /
+    # win_stop, n_variants and the dedicated scatter engines: pick the last window
+    # whose start is <= pos, then require pos < that window's end. Searching the
+    # window ENDS instead would put a variant sitting exactly on a boundary
+    # (pos == a window end == the next window's start) in the lower window,
+    # disagreeing with n_variants.
+    bin_idx = cp.searchsorted(ws_gpu, positions, side='right') - 1
+    safe = cp.clip(bin_idx, 0, n_windows - 1)
+    in_range = (bin_idx >= 0) & (bin_idx < n_windows) & (positions < we_gpu[safe])
 
     # Shared per-allele counts (used by daf_hist and mu_sfs). Per-derived-allele,
     # per-site n_valid -- the same convention as diversity.daf_histogram / mu_sfs,

--- a/tests/test_implementation_parity.py
+++ b/tests/test_implementation_parity.py
@@ -42,6 +42,7 @@ from pg_gpu.windowed_analysis import (
     _windowed_thetas_scatter,
     _windowed_twopop_scatter,
     windowed_statistics_fused,
+    _DAF_N_BINS,
 )
 
 from .conftest import simulate_hm
@@ -267,6 +268,10 @@ _STATS = {
         False, "value",
         lambda hm, md: diversity.max_daf(hm, missing_data=md),
         None, "max_daf", "max_daf", None),
+    "mu_sfs": _Stat(
+        False, "value",
+        lambda hm, md: diversity.mu_sfs(hm, missing_data=md),
+        None, None, "mu_sfs", "mu_sfs"),
     "fst_hudson": _Stat(
         True, "value",
         lambda hm, md: divergence.fst_hudson(hm, POP1, POP2, missing_data=md),
@@ -461,3 +466,36 @@ def test_path_matches_scalar(request, condition, stat, path):
     reference = _path_scalar(hm, stat, cond.missing_data)
     value = _PATHS[path](hm, stat, cond.missing_data)
     _assert_agrees(stat, reference, value)
+
+
+@pytest.mark.parametrize("condition", list(_CONDITIONS))
+def test_daf_hist_matches_scalar(request, condition):
+    """daf_hist is vector-valued (daf_bin_0 .. daf_bin_{_DAF_N_BINS - 1}), so it
+    sits outside the scalar _STATS matrix. Check its whole-region histogram
+    against diversity.daf_histogram for every engine that computes it: the fused
+    engine (include only) and the WindowedAnalyzer fallback (include and exclude).
+
+    Multi-window / boundary coverage for daf_hist (and mean_nsl) is deferred to the
+    parity-coverage followup (0006-issue-parity-coverage-gaps.md addendum)."""
+    cond = _CONDITIONS[condition]
+    hm = request.getfixturevalue(cond.fixture)
+    md = cond.missing_data
+    ref, _ = diversity.daf_histogram(hm, n_bins=_DAF_N_BINS, missing_data=md)
+
+    # fallback (pyloop) computes daf_hist for every missing mode
+    W = _whole_window_size(hm)
+    an = WindowedAnalyzer(window_type="bp", window_size=W, step_size=W,
+                          statistics=["daf_hist"], missing_data=md,
+                          span_normalize=False)
+    df = an.compute(hm)
+    got_pyloop = np.array([_one_row(df, f"daf_bin_{b}") for b in range(_DAF_N_BINS)])
+    np.testing.assert_allclose(got_pyloop, ref, rtol=RTOL, atol=ATOL)
+
+    # fused engine computes daf_hist only under missing_data='include'
+    if md == "include":
+        out = windowed_statistics_fused(hm, _whole_bp_bins(hm),
+                                        statistics=("daf_hist",), per_base=False,
+                                        missing_data=md, population=None)
+        got_fused = np.array([np.asarray(out[f"daf_bin_{b}"])[0]
+                              for b in range(_DAF_N_BINS)])
+        np.testing.assert_allclose(got_fused, ref, rtol=RTOL, atol=ATOL)

--- a/tests/test_implementation_parity.py
+++ b/tests/test_implementation_parity.py
@@ -271,7 +271,7 @@ _STATS = {
     "mu_sfs": _Stat(
         False, "value",
         lambda hm, md: diversity.mu_sfs(hm, missing_data=md),
-        None, None, "mu_sfs", "mu_sfs"),
+        None, None, "mu_sfs", None),
     "fst_hudson": _Stat(
         True, "value",
         lambda hm, md: divergence.fst_hudson(hm, POP1, POP2, missing_data=md),
@@ -471,31 +471,22 @@ def test_path_matches_scalar(request, condition, stat, path):
 @pytest.mark.parametrize("condition", list(_CONDITIONS))
 def test_daf_hist_matches_scalar(request, condition):
     """daf_hist is vector-valued (daf_bin_0 .. daf_bin_{_DAF_N_BINS - 1}), so it
-    sits outside the scalar _STATS matrix. Check its whole-region histogram
-    against diversity.daf_histogram for every engine that computes it: the fused
-    engine (include only) and the WindowedAnalyzer fallback (include and exclude).
+    sits outside the scalar _STATS matrix. The fused engine computes it under
+    missing_data='include'; check its whole-region histogram against
+    diversity.daf_histogram.
 
     This checks the whole-region histogram; multi-window and window-boundary
     coverage for daf_hist (and mean_nsl) lives in dedicated windowed tests."""
     cond = _CONDITIONS[condition]
+    if cond.missing_data != "include":
+        pytest.skip("windowed daf_hist is computed by the fused engine "
+                    "(missing_data='include') only")
     hm = request.getfixturevalue(cond.fixture)
-    md = cond.missing_data
-    ref, _ = diversity.daf_histogram(hm, n_bins=_DAF_N_BINS, missing_data=md)
+    ref, _ = diversity.daf_histogram(hm, n_bins=_DAF_N_BINS, missing_data="include")
 
-    # fallback (pyloop) computes daf_hist for every missing mode
-    W = _whole_window_size(hm)
-    an = WindowedAnalyzer(window_type="bp", window_size=W, step_size=W,
-                          statistics=["daf_hist"], missing_data=md,
-                          span_normalize=False)
-    df = an.compute(hm)
-    got_pyloop = np.array([_one_row(df, f"daf_bin_{b}") for b in range(_DAF_N_BINS)])
-    np.testing.assert_allclose(got_pyloop, ref, rtol=RTOL, atol=ATOL)
-
-    # fused engine computes daf_hist only under missing_data='include'
-    if md == "include":
-        out = windowed_statistics_fused(hm, _whole_bp_bins(hm),
-                                        statistics=("daf_hist",), per_base=False,
-                                        missing_data=md, population=None)
-        got_fused = np.array([np.asarray(out[f"daf_bin_{b}"])[0]
-                              for b in range(_DAF_N_BINS)])
-        np.testing.assert_allclose(got_fused, ref, rtol=RTOL, atol=ATOL)
+    out = windowed_statistics_fused(hm, _whole_bp_bins(hm),
+                                    statistics=("daf_hist",), per_base=False,
+                                    missing_data="include", population=None)
+    got_fused = np.array([np.asarray(out[f"daf_bin_{b}"])[0]
+                          for b in range(_DAF_N_BINS)])
+    np.testing.assert_allclose(got_fused, ref, rtol=RTOL, atol=ATOL)

--- a/tests/test_implementation_parity.py
+++ b/tests/test_implementation_parity.py
@@ -475,8 +475,8 @@ def test_daf_hist_matches_scalar(request, condition):
     against diversity.daf_histogram for every engine that computes it: the fused
     engine (include only) and the WindowedAnalyzer fallback (include and exclude).
 
-    Multi-window / boundary coverage for daf_hist (and mean_nsl) is deferred to the
-    parity-coverage followup (0006-issue-parity-coverage-gaps.md addendum)."""
+    This checks the whole-region histogram; multi-window and window-boundary
+    coverage for daf_hist (and mean_nsl) lives in dedicated windowed tests."""
     cond = _CONDITIONS[condition]
     hm = request.getfixturevalue(cond.fixture)
     md = cond.missing_data

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -746,11 +746,11 @@ class TestMultiallelicConsumers:
 
 
 class TestWindowedDafMuSfsMatchesScalar:
-    """0013 Option A: the windowed daf_hist / mu_sfs equal the scalar
-    diversity.daf_histogram / diversity.mu_sfs over the same variants -- in both
-    engines that compute them (include -> fused, exclude -> WindowedAnalyzer
-    fallback). Checked on a single whole-region window (the parity convention),
-    across biallelic / multiallelic and clean / missing data."""
+    """The windowed daf_hist / mu_sfs equal the scalar diversity.daf_histogram /
+    diversity.mu_sfs over the same variants -- in both engines that compute them
+    (include -> fused, exclude -> WindowedAnalyzer fallback). Checked on a single
+    whole-region window, across biallelic / multiallelic and clean / missing
+    data."""
 
     def _hap(self, kind, missing, seed=3, n=24, nv=90):
         rng = np.random.RandomState(seed)
@@ -760,8 +760,9 @@ class TestWindowedDafMuSfsMatchesScalar:
                 hap[:, j] = rng.randint(0, 3, n)
             for j in range(0, nv, 13):
                 hap[:, j] = rng.randint(0, 4, n)
-        # a monomorphic-derived site: with missing it is the case the old fixed
-        # n_hap edge test misclassified as a near-fixed SFS edge.
+        # a site fixed for the derived allele; with missing data present it checks
+        # that SFS-edge classification uses each site's own valid-sample count (a
+        # global count would misread it as a near-fixed edge).
         hap[:, 5] = 1
         if missing:
             hap[rng.random(hap.shape) < 0.08] = -1
@@ -798,7 +799,7 @@ class TestWindowedDafMuSfsMatchesScalar:
         # boundaries (pos == a window end == the next window's start). Each
         # window's daf_hist / mu_sfs must equal the scalar over that window's
         # right-open [start, end) slice, and the window membership must agree with
-        # n_variants. The parity harness uses one whole-region window, so it never
+        # n_variants. The whole-region test above uses a single window, so it never
         # exercises an interior boundary -- this is the case that catches the
         # bin_idx window-assignment convention.
         from pg_gpu.windowed_analysis import windowed_analysis, _DAF_N_BINS
@@ -831,7 +832,7 @@ class TestWindowedDafMuSfsMatchesScalar:
     @pytest.mark.parametrize("kind", ["biallelic", "multiallelic"])
     def test_whole_region_exclude_matches_scalar(self, kind):
         # exclude mode routes to the WindowedAnalyzer fallback (which calls the
-        # scalar functions per window); previously it raised "Unknown statistic".
+        # scalar functions per window) rather than the fused GPU engine.
         from pg_gpu.windowed_analysis import windowed_analysis, _DAF_N_BINS
         hap = self._hap(kind, missing=True)
         nv = hap.shape[1]
@@ -851,7 +852,8 @@ class TestWindowedDafMuSfsMatchesScalar:
 
     def test_monomorphic_derived_with_missing_not_edge(self):
         # A site that is monomorphic for the derived allele but has one missing
-        # haplotype must not count as an SFS edge (the old fixed-n_hap bug).
+        # haplotype must not count as an SFS edge: classification uses the site's
+        # own valid-sample count, not a global haplotype count.
         from pg_gpu.windowed_analysis import windowed_analysis, _DAF_N_BINS
         n = 20
         hap = np.zeros((n, 4), dtype=np.int8)

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -770,7 +770,7 @@ class TestWindowedDafMuSfsMatchesScalar:
     @pytest.mark.parametrize("kind", ["biallelic", "multiallelic"])
     @pytest.mark.parametrize("missing", [False, True])
     def test_whole_region_matches_scalar(self, kind, missing):
-        from pg_gpu.windowed_analysis import windowed_analysis
+        from pg_gpu.windowed_analysis import windowed_analysis, _DAF_N_BINS
         hap = self._hap(kind, missing)
         nv = hap.shape[1]
         pos = np.arange(nv) * 100
@@ -782,10 +782,10 @@ class TestWindowedDafMuSfsMatchesScalar:
                                missing_data='include')
         assert len(wa) == 1
         w_mu = wa['mu_sfs'].values[0]
-        w_hist = np.array([wa[f'daf_bin_{b}'].values[0] for b in range(20)])
+        w_hist = np.array([wa[f'daf_bin_{b}'].values[0] for b in range(_DAF_N_BINS)])
 
         sc_mu = diversity.mu_sfs(hm, missing_data='include')
-        sc_hist, _ = diversity.daf_histogram(hm, n_bins=20, missing_data='include')
+        sc_hist, _ = diversity.daf_histogram(hm, n_bins=_DAF_N_BINS, missing_data='include')
 
         if np.isnan(sc_mu):
             assert np.isnan(w_mu)
@@ -801,7 +801,7 @@ class TestWindowedDafMuSfsMatchesScalar:
         # n_variants. The parity harness uses one whole-region window, so it never
         # exercises an interior boundary -- this is the case that catches the
         # bin_idx window-assignment convention.
-        from pg_gpu.windowed_analysis import windowed_analysis
+        from pg_gpu.windowed_analysis import windowed_analysis, _DAF_N_BINS
         rng = np.random.RandomState(4)
         nv = 120
         hap = rng.randint(0, 2, (24, nv)).astype(np.int8)
@@ -822,9 +822,9 @@ class TestWindowedDafMuSfsMatchesScalar:
                 continue
             sub = HaplotypeMatrix(hap[:, m], pos[m], int(s), int(e))
             sc_mu = diversity.mu_sfs(sub, missing_data='include')
-            sc_hist, _ = diversity.daf_histogram(sub, n_bins=20,
+            sc_hist, _ = diversity.daf_histogram(sub, n_bins=_DAF_N_BINS,
                                                  missing_data='include')
-            w_hist = np.array([row[f'daf_bin_{b}'] for b in range(20)])
+            w_hist = np.array([row[f'daf_bin_{b}'] for b in range(_DAF_N_BINS)])
             np.testing.assert_allclose(row['mu_sfs'], sc_mu, atol=1e-12)
             np.testing.assert_allclose(w_hist, sc_hist, atol=1e-12)
 
@@ -832,7 +832,7 @@ class TestWindowedDafMuSfsMatchesScalar:
     def test_whole_region_exclude_matches_scalar(self, kind):
         # exclude mode routes to the WindowedAnalyzer fallback (which calls the
         # scalar functions per window); previously it raised "Unknown statistic".
-        from pg_gpu.windowed_analysis import windowed_analysis
+        from pg_gpu.windowed_analysis import windowed_analysis, _DAF_N_BINS
         hap = self._hap(kind, missing=True)
         nv = hap.shape[1]
         pos = np.arange(nv) * 100
@@ -843,16 +843,16 @@ class TestWindowedDafMuSfsMatchesScalar:
                                missing_data='exclude')
         assert len(wa) == 1
         w_mu = wa['mu_sfs'].values[0]
-        w_hist = np.array([wa[f'daf_bin_{b}'].values[0] for b in range(20)])
+        w_hist = np.array([wa[f'daf_bin_{b}'].values[0] for b in range(_DAF_N_BINS)])
         sc_mu = diversity.mu_sfs(hm, missing_data='exclude')
-        sc_hist, _ = diversity.daf_histogram(hm, n_bins=20, missing_data='exclude')
+        sc_hist, _ = diversity.daf_histogram(hm, n_bins=_DAF_N_BINS, missing_data='exclude')
         np.testing.assert_allclose(w_mu, sc_mu, atol=1e-12)
         np.testing.assert_allclose(w_hist, sc_hist, atol=1e-12)
 
     def test_monomorphic_derived_with_missing_not_edge(self):
         # A site that is monomorphic for the derived allele but has one missing
         # haplotype must not count as an SFS edge (the old fixed-n_hap bug).
-        from pg_gpu.windowed_analysis import windowed_analysis
+        from pg_gpu.windowed_analysis import windowed_analysis, _DAF_N_BINS
         n = 20
         hap = np.zeros((n, 4), dtype=np.int8)
         hap[:, :] = np.array([0, 1, 1, 1])  # sites 1..3 monomorphic-derived

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -746,11 +746,10 @@ class TestMultiallelicConsumers:
 
 
 class TestWindowedDafMuSfsMatchesScalar:
-    """The windowed daf_hist / mu_sfs equal the scalar diversity.daf_histogram /
-    diversity.mu_sfs over the same variants -- in both engines that compute them
-    (include -> fused, exclude -> WindowedAnalyzer fallback). Checked on a single
-    whole-region window, across biallelic / multiallelic and clean / missing
-    data."""
+    """The windowed daf_hist / mu_sfs (fused engine, missing_data='include')
+    equal the scalar diversity.daf_histogram / diversity.mu_sfs over the same
+    variants. Checked on a single whole-region window, across biallelic /
+    multiallelic and clean / missing data."""
 
     def _hap(self, kind, missing, seed=3, n=24, nv=90):
         rng = np.random.RandomState(seed)
@@ -792,62 +791,6 @@ class TestWindowedDafMuSfsMatchesScalar:
             assert np.isnan(w_mu)
         else:
             np.testing.assert_allclose(w_mu, sc_mu, atol=1e-12)
-        np.testing.assert_allclose(w_hist, sc_hist, atol=1e-12)
-
-    def test_multi_window_boundary_matches_scalar(self):
-        # Multiple windows with variants sitting exactly on interior window
-        # boundaries (pos == a window end == the next window's start). Each
-        # window's daf_hist / mu_sfs must equal the scalar over that window's
-        # right-open [start, end) slice, and the window membership must agree with
-        # n_variants. The whole-region test above uses a single window, so it never
-        # exercises an interior boundary -- this is the case that catches the
-        # bin_idx window-assignment convention.
-        from pg_gpu.windowed_analysis import windowed_analysis, _DAF_N_BINS
-        rng = np.random.RandomState(4)
-        nv = 120
-        hap = rng.randint(0, 2, (24, nv)).astype(np.int8)
-        for j in range(0, nv, 7):
-            hap[:, j] = rng.randint(0, 3, 24)
-        hap[rng.random(hap.shape) < 0.05] = -1
-        pos = np.arange(nv) * 100          # 3000, 6000, 9000 are interior boundaries
-        hm = HaplotypeMatrix(hap, pos, 0, nv * 100)
-        wa = windowed_analysis(hm, window_size=3000, step_size=3000,
-                               statistics=['mu_sfs', 'daf_hist'],
-                               missing_data='include')
-        assert len(wa) > 1
-        for _, row in wa.iterrows():
-            s, e = row['start'], row['end']
-            m = (pos >= s) & (pos < e)
-            assert int(m.sum()) == int(row['n_variants'])
-            if not m.any():
-                continue
-            sub = HaplotypeMatrix(hap[:, m], pos[m], int(s), int(e))
-            sc_mu = diversity.mu_sfs(sub, missing_data='include')
-            sc_hist, _ = diversity.daf_histogram(sub, n_bins=_DAF_N_BINS,
-                                                 missing_data='include')
-            w_hist = np.array([row[f'daf_bin_{b}'] for b in range(_DAF_N_BINS)])
-            np.testing.assert_allclose(row['mu_sfs'], sc_mu, atol=1e-12)
-            np.testing.assert_allclose(w_hist, sc_hist, atol=1e-12)
-
-    @pytest.mark.parametrize("kind", ["biallelic", "multiallelic"])
-    def test_whole_region_exclude_matches_scalar(self, kind):
-        # exclude mode routes to the WindowedAnalyzer fallback (which calls the
-        # scalar functions per window) rather than the fused GPU engine.
-        from pg_gpu.windowed_analysis import windowed_analysis, _DAF_N_BINS
-        hap = self._hap(kind, missing=True)
-        nv = hap.shape[1]
-        pos = np.arange(nv) * 100
-        hm = HaplotypeMatrix(hap, pos, 0, nv * 100)
-        wa = windowed_analysis(hm, window_size=nv * 100 + 1000,
-                               step_size=nv * 100 + 1000,
-                               statistics=['mu_sfs', 'daf_hist'],
-                               missing_data='exclude')
-        assert len(wa) == 1
-        w_mu = wa['mu_sfs'].values[0]
-        w_hist = np.array([wa[f'daf_bin_{b}'].values[0] for b in range(_DAF_N_BINS)])
-        sc_mu = diversity.mu_sfs(hm, missing_data='exclude')
-        sc_hist, _ = diversity.daf_histogram(hm, n_bins=_DAF_N_BINS, missing_data='exclude')
-        np.testing.assert_allclose(w_mu, sc_mu, atol=1e-12)
         np.testing.assert_allclose(w_hist, sc_hist, atol=1e-12)
 
     def test_monomorphic_derived_with_missing_not_edge(self):

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -745,10 +745,11 @@ class TestMultiallelicConsumers:
         assert len(edges) == len(hist) + 1
 
 
-class TestWindowedDafMuSfsIncludeMatchesScalar:
-    """0013 Option A: the windowed daf_hist / mu_sfs (include mode, fused engine)
-    equal the scalar diversity.daf_histogram / diversity.mu_sfs over the same
-    variants. Checked on a single whole-region window (the parity convention),
+class TestWindowedDafMuSfsMatchesScalar:
+    """0013 Option A: the windowed daf_hist / mu_sfs equal the scalar
+    diversity.daf_histogram / diversity.mu_sfs over the same variants -- in both
+    engines that compute them (include -> fused, exclude -> WindowedAnalyzer
+    fallback). Checked on a single whole-region window (the parity convention),
     across biallelic / multiallelic and clean / missing data."""
 
     def _hap(self, kind, missing, seed=3, n=24, nv=90):
@@ -826,6 +827,27 @@ class TestWindowedDafMuSfsIncludeMatchesScalar:
             w_hist = np.array([row[f'daf_bin_{b}'] for b in range(20)])
             np.testing.assert_allclose(row['mu_sfs'], sc_mu, atol=1e-12)
             np.testing.assert_allclose(w_hist, sc_hist, atol=1e-12)
+
+    @pytest.mark.parametrize("kind", ["biallelic", "multiallelic"])
+    def test_whole_region_exclude_matches_scalar(self, kind):
+        # exclude mode routes to the WindowedAnalyzer fallback (which calls the
+        # scalar functions per window); previously it raised "Unknown statistic".
+        from pg_gpu.windowed_analysis import windowed_analysis
+        hap = self._hap(kind, missing=True)
+        nv = hap.shape[1]
+        pos = np.arange(nv) * 100
+        hm = HaplotypeMatrix(hap, pos, 0, nv * 100)
+        wa = windowed_analysis(hm, window_size=nv * 100 + 1000,
+                               step_size=nv * 100 + 1000,
+                               statistics=['mu_sfs', 'daf_hist'],
+                               missing_data='exclude')
+        assert len(wa) == 1
+        w_mu = wa['mu_sfs'].values[0]
+        w_hist = np.array([wa[f'daf_bin_{b}'].values[0] for b in range(20)])
+        sc_mu = diversity.mu_sfs(hm, missing_data='exclude')
+        sc_hist, _ = diversity.daf_histogram(hm, n_bins=20, missing_data='exclude')
+        np.testing.assert_allclose(w_mu, sc_mu, atol=1e-12)
+        np.testing.assert_allclose(w_hist, sc_hist, atol=1e-12)
 
     def test_monomorphic_derived_with_missing_not_edge(self):
         # A site that is monomorphic for the derived allele but has one missing

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -792,6 +792,41 @@ class TestWindowedDafMuSfsIncludeMatchesScalar:
             np.testing.assert_allclose(w_mu, sc_mu, atol=1e-12)
         np.testing.assert_allclose(w_hist, sc_hist, atol=1e-12)
 
+    def test_multi_window_boundary_matches_scalar(self):
+        # Multiple windows with variants sitting exactly on interior window
+        # boundaries (pos == a window end == the next window's start). Each
+        # window's daf_hist / mu_sfs must equal the scalar over that window's
+        # right-open [start, end) slice, and the window membership must agree with
+        # n_variants. The parity harness uses one whole-region window, so it never
+        # exercises an interior boundary -- this is the case that catches the
+        # bin_idx window-assignment convention.
+        from pg_gpu.windowed_analysis import windowed_analysis
+        rng = np.random.RandomState(4)
+        nv = 120
+        hap = rng.randint(0, 2, (24, nv)).astype(np.int8)
+        for j in range(0, nv, 7):
+            hap[:, j] = rng.randint(0, 3, 24)
+        hap[rng.random(hap.shape) < 0.05] = -1
+        pos = np.arange(nv) * 100          # 3000, 6000, 9000 are interior boundaries
+        hm = HaplotypeMatrix(hap, pos, 0, nv * 100)
+        wa = windowed_analysis(hm, window_size=3000, step_size=3000,
+                               statistics=['mu_sfs', 'daf_hist'],
+                               missing_data='include')
+        assert len(wa) > 1
+        for _, row in wa.iterrows():
+            s, e = row['start'], row['end']
+            m = (pos >= s) & (pos < e)
+            assert int(m.sum()) == int(row['n_variants'])
+            if not m.any():
+                continue
+            sub = HaplotypeMatrix(hap[:, m], pos[m], int(s), int(e))
+            sc_mu = diversity.mu_sfs(sub, missing_data='include')
+            sc_hist, _ = diversity.daf_histogram(sub, n_bins=20,
+                                                 missing_data='include')
+            w_hist = np.array([row[f'daf_bin_{b}'] for b in range(20)])
+            np.testing.assert_allclose(row['mu_sfs'], sc_mu, atol=1e-12)
+            np.testing.assert_allclose(w_hist, sc_hist, atol=1e-12)
+
     def test_monomorphic_derived_with_missing_not_edge(self):
         # A site that is monomorphic for the derived allele but has one missing
         # haplotype must not count as an SFS edge (the old fixed-n_hap bug).

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -745,6 +745,73 @@ class TestMultiallelicConsumers:
         assert len(edges) == len(hist) + 1
 
 
+class TestWindowedDafMuSfsIncludeMatchesScalar:
+    """0013 Option A: the windowed daf_hist / mu_sfs (include mode, fused engine)
+    equal the scalar diversity.daf_histogram / diversity.mu_sfs over the same
+    variants. Checked on a single whole-region window (the parity convention),
+    across biallelic / multiallelic and clean / missing data."""
+
+    def _hap(self, kind, missing, seed=3, n=24, nv=90):
+        rng = np.random.RandomState(seed)
+        hap = rng.randint(0, 2, (n, nv)).astype(np.int8)
+        if kind == 'multiallelic':
+            for j in range(0, nv, 7):
+                hap[:, j] = rng.randint(0, 3, n)
+            for j in range(0, nv, 13):
+                hap[:, j] = rng.randint(0, 4, n)
+        # a monomorphic-derived site: with missing it is the case the old fixed
+        # n_hap edge test misclassified as a near-fixed SFS edge.
+        hap[:, 5] = 1
+        if missing:
+            hap[rng.random(hap.shape) < 0.08] = -1
+        return hap
+
+    @pytest.mark.parametrize("kind", ["biallelic", "multiallelic"])
+    @pytest.mark.parametrize("missing", [False, True])
+    def test_whole_region_matches_scalar(self, kind, missing):
+        from pg_gpu.windowed_analysis import windowed_analysis
+        hap = self._hap(kind, missing)
+        nv = hap.shape[1]
+        pos = np.arange(nv) * 100
+        hm = HaplotypeMatrix(hap, pos, 0, nv * 100)
+        # one window covering the whole region
+        wa = windowed_analysis(hm, window_size=nv * 100 + 1000,
+                               step_size=nv * 100 + 1000,
+                               statistics=['mu_sfs', 'daf_hist'],
+                               missing_data='include')
+        assert len(wa) == 1
+        w_mu = wa['mu_sfs'].values[0]
+        w_hist = np.array([wa[f'daf_bin_{b}'].values[0] for b in range(20)])
+
+        sc_mu = diversity.mu_sfs(hm, missing_data='include')
+        sc_hist, _ = diversity.daf_histogram(hm, n_bins=20, missing_data='include')
+
+        if np.isnan(sc_mu):
+            assert np.isnan(w_mu)
+        else:
+            np.testing.assert_allclose(w_mu, sc_mu, atol=1e-12)
+        np.testing.assert_allclose(w_hist, sc_hist, atol=1e-12)
+
+    def test_monomorphic_derived_with_missing_not_edge(self):
+        # A site that is monomorphic for the derived allele but has one missing
+        # haplotype must not count as an SFS edge (the old fixed-n_hap bug).
+        from pg_gpu.windowed_analysis import windowed_analysis
+        n = 20
+        hap = np.zeros((n, 4), dtype=np.int8)
+        hap[:, :] = np.array([0, 1, 1, 1])  # sites 1..3 monomorphic-derived
+        hap[0, 1] = -1                       # one missing at the monomorphic site
+        pos = np.arange(4) * 100
+        hm = HaplotypeMatrix(hap, pos, 0, 400)
+        wa = windowed_analysis(hm, window_size=5000, step_size=5000,
+                               statistics=['mu_sfs'], missing_data='include')
+        w_mu = wa['mu_sfs'].values[0]
+        sc_mu = diversity.mu_sfs(hm, missing_data='include')
+        # no segregating sites -> mu_sfs is 0.0 (matching the scalar), and in
+        # particular the monomorphic-derived-plus-missing site is not a spurious edge
+        np.testing.assert_allclose(w_mu, sc_mu, atol=1e-12)
+        np.testing.assert_allclose(w_mu, 0.0, atol=1e-12)
+
+
 class TestMultiallelicEdgeCases:
     """Hand-built sites: per-allele pi and mutation-count segregating."""
 

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -141,20 +141,6 @@ class TestWindowedAnalysisDispatch:
                                  missing_data="include")
         _assert_frames_equivalent(df_e, df_s)
 
-    @pytest.mark.xfail(reason="streaming + missing_data='exclude' diverges from "
-                              "eager at chunk boundaries for ALL windowed stats "
-                              "(pi included), a pre-existing streaming window-grid "
-                              "issue",
-                       strict=False)
-    def test_daf_hist_mu_sfs_missing_exclude_equivalent(self, vcz_store_missing):
-        eager, stream = _aligned_pair(vcz_store_missing, chunk_bp=25_000)
-        stats = ["daf_hist", "mu_sfs"]
-        df_e = windowed_analysis(eager, window_size=5_000, statistics=stats,
-                                 missing_data="exclude")
-        df_s = windowed_analysis(stream, window_size=5_000, statistics=stats,
-                                 missing_data="exclude")
-        _assert_frames_equivalent(df_e, df_s)
-
     def test_two_pop_divergence_equivalent(self, vcz_store, tmp_path):
         # Build a two-population pop file so divergence stats have something
         # to compute. Split samples 50/50.

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -30,14 +30,13 @@ def vcz_store(tmp_path):
 
 @pytest.fixture
 def vcz_store_missing(tmp_path):
-    """Like vcz_store but with ~15% missing genotypes, so streaming vs eager can
-    be checked on the missing-data path (the accumulate-then-normalize logic in
-    grm/ibs and its interaction with an accessible mask)."""
+    """Like vcz_store but with ~10% missing genotypes, to exercise the
+    missing-data paths (include and exclude) over the streaming dispatch."""
     hm = _simulate_hm()
     hap = hm.haplotypes
     hap = (hap.get() if hasattr(hap, "get") else np.asarray(hap)).copy()
     rng = np.random.RandomState(0)
-    hap[rng.random(hap.shape) < 0.15] = -1
+    hap[rng.random(hap.shape) < 0.1] = -1
     pos = hm.positions.get() if hasattr(hm.positions, "get") else hm.positions
     hm2 = HaplotypeMatrix(hap, pos, hm.chrom_start, hm.chrom_end)
     hm2.samples = [f"s{i}" for i in range(hap.shape[0] // 2)]
@@ -128,6 +127,32 @@ class TestWindowedAnalysisDispatch:
         stats = ["daf_hist", "mu_sfs"]
         df_e = windowed_analysis(eager, window_size=window_size, statistics=stats)
         df_s = windowed_analysis(stream, window_size=window_size, statistics=stats)
+        _assert_frames_equivalent(df_e, df_s)
+
+    def test_daf_hist_mu_sfs_missing_include_equivalent(self, vcz_store_missing):
+        # daf_hist / mu_sfs over missing data, include mode: per-site n_valid is
+        # chunk-invariant (a site's non-missing count does not depend on other
+        # sites), so streaming must match eager.
+        eager, stream = _aligned_pair(vcz_store_missing, chunk_bp=25_000)
+        stats = ["daf_hist", "mu_sfs"]
+        df_e = windowed_analysis(eager, window_size=5_000, statistics=stats,
+                                 missing_data="include")
+        df_s = windowed_analysis(stream, window_size=5_000, statistics=stats,
+                                 missing_data="include")
+        _assert_frames_equivalent(df_e, df_s)
+
+    @pytest.mark.xfail(reason="streaming + missing_data='exclude' diverges from "
+                              "eager at chunk boundaries for ALL windowed stats "
+                              "(pi included), a pre-existing streaming window-grid "
+                              "issue; see issue-streaming-exclude-window-grid.md",
+                       strict=False)
+    def test_daf_hist_mu_sfs_missing_exclude_equivalent(self, vcz_store_missing):
+        eager, stream = _aligned_pair(vcz_store_missing, chunk_bp=25_000)
+        stats = ["daf_hist", "mu_sfs"]
+        df_e = windowed_analysis(eager, window_size=5_000, statistics=stats,
+                                 missing_data="exclude")
+        df_s = windowed_analysis(stream, window_size=5_000, statistics=stats,
+                                 missing_data="exclude")
         _assert_frames_equivalent(df_e, df_s)
 
     def test_two_pop_divergence_equivalent(self, vcz_store, tmp_path):

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -117,6 +117,19 @@ class TestWindowedAnalysisDispatch:
                                   statistics=stats)
         _assert_frames_equivalent(df_e, df_s)
 
+    @pytest.mark.parametrize("chunk_bp,window_size", CHUNK_WINDOW_COMBOS)
+    def test_daf_hist_mu_sfs_equivalent(self, vcz_store, chunk_bp, window_size):
+        # daf_hist (normalized histogram) and mu_sfs (edge/segregating ratio) are
+        # not plain sums, so a naive per-chunk normalize-then-concatenate would be
+        # wrong. It is correct here only because the streaming grid aligns windows
+        # to chunk boundaries (a window never straddles two chunks), so each
+        # window is computed whole within one chunk. This pins that.
+        eager, stream = _aligned_pair(vcz_store, chunk_bp=chunk_bp)
+        stats = ["daf_hist", "mu_sfs"]
+        df_e = windowed_analysis(eager, window_size=window_size, statistics=stats)
+        df_s = windowed_analysis(stream, window_size=window_size, statistics=stats)
+        _assert_frames_equivalent(df_e, df_s)
+
     def test_two_pop_divergence_equivalent(self, vcz_store, tmp_path):
         # Build a two-population pop file so divergence stats have something
         # to compute. Split samples 50/50.

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -144,7 +144,7 @@ class TestWindowedAnalysisDispatch:
     @pytest.mark.xfail(reason="streaming + missing_data='exclude' diverges from "
                               "eager at chunk boundaries for ALL windowed stats "
                               "(pi included), a pre-existing streaming window-grid "
-                              "issue; see issue-streaming-exclude-window-grid.md",
+                              "issue",
                        strict=False)
     def test_daf_hist_mu_sfs_missing_exclude_equivalent(self, vcz_store_missing):
         eager, stream = _aligned_pair(vcz_store_missing, chunk_bp=25_000)


### PR DESCRIPTION
The windowed diploSHIC features `daf_hist` and `mu_sfs` derived their derived-allele counts from `dac = sum(max(hap, 0))`, which sums allele indices, so on a multiallelic site the derived-allele frequency was index-inflated and could exceed the sample size. They also diverged from the tskit-pinned scalar `diversity.daf_histogram` / `diversity.mu_sfs` on plain biallelic data: a fixed `n_hap` instead of per-site `n_valid`, raw counts instead of a normalized histogram, a total-variant instead of a segregating denominator, and a missing-data edge misclassification in `mu_sfs`.

This aligns both windowed features, in the fused (`missing_data='include'`) engine, to the scalar functions, so the windowed value over a window equals the scalar computed on that window's variants, across biallelic / multiallelic and clean / missing data. `GenotypeMatrix` input is biallelic by construction and out of scope.

#### What changed

`windowed_statistics_fused` (and its chunked twin, which delegates these stats to it) now computes `daf_hist` and `mu_sfs` per allele via `_memutil.allele_counts` with per-site `n_valid`, matching `diversity`: `daf_hist` bins one frequency per present derived allele (`count / n_valid`) into (window, bin) and normalizes per window; `mu_sfs` counts segregating (`0 < count < n_valid`) and edge (`count == 1` or `count == n_valid - 1`) (site, allele) entries and returns `edge / segregating` (0.0 when a window has none). A shared `diversity._daf_bin_index` makes the windowed scatter and the scalar histogram assign bins identically. The windowed `daf_hist` bin count, previously hardcoded as 20 in two places, is now the single module constant `_DAF_N_BINS`.

This is the include-mode fused fast path. Exclude mode is unsupported for these two stats (requesting them with `missing_data='exclude'` raises `Unknown statistic`, unchanged); adding it is future work.

#### Behaviour

These are now the per-allele definitions of the two features: multiallelic-correct, using `allele_counts` and per-site `n_valid`, the same per-allele convention as the SFS, `max_daf`, and the scalar `diversity.daf_histogram` / `diversity.mu_sfs`. Nothing is restricted to biallelic; a biallelic site is the one-derived-allele special case. Because the features now follow that one consistent per-allele convention rather than the old index-summed / fixed-`n_hap` / raw-count one, their output changes on all `HaplotypeMatrix` input, biallelic included -- an intentional redefinition of the two diploSHIC feature vectors, not a silent bugfix. `daf_hist` becomes a normalized per-window histogram over present derived alleles (no monomorphic zero-frequency spike), and `mu_sfs` uses the segregating denominator with correct per-site edge classification, returning 0.0 rather than NaN for a window with no segregating entries.

#### Verification

`diversity.daf_histogram` / `diversity.mu_sfs` (pinned to tskit's polarised allele frequency spectrum) are the oracle; the contract is that the windowed value equals the scalar over a window. Covered: whole-region windowed equals scalar for biallelic / multiallelic and clean / include-missing, including a site fixed for the derived allele with one missing haplotype (which must not count as an SFS edge); streaming equals eager across chunk and window combinations (include, and include with missing data); and both stats in the cross-implementation parity harness (`mu_sfs` in the scalar matrix, `daf_hist` as a dedicated vector check) for include mode.

#### Bugs noticed in passing

- Window-boundary membership and overlapping windows. The fused scatter assigns each variant to a single window via `searchsorted` on window ends, so a variant sitting exactly on an interior window boundary is scattered into the lower window while `n_variants` / `pi` / theta attribute it to the upper one, and with overlapping windows (`step_size < window_size`) a variant is counted in only one of its windows, so `daf_hist` / `mu_sfs` / `mean_nsl` undercount silently. Pre-existing (the earlier `daf_hist` used the same assignment), and the whole-region parity here does not exercise it. Tracked as a separate windowing issue.
- Streaming with `missing_data='exclude'` diverges from eager at chunk boundaries for all windowed stats (`pi` included), a pre-existing streaming window-grid issue, tracked separately.
- Making the bin count a caller parameter is left as a follow-up.