### PR TITLE
Cover the unphased genotype estimator in the momentsLD parity tests

### DIFF
--- a/tests/test_moments_ld.py
+++ b/tests/test_moments_ld.py
@@ -1,10 +1,22 @@
 """
 Tests for pg_gpu.moments_ld integration layer.
 
-Validates that pg_gpu produces the same LD and heterozygosity statistics
-as moments for a two-population IM model dataset.
+Validates that pg_gpu produces the same LD and heterozygosity statistics as
+moments, for both estimators: the phased haplotype estimator
+(``use_genotypes=False``) and the unphased genotype estimator
+(``use_genotypes=True``, which is what ``compute_ld_statistics`` defaults to).
+The two are different estimators of the same quantities, so each side must be
+run with the same setting as the other -- a mismatch silently compares apples to
+oranges rather than failing.
 
 Requires the 'moments' pixi environment: pixi run -e moments pytest tests/test_moments_ld.py
+
+Missing data is deliberately not covered on the genotype path. moments builds its
+0/1/2 dosages with ``to_n_alt()`` and no ``fill=`` argument, and scikit-allel
+defaults to ``fill=0``, so a missing call silently becomes homozygous reference;
+pg_gpu drops it from the per-pair sample count instead. The two are not
+comparable once any genotype is missing, so a parity assertion there would be
+pinning the wrong behavior.
 """
 
 import os
@@ -20,6 +32,7 @@ except (ImportError, AttributeError):
     pytest.skip("moments.LD not available (use pixi -e moments)",
                 allow_module_level=True)
 
+from pg_gpu import GenotypeMatrix
 from pg_gpu.moments_ld import (
     compute_ld_statistics,
     _compute_heterozygosity,
@@ -53,6 +66,24 @@ def gpu_stats():
     return compute_ld_statistics(
         VCF, pop_file=POP_FILE, pops=POPS,
         bp_bins=BP_BINS, use_genotypes=False, report=False,
+    )
+
+
+@pytest.fixture(scope="module")
+def moments_stats_geno():
+    """moments reference for the unphased genotype estimator."""
+    return moments.LD.Parsing.compute_ld_statistics(
+        VCF, pop_file=POP_FILE, pops=POPS,
+        bp_bins=BP_BINS, use_genotypes=True, report=False,
+    )
+
+
+@pytest.fixture(scope="module")
+def gpu_stats_geno():
+    """pg_gpu stats for the unphased genotype estimator."""
+    return compute_ld_statistics(
+        VCF, pop_file=POP_FILE, pops=POPS,
+        bp_bins=BP_BINS, use_genotypes=True, report=False,
     )
 
 
@@ -154,6 +185,50 @@ class TestPopAssignmentAlias:
             )
 
 
+@pytest.mark.slow
+class TestTwoPopGenotypeLD:
+    """The unphased genotype estimator on the same IM dataset.
+
+    Marked slow because moments' genotype pair loop over this VCF takes ~75 s;
+    the haplotype fixtures above cost about the same, so running both by default
+    would double the module's wall time.
+    """
+
+    def test_stats_names(self, gpu_stats_geno):
+        ld_names, het_names = gpu_stats_geno['stats']
+        assert ld_names == _ld_names(2)
+        assert het_names == _het_names(2)
+
+    def test_ld_bins_match(self, moments_stats_geno, gpu_stats_geno):
+        for m_bin, g_bin in zip(moments_stats_geno['bins'], gpu_stats_geno['bins']):
+            assert np.isclose(m_bin[0], g_bin[0])
+            assert np.isclose(m_bin[1], g_bin[1])
+
+    def test_ld_sums_match(self, moments_stats_geno, gpu_stats_geno):
+        for i in range(len(moments_stats_geno['bins'])):
+            np.testing.assert_allclose(
+                gpu_stats_geno['sums'][i], moments_stats_geno['sums'][i], rtol=1e-6,
+                err_msg=f"genotype LD sums mismatch in bin {i}")
+
+    def test_het_sums_match(self, moments_stats_geno, gpu_stats_geno):
+        np.testing.assert_allclose(
+            gpu_stats_geno['sums'][-1], moments_stats_geno['sums'][-1], rtol=1e-6,
+            err_msg="genotype heterozygosity sums mismatch")
+
+    def test_means_match_moments(self, moments_stats_geno, gpu_stats_geno):
+        means_m = moments.LD.Parsing.means_from_region_data(
+            {0: moments_stats_geno}, moments_stats_geno['stats'])
+        means_g = moments.LD.Parsing.means_from_region_data(
+            {0: gpu_stats_geno}, gpu_stats_geno['stats'])
+        for mm, mg in zip(means_m, means_g):
+            np.testing.assert_allclose(mg, mm, rtol=1e-6)
+
+    def test_differs_from_haplotype_estimator(self, gpu_stats, gpu_stats_geno):
+        """The two estimators are genuinely different, so a fixture that
+        silently ran the wrong one would not go unnoticed."""
+        assert not np.allclose(gpu_stats_geno['sums'][0], gpu_stats['sums'][0])
+
+
 class TestMomentsCompatibility:
     """Verify output can be fed into moments downstream functions."""
 
@@ -233,40 +308,42 @@ def _simulate_multipop_vcf(n_pops, n_samples=8, seq_len=30_000, seed=42):
     return vcf_file.name, pop_file.name, pops_list
 
 
-@pytest.fixture(scope="module")
-def three_pop_data():
-    """Simulate 3-population data and compute both moments and pg_gpu stats."""
-    vcf, pop_file, pops = _simulate_multipop_vcf(3)
+def _unlink_quietly(*paths):
+    for p in paths:
+        try:
+            os.unlink(p)
+        except FileNotFoundError:
+            pass
+
+
+def _multipop_data(n_pops, use_genotypes):
+    """Simulate n-population data and compute both moments and pg_gpu stats
+    under the same estimator."""
+    vcf, pop_file, pops = _simulate_multipop_vcf(n_pops)
     bp_bins = np.array([0, 1000, 5000, 15000, 30000], dtype=np.float64)
     try:
         m_stats = moments.LD.Parsing.compute_ld_statistics(
             vcf, pop_file=pop_file, pops=pops,
-            bp_bins=bp_bins, use_genotypes=False, report=False)
+            bp_bins=bp_bins, use_genotypes=use_genotypes, report=False)
         g_stats = compute_ld_statistics(
             vcf, pop_file=pop_file, pops=pops,
-            bp_bins=bp_bins, use_genotypes=False, report=False)
+            bp_bins=bp_bins, use_genotypes=use_genotypes, report=False)
         yield m_stats, g_stats, pops
     finally:
-        os.unlink(vcf)
-        os.unlink(pop_file)
+        # moments caches the parsed VCF alongside it as <stem>.h5 and reuses
+        # that file on a later run, so leaving it behind would let a stale
+        # cache shadow a regenerated VCF.
+        _unlink_quietly(vcf, pop_file, vcf.split(".vcf")[0] + ".h5")
 
 
-@pytest.fixture(scope="module")
-def four_pop_data():
-    """Simulate 4-population data and compute both moments and pg_gpu stats."""
-    vcf, pop_file, pops = _simulate_multipop_vcf(4)
-    bp_bins = np.array([0, 1000, 5000, 15000, 30000], dtype=np.float64)
-    try:
-        m_stats = moments.LD.Parsing.compute_ld_statistics(
-            vcf, pop_file=pop_file, pops=pops,
-            bp_bins=bp_bins, use_genotypes=False, report=False)
-        g_stats = compute_ld_statistics(
-            vcf, pop_file=pop_file, pops=pops,
-            bp_bins=bp_bins, use_genotypes=False, report=False)
-        yield m_stats, g_stats, pops
-    finally:
-        os.unlink(vcf)
-        os.unlink(pop_file)
+@pytest.fixture(scope="module", params=[False, True], ids=["hap", "geno"])
+def three_pop_data(request):
+    yield from _multipop_data(3, request.param)
+
+
+@pytest.fixture(scope="module", params=[False, True], ids=["hap", "geno"])
+def four_pop_data(request):
+    yield from _multipop_data(4, request.param)
 
 
 class TestThreePopLD:
@@ -335,3 +412,177 @@ class TestFourPopLD:
         assert len(means) == len(g['bins']) + 1
         for m in means:
             assert np.all(np.isfinite(m))
+
+
+# ---------------------------------------------------------------------------
+# Which sites the genotype path keeps
+# ---------------------------------------------------------------------------
+
+SMALL_VCF_SAMPLES = 16
+SMALL_VCF_POSITIONS = list(range(100, 100 + 200 * 16, 200))
+SMALL_VCF_POPS = ["popA", "popB"]
+SMALL_VCF_BINS = np.array([100, 500, 1500, 3200], dtype=np.float64)
+# The site whose two observed alleles are 0 and 2 rather than 0 and 1.
+ALT_CODED_POSITION = SMALL_VCF_POSITIONS[7]
+
+
+def _to_numpy(a):
+    return a.get() if hasattr(a, 'get') else np.asarray(a)
+
+
+def _write_small_vcf(directory, alt_coded):
+    """Write a phased diploid VCF of biallelic sites, optionally including one
+    site whose two observed alleles are 0 and 2 instead of 0 and 1.
+
+    Such a site is biallelic in the sample -- allele 1 is declared in ALT but
+    never called -- yet its allele codes are not {0, 1}. Mutation models that
+    can revert or re-hit a site produce these at a low rate, so whether any
+    given simulated dataset contains one is luck. Writing it by hand makes the
+    case deterministic.
+    """
+    rng = np.random.default_rng(20260806)
+    header = [
+        "##fileformat=VCFv4.2",
+        "##contig=<ID=1,length=5000>",
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t"
+        + "\t".join(f"s{i}" for i in range(SMALL_VCF_SAMPLES)),
+    ]
+    rows = []
+    for pos in SMALL_VCF_POSITIONS:
+        use_alt2 = alt_coded and pos == ALT_CODED_POSITION
+        alt_field, alt_code = ("C,G", 2) if use_alt2 else ("C", 1)
+        # Redraw until the site segregates; a monomorphic site is dropped by
+        # both sides and would leave the comparison with nothing to say.
+        while True:
+            haps = rng.binomial(1, 0.4, size=(SMALL_VCF_SAMPLES, 2))
+            if 0 < haps.sum() < 2 * SMALL_VCF_SAMPLES:
+                break
+        calls = "\t".join(f"{a * alt_code}|{b * alt_code}" for a, b in haps)
+        rows.append(f"1\t{pos}\t.\tA\t{alt_field}\t.\tPASS\t.\tGT\t{calls}")
+
+    suffix = "alt_coded" if alt_coded else "plain"
+    vcf_path = os.path.join(directory, f"{suffix}.vcf")
+    pop_path = os.path.join(directory, f"{suffix}_pops.txt")
+    with open(vcf_path, "w") as f:
+        f.write("\n".join(header + rows) + "\n")
+    with open(pop_path, "w") as f:
+        f.write("sample\tpop\n")
+        for i in range(SMALL_VCF_SAMPLES):
+            pop = SMALL_VCF_POPS[0] if i < SMALL_VCF_SAMPLES // 2 else SMALL_VCF_POPS[1]
+            f.write(f"s{i}\t{pop}\n")
+    return vcf_path, pop_path
+
+
+@pytest.fixture(scope="module")
+def alt_coded_vcf(tmp_path_factory):
+    return _write_small_vcf(str(tmp_path_factory.mktemp("alt_coded")), alt_coded=True)
+
+
+@pytest.fixture(scope="module")
+def plain_vcf(tmp_path_factory):
+    return _write_small_vcf(str(tmp_path_factory.mktemp("plain")), alt_coded=False)
+
+
+@pytest.fixture(scope="module")
+def alt_coded_stats(alt_coded_vcf):
+    vcf, pop_file = alt_coded_vcf
+    m_stats = moments.LD.Parsing.compute_ld_statistics(
+        vcf, pop_file=pop_file, pops=SMALL_VCF_POPS,
+        bp_bins=SMALL_VCF_BINS, use_genotypes=True, report=False)
+    g_stats = compute_ld_statistics(
+        vcf, pop_file=pop_file, pops=SMALL_VCF_POPS,
+        bp_bins=SMALL_VCF_BINS, use_genotypes=True, report=False)
+    return m_stats, g_stats
+
+
+class TestAltCodedSiteParity:
+    """A site whose observed alleles are {0, 2} must be handled the same way
+    pg_gpu and moments handle every other site, or the two accumulate LD over
+    different variant sets.
+
+    A single extra site is easy to overlook: it shifts DD and pi2, which are
+    sums of large same-sign terms, by well under a percent. Dz is signed and
+    cancels heavily, so the same site moves it by whole percent -- which reads
+    like a broken Dz estimator rather than a site-set difference.
+    """
+
+    def test_moments_drops_the_alt_coded_site(self, alt_coded_vcf):
+        """Pin the moments-side behavior this parity test is defined against:
+        moments keeps only sites whose observed alleles are exactly {0, 1}."""
+        vcf, _ = alt_coded_vcf
+        positions, *_ = moments.LD.Parsing.get_genotypes(vcf, use_h5=False, report=False)
+        assert ALT_CODED_POSITION not in set(np.asarray(positions).tolist())
+
+    def test_pg_gpu_keeps_the_same_sites_as_moments(self, alt_coded_vcf):
+        vcf, pop_file = alt_coded_vcf
+        gm = GenotypeMatrix.from_vcf(vcf)
+        assert ALT_CODED_POSITION not in set(_to_numpy(gm.positions).tolist())
+        assert gm.num_variants == len(SMALL_VCF_POSITIONS) - 1
+
+    def test_ld_sums_match(self, alt_coded_stats):
+        m, g = alt_coded_stats
+        for i in range(len(m['bins'])):
+            np.testing.assert_allclose(
+                g['sums'][i], m['sums'][i], rtol=1e-6,
+                err_msg=f"genotype LD sums mismatch in bin {i}")
+
+    def test_het_sums_match(self, alt_coded_stats):
+        m, g = alt_coded_stats
+        np.testing.assert_allclose(
+            g['sums'][-1], m['sums'][-1], rtol=1e-6,
+            err_msg="genotype heterozygosity mismatch")
+
+
+# ---------------------------------------------------------------------------
+# The haplotype_matrix= entry point on the genotype estimator
+# ---------------------------------------------------------------------------
+
+
+class TestHaplotypeMatrixGenotypePath:
+    """``compute_ld_statistics(haplotype_matrix=..., use_genotypes=True)`` goes
+    through ``GenotypeMatrix.from_haplotype_matrix``, so the conversion has to
+    recover the same individuals the VCF loader would have built.
+
+    ``HaplotypeMatrix`` stores ploidy 0 in rows ``0..n-1`` and ploidy 1 in rows
+    ``n..2n-1``; pairing rows the other way builds each "individual" from two
+    different people's chromosomes and scrambles the population assignment with
+    it, which no downstream statistic can detect.
+    """
+
+    def test_conversion_matches_vcf_genotypes(self, plain_vcf):
+        vcf, _ = plain_vcf
+        direct = GenotypeMatrix.from_vcf(vcf)
+        converted = GenotypeMatrix.from_haplotype_matrix(HaplotypeMatrix.from_vcf(vcf))
+        np.testing.assert_array_equal(
+            _to_numpy(converted.positions), _to_numpy(direct.positions))
+        np.testing.assert_array_equal(
+            _to_numpy(converted.genotypes), _to_numpy(direct.genotypes))
+
+    def test_conversion_preserves_sample_sets(self, plain_vcf):
+        vcf, pop_file = plain_vcf
+        direct = GenotypeMatrix.from_vcf(vcf)
+        direct.load_pop_file(pop_file, pops=SMALL_VCF_POPS)
+        hm = HaplotypeMatrix.from_vcf(vcf)
+        hm.load_pop_file(pop_file, pops=SMALL_VCF_POPS)
+        converted = GenotypeMatrix.from_haplotype_matrix(hm)
+        for pop in SMALL_VCF_POPS:
+            assert sorted(converted.sample_sets[pop]) == sorted(direct.sample_sets[pop])
+
+    def test_ld_sums_match_the_vcf_path(self, plain_vcf):
+        vcf, pop_file = plain_vcf
+        hm = HaplotypeMatrix.from_vcf(vcf)
+        hm.load_pop_file(pop_file, pops=SMALL_VCF_POPS)
+        from_hap = compute_ld_statistics(
+            pops=SMALL_VCF_POPS, bp_bins=SMALL_VCF_BINS, report=False,
+            haplotype_matrix=hm, use_genotypes=True)
+        from_vcf = compute_ld_statistics(
+            vcf, pop_file=pop_file, pops=SMALL_VCF_POPS,
+            bp_bins=SMALL_VCF_BINS, use_genotypes=True, report=False)
+        for i in range(len(from_vcf['bins'])):
+            np.testing.assert_allclose(
+                from_hap['sums'][i], from_vcf['sums'][i], rtol=1e-6,
+                err_msg=f"haplotype_matrix= path differs from the VCF path in bin {i}")
+        np.testing.assert_allclose(
+            from_hap['sums'][-1], from_vcf['sums'][-1], rtol=1e-6,
+            err_msg="haplotype_matrix= path differs from the VCF path on heterozygosity")

--- a/tests/test_moments_ld.py
+++ b/tests/test_moments_ld.py
@@ -544,10 +544,17 @@ class TestHaplotypeMatrixGenotypePath:
     through ``GenotypeMatrix.from_haplotype_matrix``, so the conversion has to
     recover the same individuals the VCF loader would have built.
 
-    ``HaplotypeMatrix`` stores ploidy 0 in rows ``0..n-1`` and ploidy 1 in rows
-    ``n..2n-1``; pairing rows the other way builds each "individual" from two
-    different people's chromosomes and scrambles the population assignment with
-    it, which no downstream statistic can detect.
+    pg_gpu pairs haplotypes into diploids two contradictory ways (issue #148):
+    consecutive rows ``(2i, 2i+1)``, which ``from_haplotype_matrix`` uses, and
+    split-half rows ``(i, i + n_ind)``, which the VCF/zarr loaders produce and
+    ``load_pop_file`` documents. Whichever order is eventually made canonical,
+    one VCF loaded two ways has to yield the same individuals -- so these
+    comparisons hold either way, and the fixture is VCF-loaded to keep them
+    independent of that decision.
+
+    Getting it wrong builds each "individual" from two different people's
+    chromosomes and scrambles the population assignment with it, which no
+    downstream statistic can detect.
     """
 
     def test_conversion_matches_vcf_genotypes(self, plain_vcf):


### PR DESCRIPTION
Adds momentsLD parity coverage for the unphased genotype estimator. `tests/test_moments_ld.py`
pinned `use_genotypes=False` at every call site, so the estimator `compute_ld_statistics`
actually defaults to had no end-to-end test against moments.

**Nine of the new tests fail on this branch.** That is intentional -- they pin the moments
contract for two real gaps. No library code is touched here; the fixes are out of scope.

## What's added

- `three_pop_data` / `four_pop_data` parameterized over both estimators (`ids=["hap", "geno"]`),
  passing the same setting to both sides. Adds ~2 s.
- `TestTwoPopGenotypeLD` -- the genotype counterpart of the existing 2-population IM fixtures.
  Marked `slow`: moments' genotype pair loop over that VCF runs ~75 s, and the haplotype
  fixtures already cost about the same.
- `TestAltCodedSiteParity` -- a hand-written VCF carrying one site whose two observed alleles
  are 0 and 2 rather than 0 and 1.
- `TestHaplotypeMatrixGenotypePath` -- the `haplotype_matrix=` entry point under
  `use_genotypes=True`, plus unit checks on the conversion it routes through.

Also cleans up the `.h5` cache moments writes next to each simulated VCF, so a stale cache
cannot shadow a regenerated file.

## Gap 1: which sites the genotype path keeps

`_biallelic_and_alt` calls a site biallelic if at most two alleles are *observed*, regardless
of allele code, taking the highest present allele > 0 as the alt. moments uses scikit-allel's
`is_biallelic_01()`, which requires the observed pair to be exactly `{0, 1}`. A site declaring
`ALT=C,G` where allele 1 is never called is biallelic in the sample but is kept by one side
and dropped by the other.

The broader rule is arguably the better popgen -- the site really is biallelic -- but it means
`moments_ld` is no longer bit-comparable to moments, which is the module's whole purpose. On
`cache/3pop_geno_benchmark_rep2.vcf` it is a one-variant difference (4807 vs 4806), and that
single site is what #174 was actually reporting: it moves `DD` and `pi2`, sums of large
same-sign terms, by well under a percent, while signed `Dz` cancels heavily and moves by whole
percent -- which reads like a broken `Dz` estimator. See
https://github.com/kr-colab/pg_gpu/issues/174#issuecomment-5209573246 for the full trace.

Whether to keep the broad rule and have `moments_ld` opt into `is_biallelic_01`, or narrow it
everywhere, is a design call for this branch. The likely shape is an opt-in flag on
`GenotypeMatrix.from_vcf` / `from_zarr` that `moments_ld` sets, since the alt index is consumed
building dosage and is not retained on the matrix.

Failing: `TestAltCodedSiteParity` (3), `TestTwoPopGenotypeLD` (3 -- the IM VCF carries one such
site). The 3- and 4-population `geno` cases pass, because those simulated fixtures happen not to
contain one. That is exactly why the hand-written VCF is here.

## Gap 2: haplotype pairing (#148)

`compute_ld_statistics(haplotype_matrix=..., use_genotypes=True)` -- the default
`use_genotypes` -- routes through `GenotypeMatrix.from_haplotype_matrix`, which pairs
consecutive rows `(2i, 2i+1)`. The VCF/zarr loaders produce split-half rows `(i, i + n_ind)`,
which is what `load_pop_file` documents and `relatedness._get_genotype_data` reads. So on a
VCF-loaded matrix each "individual" is built from two different people's chromosomes and the
population assignment is scrambled with it:

```
sample_sets['popA']:  from_vcf [0..7]   from_haplotype_matrix [0,1,2,3,8,9,10,11]
64% of genotypes differ
```

That is #148, which already has the full picture -- both conventions, every consumer on each
side, and the loaders (`from_ts` consecutive, VCF/zarr split-half) that make which-one-is-wrong
depend on data provenance. Nothing new is claimed here; this only adds coverage on the
`moments_ld` entry point, which #148 does not mention.

The tests are written to survive whichever order #148 settles on: they load one VCF two ways
and assert the results agree, which has to hold under either canonical order. If #148 lands on
consecutive rows, the assertions stay valid and the loaders move under them.

Failing: `TestHaplotypeMatrixGenotypePath` (3).

## Verification

```
pixi run -e moments pytest tests/test_moments_ld.py -v          # 6 failed, 34 passed, 6 skipped
pixi run -e moments pytest tests/test_moments_ld.py -v --slow -k TwoPopGenotype   # 3 failed, 3 passed
pixi run ruff check pg_gpu/ tests/ examples/                    # clean
```

Every pre-existing test still passes, as do both `hap` and `geno` parameters of the 3- and
4-population fixtures.

