### PR TITLE
Fix genomic range validation in get_subset_from_range

### DIFF
--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -1058,7 +1058,7 @@ class HaplotypeMatrix:
             HaplotypeMatrix: A new instance containing the subset of the haplotype matrix.
         """
         # Validate range
-        if low < 0 or high > self.positions.size or low >= high:
+        if low < 0 or low >= high:
             raise ValueError("Invalid range specified")
 
         # Check device and find indices of positions within the specified range

--- a/tests/test_accessible_mask.py
+++ b/tests/test_accessible_mask.py
@@ -367,15 +367,12 @@ class TestHaplotypeMatrixAccessibleMask:
         mask = np.ones(1000, dtype=bool)
         mask[40:60] = False  # 20 inaccessible
         hm.set_accessible_mask(mask)
-        # get_subset_from_range checks high <= positions.size
-        # so use a range within the number of positions
-        low, high = 30, 80
+        low, high = 30, 800
         subset = hm.get_subset_from_range(low, high)
         assert subset.has_accessible_mask
         assert subset.accessible_mask.offset == low
         assert len(subset.accessible_mask) == (high - low)
-        # 40-60 is inaccessible; within [30,80) that's 20 inaccessible
-        assert subset.accessible_mask.total_accessible == 30
+        assert subset.accessible_mask.total_accessible == 750
 
 
 # ---- GenotypeMatrix integration tests ----

--- a/tests/test_haplotype_matrix.py
+++ b/tests/test_haplotype_matrix.py
@@ -229,6 +229,21 @@ def test_get_subset_from_range(sample_vcf):
     assert isinstance(subset, HaplotypeMatrix)
     assert subset.shape == (20, count)
 
+
+def test_get_subset_from_range_uses_genomic_coordinates():
+    """Ranges use genomic coordinates rather than variant counts."""
+    haplotypes = np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int8)
+    positions = np.array([100, 250, 900], dtype=np.int64)
+    hap_matrix = HaplotypeMatrix(haplotypes, positions)
+
+    subset = hap_matrix.get_subset_from_range(200, 1000)
+
+    np.testing.assert_array_equal(subset.positions, [250, 900])
+    np.testing.assert_array_equal(subset.haplotypes, haplotypes[:, 1:])
+    assert subset.chrom_start == 200
+    assert subset.chrom_end == 1000
+
+
 def test_get_subset(sample_vcf):
     """Test get_subset method."""
     hap_matrix = HaplotypeMatrix.from_vcf(sample_vcf)


### PR DESCRIPTION
Fixes #172

`low` and `high` are genomic coordinates, so comparing `high` with the variant count rejects valid intervals. Keep the range-order checks and add regression coverage for coordinate ranges beyond the number of variants, including accessible-mask slicing.

Tests:
- 80 haplotype and accessibility tests
- 3 WindowedAnalyzer tests
- `ruff check pg_gpu/ tests/ examples/`