### PR TITLE
 Unify the biallelic definition across GenotypeMatrix loaders and make biallelic restriction evident with warning

### DIFF
--- a/pg_gpu/__init__.py
+++ b/pg_gpu/__init__.py
@@ -69,10 +69,10 @@ from .decomposition import (
 from .resampling import block_jackknife, block_bootstrap
 from ._warnings import (
     BadlyChunkedWarning, HaploidDataWarning, MemoryLimitedWarning,
-    MultiallelicCapWarning,
+    MultiallelicCapWarning, BiallelicOnlyWarning,
 )
 
-__all__ = ['ld_statistics', 'diversity', 'divergence', 'windowed_analysis', 'selection', 'sfs', 'admixture', 'decomposition', 'plotting', 'distance_stats', 'resampling', 'HaplotypeMatrix', 'GenotypeMatrix', 'WindowedAnalyzer', 'windowed_analysis', 'AccessibleMask', 'bed_to_mask', 'parse_bed', 'LocalPCAResult', 'LostructResult', 'pca', 'randomized_pca', 'pca_dosage', 'randomized_pca_dosage', 'local_pca', 'local_pca_jackknife', 'lostruct', 'pc_dist', 'corners', 'block_jackknife', 'block_bootstrap', 'MemoryLimitedWarning', 'HaploidDataWarning', 'BadlyChunkedWarning', 'MultiallelicCapWarning']
+__all__ = ['ld_statistics', 'diversity', 'divergence', 'windowed_analysis', 'selection', 'sfs', 'admixture', 'decomposition', 'plotting', 'distance_stats', 'resampling', 'HaplotypeMatrix', 'GenotypeMatrix', 'WindowedAnalyzer', 'windowed_analysis', 'AccessibleMask', 'bed_to_mask', 'parse_bed', 'LocalPCAResult', 'LostructResult', 'pca', 'randomized_pca', 'pca_dosage', 'randomized_pca_dosage', 'local_pca', 'local_pca_jackknife', 'lostruct', 'pc_dist', 'corners', 'block_jackknife', 'block_bootstrap', 'MemoryLimitedWarning', 'HaploidDataWarning', 'BadlyChunkedWarning', 'MultiallelicCapWarning', 'BiallelicOnlyWarning']
 
 # Version is derived from the git tag at build time (hatch-vcs) and read here
 # from the installed package metadata, so there is no hardcoded string to keep

--- a/pg_gpu/_gpu_genotype_prep.py
+++ b/pg_gpu/_gpu_genotype_prep.py
@@ -23,8 +23,8 @@ handle them via the ``'include'`` / ``'exclude'`` missing-data modes.
 ``build_haplotype_matrix`` keeps raw allele indices (the per-allele haplotype
 statistics are multiallelic-capable). ``build_genotype_matrix`` needs a 0/1/2
 dosage, so it classifies each site by the shared biallelic definition and
-recodes any >= 3-allele site to a fully-missing row (no valid dosage exists),
-matching the eager from_vcf loader.
+recodes any site with three or more distinct alleles present in the sample to a
+fully-missing row (no valid dosage exists), matching the eager from_vcf loader.
 """
 
 import cupy as cp
@@ -108,10 +108,11 @@ def build_genotype_matrix(gt, pos, *,
     GenotypeMatrix
         With genotypes on the GPU in ``(n_indiv, n_var)`` int8 layout.
         Each cell is ``0/1/2`` (count of the site's alt allele) or ``-1``
-        when either ploidy on that variant was missing. A ``>= 3``-allele
-        site cannot be a 0/1/2 dosage, so its whole row is set to ``-1``
-        (present but fully missing), keeping the row/chunk alignment the
-        streaming path relies on. The number of such recoded sites is
+        when either ploidy on that variant was missing. A site with three or
+        more distinct alleles present in the sample cannot be a 0/1/2 dosage,
+        so its whole row is set to ``-1`` (present but fully missing), keeping
+        the row/chunk alignment the streaming path relies on. The number of
+        such recoded sites is
         stashed on the result as ``_n_multiallelic_recoded`` for the caller
         to surface as a BiallelicOnlyWarning (once per load).
     """
@@ -142,7 +143,8 @@ def build_genotype_matrix(gt, pos, *,
     missing = (gt_gpu < 0).any(axis=2)
     geno = (gt_gpu == alt[:, None, None]).sum(axis=2).astype(cp.int8)
     geno = cp.where(missing, cp.int8(-1), geno)
-    # A >= 3-allele site has no valid 0/1/2 dosage -> the whole row is missing.
+    # A site with three or more distinct present alleles has no valid 0/1/2
+    # dosage -> the whole row is missing.
     n_multiallelic = int((~biallelic).sum())
     if n_multiallelic:
         geno[~biallelic, :] = cp.int8(-1)

--- a/pg_gpu/_gpu_genotype_prep.py
+++ b/pg_gpu/_gpu_genotype_prep.py
@@ -9,8 +9,8 @@ classes consume it differently:
   ploidy 1. ``build_haplotype_matrix`` does the ploidy interleave +
   transpose on the GPU.
 * ``GenotypeMatrix`` wants ``(n_indiv, n_var)`` int8 dosages (0/1/2 with
-  ``-1`` for missing). ``build_genotype_matrix`` sums the two ploidies on
-  the GPU and propagates missing.
+  ``-1`` for missing). ``build_genotype_matrix`` counts each site's alt
+  allele on the GPU and propagates missing.
 
 Both helpers take the same raw input shape and exist to keep the
 host-side numpy reshape (which on a 1 Mb / 200k-haplotype block is
@@ -18,10 +18,13 @@ host-side numpy reshape (which on a 1 Mb / 200k-haplotype block is
 off the per-chunk hot path. cupy's tiled transpose / fused add runs in
 seconds with a fixed memory footprint.
 
-Missing / multiallelic cells (gt = -1) are preserved by both helpers --
-downstream kernels handle them via the ``'include'`` / ``'exclude'``
-missing-data modes, and dropping them at build time would silently
-change semantics for callers that opted into 'include'.
+Missing cells (gt = -1) are preserved by both helpers -- downstream kernels
+handle them via the ``'include'`` / ``'exclude'`` missing-data modes.
+``build_haplotype_matrix`` keeps raw allele indices (the per-allele haplotype
+statistics are multiallelic-capable). ``build_genotype_matrix`` needs a 0/1/2
+dosage, so it classifies each site by the shared biallelic definition and
+recodes any >= 3-allele site to a fully-missing row (no valid dosage exists),
+matching the eager from_vcf loader.
 """
 
 import cupy as cp
@@ -36,8 +39,10 @@ def build_haplotype_matrix(gt, pos, *,
     Parameters
     ----------
     gt : ndarray, shape (n_var, n_dip, 2)
-        Raw call_genotype block. ``-1`` marks multiallelic / missing
-        cells; rows are preserved. Host or device.
+        Raw call_genotype block of allele indices (0 = reference, 1.. =
+        alternate), ``-1`` missing. Indices are preserved as-is (the
+        per-allele haplotype statistics are multiallelic-capable). Host or
+        device.
     pos : ndarray, shape (n_var,)
         Variant positions. Host or device.
 
@@ -91,9 +96,8 @@ def build_genotype_matrix(gt, pos, *,
     Parameters
     ----------
     gt : ndarray, shape (n_var, n_dip, 2)
-        Raw call_genotype block. ``-1`` marks multiallelic / missing
-        cells; a row is treated as missing for a given diploid if
-        either ploidy is ``-1``. Host or device.
+        Raw call_genotype block of allele indices (0 = reference, 1.. =
+        alternate), ``-1`` missing. Host or device.
     pos : ndarray, shape (n_var,)
         Variant positions. Host or device.
 
@@ -103,10 +107,16 @@ def build_genotype_matrix(gt, pos, *,
     -------
     GenotypeMatrix
         With genotypes on the GPU in ``(n_indiv, n_var)`` int8 layout.
-        Each cell is ``0/1/2`` (dosage) or ``-1`` when either ploidy
-        on that variant was missing in the input.
+        Each cell is ``0/1/2`` (count of the site's alt allele) or ``-1``
+        when either ploidy on that variant was missing. A ``>= 3``-allele
+        site cannot be a 0/1/2 dosage, so its whole row is set to ``-1``
+        (present but fully missing), keeping the row/chunk alignment the
+        streaming path relies on. The number of such recoded sites is
+        stashed on the result as ``_n_multiallelic_recoded`` for the caller
+        to surface as a BiallelicOnlyWarning (once per load).
     """
-    from .genotype_matrix import GenotypeMatrix
+    from .genotype_matrix import GenotypeMatrix, _biallelic_and_alt
+    from ._memutil import allele_counts
 
     if gt.ndim != 3 or gt.shape[2] != 2:
         raise ValueError(
@@ -118,11 +128,25 @@ def build_genotype_matrix(gt, pos, *,
         )
 
     gt_gpu = cp.asarray(gt)
-    # Dosage = sum of ploidies, clamping -1 to 0 first so the sum
-    # makes sense before we paint missing back in.
+    n_var, n_dip, _ = gt_gpu.shape
+
+    # Biallelic = at most two distinct present alleles; dosage counts the chosen
+    # alt (highest present allele > 0). Matches from_vcf / from_haplotype_matrix,
+    # so all three GenotypeMatrix loaders agree. allele_counts wants an
+    # (n_hap, n_var) layout; a site sits entirely on the variant axis of this
+    # chunk, so per-chunk counts are complete.
+    haps = gt_gpu.reshape(n_var, 2 * n_dip).T
+    ac, _ = allele_counts(haps)
+    biallelic, alt = _biallelic_and_alt(ac)
+
     missing = (gt_gpu < 0).any(axis=2)
-    geno = cp.maximum(gt_gpu, 0).sum(axis=2).astype(cp.int8)
+    geno = (gt_gpu == alt[:, None, None]).sum(axis=2).astype(cp.int8)
     geno = cp.where(missing, cp.int8(-1), geno)
+    # A >= 3-allele site has no valid 0/1/2 dosage -> the whole row is missing.
+    n_multiallelic = int((~biallelic).sum())
+    if n_multiallelic:
+        geno[~biallelic, :] = cp.int8(-1)
+
     # transpose to the (n_indiv, n_var) layout GenotypeMatrix kernels
     # expect; cupy's tiled transpose handles the strided write
     # efficiently.
@@ -131,9 +155,11 @@ def build_genotype_matrix(gt, pos, *,
 
     positions = cp.asarray(pos)
 
-    return GenotypeMatrix(
+    gm = GenotypeMatrix(
         geno, positions,
         chrom_start=chrom_start, chrom_end=chrom_end,
         sample_sets=sample_sets, n_total_sites=n_total_sites,
         samples=samples, accessible_mask=accessible_mask,
     )
+    gm._n_multiallelic_recoded = n_multiallelic
+    return gm

--- a/pg_gpu/_warnings.py
+++ b/pg_gpu/_warnings.py
@@ -84,6 +84,42 @@ class MultiallelicCapWarning(UserWarning):
     """
 
 
+class BiallelicOnlyWarning(UserWarning):
+    """Emitted when a biallelic-only statistic or loader drops multiallelic sites.
+
+    Some statistics and loaders are defined only on biallelic sites and otherwise
+    exclude multiallelic ones silently. This warning reports how many sites were
+    dropped, so a partial result is not mistaken for a whole-data one. It marks a
+    statistical-domain restriction, distinct from ``MultiallelicCapWarning``,
+    which caps a multiallelic-capable windowed kernel at its fixed per-allele
+    capacity. Silence with::
+
+        import warnings
+        from pg_gpu import BiallelicOnlyWarning
+        warnings.filterwarnings("ignore", category=BiallelicOnlyWarning)
+    """
+
+
+def _warn_biallelic_only(n_dropped, *, context, stacklevel=3):
+    """Emit ``BiallelicOnlyWarning`` that ``context`` dropped ``n_dropped`` sites.
+
+    A no-op when ``n_dropped`` is 0, so callers can pass a raw count
+    unconditionally. ``context`` names the operation that restricted to biallelic
+    (e.g. ``"GenotypeMatrix.from_vcf"``, ``"patterson_d"``) and leads the message.
+    """
+    n_dropped = int(n_dropped)
+    if n_dropped <= 0:
+        return
+    warnings.warn(
+        f"{context} is defined on biallelic sites; dropped {n_dropped} "
+        f"multiallelic site(s). To silence:\n"
+        "    import warnings\n"
+        "    from pg_gpu import BiallelicOnlyWarning\n"
+        "    warnings.filterwarnings('ignore', category=BiallelicOnlyWarning)",
+        BiallelicOnlyWarning, stacklevel=stacklevel,
+    )
+
+
 # ── VCF size heuristic ──────────────────────────────────────────────────────
 #
 # VCF text parsing is single-threaded in htslib and the whole genotype matrix

--- a/pg_gpu/admixture.py
+++ b/pg_gpu/admixture.py
@@ -238,9 +238,9 @@ def patterson_d(haplotype_matrix: HaplotypeMatrix,
     Notes
     -----
     D is a biallelic-SNP statistic: sites with more than two alleles across the
-    four populations are excluded (num = den = 0), silently, as biallelic
-    filtering is handled elsewhere in the package. A multiallelic generalization
-    is a possible future extension.
+    four populations are excluded (num = den = 0) and a ``BiallelicOnlyWarning``
+    is emitted with the dropped-site count. A multiallelic generalization is a
+    possible future extension.
     """
     return tuple(v.get() for v in
                  _patterson_d_gpu(haplotype_matrix, pop_a, pop_b, pop_c, pop_d,
@@ -268,10 +268,14 @@ def _patterson_d_gpu(haplotype_matrix, pop_a, pop_b, pop_c, pop_d,
         haplotype_matrix, [pop_a, pop_b, pop_c, pop_d])
 
     # Sites with >2 alleles across the four pops are dropped (num=den=0),
-    # silently -- consistent with the package's biallelic filtering elsewhere
-    # (e.g. GenotypeMatrix.from_vcf); the biallelic-only contract is documented.
+    # consistent with the package's biallelic filtering elsewhere (e.g.
+    # GenotypeMatrix.from_vcf). Called once per top-level D computation
+    # (patterson_d / moving_patterson_d / average_patterson_d all take the full
+    # num/den arrays and window afterward), so the warning fires once per call.
     present = (xa + xb + xc + xd) > 0
     biallelic = present.sum(axis=1) <= 2
+    from ._warnings import _warn_biallelic_only
+    _warn_biallelic_only(int((~biallelic).sum()), context="patterson_d")
 
     # Alt allele = highest-index present allele (== allele 1 for a {0,1} site,
     # so this reduces to the previous behaviour on standard biallelic data);

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -12,6 +12,30 @@ from typing import Optional
 from .accessible import AccessibleMask, resolve_accessible_mask
 
 
+def _biallelic_and_alt(ac):
+    """Per-site biallelic mask and alt-allele index from an (n_var, K) allele-count
+    matrix (any array namespace).
+
+    Biallelic = at most two distinct present alleles. Allele 0 is the reference;
+    ``alt`` is the highest-index present allele > 0, which the 0/1/2 dosage counts --
+    code-independent, so {0,2} and reference-absent {1,2} sites work, while {0,1}
+    stays bit-identical (including a site fixed for allele 1). A site with no alt
+    allele present (all reference / all missing) gets the out-of-range sentinel ``K``
+    so its dosage counts to 0 and never matches the -1 missing code.
+    """
+    xp = cp if isinstance(ac, cp.ndarray) else np
+    present = ac > 0
+    biallelic = present.sum(axis=1) <= 2
+    K = ac.shape[1]
+    if K <= 1:
+        return biallelic, xp.full(ac.shape[0], K)
+    alt_present = present[:, 1:]                                  # alleles 1..K-1
+    has_alt = alt_present.any(axis=1)
+    highest_alt = K - 1 - alt_present[:, ::-1].argmax(axis=1)     # highest present > 0
+    alt = xp.where(has_alt, highest_alt, K)
+    return biallelic, alt
+
+
 class GenotypeMatrix:
     """Diploid genotype matrix with values 0 (hom ref), 1 (het), 2 (hom alt).
 
@@ -278,12 +302,18 @@ class GenotypeMatrix:
         positions = hap_matrix.positions
         xp = cp if isinstance(hap, cp.ndarray) else np
 
-        # A 0/1/2 dosage can only represent {0,1}-coded sites; an allele index
-        # >= 2 would make the paired-haplotype sum a bogus dosage (2+2 -> 4).
-        # Drop those sites (and their positions) and warn with the count, rather
-        # than silently producing garbage. positions shares hap's array
-        # namespace, so the same boolean mask indexes both.
-        biallelic = hap.max(axis=0) <= 1
+        # Biallelic = at most two distinct present alleles; the dosage counts the
+        # alt (highest present allele > 0), so {0,2} and reference-absent {1,2}
+        # sites are handled correctly and {0,1} is unchanged. Sites with >= 3
+        # alleles cannot be a dosage and are dropped with a warning; positions
+        # shares hap's array namespace, so the same mask indexes both.
+        if xp is cp:
+            from ._memutil import allele_counts
+            ac, _ = allele_counts(hap)
+        else:
+            n_a = (int(hap.max()) + 1) if hap.size else 1
+            ac = np.stack([(hap == a).sum(axis=0) for a in range(n_a)], axis=1)
+        biallelic, alt = _biallelic_and_alt(ac)
         n_dropped = int((~biallelic).sum())
         if n_dropped:
             from ._warnings import _warn_biallelic_only
@@ -291,17 +321,18 @@ class GenotypeMatrix:
                 n_dropped, context="GenotypeMatrix.from_haplotype_matrix")
             hap = hap[:, biallelic]
             positions = positions[biallelic]
+            alt = alt[biallelic]
 
         h1 = hap[0::2]  # even indices
         h2 = hap[1::2]  # odd indices
         n_ind = h1.shape[0]
         n_var = h1.shape[1]
 
-        # Chunk over variants to avoid OOM from boolean intermediates
+        # Dosage = per-individual count of the alt allele (0/1/2); a pair with any
+        # missing haplotype -> -1. Chunk over variants to bound memory.
         geno = xp.empty((n_ind, n_var), dtype=xp.int8)
         if xp is cp:
             free_mem = cp.cuda.Device().mem_info[0]
-            # Each variant needs ~4 * n_ind bytes for intermediates
             chunk = max(1, int(free_mem * 0.3 / (n_ind * 4)))
         else:
             chunk = n_var
@@ -310,8 +341,9 @@ class GenotypeMatrix:
             ve = min(vs + chunk, n_var)
             c1 = h1[:, vs:ve]
             c2 = h2[:, vs:ve]
+            a = alt[vs:ve][None, :]
             missing = (c1 < 0) | (c2 < 0)
-            geno[:, vs:ve] = (xp.maximum(c1, 0) + xp.maximum(c2, 0)).astype(xp.int8)
+            geno[:, vs:ve] = ((c1 == a).astype(xp.int8) + (c2 == a).astype(xp.int8))
             geno[:, vs:ve][missing] = -1
 
         # remap sample_sets: haplotype indices -> individual indices
@@ -408,15 +440,23 @@ class GenotypeMatrix:
         from ._warnings import check_diploid_encoding, _warn_biallelic_only
         check_diploid_encoding(gt, sample_names=samples, source=f"VCF '{path}'")
 
-        # Filter to biallelic sites (max allele index <= 1)
-        is_biallelic = np.all(gt <= 1, axis=(1, 2)) | np.all(gt < 0, axis=(1, 2))
-        gt_array = allel.GenotypeArray(gt)
-        ac = gt_array.count_alleles()
-        is_biallelic = ac.is_biallelic_01()
+        # Biallelic = at most two distinct present alleles; the dosage counts the
+        # alt (highest present allele > 0), so {0,2} and reference-absent {1,2}
+        # sites are handled correctly and {0,1} is unchanged. Only sites with
+        # >= 3 alleles are dropped (with a warning); monomorphic and all-missing
+        # sites are retained, matching from_haplotype_matrix. The allele-count
+        # matrix is built with numpy -- allel is used only to parse the VCF --
+        # and missing (-1) is never counted, so it matches allel.count_alleles().
+        gt_max = int(gt.max()) if gt.size else -1
+        n_alleles = gt_max + 1 if gt_max >= 0 else 1
+        ac = np.stack([(gt == a).sum(axis=(1, 2)) for a in range(n_alleles)],
+                      axis=1)
+        is_biallelic, alt = _biallelic_and_alt(ac)
         _warn_biallelic_only(int(np.sum(~is_biallelic)),
                              context="GenotypeMatrix.from_vcf")
         gt = gt[is_biallelic]
         pos = pos[is_biallelic]
+        alt = alt[is_biallelic]
 
         qc_fields = (_resolve_qc_fields_vcf(callset, tag_to_path, unknown_tags)
                      if fields else {})
@@ -426,9 +466,9 @@ class GenotypeMatrix:
         for tag, arr in qc_fields.items():
             qc_fields[tag] = arr[is_biallelic]
 
-        # sum alleles to get alt count (0/1/2)
-        geno = np.sum(gt, axis=2).astype(np.int8)  # (n_variants, n_samples)
-        # handle missing (-1 in either allele)
+        # Dosage = per-genotype count of the alt allele (0/1/2); a call with any
+        # missing allele (-1) -> -1.
+        geno = (gt == alt[:, None, None]).sum(axis=2).astype(np.int8)
         missing = np.any(gt < 0, axis=2)
         geno[missing] = -1
 
@@ -555,6 +595,9 @@ class GenotypeMatrix:
             n_total_sites=n_total_sites,
             samples=list(samples) if samples else None,
         )
+        from ._warnings import _warn_biallelic_only
+        _warn_biallelic_only(gm._n_multiallelic_recoded,
+                             context="GenotypeMatrix.from_zarr")
         if fields:
             gm.fields = read_qc_fields(
                 path, fields,
@@ -791,10 +834,13 @@ class GenotypeMatrix:
         self.sample_sets = pop_sets
 
     def apply_biallelic_filter(self):
-        """Filter to biallelic variant sites.
+        """Drop monomorphic (non-segregating) sites.
 
-        Keeps variants where both ref and alt alleles are present
-        among non-missing individuals.
+        The matrix is already biallelic by construction (0/1/2 dosage), so this
+        does not classify alleles. It keeps only sites still segregating among the
+        non-missing individuals: the alt allele is present but not fixed
+        (0 < total alt dosage < 2 * n_called) and at least two individuals are
+        called. The name is kept for backwards compatibility.
 
         Returns
         -------

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -18,10 +18,11 @@ class GenotypeMatrix:
     Shape: (n_individuals, n_variants). Missing data encoded as -1.
 
     Biallelic by construction: values are alt-allele dosage (0/1/2), so this
-    structure cannot represent multiallelic genotypes -- ``from_vcf`` filters
-    multiallelic sites out and ``from_haplotype_matrix`` sums paired haplotypes
-    (well-defined only for {0,1} alleles). For multiallelic data use the
-    allele-index ``HaplotypeMatrix``.
+    structure cannot represent multiallelic genotypes. ``from_vcf`` filters
+    multiallelic sites out and ``from_haplotype_matrix`` drops sites with an
+    allele index >= 2 (the dosage is well-defined only for {0,1} alleles); both
+    emit a ``BiallelicOnlyWarning`` with the dropped-site count. For multiallelic
+    data use the allele-index ``HaplotypeMatrix``.
 
     Parameters
     ----------
@@ -274,7 +275,22 @@ class GenotypeMatrix:
                 f"Need even number of haplotypes for diploid conversion, got {n_hap}")
 
         hap = hap_matrix.haplotypes
+        positions = hap_matrix.positions
         xp = cp if isinstance(hap, cp.ndarray) else np
+
+        # A 0/1/2 dosage can only represent {0,1}-coded sites; an allele index
+        # >= 2 would make the paired-haplotype sum a bogus dosage (2+2 -> 4).
+        # Drop those sites (and their positions) and warn with the count, rather
+        # than silently producing garbage. positions shares hap's array
+        # namespace, so the same boolean mask indexes both.
+        biallelic = hap.max(axis=0) <= 1
+        n_dropped = int((~biallelic).sum())
+        if n_dropped:
+            from ._warnings import _warn_biallelic_only
+            _warn_biallelic_only(
+                n_dropped, context="GenotypeMatrix.from_haplotype_matrix")
+            hap = hap[:, biallelic]
+            positions = positions[biallelic]
 
         h1 = hap[0::2]  # even indices
         h2 = hap[1::2]  # odd indices
@@ -307,7 +323,7 @@ class GenotypeMatrix:
                 ind_indices = sorted(set(i // 2 for i in indices))
                 new_sample_sets[name] = ind_indices
 
-        return cls(geno, hap_matrix.positions, hap_matrix.chrom_start,
+        return cls(geno, positions, hap_matrix.chrom_start,
                    hap_matrix.chrom_end, sample_sets=new_sample_sets,
                    n_total_sites=hap_matrix.n_total_sites,
                    accessible_mask=hap_matrix.accessible_mask)
@@ -389,7 +405,7 @@ class GenotypeMatrix:
         pos = callset['variants/POS']
         samples = list(callset['samples'])
 
-        from ._warnings import check_diploid_encoding
+        from ._warnings import check_diploid_encoding, _warn_biallelic_only
         check_diploid_encoding(gt, sample_names=samples, source=f"VCF '{path}'")
 
         # Filter to biallelic sites (max allele index <= 1)
@@ -397,6 +413,8 @@ class GenotypeMatrix:
         gt_array = allel.GenotypeArray(gt)
         ac = gt_array.count_alleles()
         is_biallelic = ac.is_biallelic_01()
+        _warn_biallelic_only(int(np.sum(~is_biallelic)),
+                             context="GenotypeMatrix.from_vcf")
         gt = gt[is_biallelic]
         pos = pos[is_biallelic]
 

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -42,11 +42,13 @@ class GenotypeMatrix:
     Shape: (n_individuals, n_variants). Missing data encoded as -1.
 
     Biallelic by construction: values are alt-allele dosage (0/1/2), so this
-    structure cannot represent multiallelic genotypes. ``from_vcf`` filters
-    multiallelic sites out and ``from_haplotype_matrix`` drops sites with an
-    allele index >= 2 (the dosage is well-defined only for {0,1} alleles); both
-    emit a ``BiallelicOnlyWarning`` with the dropped-site count. For multiallelic
-    data use the allele-index ``HaplotypeMatrix``.
+    structure cannot represent multiallelic genotypes. ``from_vcf`` and
+    ``from_haplotype_matrix`` keep sites with at most two distinct present
+    alleles -- so {0,1}, {0,2}, and reference-absent {1,2} are all kept, with the
+    dosage counting the alt allele -- and drop sites with three or more distinct
+    present alleles, emitting a ``BiallelicOnlyWarning`` with the dropped-site
+    count. For
+    multiallelic data use the allele-index ``HaplotypeMatrix``.
 
     Parameters
     ----------
@@ -282,7 +284,11 @@ class GenotypeMatrix:
         """Convert a HaplotypeMatrix to a GenotypeMatrix.
 
         Pairs consecutive haplotypes (0,1), (2,3), ... as diploid individuals.
-        Genotype = sum of paired haplotypes (0, 1, or 2).
+        Each genotype is the count of the site's alt allele in the pair (0, 1, or
+        2); a pair with any missing haplotype is -1. Only biallelic sites (at most
+        two distinct present alleles) are kept -- sites with three or more
+        distinct present alleles cannot be a 0/1/2 dosage and are dropped with a
+        BiallelicOnlyWarning.
 
         Parameters
         ----------
@@ -298,21 +304,18 @@ class GenotypeMatrix:
             raise ValueError(
                 f"Need even number of haplotypes for diploid conversion, got {n_hap}")
 
+        if hap_matrix.device == 'CPU':
+            hap_matrix.transfer_to_gpu()
         hap = hap_matrix.haplotypes
         positions = hap_matrix.positions
-        xp = cp if isinstance(hap, cp.ndarray) else np
 
         # Biallelic = at most two distinct present alleles; the dosage counts the
         # alt (highest present allele > 0), so {0,2} and reference-absent {1,2}
         # sites are handled correctly and {0,1} is unchanged. Sites with >= 3
         # alleles cannot be a dosage and are dropped with a warning; positions
         # shares hap's array namespace, so the same mask indexes both.
-        if xp is cp:
-            from ._memutil import allele_counts
-            ac, _ = allele_counts(hap)
-        else:
-            n_a = (int(hap.max()) + 1) if hap.size else 1
-            ac = np.stack([(hap == a).sum(axis=0) for a in range(n_a)], axis=1)
+        from ._memutil import allele_counts
+        ac, _ = allele_counts(hap)
         biallelic, alt = _biallelic_and_alt(ac)
         n_dropped = int((~biallelic).sum())
         if n_dropped:
@@ -329,13 +332,10 @@ class GenotypeMatrix:
         n_var = h1.shape[1]
 
         # Dosage = per-individual count of the alt allele (0/1/2); a pair with any
-        # missing haplotype -> -1. Chunk over variants to bound memory.
-        geno = xp.empty((n_ind, n_var), dtype=xp.int8)
-        if xp is cp:
-            free_mem = cp.cuda.Device().mem_info[0]
-            chunk = max(1, int(free_mem * 0.3 / (n_ind * 4)))
-        else:
-            chunk = n_var
+        # missing haplotype -> -1. Chunk over variants to bound GPU memory.
+        geno = cp.empty((n_ind, n_var), dtype=cp.int8)
+        free_mem = cp.cuda.Device().mem_info[0]
+        chunk = max(1, int(free_mem * 0.3 / (n_ind * 4)))
 
         for vs in range(0, n_var, chunk):
             ve = min(vs + chunk, n_var)
@@ -343,7 +343,7 @@ class GenotypeMatrix:
             c2 = h2[:, vs:ve]
             a = alt[vs:ve][None, :]
             missing = (c1 < 0) | (c2 < 0)
-            geno[:, vs:ve] = ((c1 == a).astype(xp.int8) + (c2 == a).astype(xp.int8))
+            geno[:, vs:ve] = ((c1 == a).astype(cp.int8) + (c2 == a).astype(cp.int8))
             geno[:, vs:ve][missing] = -1
 
         # remap sample_sets: haplotype indices -> individual indices
@@ -443,14 +443,11 @@ class GenotypeMatrix:
         # Biallelic = at most two distinct present alleles; the dosage counts the
         # alt (highest present allele > 0), so {0,2} and reference-absent {1,2}
         # sites are handled correctly and {0,1} is unchanged. Only sites with
-        # >= 3 alleles are dropped (with a warning); monomorphic and all-missing
-        # sites are retained, matching from_haplotype_matrix. The allele-count
-        # matrix is built with numpy -- allel is used only to parse the VCF --
-        # and missing (-1) is never counted, so it matches allel.count_alleles().
-        gt_max = int(gt.max()) if gt.size else -1
-        n_alleles = gt_max + 1 if gt_max >= 0 else 1
-        ac = np.stack([(gt == a).sum(axis=(1, 2)) for a in range(n_alleles)],
-                      axis=1)
+        # three or more distinct present alleles are dropped (with a warning);
+        # monomorphic and all-missing sites are retained, matching
+        # from_haplotype_matrix. count_alleles ignores missing (-1), giving an
+        # (n_variants, n_alleles) count matrix.
+        ac = np.asarray(allel.GenotypeArray(gt).count_alleles())
         is_biallelic, alt = _biallelic_and_alt(ac)
         _warn_biallelic_only(int(np.sum(~is_biallelic)),
                              context="GenotypeMatrix.from_vcf")
@@ -840,7 +837,7 @@ class GenotypeMatrix:
         does not classify alleles. It keeps only sites still segregating among the
         non-missing individuals: the alt allele is present but not fixed
         (0 < total alt dosage < 2 * n_called) and at least two individuals are
-        called. The name is kept for backwards compatibility.
+        called.
 
         Returns
         -------

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -439,6 +439,9 @@ class _StreamingMatrixBase:
         # None when no accessible BED was supplied at load; see get_span.
         self.accessible_mask = accessible_mask
         self.n_total_sites = n_total_sites
+        # Emit the multiallelic->missing BiallelicOnlyWarning at most once per
+        # streaming load, on the first chunk that recodes any site.
+        self._biallelic_warned = False
 
     @property
     def num_variants(self):
@@ -740,7 +743,13 @@ class StreamingGenotypeMatrix(_StreamingMatrixBase):
         return self.num_individuals
 
     def _build_chunk(self, gt, pos, **kwargs):
-        return build_genotype_matrix(gt, pos, **kwargs)
+        m = build_genotype_matrix(gt, pos, **kwargs)
+        if m._n_multiallelic_recoded and not self._biallelic_warned:
+            from ._warnings import _warn_biallelic_only
+            _warn_biallelic_only(m._n_multiallelic_recoded,
+                                 context="GenotypeMatrix.from_zarr (streaming)")
+            self._biallelic_warned = True
+        return m
 
     def _repr_sample_axis(self):
         return f"num_individuals={self.num_individuals}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,9 @@ filterwarnings = [
     "ignore::zarr.errors.UnstableSpecificationWarning",
     "ignore::zarr.errors.ZarrDeprecationWarning",
     "ignore:The `compressor` argument is deprecated:UserWarning:zarr",
+    # Runtime-visible loader diagnostic; the dedicated tests assert it via local
+    # pytest.warns / simplefilter, which override this global ignore.
+    "ignore::pg_gpu._warnings.BiallelicOnlyWarning",
 ]
 
 [tool.ruff]

--- a/tests/test_biallelic_only_warning.py
+++ b/tests/test_biallelic_only_warning.py
@@ -10,10 +10,39 @@ import pytest
 
 from pg_gpu import BiallelicOnlyWarning, GenotypeMatrix, HaplotypeMatrix
 from pg_gpu._warnings import _warn_biallelic_only
+from pg_gpu.genotype_matrix import _biallelic_and_alt
 
 
 def _host(a):
     return a.get() if hasattr(a, "get") else np.asarray(a)
+
+
+class TestBiallelicAndAlt:
+    """The shared definition: biallelic = <= 2 distinct present alleles; alt =
+    highest-index present allele (K sentinel for monomorphic)."""
+
+    def test_classification_and_alt(self):
+        K = 3
+        ac = np.array([
+            [3, 1, 0],   # {0,1}      -> biallelic, alt=1
+            [3, 0, 1],   # {0,2}      -> biallelic, alt=2 (code-independent)
+            [0, 2, 2],   # {1,2}      -> biallelic, alt=2 (reference absent)
+            [4, 0, 0],   # mono {0}   -> biallelic, alt=K sentinel (dosage 0)
+            [0, 5, 0],   # mono {1}   -> biallelic, alt=1 (fixed alt; dosage stays 2)
+            [1, 1, 2],   # {0,1,2}    -> multiallelic
+        ], dtype=np.int64)
+        bi, alt = _biallelic_and_alt(ac)
+        np.testing.assert_array_equal(bi, [True, True, True, True, True, False])
+        np.testing.assert_array_equal(alt, [1, 2, 2, K, 1, 2])
+
+    def test_alt_sentinel_counts_zero_and_never_missing(self):
+        # the monomorphic sentinel K matches no real call (0..K-1) and not the
+        # -1 missing code, so (calls == alt) is all-False -> dosage 0.
+        ac = np.array([[5, 0, 0]], dtype=np.int64)   # monomorphic, K=3
+        _, alt = _biallelic_and_alt(ac)
+        calls = np.array([[0, 0, -1, 0]])            # some ref, one missing
+        assert int(alt[0]) == 3
+        assert not (calls == alt[0]).any()
 
 
 _VCF_HEADER = (
@@ -79,6 +108,25 @@ class TestFromVcfWarns:
             gm = GenotypeMatrix.from_vcf(vcf)   # must not raise
         assert gm.num_variants == 2
 
+    def test_keeps_non_01_biallelic_and_monomorphic(self, tmp_path):
+        # {0,2}, reference-absent {1,2}, and monomorphic {0} sites are all
+        # biallelic-or-fewer and KEPT (were dropped by is_biallelic_01); only the
+        # triallelic site is dropped. Dosage counts the alt (highest present > 0).
+        vcf = _write_vcf(tmp_path / "nz.vcf", [
+            "1\t100\t.\tA\tT\t.\tPASS\t.\tGT\t0|1\t1|0",       # {0,1} -> 1, 1
+            "1\t200\t.\tA\tT,G\t.\tPASS\t.\tGT\t0|2\t0|0",     # {0,2}, alt=2 -> 1, 0
+            "1\t300\t.\tA\tT,G\t.\tPASS\t.\tGT\t1|2\t1|1",     # {1,2}, alt=2 -> 1, 0
+            "1\t400\t.\tA\tT\t.\tPASS\t.\tGT\t0|0\t0|0",       # mono {0} -> 0, 0
+            "1\t500\t.\tA\tT,G\t.\tPASS\t.\tGT\t0|1\t2|0",     # {0,1,2} -> dropped
+        ])
+        with pytest.warns(BiallelicOnlyWarning, match="dropped 1 multiallelic"):
+            gm = GenotypeMatrix.from_vcf(vcf)
+        assert gm.num_variants == 4
+        np.testing.assert_array_equal(_host(gm.positions), [100, 200, 300, 400])
+        np.testing.assert_array_equal(
+            _host(gm.genotypes),
+            np.array([[1, 1, 1, 0], [1, 0, 0, 0]], dtype=np.int8))
+
 
 class TestFromHaplotypeMatrixWarns:
     def test_drops_and_warns_on_multiallelic(self):
@@ -110,6 +158,67 @@ class TestFromHaplotypeMatrixWarns:
         assert gm.num_variants == 3
         expected = (hap[0::2] + hap[1::2]).astype(np.int8)   # no missing
         np.testing.assert_array_equal(_host(gm.genotypes), expected)
+
+    @pytest.mark.parametrize("alt_code", [1, 2, 3])
+    def test_alt_code_independent(self, alt_code):
+        # A biallelic {0, alt} site gives the same dosage regardless of the alt's
+        # integer code -- {0,2}/{0,3} are now KEPT (were dropped under codes<=1).
+        col = np.array([0, alt_code, alt_code, alt_code], dtype=np.int8)[:, None]
+        hm = HaplotypeMatrix(col, np.array([100]), 0, 200)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", BiallelicOnlyWarning)   # biallelic -> no warn
+            gm = GenotypeMatrix.from_haplotype_matrix(hm)
+        np.testing.assert_array_equal(_host(gm.genotypes),
+                                      np.array([[1], [2]], dtype=np.int8))
+
+    def test_reference_absent_site_kept(self):
+        # {1,2} (reference allele 0 absent, e.g. after subsetting) is biallelic:
+        # alt=2, ref implicitly allele 1; dosage = count of allele 2.
+        col = np.array([1, 2, 1, 1], dtype=np.int8)[:, None]   # ind0=(1,2), ind1=(1,1)
+        hm = HaplotypeMatrix(col, np.array([100]), 0, 200)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", BiallelicOnlyWarning)
+            gm = GenotypeMatrix.from_haplotype_matrix(hm)
+        np.testing.assert_array_equal(_host(gm.genotypes),
+                                      np.array([[1], [0]], dtype=np.int8))
+
+    def test_half_call_is_fully_missing(self):
+        # If either haplotype of an individual is missing (-1), the whole diploid
+        # genotype is -1 -- even when the called haplotype carries the alt (the
+        # count underneath is discarded; a 0/1/2 dosage has no half-missing state).
+        # ind0 = (1, -1) alt half-call -> -1; ind1 = (0, 1) -> 1.
+        col = np.array([1, -1, 0, 1], dtype=np.int8)[:, None]
+        hm = HaplotypeMatrix(col, np.array([100]), 0, 200)
+        gm = GenotypeMatrix.from_haplotype_matrix(hm)
+        np.testing.assert_array_equal(_host(gm.genotypes),
+                                      np.array([[-1], [1]], dtype=np.int8))
+
+
+class TestDegenerateColumnsDownstream:
+    """The loaders now retain monomorphic and all-missing columns; the diploid
+    stats must tolerate them (guarded divisions), not error or return NaN, as
+    long as at least one usable column is present."""
+
+    def _gm(self):
+        # cols: 0 = polymorphic, 1 = monomorphic (all 0), 2 = all-missing (-1),
+        # 3 = polymorphic. Three individuals.
+        geno = np.array([
+            [2, 0, -1, 1],
+            [1, 0, -1, 2],
+            [0, 0, -1, 0],
+        ], dtype=np.int8)
+        return GenotypeMatrix(geno, np.arange(4) * 100)
+
+    def test_grm_finite(self):
+        from pg_gpu import relatedness
+        g = _host(relatedness.grm(self._gm()))
+        assert np.isfinite(g).all()
+
+    def test_pca_dosage_finite(self):
+        from pg_gpu import decomposition
+        coords, evr = decomposition.pca_dosage(self._gm(), n_components=2)
+        assert np.isfinite(_host(coords)).all()
+        assert np.isfinite(_host(evr)).all()
 
 
 class TestPattersonDWarns:

--- a/tests/test_biallelic_only_warning.py
+++ b/tests/test_biallelic_only_warning.py
@@ -1,0 +1,163 @@
+"""BiallelicOnlyWarning: the shared warning class and its emit helper (0014).
+
+Site-specific tests (from_vcf, from_haplotype_matrix, patterson_d) are added
+alongside their conversions in later tasks.
+"""
+import warnings
+
+import numpy as np
+import pytest
+
+from pg_gpu import BiallelicOnlyWarning, GenotypeMatrix, HaplotypeMatrix
+from pg_gpu._warnings import _warn_biallelic_only
+
+
+def _host(a):
+    return a.get() if hasattr(a, "get") else np.asarray(a)
+
+
+_VCF_HEADER = (
+    "##fileformat=VCFv4.2\n"
+    "##contig=<ID=1>\n"
+    '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
+    "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tind0\tind1\n"
+)
+
+
+def _write_vcf(path, rows):
+    with open(path, "w") as f:
+        f.write(_VCF_HEADER)
+        f.write("\n".join(rows) + "\n")
+    return str(path)
+
+
+def test_is_userwarning_subclass():
+    assert issubclass(BiallelicOnlyWarning, UserWarning)
+
+
+def test_helper_warns_with_count_and_context():
+    with pytest.warns(BiallelicOnlyWarning, match=r"foo\.bar .*dropped 3 multiallelic"):
+        _warn_biallelic_only(3, context="foo.bar")
+
+
+def test_helper_accepts_numpy_scalar_count():
+    with pytest.warns(BiallelicOnlyWarning, match="dropped 7 multiallelic"):
+        _warn_biallelic_only(np.int64(7), context="ctx")
+
+
+def test_helper_no_warn_when_zero():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")   # any warning becomes an error
+        _warn_biallelic_only(0, context="ctx")   # must be a no-op
+
+
+def test_silenceable_by_category():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        warnings.filterwarnings("ignore", category=BiallelicOnlyWarning)
+        _warn_biallelic_only(4, context="ctx")   # silenced -> no error raised
+
+
+class TestFromVcfWarns:
+    def test_warns_on_multiallelic(self, tmp_path):
+        vcf = _write_vcf(tmp_path / "m.vcf", [
+            "1\t100\t.\tA\tT\t.\tPASS\t.\tGT\t1|1\t0|1",     # biallelic
+            "1\t200\t.\tA\tT,G\t.\tPASS\t.\tGT\t2|1\t0|0",   # triallelic -> dropped
+            "1\t300\t.\tA\tT\t.\tPASS\t.\tGT\t0|1\t1|0",     # biallelic
+        ])
+        with pytest.warns(BiallelicOnlyWarning, match="dropped 1 multiallelic"):
+            gm = GenotypeMatrix.from_vcf(vcf)
+        assert gm.num_variants == 2   # the multiallelic site is dropped
+
+    def test_no_warn_when_all_biallelic(self, tmp_path):
+        vcf = _write_vcf(tmp_path / "b.vcf", [
+            "1\t100\t.\tA\tT\t.\tPASS\t.\tGT\t1|1\t0|1",
+            "1\t300\t.\tA\tT\t.\tPASS\t.\tGT\t0|1\t1|0",
+        ])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", BiallelicOnlyWarning)
+            gm = GenotypeMatrix.from_vcf(vcf)   # must not raise
+        assert gm.num_variants == 2
+
+
+class TestFromHaplotypeMatrixWarns:
+    def test_drops_and_warns_on_multiallelic(self):
+        # site 1 (col index 1) carries allele index 2 -> not representable as a
+        # 0/1/2 dosage, so it is dropped. Rows are haplotypes; cols are sites.
+        hap = np.array([[0, 0, 1],
+                        [1, 1, 1],
+                        [0, 2, 0],
+                        [1, 0, 0]], dtype=np.int8)
+        hm = HaplotypeMatrix(hap, np.array([100, 200, 300]), 0, 400)
+        with pytest.warns(BiallelicOnlyWarning, match="dropped 1 multiallelic"):
+            gm = GenotypeMatrix.from_haplotype_matrix(hm)
+        assert gm.num_variants == 2
+        # paired sums of the two retained {0,1} sites; no bogus >2 dosage
+        np.testing.assert_array_equal(_host(gm.genotypes),
+                                      np.array([[1, 2], [1, 0]], dtype=np.int8))
+        np.testing.assert_array_equal(_host(gm.positions), [100, 300])
+        assert int(_host(gm.genotypes).max()) <= 2
+
+    def test_biallelic_unchanged_no_warn(self):
+        hap = np.array([[0, 1, 0],
+                        [1, 1, 0],
+                        [0, 0, 1],
+                        [1, 0, 1]], dtype=np.int8)
+        hm = HaplotypeMatrix(hap, np.array([100, 200, 300]), 0, 400)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", BiallelicOnlyWarning)
+            gm = GenotypeMatrix.from_haplotype_matrix(hm)   # must not warn
+        assert gm.num_variants == 3
+        expected = (hap[0::2] + hap[1::2]).astype(np.int8)   # no missing
+        np.testing.assert_array_equal(_host(gm.genotypes), expected)
+
+
+class TestPattersonDWarns:
+    """patterson_d (and its moving/average variants) drops sites with >2 alleles
+    across the four populations; warn once per top-level call."""
+
+    def _hm4(self, sites):
+        # ``sites`` is a list of 8-long allele-index rows (one per site); rows
+        # are haplotypes, so the matrix is (8 haplotypes, n_sites). Four pops of
+        # two haplotypes each.
+        hap = np.array(sites, dtype=np.int8).T
+        pos = np.arange(hap.shape[1]) * 100
+        return HaplotypeMatrix(
+            hap, pos, 0, hap.shape[1] * 100,
+            sample_sets={"A": [0, 1], "B": [2, 3], "C": [4, 5], "D": [6, 7]})
+
+    def test_warns_on_multiallelic(self):
+        from pg_gpu import admixture
+        hm = self._hm4([
+            [0, 1, 0, 1, 0, 1, 0, 1],   # biallelic
+            [0, 1, 2, 0, 1, 0, 1, 0],   # triallelic (0,1,2) -> dropped
+            [1, 0, 1, 0, 1, 0, 1, 0],   # biallelic
+        ])
+        with pytest.warns(BiallelicOnlyWarning, match="dropped 1 multiallelic"):
+            admixture.patterson_d(hm, "A", "B", "C", "D")
+
+    def test_no_warn_when_biallelic(self):
+        from pg_gpu import admixture
+        hm = self._hm4([
+            [0, 1, 0, 1, 0, 1, 0, 1],
+            [1, 0, 1, 0, 1, 0, 1, 0],
+        ])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", BiallelicOnlyWarning)
+            admixture.patterson_d(hm, "A", "B", "C", "D")
+
+    def test_moving_warns_at_most_once(self):
+        from pg_gpu import admixture
+        hm = self._hm4([
+            [0, 1, 0, 1, 0, 1, 0, 1],
+            [0, 1, 2, 0, 1, 0, 1, 0],   # multiallelic
+            [1, 0, 1, 0, 1, 0, 1, 0],
+            [0, 3, 1, 0, 1, 0, 1, 0],   # multiallelic
+            [1, 1, 0, 0, 1, 0, 1, 0],
+        ])
+        with warnings.catch_warnings(record=True) as rec:
+            warnings.simplefilter("always")
+            admixture.moving_patterson_d(hm, "A", "B", "C", "D", size=2)
+        bo = [w for w in rec if issubclass(w.category, BiallelicOnlyWarning)]
+        assert len(bo) == 1
+        assert "dropped 2 multiallelic" in str(bo[0].message)

--- a/tests/test_biallelic_only_warning.py
+++ b/tests/test_biallelic_only_warning.py
@@ -1,7 +1,5 @@
-"""BiallelicOnlyWarning: the shared warning class and its emit helper (0014).
-
-Site-specific tests (from_vcf, from_haplotype_matrix, patterson_d) are added
-alongside their conversions in later tasks.
+"""Tests for BiallelicOnlyWarning: the shared warning class and its emit helper,
+and the sites that raise it (from_vcf, from_haplotype_matrix, patterson_d).
 """
 import warnings
 

--- a/tests/test_loader_parity.py
+++ b/tests/test_loader_parity.py
@@ -1,0 +1,178 @@
+"""Cross-loader parity for GenotypeMatrix.
+
+The three GenotypeMatrix loaders -- from_vcf, from_zarr (eager), and from_zarr
+(streaming) -- must agree on the dosage matrix they produce from equivalent
+data. They historically did not (from_vcf used one biallelic definition, the
+zarr paths a raw ploidy sum), and nothing in the suite compared them. These
+tests drive all three from a single call_genotype block so a future divergence
+fails loudly.
+"""
+import warnings
+
+import numpy as np
+import pytest
+
+from pg_gpu import BiallelicOnlyWarning, GenotypeMatrix
+from pg_gpu.zarr_io import write_vcz
+
+
+def _host(a):
+    return a.get() if hasattr(a, "get") else np.asarray(a)
+
+
+_ALT_POOL = ["C", "G", "T", "N"]
+
+
+def _write_vcf_from_cg(path, cg, positions, sample_names):
+    """Write a VCF whose per-diploid genotypes are exactly ``cg[v, d, :]``."""
+    n_var, n_dip, _ = cg.shape
+    header = (
+        "##fileformat=VCFv4.2\n##contig=<ID=1>\n"
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="GT">\n'
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t"
+        + "\t".join(sample_names) + "\n"
+    )
+    rows = []
+    for v in range(n_var):
+        site = cg[v]
+        m = int(site.max())            # highest allele index present (-1 => all missing)
+        alt = ",".join(_ALT_POOL[:max(m, 1)])
+        calls = []
+        for d in range(n_dip):
+            a, b = site[d]
+            sa = "." if a < 0 else str(int(a))
+            sb = "." if b < 0 else str(int(b))
+            calls.append(f"{sa}|{sb}")
+        rows.append(f"1\t{int(positions[v])}\t.\tA\t{alt}\t.\tPASS\t.\tGT\t"
+                    + "\t".join(calls))
+    with open(path, "w") as f:
+        f.write(header + "\n".join(rows) + "\n")
+    return str(path)
+
+
+def _expected_dosage(cg):
+    """Unified rule, computed on the host: biallelic = <= 2 distinct present
+    alleles; dosage = count of the highest present alt (> 0); any missing ploidy
+    -> -1; a >= 3-allele site -> whole row -1."""
+    n_var, n_dip, _ = cg.shape
+    out = np.zeros((n_dip, n_var), dtype=np.int8)
+    for v in range(n_var):
+        site = cg[v]
+        present = sorted({int(x) for x in site.ravel() if x >= 0})
+        alts = [a for a in present if a > 0]
+        alt = max(alts) if alts else None
+        for d in range(n_dip):
+            a, b = int(site[d, 0]), int(site[d, 1])
+            if a < 0 or b < 0:
+                out[d, v] = -1
+            elif alt is None:
+                out[d, v] = 0
+            else:
+                out[d, v] = (a == alt) + (b == alt)
+        if len(present) > 2:            # multiallelic -> fully-missing row
+            out[:, v] = -1
+    return out
+
+
+# call_genotype (n_var, n_dip, 2); n_dip = 3.
+_SAMPLES = ["s0", "s1", "s2"]
+_BIALLELIC_CG = np.array([
+    [[0, 1], [1, 1], [0, 0]],   # {0,1}          -> 1, 2, 0
+    [[0, 2], [0, 0], [2, 2]],   # {0,2} alt=2     -> 1, 0, 2
+    [[1, 2], [1, 1], [2, 2]],   # {1,2} ref-absent-> 1, 0, 2
+    [[0, 0], [0, 0], [0, 0]],   # mono {0}        -> 0, 0, 0
+    [[0, 1], [-1, 1], [0, 0]],  # ind1 half-call  -> 1, -1, 0
+], dtype=np.int8)
+_BIALLELIC_POS = np.array([100, 200, 300, 400, 500])
+
+_MULTI_CG = np.concatenate([
+    _BIALLELIC_CG,
+    np.array([[[0, 1], [2, 0], [1, 2]]], dtype=np.int8),   # {0,1,2} triallelic
+])
+_MULTI_POS = np.array([100, 200, 300, 400, 500, 600])
+
+
+def _load_all_zarr(tmp_path, cg, pos):
+    path = str(tmp_path / "parity.vcz.zarr")
+    write_vcz(path, cg, pos, samples=_SAMPLES, contig_name="1")
+    eager = GenotypeMatrix.from_zarr(path, streaming="never")
+    streaming = GenotypeMatrix.from_zarr(path, streaming="always")
+    return path, eager, streaming
+
+
+class TestBiallelicParity:
+    """No >= 3-allele sites: all three loaders must be byte-identical."""
+
+    def test_all_three_loaders_agree(self, tmp_path):
+        expected = _expected_dosage(_BIALLELIC_CG)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", BiallelicOnlyWarning)   # none expected
+            path, eager, streaming = _load_all_zarr(
+                tmp_path, _BIALLELIC_CG, _BIALLELIC_POS)
+            strm = streaming.materialize()
+            vcf = _write_vcf_from_cg(
+                tmp_path / "parity.vcf", _BIALLELIC_CG, _BIALLELIC_POS, _SAMPLES)
+            from_vcf = GenotypeMatrix.from_vcf(vcf)
+
+        np.testing.assert_array_equal(_host(eager.genotypes), expected)
+        np.testing.assert_array_equal(_host(strm.genotypes), expected)
+        np.testing.assert_array_equal(_host(from_vcf.genotypes), expected)
+        for gm in (eager, strm, from_vcf):
+            np.testing.assert_array_equal(_host(gm.positions), _BIALLELIC_POS)
+
+
+class TestMultiallelicParity:
+    """A >= 3-allele site: the two zarr paths agree (row -> -1); from_vcf drops
+    it instead. Both surface exactly one BiallelicOnlyWarning."""
+
+    def test_zarr_eager_and_streaming_agree(self, tmp_path):
+        expected = _expected_dosage(_MULTI_CG)   # last row all -1
+        path = str(tmp_path / "m.vcz.zarr")
+        write_vcz(path, _MULTI_CG, _MULTI_POS, samples=_SAMPLES, contig_name="1")
+
+        with pytest.warns(BiallelicOnlyWarning, match="dropped 1 multiallelic"):
+            eager = GenotypeMatrix.from_zarr(path, streaming="never")
+        streaming = GenotypeMatrix.from_zarr(path, streaming="always")
+        with pytest.warns(BiallelicOnlyWarning, match="dropped 1 multiallelic"):
+            strm = streaming.materialize()
+
+        np.testing.assert_array_equal(_host(eager.genotypes), expected)
+        np.testing.assert_array_equal(_host(strm.genotypes), expected)
+        assert eager.num_variants == 6
+        # the multiallelic row is present but fully missing
+        np.testing.assert_array_equal(_host(eager.genotypes)[:, 5], [-1, -1, -1])
+
+    def test_from_vcf_drops_the_site(self, tmp_path):
+        vcf = _write_vcf_from_cg(
+            tmp_path / "m.vcf", _MULTI_CG, _MULTI_POS, _SAMPLES)
+        with pytest.warns(BiallelicOnlyWarning, match="dropped 1 multiallelic"):
+            from_vcf = GenotypeMatrix.from_vcf(vcf)
+        # from_vcf drops the multiallelic site entirely (5 kept, not 6)...
+        assert from_vcf.num_variants == 5
+        np.testing.assert_array_equal(_host(from_vcf.positions), _BIALLELIC_POS)
+        # ...and the retained biallelic rows match the zarr loaders' first 5.
+        np.testing.assert_array_equal(
+            _host(from_vcf.genotypes), _expected_dosage(_BIALLELIC_CG))
+
+    def test_streaming_warns_once_across_chunks(self, tmp_path):
+        # Two chunks, each carrying a multiallelic site; the warning must fire
+        # exactly once per streaming load, not once per affected chunk.
+        cg = np.array([
+            [[0, 1], [2, 0], [1, 2]],   # chunk 0: {0,1,2} multiallelic
+            [[0, 1], [1, 1], [0, 0]],   # chunk 0: biallelic
+            [[0, 1], [3, 0], [1, 3]],   # chunk 1: {0,1,3} multiallelic
+            [[0, 0], [0, 1], [1, 1]],   # chunk 1: biallelic
+        ], dtype=np.int8)
+        pos = np.array([100, 200, 2_000_000, 2_000_100])
+        path = str(tmp_path / "chunks.vcz.zarr")
+        write_vcz(path, cg, pos, samples=_SAMPLES, contig_name="1")
+
+        streaming = GenotypeMatrix.from_zarr(
+            path, streaming="always", chunk_bp=1_000_000)
+        with warnings.catch_warnings(record=True) as rec:
+            warnings.simplefilter("always")
+            chunks = list(streaming.iter_gpu_chunks())
+        assert len(chunks) >= 2   # the sites really did split across chunks
+        bo = [w for w in rec if issubclass(w.category, BiallelicOnlyWarning)]
+        assert len(bo) == 1

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -11,6 +11,7 @@ import allel
 import pytest
 
 from pg_gpu import HaplotypeMatrix
+from pg_gpu import BiallelicOnlyWarning
 from pg_gpu import diversity
 from pg_gpu import sfs
 from pg_gpu.diversity import FrequencySpectrum
@@ -645,12 +646,13 @@ class TestFStatisticsVsTskit:
         np.testing.assert_allclose(f4_pg, f4_ts, rtol=1e-9)
 
     def test_patterson_d_is_biallelic_restricted(self, multiallelic_ts):
-        # D silently excludes >2-allele sites (num=den=0) and stays in [-1, 1];
-        # exclusion is silent, matching the package's biallelic filtering.
+        # D excludes >2-allele sites (num=den=0) and stays in [-1, 1]; the
+        # exclusion now emits a BiallelicOnlyWarning with the dropped-site count.
         from pg_gpu import admixture
         ts = multiallelic_ts
         hm = self._hm(ts)
-        num, den = admixture.patterson_d(hm, 'A', 'B', 'C', 'D')
+        with pytest.warns(BiallelicOnlyWarning, match="multiallelic"):
+            num, den = admixture.patterson_d(hm, 'A', 'B', 'C', 'D')
         d_val = np.nansum(num) / np.nansum(den)
         assert -1.0 <= d_val <= 1.0
         # reference: strictly-biallelic subset ({0,1} across all four pops) gives
@@ -664,6 +666,8 @@ class TestFStatisticsVsTskit:
         d_all = num[n_alleles <= 2]
         assert np.allclose(num[n_alleles > 2], 0.0)   # multiallelic sites zeroed
 
+    @pytest.mark.filterwarnings(
+        "ignore::pg_gpu._warnings.BiallelicOnlyWarning")
     def test_moving_and_jackknife_inherit_per_allele_fix(self, multiallelic_ts):
         # moving_* / average_* build on the corrected _patterson_*_gpu helpers,
         # so they inherit the per-allele fix. A single all-variant window


### PR DESCRIPTION
#### Background

Two related problems. (1) Several entry points restrict to biallelic sites without telling the user,
so a biallelic-only statistic run on multiallelic data silently returns a partial result. (2) The
loaders disagreed on what "biallelic" even means, and on how to build a dosage -- so the same data
produced different genotype matrices depending on which loader you used, and none of that was
caught by the test suite because nothing compared the loaders.

This PR adds a shared BiallelicOnlyWarning, unifies the biallelic definition and the dosage rule
across all three GenotypeMatrix loaders (from_vcf, from_zarr eager, from_zarr streaming) and
from_haplotype_matrix, and adds a cross-loader parity harness.

#### The unified definition

- Biallelic = at most two distinct *present* alleles (label / reference independent). A {0,2} site,
  or a reference-absent {1,2} site (possible after subsetting), is biallelic. This replaces the
  narrower "codes in {0,1}" notion that wrongly dropped genuinely-biallelic non-{0,1} sites.
- Dosage = count of the chosen alt allele: allele 0 is reference, alt = highest present allele > 0,
  with a sentinel (out of range) when no alt is present so a monomorphic site counts to 0. This
  replaces summing allele indices (wrong for {0,2}) and `gt > 0` (folds distinct alts; breaks on
  reference-absent {1,2}).
- {0,1} input stays byte-identical, including a monomorphic-derived {1}-only site (dosage 2). This
  is what forced "allele 0 = reference" rather than "highest present allele" in the alt choice.
- Both loaders retain monomorphic and all-missing sites (they load faithfully); dropping
  uninformative sites is the job of apply_biallelic_filter, not the loaders. The diploid stats
  tolerate such columns (grm excludes them via its polymorphic mask; pca/ibs guard every division).

The source of truth for biallelic sites is `_biallelic_and_alt(ac)` in genotype_matrix.py.

#### What changed

- _warnings.py: BiallelicOnlyWarning(UserWarning) plus _warn_biallelic_only(n_dropped, *, context,
  stacklevel): coerces the count to int, no-ops at 0, emits a message leading with the context and
  dropped-site count.
- GenotypeMatrix.from_haplotype_matrix: onto the shared definition. Counts the alt allele instead of
  summing indices; kepps {0,2}/{1,2}/monomorphic (previously {0,2}/{1,2} were dropped and index-sum
  gave impossible dosages like 2+2 -> 4); drops >= 3-allele sites + warns. {0,1} bit-identical.
- GenotypeMatrix.from_vcf: moved off scikit-allel's is_biallelic_01() onto the shared definition.
  keeps {0,2}/{1,2}/monomorphic (is_biallelic_01 dropped all three); counts the alt allele; builds
  the allele-count matrix with numpy so scikit-allel's library footprint is now purely VCF parsing
  (read_vcf). Drops >= 3-allele sites + warns.
- GenotypeMatrix.from_zarr (eager AND streaming, via build_genotype_matrix): onto the shared
  definition. Both zarr paths used a raw ploidy-sum with no classification, so a {0,2} site or any
  multiallelic site produced impossible dosages, silently, and disagreed with from_vcf. Now counts
  the alt allele. A >= 3-allele site has no valid 0/1/2 dosage, so its whole row is recoded to -1
  (present but fully missing) -- this preserves the row/chunk alignment the streaming path relies on
  (from_vcf drops the site instead). The warning is surfaced by the callers: the eager path with the
  exact count, the streaming path once per load on the first affected chunk.
- admixture.patterson_d: warn with the count of >2-allele sites it already drops (num=den=0), once
  per top-level D computation (patterson_d / moving_patterson_d / average_patterson_d). D unchanged.
- GenotypeMatrix.apply_biallelic_filter: docstring corrected. It does no allele classification (the
  matrix is biallelic by construction) -- it drops monomorphic (non-segregating) sites. Name kept
  for backwards compatibility; a rename is deferred as a follow-up.

#### Behaviour

- {0,1} input is byte-identical across every loader, silent.
- {0,2} / reference-absent {1,2} / monomorphic sites are now KEPT (and correctly dosed) by all
  loaders; previously from_vcf dropped them and the other paths mis-handled them.
- A >= 3-allele site: from_vcf and from_haplotype_matrix drop it (fewer variants); from_zarr recodes
  its whole row to -1 (present but fully missing). All paths emit one BiallelicOnlyWarning.
- All three GenotypeMatrix loaders now produce byte-identical dosage matrices from equivalent
  biallelic data, and stay consistent on multiallelic data.
- The warning is silenceable by category (from pg_gpu import BiallelicOnlyWarning;
  warnings.filterwarnings("ignore", category=BiallelicOnlyWarning)).

#### Not in scope / deferred

- LD / moments-LD paths keep the old "codes in {0,1}" notion by design (they are on their way to a
  separate multiallelic-correct LD rewrite): haplotype_matrix.apply_biallelic_filter (a moments
  is_biallelic_01 reimplementation), the moments-LD biallelic filter + alt construction, and the
  Rogers-Huff matrix dosage. These three call sites are documented in the LD subproject plan so the
  reconciliation is not lost. rogers_huff itself restricts to biallelic and will use this warning
  there.
- apply_biallelic_filter is misnamed (it drops monomorphic sites, not a biallelic classification).
  Docstring fixed here; a rename or a clearer alias with soft-deprecation is a public-API change
  deferred as a follow-up issue.

#### Verification

- tests/test_biallelic_only_warning.py: the class and helper (subclass, count/context message,
  numpy-scalar count, no-op at 0, silenceable); the shared _biallelic_and_alt definition and alt
  choice; from_vcf keeps {0,2}/{1,2}/monomorphic and drops the triallelic site with correct
  dosages; from_haplotype_matrix bit-identity on {0,1}, alt-code independence, reference-absent
  {1,2}, and the one-missing-haplotype -> fully-missing (-1) case; degenerate-column downstream
  safety (grm and pca_dosage stay finite on explicit monomorphic and all-missing columns);
  patterson_d warns once.
- tests/test_loader_parity.py (new): drives from_vcf, from_zarr (eager), and from_zarr (streaming)
  from a single call_genotype block and asserts they agree byte-for-byte on biallelic data, stay
  consistent on multiallelic data (zarr recodes to a -1 row where from_vcf drops), and that the
  streaming warning fires exactly once across multiple chunks. This is the cross-loader coverage
  that was missing when the three loaders silently diverged.