### PR TITLE
Update README for robust use of pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To use pg_gpu from your own workflow (Snakemake, Jupyter, an existing conda
 env), install it from PyPI with pip:
 
 ```bash
-pip install pg_gpu
+python -m pip install pg_gpu
 ```
 
 This pulls the full runtime stack (cupy-cuda12x with toolkit headers, bio2zarr,
@@ -36,7 +36,7 @@ kvikio, nvcomp) as declared in `pyproject.toml`. For development against a local
 checkout, use an editable install:
 
 ```bash
-pip install -e ".[dev]"
+python -m pip install -e ".[dev]"
 ```
 
 ## Quick Start

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ This directory contains the documentation for pg_gpu.
 
 ```bash
 cd docs
-pip install -r requirements.txt
+python -m pip install -r requirements.txt
 make html
 ```
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -89,7 +89,7 @@ adopting pixi:
 
 .. code-block:: bash
 
-   pip install pg_gpu
+   python -m pip install pg_gpu
 
 This pulls the full runtime stack declared in ``pyproject.toml``:
 ``cupy-cuda12x[ctk]``, ``kvikio`` / ``nvcomp``,
@@ -105,11 +105,11 @@ For development against a local checkout, use an editable install with the
 
    git clone https://github.com/kr-colab/pg_gpu.git
    cd pg_gpu
-   pip install -e ".[dev]"
+   python -m pip install -e ".[dev]"
 
 The optional extras mirror the pixi environments: ``docs`` for the
 documentation toolchain and ``moments`` for the moments LD integration
-(e.g. ``pip install -e ".[dev,moments]"``).
+(e.g. ``python -m pip install -e ".[dev,moments]"``).
 
 Pixi remains the recommended, fully pinned environment (see above); the
 pip path trades that reproducibility for fitting into an environment you


### PR DESCRIPTION
`pip install foo` is not robust -- it is possible that the pip in `$PATH` does not correspond to the `python` in `$PATH`.
(This happens a LOT due to venvs, conda, etc., all being mixed together.)
Best practice is to call the pip module from the current interpreter.
See the [tskit](https://tskit.dev/tskit/docs/stable/installation.html#pip) documentation, for example.
