### PR TITLE
Update user documentation for the multiallelic statistics pass

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -57,10 +57,33 @@ diploid genotypes; haploid and polyploid stores are rejected.
    :members: iter_chunks
    :show-inheritance:
 
+.. autofunction:: pg_gpu.zarr_io.allel_zarr_to_vcz
+
+Warnings
+--------
+
+pg_gpu warns you when it silently changes or skips some of your data.
+Each kind of warning has its own class, so you can turn off just the one
+you have already understood and leave the rest on::
+
+   import warnings
+   from pg_gpu import BiallelicOnlyWarning
+   warnings.filterwarnings("ignore", category=BiallelicOnlyWarning)
+
+.. autoclass:: pg_gpu.BiallelicOnlyWarning
+   :show-inheritance:
+
+.. autoclass:: pg_gpu.MultiallelicCapWarning
+   :show-inheritance:
+
 .. autoclass:: pg_gpu.MemoryLimitedWarning
    :show-inheritance:
 
-.. autofunction:: pg_gpu.zarr_io.allel_zarr_to_vcz
+.. autoclass:: pg_gpu.HaploidDataWarning
+   :show-inheritance:
+
+.. autoclass:: pg_gpu.BadlyChunkedWarning
+   :show-inheritance:
 
 LD Statistics
 -------------
@@ -143,6 +166,7 @@ Core Functions
 
 .. autofunction:: pg_gpu.divergence.fst
 .. autofunction:: pg_gpu.divergence.fst_hudson
+.. autofunction:: pg_gpu.divergence.fst_tskit
 .. autofunction:: pg_gpu.divergence.fst_weir_cockerham
 .. autofunction:: pg_gpu.divergence.fst_nei
 .. autofunction:: pg_gpu.divergence.dxy
@@ -154,6 +178,15 @@ Convenience Functions
 .. autofunction:: pg_gpu.divergence.divergence_stats
 .. autofunction:: pg_gpu.divergence.pairwise_fst
 .. autofunction:: pg_gpu.divergence.pbs
+
+Component-Level Access
+~~~~~~~~~~~~~~~~~~~~~~
+
+Raw per-site difference and comparison counts, for callers doing their
+own aggregation. See :doc:`missing_data` for worked usage.
+
+.. autofunction:: pg_gpu.divergence.dxy_components
+.. autofunction:: pg_gpu.diversity.pi_components
 
 Distance-Based Two-Population Statistics
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -242,6 +275,7 @@ Per-Variant Statistics
 
 .. autofunction:: pg_gpu.admixture.patterson_f2
 .. autofunction:: pg_gpu.admixture.patterson_f3
+.. autofunction:: pg_gpu.admixture.patterson_f4
 .. autofunction:: pg_gpu.admixture.patterson_d
 
 Windowed Statistics
@@ -308,6 +342,7 @@ or want to recompute one stage with different parameters.
 Relatedness and Kinship
 -----------------------
 
+.. autofunction:: pg_gpu.relatedness.genetic_relatedness
 .. autofunction:: pg_gpu.relatedness.grm
 .. autofunction:: pg_gpu.relatedness.ibs
 
@@ -372,6 +407,8 @@ Distance Distribution Statistics
 ---------------------------------
 
 .. autofunction:: pg_gpu.distance_stats.pairwise_diffs
+.. autofunction:: pg_gpu.distance_stats.pairwise_diffs_haploid
+.. autofunction:: pg_gpu.distance_stats.pairwise_diffs_diploid
 .. autofunction:: pg_gpu.distance_stats.dist_moments
 .. autofunction:: pg_gpu.distance_stats.dist_var
 .. autofunction:: pg_gpu.distance_stats.dist_skew

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,8 +1,116 @@
 Changelog
 =========
 
-v0.1.0 (Current)
------------------
+Unreleased
+----------
+
+Sites with more than two alleles are now handled correctly
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Statistics used to lump every alternate allele into one "non-reference"
+group. That is fine when a site has two alleles and wrong when it has
+three or four. Each allele is now counted on its own, which is what
+``tskit`` does. See :doc:`missing_data` for what this means in
+practice.
+
+**If your data only has two alleles per site, nothing here changes your
+results**, except where the next section says so.
+
+* Diversity and frequency spectra: :math:`\pi`, ``theta_w`` /
+  ``theta_h`` / ``theta_l``, ``tajimas_d``, ``fay_wus_h``, ``zeng_e``,
+  ``segregating_sites``, ``singleton_count``,
+  ``heterozygosity_expected``, and every SFS function.
+  ``segregating_sites`` now counts mutations rather than variable
+  sites, so a site with three alleles counts as 2. ``theta_w`` and
+  Tajima's D use that count too.
+* Divergence: ``dxy``, ``da``, ``fst_hudson``, ``fst_nei``,
+  ``fst_weir_cockerham``, and ``pbs``. Added ``fst_tskit``, also
+  available as ``fst(method='tskit')``.
+* Admixture: ``patterson_f2`` and ``patterson_f3``. Added
+  ``patterson_f4``. ``patterson_d`` only works on two-allele sites and
+  now says so.
+* Selection: ``ihs`` and ``nsl`` score each alternate allele against
+  the reference separately, so they return one column per alternate
+  allele when a site has more than two. ``min_maf`` now applies to each
+  allele's own frequency.
+* Distances: pairwise distances count how many sites two haplotypes
+  differ at, instead of doing arithmetic on the allele numbers.
+  ``decomposition.pairwise_distance`` uses the same count.
+* Relatedness: added ``genetic_relatedness``, which matches
+  ``tskit``'s function of the same name.
+* Windowed analysis: every windowed statistic now gives the same answer
+  as running the plain function on that window's variants.
+
+Results that change even for two-allele data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Read this section if you are comparing against older pg_gpu results.
+
+* Frequency spectra: sites where nothing varies no longer contribute,
+  folded spectra are returned as ``float64`` rather than integers, and
+  ``joint_sfs_folded`` returns a full ``(n1 + 1, n2 + 1)`` grid folded
+  by the site's overall minor allele.
+* ``pca`` and ``randomized_pca`` now take haplotypes and give every
+  allele its own column. The old diploid behavior is now
+  ``pca_dosage`` / ``randomized_pca_dosage``, which take a
+  ``GenotypeMatrix``. The ``scaler`` argument is gone, and each
+  function raises a ``TypeError`` on the wrong matrix type.
+  ``local_pca`` and ``lostruct`` changed the same way. They no longer
+  match the R ``lostruct`` package number for number -- the eigenvalue
+  scale differs -- though the component directions still agree closely,
+  so plots and outlier detection are unaffected.
+* ``grm`` and ``ibs`` now require a ``GenotypeMatrix`` and reject
+  haplotypes. ``grm(GenotypeMatrix, population=...)`` used to raise an
+  error and now works.
+* Windowed ``daf_hist`` is now a histogram normalized to sum to 1, and
+  windowed ``mu_sfs`` divides by the number of variable sites and
+  returns 0.0 instead of NaN for an empty window.
+* In ``windowed_statistics``, ``singletons`` now counts only alternate
+  alleles seen once (it used to also count reference alleles seen
+  once), and ``segregating_sites`` counts mutations.
+* ``dxy(span_normalize=False)`` and ``da(span_normalize=False)`` return
+  the raw sum, matching every other statistic. They used to divide by
+  the number of sites.
+* ``decomposition.pairwise_distance`` supports ``euclidean``,
+  ``sqeuclidean``, and ``cityblock``. Other metrics now raise
+  ``NotImplementedError``, and passing a ``GenotypeMatrix`` raises a
+  ``TypeError``.
+
+Bug fixes
+~~~~~~~~~
+
+* Pairwise distances treated a missing genotype as if it were a
+  reference homozygote, so a missing call could count as a difference.
+  Missing data is now skipped on both sides of the calculation.
+* ``GenotypeMatrix.from_zarr`` ignored ``accessible_bed`` when
+  streaming, so streaming ``grm`` and ``ibs`` silently used every
+  variant while the non-streaming path filtered correctly. Both now
+  apply the mask, and results agree exactly.
+* The three ``GenotypeMatrix`` loaders disagreed about which sites to
+  keep and how to build genotype values, so the same data could give
+  different matrices. They now share one definition. Sites showing only
+  alleles ``0`` and ``2``, or only ``1`` and ``2``, are kept rather
+  than dropped, and sites where nothing varies are kept too.
+
+New warnings
+~~~~~~~~~~~~
+
+* ``BiallelicOnlyWarning`` -- something that only works on two-allele
+  sites threw multiallelic sites away, and tells you how many. Comes
+  from ``patterson_d`` and the ``GenotypeMatrix`` loaders.
+* ``MultiallelicCapWarning`` -- a windowed calculation skipped sites
+  with more than 8 alleles. You will not see this with DNA.
+
+Removed
+~~~~~~~
+
+* ``diversity.allele_frequency_spectrum`` and
+  ``HaplotypeMatrix.allele_frequency_spectrum``. Use the ``sfs`` module
+  instead.
+* The ``scaler`` argument on the PCA functions.
+
+v0.1.0
+------
 
 First public release of pg_gpu.
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -141,7 +141,10 @@ Selection Scan Pipeline
    # iHS with standardization by allele count
    ihs_raw = selection.ihs(h)
 
-   # Get allele counts for binned standardization
+   # Get allele counts for binned standardization. Adding up the
+   # matrix only counts alternate alleles if your data uses 0 and 1.
+   # If a site has a third allele stored as 2, that 2 gets added as a
+   # 2. Run h.apply_biallelic_filter() first if you are unsure.
    dac = np.sum(h.haplotypes.get(), axis=0)
    ihs_std, bins = selection.standardize_by_allele_count(ihs_raw, dac)
 

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -63,14 +63,12 @@ Diversity Statistics
    * - ``inbreeding_coefficient``
      - Wright's F per variant
      - Wright (1951)
-   * - ``allele_frequency_spectrum``
-     - Allele frequency spectrum
-     -
    * - ``max_daf``
-     - Maximum derived allele frequency
+     - Frequency of the most common alternate allele at a site
      -
    * - ``daf_histogram``
-     - Derived allele frequency histogram
+     - Histogram of alternate-allele frequencies, scaled to sum to 1, with
+       one entry per alternate allele present
      -
    * - ``diplotype_frequency_spectrum``
      - Diplotype (multi-locus genotype) frequency spectrum
@@ -90,8 +88,12 @@ Divergence Statistics
      - Description
      - Reference
    * - ``fst_hudson``
-     - Hudson's FST
+     - Hudson's FST. The usual choice.
      - Hudson et al. (1992)
+   * - ``fst_tskit``
+     - Same ingredients as Hudson's, combined the way tskit does it.
+       Use this if you want to match ``TreeSequence.Fst``.
+     -
    * - ``fst_weir_cockerham``
      - Weir & Cockerham's FST (method of moments)
      - Weir & Cockerham (1984)
@@ -189,10 +191,12 @@ Selection Scans
      - Description
      - Reference
    * - ``ihs``
-     - Integrated Haplotype Score
+     - Integrated Haplotype Score. Each alternate allele is scored against
+       the reference separately -- see the note below.
      - Voight et al. (2006)
    * - ``nsl``
-     - Number of Segregating Sites by Length
+     - Number of Segregating Sites by Length. Scores each alternate allele
+       separately, same as ``ihs``.
      - Ferrer-Admetlla et al. (2014)
    * - ``xpehh``
      - Cross-population Extended Haplotype Homozygosity
@@ -210,6 +214,32 @@ Selection Scans
      - Extended Haplotype Homozygosity decay
      - Sabeti et al. (2002)
 
+``ihs`` and ``nsl`` ask whether one allele sits on unusually long
+shared haplotypes. When a site has more than one alternate allele,
+they score each alternate against the reference separately.
+
+That changes the shape of what you get back. With ordinary two-allele
+data you get one score per site, as usual::
+
+   scores = selection.nsl(h)      # shape (n_variants,)
+
+If any site in the matrix has more than two alleles, you get one column
+per alternate allele instead::
+
+   scores = selection.nsl(h)      # shape (n_variants, n_alt_alleles)
+   scores[:, 0]                   # scores for allele 1
+   scores[:, 1]                   # scores for allele 2
+
+An entry is ``NaN`` where that allele is not present at that site, or
+where it was filtered out by ``min_maf``. The ``min_maf`` cutoff is
+applied to each alternate allele's own frequency, so a common allele is
+never missed just because it has a high allele number.
+
+``xpehh``, ``xpnsl``, ``ehh_decay``, and Garud's H compare whole
+haplotypes rather than focusing on one allele, so they are unaffected
+and always return their usual shape. Windowed ``mean_nsl`` averages all
+the scores in a window, across sites and alleles alike.
+
 Site Frequency Spectrum
 -----------------------
 
@@ -224,7 +254,8 @@ Site Frequency Spectrum
      - Unfolded SFS
      -
    * - ``sfs_folded``
-     - Folded SFS (minor allele counts)
+     - Folded SFS (minor allele counts). Returned as ``float64`` -- see
+       :ref:`sfs-conventions`.
      -
    * - ``sfs_scaled``
      - Scaled unfolded SFS
@@ -236,7 +267,8 @@ Site Frequency Spectrum
      - Joint SFS (two populations)
      -
    * - ``joint_sfs_folded``
-     - Folded joint SFS
+     - Folded joint SFS. Folded once per site using the overall minor
+       allele; shape ``(n1 + 1, n2 + 1)``.
      -
    * - ``joint_sfs_scaled``
      - Scaled joint SFS
@@ -267,8 +299,13 @@ Admixture and F-Statistics
    * - ``patterson_f3``
      - F3 admixture test
      - Patterson et al. (2012)
+   * - ``patterson_f4``
+     - F4: tests whether four populations fit a given tree. Matches
+       ``TreeSequence.f4``. Works on sites with any number of alleles.
+     - Patterson et al. (2012)
    * - ``patterson_d``
-     - Patterson's D (ABBA-BABA)
+     - Patterson's D (ABBA-BABA). Only works on two-allele sites; others
+       are skipped, and a warning tells you how many.
      - Patterson et al. (2012)
    * - ``moving_patterson_f3``
      - Windowed F3
@@ -344,13 +381,25 @@ Dimensionality Reduction and Distance
      - Description
      - Reference
    * - ``pca``
-     - Principal Component Analysis (GPU-accelerated SVD)
-     - Patterson et al. (2006)
+     - PCA with one point per haplotype. Gives every allele its own
+       column, so it works with any number of alleles. Takes a
+       ``HaplotypeMatrix``.
+     -
    * - ``randomized_pca``
-     - Randomized PCA (truncated SVD approximation)
+     - Faster approximate version of ``pca``
+     - Halko et al. (2011)
+   * - ``pca_dosage``
+     - PCA with one point per individual, counting alternate alleles as
+       0, 1, or 2. The classical version, matching scikit-allel. Takes a
+       ``GenotypeMatrix``.
+     - Patterson et al. (2006)
+   * - ``randomized_pca_dosage``
+     - Faster approximate version of ``pca_dosage``
      - Halko et al. (2011)
    * - ``pairwise_distance``
-     - Pairwise genetic distance (Euclidean, cityblock, etc.)
+     - Genetic distance between each pair of haplotypes, based on how
+       many sites they differ at (``euclidean``, ``sqeuclidean``,
+       ``cityblock``)
      -
    * - ``pcoa``
      - Principal Coordinate Analysis (classical MDS)
@@ -368,6 +417,38 @@ Dimensionality Reduction and Distance
      - Extreme-cluster selection in a 2D MDS embedding (Welzl MEC)
      - Li & Ralph (2019)
 
+There are two PCAs because there are two genuinely different things
+people mean by "PCA of genetic data", and they need different input.
+``pca`` works on haplotypes and handles any number of alleles;
+``pca_dosage`` works on diploid genotypes and is the classical version
+you will find in textbooks and in scikit-allel. Each one raises a
+``TypeError`` if handed the other's matrix, naming the one you want.
+
+The reason ``pca`` cannot simply use the allele numbers is that they are
+arbitrary labels. Whether an allele is called ``2`` or ``3`` carries no
+meaning, but arithmetic on those numbers would treat ``3`` as bigger
+than ``2``. So ``pca`` gives every allele its own column instead, which
+makes the result independent of how the alleles were numbered.
+
+``local_pca``, ``lostruct``, and ``local_pca_jackknife`` use the same
+approach as ``pca`` and also take haplotypes. Because of that they no
+longer match the R ``lostruct`` package number for number: pg_gpu keeps
+one column per allele where R keeps one per site, and the two center
+the data differently, which shifts the scale of the eigenvalues.
+
+The directions the components point in still agree with R closely
+(correlations above 0.999 in the test suite), so window-to-window
+comparisons, the MDS plot, and outlier detection all behave the same.
+It is the absolute eigenvalue scale that differs, not the structure you
+would read off the plot.
+
+``pairwise_distance`` counts, for each pair of haplotypes, how many
+sites they differ at (skipping sites where either is missing). Call
+that count :math:`m`. Then ``cityblock`` and ``sqeuclidean`` both
+return :math:`m`, and ``euclidean`` returns :math:`\sqrt{m}`. Counting
+mismatches this way means the answer does not depend on how the alleles
+were numbered. Any other metric raises ``NotImplementedError``.
+
 Relatedness and Kinship
 -----------------------
 
@@ -378,12 +459,39 @@ Relatedness and Kinship
    * - Function
      - Description
      - Reference
+   * - ``genetic_relatedness``
+     - How much two groups of samples share alleles, relative to the
+       average across groups. Matches
+       ``TreeSequence.genetic_relatedness``. Takes a ``HaplotypeMatrix``.
+     -
    * - ``grm``
-     - Genetic Relationship Matrix
+     - Genetic Relationship Matrix (GCTA). Takes a ``GenotypeMatrix``.
      - Yang et al. (2011)
    * - ``ibs``
-     - Pairwise Identity by State proportions
+     - Pairwise Identity by State proportions (PLINK). Takes a
+       ``GenotypeMatrix``.
      -
+
+``genetic_relatedness`` is the general-purpose one. It already counts
+alleles separately, so it works on multiallelic sites without any
+special handling. You choose what a "sample" means by grouping
+haplotypes:
+
+* leave the grouping out and every haplotype is its own sample, giving
+  a haplotype-by-haplotype matrix;
+* group haplotypes in pairs to get relatedness between individuals;
+* group them by population to get relatedness between populations.
+
+``grm`` and ``ibs`` are the two classic diploid measures -- the GCTA
+relationship matrix and PLINK-style identity by state. Both need a
+``GenotypeMatrix`` (or a streaming one). Handing them haplotypes raises
+a ``TypeError`` that points you at the alternative. To use them on
+haplotype data, convert first::
+
+   gm = GenotypeMatrix.from_haplotype_matrix(h)
+   k = grm(gm)
+
+Or use ``genetic_relatedness`` instead, which needs no conversion.
 
 Distance Distribution Statistics
 ---------------------------------
@@ -396,7 +504,10 @@ Distance Distribution Statistics
      - Description
      - Reference
    * - ``pairwise_diffs``
-     - Pairwise Hamming distances (haploid or diploid)
+     - Number of sites at which each pair differs, skipping sites where
+       either one is missing. The haplotype version compares alleles
+       directly, so it works with any number of alleles; the diploid
+       version works on two-allele sites only.
      -
    * - ``dist_var``
      - Variance of pairwise distance distribution
@@ -447,8 +558,10 @@ What runs on a streaming matrix:
      - Same per-chunk accumulation, but the joint SFS is projected (via hypergeometric sampling) to a small target grid as it is built, so the full ``(n1+1, n2+1)`` histogram is never materialized.
    * - ``HaplotypeMatrix.compute_ld_statistics_gpu_single_pop`` / ``_two_pops``
      - Variant-pair statistics within ``max_bp_dist`` are summed per chunk into the bp bins. Pairs that fall on opposite sides of a chunk boundary would be missed by naive per-chunk sums, so the last ``max_bp_dist`` of one chunk is carried forward and paired with the start of the next, counted exactly once. Returns moments-LD ``DD``, ``Dz``, ``pi²`` (3 stats single-pop, 15 stats two-pop).
-   * - ``relatedness.ibs``, ``relatedness.grm``
+   * - ``relatedness.ibs``, ``relatedness.grm`` (``StreamingGenotypeMatrix``)
      - Streamed along the variant axis; the individual axis is tiled into row blocks. ``(n_ind, n_ind)`` accumulators live on host so the output can exceed GPU memory. ``grm`` is a two-pass operation (first to calculate chromosome-wide allele frequencies, second to accumulate a per-chunk outer product).
+   * - ``relatedness.genetic_relatedness`` (``StreamingHaplotypeMatrix``)
+     - One pass along the variants, adding each chunk's contribution into an ``(n, n)`` result kept in CPU memory -- the same approach as the streaming GRM and IBS above.
    * - ``StreamingHaplotypeMatrix.materialize(region, sample_subset)``
      - Pulls one sub-region (and optionally a subset of haplotypes) of the chromosome into GPU memory for kernels that need every variant simultaneously -- ``pairwise_r2``, Garud's H, or any custom recipe. 
    * - ``zarr_io.allel_zarr_to_vcz``
@@ -458,7 +571,9 @@ Fused Windowed Statistics
 -------------------------
 
 The ``windowed_analysis()`` function computes statistics across all genomic
-windows in a single GPU pass via fused CUDA kernels.
+windows in a single GPU pass via fused CUDA kernels. That fast path
+needs ``missing_data='include'``. With any other setting pg_gpu quietly
+falls back to a slower route that produces the same numbers.
 
 .. list-table::
    :header-rows: 1
@@ -473,20 +588,59 @@ windows in a single GPU pass via fused CUDA kernels.
    * - ``tajimas_d``
      - Tajima's D per window
    * - ``segregating_sites``
-     - Segregating site count per window
+     - Number of mutations per window (a site with 3 alleles counts as 2)
    * - ``singletons``
-     - Singleton count per window
-   * - ``fst``
+     - Number of alternate alleles seen exactly once in the window
+   * - ``theta_h``, ``fay_wu_h``
+     - Fay & Wu's theta_H and H per window
+   * - ``max_daf``
+     - Frequency of the most common alternate allele in the window
+   * - ``fst``, ``fst_hudson``
      - Hudson's FST per window
    * - ``fst_wc``
-     - Weir-Cockerham FST per window
+     - Weir-Cockerham FST per window (treats data as haploid; see below)
    * - ``dxy``
      - Absolute divergence per window
    * - ``da``
      - Net divergence per window
    * - ``garud_h1``, ``garud_h12``, ``garud_h123``, ``garud_h2h1``
      - Garud's H statistics per window
+   * - ``haplotype_count``
+     - Number of distinct haplotypes per window
    * - ``mean_nsl``
-     - Mean nSL per window
+     - Mean nSL per window, averaged over every finite (site, allele) score
+   * - ``zns``, ``omega``, ``mu_ld``
+     - Per-window LD summaries
+   * - ``mu_var``, ``mu_sfs``, ``daf_hist``
+     - Features used by RAiSD and diploSHIC. ``daf_hist`` is a histogram
+       of alternate-allele frequencies in the window, scaled to sum to 1.
+       ``mu_sfs`` is the fraction of variable alleles sitting at the very
+       low or very high end of the frequency range, and is 0.0 for a
+       window with nothing variable in it. Both need
+       ``missing_data='include'``.
+   * - ``snp_dist_mean``, ``snp_dist_var``, ``snp_dist_min``, ``snp_dist_max``
+     - Inter-SNP spacing summaries per window
+   * - ``dist_var``, ``dist_skew``, ``dist_kurt``
+     - Moments of the pairwise-distance distribution per window
    * - ``local_pca``
      - Per-window local PCA (lostruct); returns a ``LocalPCAResult`` with eigvals, eigvecs, and window metadata
+
+The rule to expect is that a windowed statistic gives the same answer
+as calling the plain function on just that window's variants. Alleles
+are counted separately here too, the same as everywhere else. There are
+two known exceptions:
+
+* Windowed ``fst_wc`` treats the data as haploid, so it will not match
+  the plain ``fst_weir_cockerham``, which treats it as diploid. This
+  holds even for two-allele data.
+* When data is missing, the windowed neutrality tests (``tajimas_d``,
+  ``normalized_fay_wu_h``, ``zeng_e``, ``zeng_dh``) use the full sample
+  size in their variance formula, while the plain versions use an
+  average of the per-site sample sizes. Without missing data the two
+  agree.
+
+One more limit: the windowed kernels can handle at most 8 alleles at a
+single site. Anything beyond that is skipped, and a
+``MultiallelicCapWarning`` tells you how many sites that affected. DNA
+has 4 bases, so in practice this never comes up. The plain
+``diversity`` and ``divergence`` functions have no such limit.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,7 +30,7 @@ Key Features
 ~~~~~~~~~~~~
 
 * **Fast GPU computation** using CuPy with fused CUDA kernels for compute-intensive operations
-* **Comprehensive statistics**: LD (D, D-squared, Dz, pi2, r/r-squared), diversity (pi, theta, Tajima's D, heterozygosity, Fay & Wu's H), divergence (FST Hudson/Weir-Cockerham/Nei, Dxy, Da, Snn, Gmin, dd, dd_rank, Zx), selection scans (iHS, XP-EHH, nSL, XP-nSL, Garud's H, EHH decay), SFS (unfolded, folded, joint, scaled), admixture (Patterson's F2, F3, D)
+* **Comprehensive statistics**: LD (D, D-squared, Dz, pi2, r/r-squared), diversity (pi, theta, Tajima's D, heterozygosity, Fay & Wu's H), divergence (FST Hudson/tskit/Weir-Cockerham/Nei, Dxy, Da, Snn, Gmin, dd, dd_rank, Zx), selection scans (iHS, XP-EHH, nSL, XP-nSL, Garud's H, EHH decay), SFS (unfolded, folded, joint, scaled), admixture (Patterson's F2, F3, F4, D)
 * **Fused windowed analysis**: compute all statistics across all genomic windows in a single GPU pass -- up to 60x faster than scikit-allel
 * **Automatic missing data handling** across all modules
 * **Quality-aware filtering** -- load VCF FORMAT / INFO arrays (``GQ``, ``DP``, ``MQ``, ...) with ``fields=``, mask variants and genotypes from them, and round-trip the survivors into a clean VCZ. See :doc:`tutorials/qc_fields`.

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -25,16 +25,19 @@ What's in the box
 
 * **Diversity** -- :math:`\pi`, Watterson's :math:`\theta`,
   Tajima's D, Fay-Wu's H, Zeng's E, Achaz framework theta estimators,
-  heterozygosity, AFS.
-* **Divergence** -- F\ :sub:`ST` (Hudson / Weir-Cockerham / Nei),
+  heterozygosity.
+* **Frequency spectra** -- folded and unfolded, one or two
+  populations, with projection to a smaller sample size.
+* **Divergence** -- F\ :sub:`ST` (Hudson / tskit / Weir-Cockerham / Nei),
   d\ :sub:`xy`, d\ :sub:`a`, PBS, S\ :sub:`nn`, G\ :sub:`min`, dd, Z\ :sub:`x`.
 * **Selection** -- iHS, nSL, XP-EHH, XP-nSL, EHH decay, Garud's H.
 * **LD** -- pairwise r\ :sup:`2`, ZnS, omega, sigma_D\ :sup:`2`,
   windowed LD decay, two-population moments-LD compatible with
   ``moments.LD``.
-* **Admixture** -- Patterson's F2 / F3 / D, with block-jackknife
+* **Admixture** -- Patterson's F2 / F3 / F4 / D, with block-jackknife
   wrappers.
-* **Structure** -- PCA, randomized PCA, PCoA, GRM,
+* **Structure** -- PCA on haplotypes or on diploid genotypes (each with
+  a faster approximate version), PCoA, relatedness matrices (GRM, IBS),
   local PCA / lostruct.
 * **Resampling** -- general-purpose ``block_jackknife`` and
   ``block_bootstrap`` (including the ratio-of-sums case).

--- a/docs/source/missing_data.rst
+++ b/docs/source/missing_data.rst
@@ -103,7 +103,7 @@ Most sites in a real dataset have two alleles: the reference base and
 one alternate. A few have three or four. Those are called
 **multiallelic** sites, and they need a little care.
 
-pg_gpu stores each haplotype's allele as a small whole number. ``0``
+pg_gpu stores each haplotype's allele as an integer. ``0``
 means the reference base, ``1`` the first alternate, ``2`` the second,
 and so on. Missing data is ``-1``.
 
@@ -160,8 +160,8 @@ against older results or against another tool.
   ``daf_histogram`` whenever invariant sites are in your matrix. No
   theta estimator changes, because none of them uses those two bins.
 
-* **Folded spectra are returned as decimals** (``float64``) rather than
-  whole numbers. On two-allele data the values still come out whole, so
+* **Folded spectra are returned as floating point numbers** (``float64``) rather than
+  integers. On two-allele data the values still come out whole, so
   only the array's type changes. On a multiallelic site each allele is
   folded on its own and contributes one half, so you will see genuine
   half-counts there. For example, a site with three alleles at counts
@@ -196,11 +196,11 @@ of them throws multiallelic sites away, it tells you how many with a
 ``BiallelicOnlyWarning``, so you do not mistake a partial answer for a
 complete one.
 
-Right now that means ``admixture.patterson_d`` and the
+That means ``admixture.patterson_d`` and the
 ``GenotypeMatrix`` loaders described below. If you want a statistic like
 Patterson's D that does handle multiallelic sites, use
 ``admixture.patterson_f4``, which measures the same thing without the
-restriction.
+restriction, at the expense of normalization (it is not bounded in [-1, 1]).
 
 To turn the warning off:
 
@@ -214,7 +214,7 @@ To turn the warning off:
 There is a second, unrelated warning called ``MultiallelicCapWarning``.
 It does *not* mean a statistic is two-allele-only. It means a windowed
 calculation that normally handles multiallelic sites just fine hit its
-internal limit of 8 alleles at one site. DNA has 4 bases, so you will
+internal limit of 8 alleles at one site and discarded the site. DNA has 4 bases, so you will
 almost certainly never see it.
 
 Some other statistics are two-allele-only but never have to drop
@@ -249,7 +249,7 @@ which one you use.
   which keeps the rows lined up for the streaming reader. Either way
   you get a ``BiallelicOnlyWarning`` with the count.
 
-* **Sites where nothing varies are kept.** Loaders load your data as it
+* **Sites with no variation (a single present allele) are kept.** Loaders load your data as it
   is; throwing away uninformative sites is
   ``apply_biallelic_filter``'s job, not theirs.
 

--- a/docs/source/missing_data.rst
+++ b/docs/source/missing_data.rst
@@ -77,7 +77,7 @@ Every public function accepts the ``missing_data`` parameter:
    * - SFS (sfs, joint_sfs, folded variants)
      - per-site n
      - filter sites
-   * - Admixture (patterson_d, f2, f3)
+   * - Admixture (patterson_d, f2, f3, f4)
      - per-site n
      - filter sites
    * - Selection scans (ihs, nsl, xpehh)
@@ -87,7 +87,7 @@ Every public function accepts the ``missing_data`` parameter:
      - wildcard match
      - filter sites
    * - Distance (pairwise_diffs, pca)
-     - per-pair norm
+     - per-pair, over jointly non-missing sites
      - filter sites
    * - LD (zns, omega)
      - per-site n
@@ -99,30 +99,186 @@ Every public function accepts the ``missing_data`` parameter:
 Multiallelic Sites
 ------------------
 
-pg_gpu encodes haplotype alleles as integers: ``0`` = reference,
-``1`` = first alternate, ``2`` = second alternate, etc. Missing data
-is ``-1``.
+Most sites in a real dataset have two alleles: the reference base and
+one alternate. A few have three or four. Those are called
+**multiallelic** sites, and they need a little care.
 
-For derived allele counting (used by all SFS-based statistics),
-any non-reference allele is treated as derived: allele values
-1, 2, 3, etc. all contribute 1 to the derived allele count. This
-is the standard "reference vs any alternate" folding used by most
-population genetics tools.
+pg_gpu stores each haplotype's allele as a small whole number. ``0``
+means the reference base, ``1`` the first alternate, ``2`` the second,
+and so on. Missing data is ``-1``.
 
-This means multiallelic VCF sites are handled correctly without
-filtering -- a site with REF=A, ALT=T,C where some samples carry
-the C allele will count all non-reference haplotypes as derived.
+Each allele is counted on its own
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you need strictly biallelic data (e.g., for LD statistics or
-compatibility with other tools), use ``apply_biallelic_filter()``:
+Suppose a site has reference ``A`` and two alternates, ``T`` and ``C``.
+Across 10 haplotypes you observe 6 A's, 3 T's, and 1 C.
+
+One way to handle this is to lump the alternates together and say "4 of
+10 haplotypes are non-reference". **pg_gpu does not do that.** It keeps
+T and C apart and counts each separately: T is at 3/10, C is at 1/10.
+
+Lumping them would be misleading, because T and C are two different
+mutations with two different histories. Treating them as one allele at
+frequency 4/10 describes a variant that does not exist. Counting them
+separately is also what ``tskit`` does, so :math:`\pi`, the theta
+estimators, Tajima's D, Fay-Wu's H, Zeng's E, and every SFS function
+give the same answer here that ``tskit`` would.
+
+Two things follow from this.
+
+**A three-allele site counts as two mutations.** It takes two mutations
+to produce three different alleles, so that site adds 2 to
+``segregating_sites`` rather than 1. In general a site with :math:`k`
+alleles adds :math:`k - 1`. ``theta_w`` and Tajima's D use the same
+count. On ordinary two-allele data this is just the number of variable
+sites, as you would expect. On multiallelic data it is larger -- and
+larger than what scikit-allel reports, which counts variable sites
+rather than mutations.
+
+**Frequencies are per allele.** For the site above, the frequency
+spectrum gets one entry at 3 and another at 1 -- not a single entry at
+4. Likewise ``max_daf`` reports the most common alternate (3/10 here),
+and ``daf_histogram`` records one frequency for T and one for C.
+
+If your data is entirely two-allele, none of this changes anything. A
+site with one alternate has nothing to keep apart, so these rules give
+the familiar answers.
+
+.. _sfs-conventions:
+
+Three SFS rules that also affect two-allele data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The frequency-spectrum functions follow ``tskit`` on three points.
+Unlike everything above, these change the output even when every site
+has just two alleles, so they are worth reading if you are comparing
+against older results or against another tool.
+
+* **Sites where nothing varies are left out.** If every haplotype
+  carries the same allele, the site contributes nothing -- not to the
+  first bin, not to the last. This changes ``sfs`` and
+  ``daf_histogram`` whenever invariant sites are in your matrix. No
+  theta estimator changes, because none of them uses those two bins.
+
+* **Folded spectra are returned as decimals** (``float64``) rather than
+  whole numbers. On two-allele data the values still come out whole, so
+  only the array's type changes. On a multiallelic site each allele is
+  folded on its own and contributes one half, so you will see genuine
+  half-counts there. For example, a site with three alleles at counts
+  3, 2, and 1 out of 6 folds to ``0.5`` in each of three bins.
+
+* **``joint_sfs_folded`` folds the site once, not each population
+  separately.** The site is folded using its overall minor allele, so
+  every cell in the result refers to one specific allele.
+  scikit-allel folds each population's axis on its own, which can put
+  two different alleles into the same cell. The result is a full
+  ``(n1 + 1, n2 + 1)`` grid rather than the smaller
+  ``(n1 // 2 + 1, n2 // 2 + 1)``.
+
+Which value to trust on multiallelic data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The plain functions -- ``diversity.pi``, ``diversity.tajimas_d``, and
+friends -- are the ones to trust. They match ``tskit`` exactly.
+
+``FrequencySpectrum`` also offers :math:`\pi`, Tajima's D, and Fay-Wu's
+H, but on multiallelic data these are close approximations rather than
+exact. The reason is that a frequency spectrum records *how many* sites
+sit at each frequency, but not *which alleles came from the same site*,
+and you need that grouping to get :math:`\pi` exactly right. On
+two-allele data the two routes agree exactly.
+
+Statistics that only work on two-allele sites
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A few statistics are only defined for sites with two alleles. When one
+of them throws multiallelic sites away, it tells you how many with a
+``BiallelicOnlyWarning``, so you do not mistake a partial answer for a
+complete one.
+
+Right now that means ``admixture.patterson_d`` and the
+``GenotypeMatrix`` loaders described below. If you want a statistic like
+Patterson's D that does handle multiallelic sites, use
+``admixture.patterson_f4``, which measures the same thing without the
+restriction.
+
+To turn the warning off:
 
 .. code-block:: python
 
-   h = h.apply_biallelic_filter()  # keeps only 0/1 sites
+   import warnings
+   from pg_gpu import BiallelicOnlyWarning
 
-This is available on both ``HaplotypeMatrix`` and ``GenotypeMatrix``.
-Note that ``GenotypeMatrix.from_vcf()`` applies this filter
-automatically during loading.
+   warnings.filterwarnings("ignore", category=BiallelicOnlyWarning)
+
+There is a second, unrelated warning called ``MultiallelicCapWarning``.
+It does *not* mean a statistic is two-allele-only. It means a windowed
+calculation that normally handles multiallelic sites just fine hit its
+internal limit of 8 alleles at one site. DNA has 4 bases, so you will
+almost certainly never see it.
+
+Some other statistics are two-allele-only but never have to drop
+anything, because the restriction was already applied when the data was
+loaded. ``relatedness.grm``, ``relatedness.ibs``, the dosage PCA, and
+``distance_stats.pairwise_diffs_diploid`` all take a ``GenotypeMatrix``,
+which only ever holds two-allele sites. The LD statistics apply their
+own filter.
+
+What the ``GenotypeMatrix`` loaders keep
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``GenotypeMatrix.from_vcf``, ``GenotypeMatrix.from_zarr``, and
+``GenotypeMatrix.from_haplotype_matrix`` all agree on what counts as a
+two-allele site, so the same data gives you the same matrix no matter
+which one you use.
+
+* **A site is kept if at most two different alleles actually show up in
+  the data.** What matters is how many distinct alleles are present,
+  not which numbers they happen to be. A site where you only see
+  alleles ``0`` and ``2`` is kept. So is a site showing only ``1`` and
+  ``2``, which can happen after you subset to a few samples and the
+  reference allele disappears.
+
+* **The genotype value is a count of the alternate allele**, giving the
+  usual 0, 1, or 2 per individual. Allele ``0`` is the reference and the
+  alternate is the highest-numbered allele present.
+
+* **Sites with three or more alleles cannot be written as a 0/1/2
+  count**, so they are removed. ``from_vcf`` drops the site outright;
+  the zarr loaders instead mark the whole site as missing (``-1``),
+  which keeps the rows lined up for the streaming reader. Either way
+  you get a ``BiallelicOnlyWarning`` with the count.
+
+* **Sites where nothing varies are kept.** Loaders load your data as it
+  is; throwing away uninformative sites is
+  ``apply_biallelic_filter``'s job, not theirs.
+
+Ordinary data using only alleles ``0`` and ``1`` is unaffected by all of
+this and loads without any warning.
+
+Filtering down to two-allele sites yourself
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``apply_biallelic_filter()`` does two different jobs depending on which
+matrix you call it on. The name is the same for backwards
+compatibility, but the behavior is not.
+
+On a ``HaplotypeMatrix`` it keeps only the sites that show exactly
+alleles ``0`` and ``1`` and nothing else. This is the filter ``moments``
+uses, and what the LD statistics expect:
+
+.. code-block:: python
+
+   h = h.apply_biallelic_filter()   # keep only 0/1 sites
+
+On a ``GenotypeMatrix`` there is nothing to filter -- it only ever holds
+two-allele sites already. So instead it drops sites where nothing
+varies, keeping those where the alternate allele is present but not
+fixed and at least two individuals were called:
+
+.. code-block:: python
+
+   gm = gm.apply_biallelic_filter()  # drop sites that aren't variable
 
 LD Estimator Choice
 -------------------
@@ -247,6 +403,12 @@ and the mask can be swapped or removed at any time.
 
 * The mask stays on CPU and uses a lazy prefix-sum for O(1) range
   queries, so windowed analysis over many windows is efficient.
+
+* A mask given to ``from_zarr`` as ``accessible_bed`` works the same
+  whether the data is loaded all at once or streamed in pieces, and for
+  both ``HaplotypeMatrix`` and ``GenotypeMatrix``. Streaming applies the
+  mask to each piece as it arrives, so you get exactly the same numbers
+  either way.
 
 Site Count Properties
 ---------------------

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -136,8 +136,9 @@ Diversity Statistics
    ho = diversity.heterozygosity_observed(h)
    f = diversity.inbreeding_coefficient(h)
 
-   # Allele frequency spectrum
-   afs = diversity.allele_frequency_spectrum(h)
+   # Allele frequency spectrum -- see the sfs module
+   from pg_gpu import sfs
+   afs = sfs.sfs(h)
 
    # Population-specific
    pi_pop1 = diversity.pi(h, population='pop1')
@@ -175,7 +176,12 @@ Divergence Statistics
 
    from pg_gpu import divergence
 
+   # There are four FST estimators. They use the same ingredients but
+   # combine them differently, so they give slightly different numbers.
+   # method= picks one: 'hudson' (default), 'tskit', 'weir_cockerham',
+   # or 'nei'. Use 'hudson' unless you have a reason not to.
    fst = divergence.fst(h, 'pop1', 'pop2')
+   fst_tskit = divergence.fst(h, 'pop1', 'pop2', method='tskit')
    dxy_val = divergence.dxy(h, 'pop1', 'pop2')
 
    # Population Branch Statistic (3 populations)
@@ -205,14 +211,16 @@ Selection Scans
 
    from pg_gpu import selection
 
-   # Integrated haplotype score
+   # Integrated haplotype score: one value per site for ordinary
+   # two-allele data. If any site has more than two alleles you get one
+   # column per alternate allele instead -- see the Features page.
    ihs_scores = selection.ihs(h)
    ihs_std = selection.standardize(ihs_scores)
 
    # Cross-population EHH
    xpehh_scores = selection.xpehh(h, 'pop1', 'pop2')
 
-   # nSL (no distance weighting)
+   # nSL (no distance weighting); same output shape rule as ihs
    nsl_scores = selection.nsl(h)
 
    # Garud's H statistics
@@ -237,7 +245,13 @@ Site Frequency Spectrum
 
    # Joint SFS (two populations)
    j = sfs.joint_sfs(h, 'pop1', 'pop2')
-   j_folded = sfs.joint_sfs_folded(h, 'pop1', 'pop2')
+   j_folded = sfs.joint_sfs_folded(h, 'pop1', 'pop2')  # (n1+1, n2+1), float64
+
+If a site has more than one alternate allele, each one gets counted
+separately rather than being lumped together. Sites where nothing
+varies are left out. See :ref:`sfs-conventions` for the details --
+including a few that change the answer even for ordinary two-allele
+data.
 
 Admixture / F-Statistics
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -261,7 +275,14 @@ combine-and-jackknife step for you.
        h, 'test_pop', 'source1', 'source2')
    f3_star = np.nansum(f3_numer) / np.nansum(f3_denom)
 
+   # Patterson's F4: tests whether four populations fit a given tree
+   f4 = admixture.patterson_f4(h, 'popA', 'popB', 'popC', 'popD')
+
    # Patterson's D (ABBA-BABA): per-site numerator and denominator.
+   # D only works on sites with two alleles. Sites with more are
+   # skipped, and a warning tells you how many. If that matters for
+   # your data, use patterson_f4 above -- it measures the same signal
+   # and handles every site.
    d_numer, d_denom = admixture.patterson_d(
        h, 'popA', 'popB', 'popC', 'popD')
 
@@ -329,13 +350,37 @@ PCA and Distance
 
 .. code-block:: python
 
-   from pg_gpu import decomposition
+pg_gpu has two PCAs. Pick based on what your samples are:
 
-   # PCA (GPU-accelerated SVD)
+* **One point per haplotype:** use ``pca`` (or ``randomized_pca`` for a
+  faster approximation) on a ``HaplotypeMatrix``. Every allele gets its
+  own column, so this works no matter how many alleles a site has, and
+  at any ploidy.
+
+* **One point per individual:** use ``pca_dosage`` (or
+  ``randomized_pca_dosage``) on a ``GenotypeMatrix``. This is the
+  classical diploid PCA, counting each individual's alternate alleles
+  as 0, 1, or 2 and scaling each variant by how variable it is. It
+  gives the same answer as scikit-allel.
+
+Passing the wrong matrix type raises a ``TypeError`` that tells you
+which function you wanted.
+
+.. code-block:: python
+
+   from pg_gpu import decomposition, GenotypeMatrix
+
+   # One point per haplotype
    coords, var_ratio = decomposition.pca(h, n_components=10)
 
-   # Randomized PCA (faster for large datasets)
+   # Same thing, approximated -- much faster on large datasets
    coords, var_ratio = decomposition.randomized_pca(h, n_components=10)
+
+   # One point per individual
+   gm = GenotypeMatrix.from_haplotype_matrix(h)
+   coords, var_ratio = decomposition.pca_dosage(gm, n_components=10)
+   coords, var_ratio = decomposition.randomized_pca_dosage(
+       gm, n_components=10)
 
    # Pairwise genetic distance
    dist = decomposition.pairwise_distance(h, metric='euclidean')
@@ -432,10 +477,20 @@ automatically routes through fused kernels when possible.
 
 Supported fused windowed statistics:
 
-- **Single-pop**: ``pi``, ``theta_w``, ``tajimas_d``, ``segregating_sites``, ``singletons``
+- **Single-pop**: ``pi``, ``theta_w``, ``tajimas_d``, ``segregating_sites``, ``singletons``, ``theta_h``, ``fay_wu_h``, ``max_daf``
 - **Two-pop**: ``fst``, ``fst_hudson``, ``fst_wc``, ``dxy``, ``da``
-- **Selection**: ``garud_h1``, ``garud_h12``, ``garud_h123``, ``garud_h2h1``, ``mean_nsl``
+- **Selection**: ``garud_h1``, ``garud_h12``, ``garud_h123``, ``garud_h2h1``, ``haplotype_count``, ``mean_nsl``
+- **LD**: ``zns``, ``omega``, ``mu_ld``
+- **diploSHIC / RAiSD**: ``mu_var``, ``mu_sfs``, ``daf_hist``, ``snp_dist_mean``, ``snp_dist_var``, ``snp_dist_min``, ``snp_dist_max``, ``dist_var``, ``dist_skew``, ``dist_kurt``
 - **Structure**: ``local_pca`` (lostruct); returns a ``LocalPCAResult`` rather than a scalar-stat DataFrame. See the `Local PCA / lostruct`_ section.
+
+The single-pass fused kernels need ``missing_data='include'``. With any
+other setting pg_gpu falls back to a slower route that computes the
+same values, so your results do not change -- only the speed.
+
+A windowed statistic should give you the same number as calling the
+plain function on just that window's variants. See :doc:`features` for
+the two cases where that is not quite true.
 
 For advanced usage with custom bin edges, use ``windowed_statistics_fused()``
 directly:

--- a/docs/source/tutorials/admixture_detection.rst
+++ b/docs/source/tutorials/admixture_detection.rst
@@ -66,6 +66,10 @@ calibration check. A few directions to extend:
 * **Different statistic.** ``average_patterson_d`` has a sibling
   ``average_patterson_f3`` for the F3 admixture test; the two share
   the ratio-of-sums structure, so the wrapper code is interchangeable.
+  Note that :math:`D` is only defined on sites with two alleles, so it
+  skips multiallelic sites and warns about how many. If your data has
+  many of those, ``admixture.patterson_f4`` tests the same four-population
+  signal and uses every site.
 * **Different demographic model.** Edit the ``msprime`` model to add
   bottlenecks, varying admixture proportions, ghost populations, etc.
   This is also the right structure for calibrating a statistic on

--- a/docs/source/tutorials/biobank_streaming.rst
+++ b/docs/source/tutorials/biobank_streaming.rst
@@ -92,8 +92,12 @@ Statistics that combine across chunks naturally:
   does not fit (``sfs.project_joint_sfs``),
 * moments-LD pair bins (``DD``, ``Dz``, ``pi2``, derived
   :math:`\sigma_D^2`),
-* identity by state (``relatedness.ibs``) and the genetic
-  relationship matrix (``relatedness.grm``).
+* relatedness between samples or groups of samples
+  (``relatedness.genetic_relatedness``), which runs on a streaming
+  ``HaplotypeMatrix``,
+* identity by state (``relatedness.ibs``) and the genetic relationship
+  matrix (``relatedness.grm``). These are diploid measures, so they need
+  a streaming ``GenotypeMatrix`` rather than a haplotype one.
 
 Statistics that need every variant present at the same time --
 pairwise :math:`r^2` heatmaps, Garud's H hash tables -- cannot be
@@ -118,8 +122,8 @@ functions:
 
 .. code-block:: python
 
-   from pg_gpu import HaplotypeMatrix, windowed_analysis, sfs
-   from pg_gpu.relatedness import ibs, grm
+   from pg_gpu import HaplotypeMatrix, GenotypeMatrix, windowed_analysis, sfs
+   from pg_gpu.relatedness import genetic_relatedness, ibs, grm
 
    stream = HaplotypeMatrix.from_zarr(
        "biobank/chr15.vcz",
@@ -156,10 +160,18 @@ functions:
    )
 
    # Pairwise relatedness. The variant axis is streamed; the
-   # (n_indiv, n_indiv) output lives in CPU memory so the result
-   # itself can be larger than the GPU can hold.
-   ibs_mat = ibs(stream)
-   grm_mat = grm(stream)
+   # (n, n) output lives in CPU memory so the result itself can be
+   # larger than the GPU can hold.
+
+   # Sample-set relatedness works directly on the haplotype stream.
+   rel = genetic_relatedness(stream)
+
+   # grm and ibs are diploid measures, so they need a GenotypeMatrix.
+   # Open the same store as one rather than converting after the fact.
+   gstream = GenotypeMatrix.from_zarr("biobank/chr15.vcz",
+                                       streaming="always")
+   ibs_mat = ibs(gstream)
+   grm_mat = grm(gstream)
 
 The same code run on a fully loaded ``HaplotypeMatrix`` is
 unchanged -- the only difference is which kind of object
@@ -169,6 +181,19 @@ The ``pop_assignment`` kwarg accepts a path to a TSV, a dict mapping
 sample to population, a numpy array of labels (one per sample), or
 the name of a zarr key in the store that holds a 1-D population
 array. See ``HaplotypeMatrix.from_zarr`` for the full list.
+
+``from_zarr`` also takes ``accessible_bed`` on the streaming path. The
+mask is resolved once at load and attached to every chunk as it is
+produced, so both variant filtering and the span used for
+normalization match what you would get from a fully loaded matrix
+built from the same store:
+
+.. code-block:: python
+
+   stream = HaplotypeMatrix.from_zarr(
+       "biobank/chr15.vcz", streaming="always",
+       accessible_bed="chr15.accessible.bed",
+   )
 
 Pulling a sub-region into memory for kernels that need every variant at once
 ----------------------------------------------------------------------------

--- a/docs/source/tutorials/pg_gpu_skill_walkthrough.ipynb
+++ b/docs/source/tutorials/pg_gpu_skill_walkthrough.ipynb
@@ -676,10 +676,10 @@
     "\n",
     "*Skill action:*\n",
     "\n",
-    "*1. `HaplotypeMatrix.from_zarr(region='X:1-2000000', streaming='never')` then `.apply_biallelic_filter()` \u2014 PCA assumes 0/1 coding.*\n",
+    "*1. `HaplotypeMatrix.from_zarr(region='X:1-2000000', streaming='never')` then `.apply_biallelic_filter()`. `pca` itself handles any number of alleles; the filter is here because the LD pruning in step 3 expects 0/1 sites.*\n",
     "*2. Filter sites with **MAF > 0.05** \u2014 compute AF per site from `hm.haplotypes` (numpy), mask `-1` missing, drop monomorphic and rare. Subsumes 'segregating only'.*\n",
     "*3. `hm.locate_unlinked(size=100, step=20, threshold=0.1)` \u2192 `get_subset()` \u2014 LD-prune so PCs reflect population structure, not LD blocks.*\n",
-    "*4. `decomposition.randomized_pca(hm, n_components=10)` \u2014 faster than full SVD on big matrices.*\n",
+    "*4. `decomposition.randomized_pca(hm, n_components=10)` \u2014 a faster approximation of `decomposition.pca`. Both take a `HaplotypeMatrix` and give one point per haplotype. For one point per individual instead, use `decomposition.pca_dosage` on a `GenotypeMatrix`.*\n",
     "*5. Average per-haplotype coords to per-sample. **pg_gpu's VCZ-loaded matrix lays out the haplotype axis as `[hap0 of every sample, then hap1 of every sample]`** \u2014 sample `i`'s haplotypes are at rows `i` and `i + n_samples`, NOT at `2i` and `2i+1`. Average: `(coords[:n_samples] + coords[n_samples:]) / 2`.*\n",
     "*6. Merge with the metadata CSV on `sample_id`, scatter PC1 vs PC2 colored by `country`, `taxon`, `rdl_gt`.*\n"
    ]
@@ -1028,7 +1028,7 @@
     "*Skill action:*\n",
     "\n",
     "*1. For each population: `sfs.sfs(hm_stats, population=pop)` for the unfolded spectrum, `sfs.sfs_folded(hm_stats, population=pop)` for the folded.*\n",
-    "*2. Each returns a length-`n_haps+1` count vector. Drop the fixed bins (index 0 and index `n_haps`) for readability.*\n",
+    "*2. The unfolded spectrum has length `n_haps+1`; the folded one is about half that. Sites where nothing varies are already left out, so the first and last bins are zero and are sliced off only to tidy the plot.*\n",
     "*3. Plot all populations on log-y axes \u2014 side-by-side panels.*\n"
    ]
   },
@@ -1068,7 +1068,7 @@
     "    s_fo = pg_sfs.sfs_folded(hm_stats, population=pop)\n",
     "    s_un = s_un.get() if hasattr(s_un, 'get') else np.asarray(s_un)\n",
     "    s_fo = s_fo.get() if hasattr(s_fo, 'get') else np.asarray(s_fo)\n",
-    "    # Drop fixed bins (0 and n) for readability.\n",
+    "    # Trim the always-zero end bins so the log axis looks clean.\n",
     "    axes[0].plot(np.arange(1, len(s_un)-1), s_un[1:-1], label=pop, lw=1.2)\n",
     "    axes[1].plot(np.arange(1, len(s_fo)),   s_fo[1:],   label=pop, lw=1.2)\n",
     "for ax, title in zip(axes, ['Unfolded SFS', 'Folded SFS']):\n",

--- a/examples/pg_gpu_tour.ipynb
+++ b/examples/pg_gpu_tour.ipynb
@@ -389,7 +389,7 @@
    "source": [
     "## 7. PCA and Population Structure\n",
     "\n",
-    "Run PCA on the GPU to visualize population structure among samples."
+    "Run PCA on the GPU to visualize population structure. `decomposition.pca` takes a `HaplotypeMatrix` and gives one point per haplotype, so the 200 haplotypes below become 200 points. For one point per diploid individual instead, use `decomposition.pca_dosage` on a `GenotypeMatrix`."
    ]
   },
   {
@@ -400,7 +400,7 @@
    "outputs": [],
    "source": [
     "t0 = time.time()\n",
-    "coords, explained_var = decomposition.pca(h, n_components=4, scaler=\"patterson\")\n",
+    "coords, explained_var = decomposition.pca(h, n_components=4)\n",
     "pca_time = time.time() - t0\n",
     "\n",
     "print(f\"PCA computed in {pca_time:.1f}s\")\n",
@@ -491,8 +491,10 @@
     "nsl_time = time.time() - t0\n",
     "print(f\"nSL computed on {h.num_variants:,} variants in {nsl_time:.1f}s\")\n",
     "\n",
-    "# Standardize by derived allele count\n",
-    "dac, _ = sfs._derived_allele_counts(h)\n",
+    "# Standardize by alternate allele count. This dataset is biallelic\n",
+    "# (alleles 0 and 1 only), so the per-site alternate count is just the\n",
+    "# number of 1s; missing calls are -1 and are excluded by the comparison.\n",
+    "dac = (h.haplotypes == 1).sum(axis=0)\n",
     "dac_np = dac.get() if hasattr(dac, 'get') else np.asarray(dac)\n",
     "nsl_std, bins_used = selection.standardize_by_allele_count(nsl_scores, dac_np)\n",
     "\n",

--- a/pg_gpu/sfs.py
+++ b/pg_gpu/sfs.py
@@ -469,12 +469,6 @@ def joint_sfs_folded(haplotype_matrix: HaplotypeMatrix,
                      missing_data: str = 'include'):
     """Compute the folded joint site frequency spectrum.
 
-    Parameters
-    ----------
-    haplotype_matrix : HaplotypeMatrix
-    pop1, pop2 : str or list
-    missing_data : str
-
     Per-allele and conforming to tskit's ``allele_frequency_spectrum([popA,
     popB], polarised=False)``: each allele (ancestral included) is folded as a
     unit by the global minor and contributes weight 1/2 to the kept cell. The
@@ -482,6 +476,12 @@ def joint_sfs_folded(haplotype_matrix: HaplotypeMatrix,
     lower-total triangle; the rest is zero), with half-integer weights on
     multiallelic data. **This departs from scikit-allel's per-axis fold even on
     biallelic data** -- we pin to tskit here.
+
+    Parameters
+    ----------
+    haplotype_matrix : HaplotypeMatrix
+    pop1, pop2 : str or list
+    missing_data : str
 
     Returns
     -------

--- a/utils/genome_scan.py
+++ b/utils/genome_scan.py
@@ -267,9 +267,10 @@ def plot_genome_scan(windowed, sfs_results, hm, args):
         else:
             ax.set_xlabel(f"{region_label} position (Mb)", fontsize=8)
 
-    # right column: SFS
+    # right column: SFS. The spectrum omits fixed classes, so bins 0 and n
+    # are always empty; trim them so the bars fill the axes.
     sfs_arr = sfs_results["sfs"]
-    sfs_arr = sfs_arr[1:-1]  # exclude fixed classes
+    sfs_arr = sfs_arr[1:-1]
     rows_sfs = n_panels // 2
 
     ax_sfs = fig.add_subplot(gs[:rows_sfs, 1])


### PR DESCRIPTION
Brings the user-facing docs in line with the fourteen PRs merged onto
`nsp-multiallelic-trunk`, and repairs the two example scripts that the API changes broke.

Targets `nsp-multiallelic-trunk`, not `main`.

## Why

Statistics on this branch moved from collapsing every non-reference allele into one derived
class to counting each allele separately. The docs still described the old behaviour, documented
functions that no longer exist, and in two places showed code that now raises.

## Documentation

- **`missing_data`** -- the multiallelic section is rewritten around a worked example (a site
  with reference A and alternates T and C), covering per-allele counting, the mutation-count
  weighting of `segregating_sites`, the three SFS conventions that change output even on
  two-allele data, both new warning categories, the unified `GenotypeMatrix` loader rules, and
  the two different behaviours `apply_biallelic_filter` has depending on matrix type.
- **`features` / `quickstart`** -- the PCA entry points are split by input type, the per-allele
  `ihs` / `nsl` output shape is shown as code, the fused windowed statistic lists are corrected
  against the actual registry (they were missing 17 names), and `grm` / `ibs` are rescoped to
  `GenotypeMatrix`.
- **`api`** -- adds `fst_tskit`, `patterson_f4`, `genetic_relatedness`, the component accessors,
  the haploid/diploid `pairwise_diffs` entry points, and a Warnings section covering all five
  categories.
- **`biobank_streaming`** -- `grm` / `ibs` on a streaming `HaplotypeMatrix` now raises, so the
  example uses `genetic_relatedness` or a streaming `GenotypeMatrix`; documents `accessible_bed`
  on the streaming path.
- **`quickstart`** -- drops the removed `diversity.allele_frequency_spectrum`.
- **`changelog`** -- an unreleased section covering the branch.

Language throughout is aimed at a reader meeting these concepts for the first time.

## Examples

- **`pg_gpu_tour.ipynb`** -- two cells raised on current code. The PCA cell passed
  `scaler="patterson"`, dropped when `pca` moved to the all-allele haploid form; the nSL cell
  called `sfs._derived_allele_counts`, a private helper that no longer exists. Both fixed and
  executed against `examples/data/gamb.X.8-12Mb.n100.derived.vcf.gz` to confirm.
- **`utils/genome_scan.py`** -- the SFS trimming comment claimed the slice excluded the fixed
  classes. The spectrum already omits them, so the slice only trims empty bins.

## Library

One change outside `docs/`: the `joint_sfs_folded` docstring had its prose inside the numpydoc
Parameters block, which emitted two docutils warnings and broke that function's rendered API
page. Moving it above Parameters fixes the build. No behaviour change.

## Verification

Sphinx builds with zero warnings, `ruff` clean over `pg_gpu/ tests/ examples/ utils/`, and 95
tests pass across `test_multiallelic`, `test_sfs_allel_comparison`, and
`test_biallelic_only_warning`.

Documented claims were checked against the code rather than the PR descriptions. On a JC69
fixture with 4,434 multiallelic sites: `segregating_sites = 28694` equals `sum(alleles - 1)`
against 23,987 polymorphic sites, SFS bins 0 and n are both zero, `ihs` / `nsl` return
`(24281, 3)`, and the loaders keep `{0,2}` / `{1,2}` / monomorphic sites with the documented
dosages. The folded-spectrum half-weights were verified directly: a three-allele site at counts
3/2/1 out of 6 folds to `0.5` in three bins.

## Not included

- Stale stored outputs in `docs/source/tutorials/pg_gpu_skill_walkthrough.ipynb` (#173). Its
  prose is corrected here; regenerating the PCA figure needs the full Ag1000G dataset.
- `examples/admixture_detection.py` now emits a `BiallelicOnlyWarning`, since msprime's default
  mutation model produces a small number of multiallelic sites. Correct behaviour, left as is.
- A pre-existing three-population `Dz` disagreement with moments on the genotype path (#174),
  found while auditing the examples. Unrelated to this branch and present at the merge base.
