### PR TITLE
Validate get_subset_from_range against coordinates, not variant count

### DIFF
--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -219,11 +219,18 @@ class HaplotypeMatrix:
                 accessible_mask, chrom_start, chrom_end)
         self.accessible_mask = accessible_mask
         if self._accessible_mask is not None and self.n_total_sites is None:
-            if chrom_start is not None and chrom_end is not None:
-                self.n_total_sites = self._accessible_mask.count_accessible(
-                    chrom_start, chrom_end + 1)
-            else:
-                self.n_total_sites = self._accessible_mask.total_accessible
+            self.n_total_sites = self._accessible_bases_in_range()
+
+    def _accessible_bases_in_range(self):
+        """Count the accessible bases inside [chrom_start, chrom_end].
+
+        ``chrom_end`` is inclusive, so the half-open count needs one more
+        base. A matrix without bounds counts the whole mask.
+        """
+        if self.chrom_start is not None and self.chrom_end is not None:
+            return self._accessible_mask.count_accessible(
+                self.chrom_start, self.chrom_end + 1)
+        return self._accessible_mask.total_accessible
 
     @property
     def haplotypes(self):
@@ -341,11 +348,7 @@ class HaplotypeMatrix:
         # span more (we widen it to avoid losing bases inside the range
         # when chrom_end < BED max), but only in-range bases count toward
         # the per-base normalization denominator.
-        if self.chrom_start is not None and self.chrom_end is not None:
-            self.n_total_sites = self.accessible_mask.count_accessible(
-                self.chrom_start, self.chrom_end + 1)
-        else:
-            self.n_total_sites = self.accessible_mask.total_accessible
+        self.n_total_sites = self._accessible_bases_in_range()
         return self
 
     def remove_accessible_mask(self):
@@ -979,6 +982,32 @@ class HaplotypeMatrix:
         return (f"HaplotypeMatrix(shape={self.shape}, "
                 f"first_position={first_pos}, last_position={last_pos})")
 
+    def _empty_subset(self) -> "HaplotypeMatrix":
+        """Build a copy of this matrix that holds no variants.
+
+        The constructor rejects zero-size arrays, so a subset that keeps no
+        variant must be assembled attribute by attribute. The caller narrows
+        the coordinates and the callable-site count afterwards if the subset
+        covers less than the parent.
+        """
+        xp = cp if self._device == 'GPU' else np
+        result = object.__new__(HaplotypeMatrix)
+        result._haplotypes = xp.empty((self.haplotypes.shape[0], 0),
+                                      dtype=self.haplotypes.dtype)
+        result._positions = xp.array([], dtype=self.positions.dtype)
+        result._accessible_idx = None
+        result._hap_filtered = None
+        result._pos_filtered = None
+        result._device = self._device
+        result._sample_sets = self._sample_sets
+        result.chrom_start = self.chrom_start
+        result.chrom_end = self.chrom_end
+        result.n_total_sites = self.n_total_sites
+        result.samples = self.samples
+        result.fields = {}
+        result.accessible_mask = None
+        return result
+
     def get_subset(self, positions) -> "HaplotypeMatrix":
         """
         Get a subset of the haplotype matrix based on the provided positions.
@@ -1006,30 +1035,7 @@ class HaplotypeMatrix:
 
         # Handle empty positions array
         if len(positions) == 0:
-            # Create empty subset maintaining the same structure
-            # Need to create arrays that have non-zero size to satisfy constructor
-            if self.device == 'GPU':
-                empty_haplotypes = cp.empty((self.haplotypes.shape[0], 0), dtype=self.haplotypes.dtype)
-                empty_positions = cp.array([], dtype=self.positions.dtype)
-            else:
-                empty_haplotypes = np.empty((self.haplotypes.shape[0], 0), dtype=self.haplotypes.dtype)
-                empty_positions = np.array([], dtype=self.positions.dtype)
-
-            # For empty subsets, bypass constructor validation
-            result = object.__new__(HaplotypeMatrix)
-            result._haplotypes = empty_haplotypes
-            result._positions = empty_positions
-            result._accessible_idx = None
-            result._hap_filtered = None
-            result._pos_filtered = None
-            result.chrom_start = self.chrom_start
-            result.chrom_end = self.chrom_end
-            result._sample_sets = self._sample_sets
-            result._device = self._device
-            result.n_total_sites = self.n_total_sites
-            result.accessible_mask = None
-            result.samples = self.samples
-            return result
+            return self._empty_subset()
 
         if not (positions >= 0).all() or not (positions < self.haplotypes.shape[1]).all():
             raise ValueError("Positions must be valid indices within the haplotype matrix.")
@@ -1048,33 +1054,49 @@ class HaplotypeMatrix:
 
     def get_subset_from_range(self, low: int, high: int) -> "HaplotypeMatrix":
         """
-        Get a subset of the haplotype matrix based on a range of positions.
+        Get a subset of the haplotype matrix over a range of genomic coordinates.
 
         Parameters:
-            low (int): The lower bound of the range (inclusive).
-            high (int): The upper bound of the range (exclusive).
+            low (int): Start of the range in base pairs (inclusive).
+            high (int): End of the range in base pairs (exclusive).
 
         Returns:
-            HaplotypeMatrix: A new instance containing the subset of the haplotype matrix.
+            HaplotypeMatrix: A new instance holding the variants inside the
+                range. The result holds no variants when the range covers none.
         """
-        # Validate range
-        if low < 0 or high > self.positions.size or low >= high:
+        # low and high are genomic coordinates, not variant indices, so the
+        # only bounds that mean anything are that the range starts at or after
+        # zero and is not empty. A range that reaches past the last variant is
+        # a valid query: it returns the variants that do fall inside it.
+        if low < 0 or low >= high:
             raise ValueError("Invalid range specified")
 
-        # Check device and find indices of positions within the specified range
-        positions = cp.asarray(self.positions) if self.device == 'GPU' else np.asarray(self.positions)
-        indices = cp.where((positions >= low) & (positions < high))[0] if self.device == 'GPU' else np.where((positions >= low) & (positions < high))[0]
+        xp = cp if self.device == 'GPU' else np
+        positions = xp.asarray(self.positions)
+        indices = xp.where((positions >= low) & (positions < high))[0]
 
-        # Create the subset of haplotypes based on the found indices
         sliced_mask = None
         if self.accessible_mask is not None:
             sliced_mask = self.accessible_mask.slice(low, high)
+
+        # chrom_end is inclusive, so the last base of [low, high) is high - 1.
+        if len(indices) == 0:
+            result = self._empty_subset()
+            result.chrom_start = low
+            result.chrom_end = high - 1
+            result.accessible_mask = sliced_mask
+            # The parent count covers the whole parent range, not this one.
+            result.n_total_sites = (result._accessible_bases_in_range()
+                                    if sliced_mask is not None else None)
+            return result
+
         return HaplotypeMatrix(
             self.haplotypes[:, indices],
             self.positions[indices],
             chrom_start=low,
-            chrom_end=high,
+            chrom_end=high - 1,
             sample_sets=self._sample_sets,
+            samples=self.samples,
             accessible_mask=sliced_mask,
         )
 

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -368,6 +368,11 @@ class WindowIterator:
 
     def _iter_bp_windows(self) -> Iterator[WindowData]:
         """Iterate over fixed base pair windows."""
+        # Window bounds come from the first and last variant, so a matrix with
+        # no variants -- a region that covers none, for example -- has no
+        # windows to yield.
+        if len(self.positions_np) == 0:
+            return
         chrom_start = int(self.positions_np[0])
         chrom_end = int(self.positions_np[-1])
 
@@ -469,6 +474,8 @@ class WindowIterator:
     def count_windows(self) -> int:
         """Count total number of windows."""
         if self.params.window_type == 'bp':
+            if len(self.positions_np) == 0:
+                return 0
             chrom_start = int(self.positions_np[0])
             chrom_end = int(self.positions_np[-1])
             return max(1, (chrom_end - chrom_start - self.params.window_size) //

--- a/tests/test_haplotype_matrix.py
+++ b/tests/test_haplotype_matrix.py
@@ -229,6 +229,89 @@ def test_get_subset_from_range(sample_vcf):
     assert isinstance(subset, HaplotypeMatrix)
     assert subset.shape == (20, count)
 
+def _sparse_matrix(n_var=100, span=1_000_000, seed=0):
+    """A matrix whose coordinates are far larger than its variant count.
+
+    Real data always looks like this, and it is the case that separates a
+    coordinate range from a range of variant indices.
+    """
+    rng = np.random.RandomState(seed)
+    pos = np.sort(rng.choice(np.arange(1, span), n_var, replace=False))
+    hap = rng.randint(0, 2, size=(20, n_var)).astype(np.int8)
+    return HaplotypeMatrix(hap, pos, chrom_start=1, chrom_end=span - 1)
+
+
+def test_get_subset_from_range_accepts_real_coordinates():
+    """The range is in base pairs, so it may run far past the variant count."""
+    hm = _sparse_matrix()
+    pos = np.asarray(hm.positions)
+    low, high = 200_000, 300_000
+    expected = int(((pos >= low) & (pos < high)).sum())
+    assert expected > 0
+
+    subset = hm.get_subset_from_range(low, high)
+    assert subset.shape == (20, expected)
+    np.testing.assert_array_equal(
+        np.asarray(subset.positions), pos[(pos >= low) & (pos < high)])
+
+
+def test_get_subset_from_range_sets_inclusive_chrom_end():
+    """high is exclusive, but chrom_end is inclusive."""
+    hm = _sparse_matrix()
+    subset = hm.get_subset_from_range(200_000, 300_000)
+    assert subset.chrom_start == 200_000
+    assert subset.chrom_end == 299_999
+
+
+def test_get_subset_from_range_keeps_sample_names():
+    hm = _sparse_matrix()
+    hm.samples = [f"s{i}" for i in range(10)]
+    subset = hm.get_subset_from_range(200_000, 300_000)
+    assert subset.samples == hm.samples
+
+
+def test_get_subset_from_range_empty_window():
+    """A valid range that covers no variant gives an empty matrix."""
+    hm = _sparse_matrix()
+    pos = np.asarray(hm.positions)
+    gap_low = int(pos[0]) + 1
+    gap_high = int(pos[1])
+    assert gap_low < gap_high  # the two first variants are not adjacent
+
+    subset = hm.get_subset_from_range(gap_low, gap_high)
+    assert subset.shape[1] == 0
+    assert subset.positions.size == 0
+    assert subset.chrom_start == gap_low
+    assert subset.chrom_end == gap_high - 1
+    assert subset.fields == {}
+
+
+def test_get_subset_from_range_beyond_last_variant():
+    """A range past the data returns nothing rather than an error."""
+    hm = _sparse_matrix()
+    subset = hm.get_subset_from_range(2_000_000, 3_000_000)
+    assert subset.shape[1] == 0
+
+
+def test_get_subset_from_range_rejects_malformed_range():
+    hm = _sparse_matrix()
+    with pytest.raises(ValueError, match="Invalid range"):
+        hm.get_subset_from_range(-1, 100)
+    with pytest.raises(ValueError, match="Invalid range"):
+        hm.get_subset_from_range(500, 500)
+    with pytest.raises(ValueError, match="Invalid range"):
+        hm.get_subset_from_range(500, 100)
+
+
+def test_empty_subset_exposes_fields(sample_vcf):
+    """An empty subset is a usable matrix, not a half-built one."""
+    hap_matrix = HaplotypeMatrix.from_vcf(sample_vcf)
+    empty = hap_matrix.get_subset(np.array([], dtype=np.int64))
+    assert empty.fields == {}
+    assert empty.shape[1] == 0
+    assert empty.samples == hap_matrix.samples
+
+
 def test_get_subset(sample_vcf):
     """Test get_subset method."""
     hap_matrix = HaplotypeMatrix.from_vcf(sample_vcf)

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -218,6 +218,41 @@ class TestWindowedAnalyzer:
         assert 'end' in results.columns
         assert len(results) > 0
 
+    def test_compute_region(self):
+        """compute_region takes genomic coordinates, which normally run far
+        past the variant count."""
+        rng = np.random.RandomState(7)
+        n_variants = 400
+        positions = np.sort(rng.choice(np.arange(1, 1000000), n_variants,
+                                       replace=False))
+        haplotypes = rng.randint(0, 2, size=(20, n_variants))
+        matrix = HaplotypeMatrix(haplotypes, positions, 1, 999999)
+
+        analyzer = WindowedAnalyzer(
+            window_size=20000, step_size=20000,
+            statistics=['pi', 'n_variants'], progress_bar=False)
+
+        results = analyzer.compute_region(matrix, '1', 200000, 300000)
+
+        assert isinstance(results, pd.DataFrame)
+        assert len(results) > 0
+        in_region = ((positions >= 200000) & (positions < 300000)).sum()
+        assert results['n_variants'].sum() == in_region
+
+    def test_compute_region_without_variants(self):
+        """A region that covers no variant gives no windows, not an error."""
+        positions = np.array([1000, 2000, 900000])
+        haplotypes = np.random.randint(0, 2, size=(10, 3))
+        matrix = HaplotypeMatrix(haplotypes, positions, 1, 999999)
+
+        analyzer = WindowedAnalyzer(
+            window_size=10000, statistics=['pi'], progress_bar=False)
+
+        results = analyzer.compute_region(matrix, '1', 400000, 500000)
+
+        assert isinstance(results, pd.DataFrame)
+        assert len(results) == 0
+
     def test_population_analysis(self):
         """Test analysis with multiple populations."""
         n_variants = 500


### PR DESCRIPTION
Fixes #172.

`low` and `high` are genomic coordinates. The guard compared `high` to `positions.size`,
which is the variant count:

```python
if low < 0 or high > self.positions.size or low >= high:
```

Everything else in the method treats them as coordinates: it filters `self.positions`,
calls `accessible_mask.slice(low, high)`, and stores them as `chrom_start`/`chrom_end`.
The sibling `get_subset` validates against `haplotypes.shape[1]` correctly, because its
argument really is indices. This check looks inherited from there. It has been in the
file since the first commit.

## What it broke

**Almost every real range was refused.** Only ranges inside `[0, n_variants)` passed. A
matrix of 100 variants over 1 Mb rejected the window `[200000, 300000)` with
`ValueError: Invalid range specified`. `WindowedAnalyzer.compute_region`
(`windowed_analysis.py:631`) is the only caller and failed the same way.

**A range with no variants crashed.** A range that passed the guard but held no variant
reached the constructor, which rejects zero-size arrays, and raised
`ValueError: genotypes cannot be empty`. `get_subset` has an empty-result path; this
method had none, so the guard was hiding the gap.

## The fix

Keep `low < 0` and `low >= high`, and drop the third check. A range that reaches past
the last variant is a valid query -- it returns the variants that do fall inside it.
Validating against `chrom_start`/`chrom_end` would recreate the same problem for windows
at the edge of a chromosome.

Two further faults in the same method:

- `chrom_end` was set to `high`, which is exclusive. `chrom_end` is inclusive: the
  constructor counts accessible bases up to `chrom_end + 1`, `from_ts` stores
  `sequence_length - 1` with a comment saying so, and `_iter_bp_windows` writes
  `end - 1`. The subset claimed one base more than it covered.
- The `samples` list was dropped, so `load_pop_file` did not work on the result.

Two cleanups that the fix needs:

- `_empty_subset` now holds the empty-result builder that only `get_subset` had. It also
  sets `fields`, which the old code left unset -- reading `.fields` on an empty subset
  raised `AttributeError`. That object is reachable today: `test_windowed_analysis.py`
  builds one, and every variant-free window produces one.
- `_accessible_bases_in_range` replaces three copies of the same accessible-base count.

## Outside the method

An empty region matrix now reaches `WindowIterator`, which read `positions_np[0]` with no
guard. `_iter_bp_windows` and `count_windows` return nothing for a matrix with no
variants. Without this, `compute_region` would trade one error for another. Drop this
part if you would rather keep the PR inside `haplotype_matrix.py`.

## Tests

`get_subset_from_range` had two tests and both were written around the bug.
`test_accessible_mask.py:370` says so outright: *"get_subset_from_range checks
high <= positions.size, so use a range within the number of positions"*.
`test_haplotype_matrix.py:221` passes only because that fixture's 10th position is below
its variant count. Both still pass unchanged.

New tests cover a coordinate range far past the variant count, the inclusive `chrom_end`,
the kept sample names, an empty window, a range past the last variant, malformed ranges,
and `fields` on an empty subset. `compute_region` gets its first two tests.

```
pixi run pytest tests/ -q -n 10          # 886 passed, 64 skipped
pixi run ruff check pg_gpu/ tests/ examples/   # clean
```

## Not fixed here

`_iter_bp_windows` anchors windows at `positions[0]` and ignores `chrom_start`. After
this fix, `compute_region(hm, "1", 200000, 300000)` returns windows that start at the
first variant in the region and can end past 300000, so two neighbouring region calls
give windows that do not line up. That is a decision about what `compute_region`
promises, so it belongs in its own issue.
