### PR TITLE
One window grid and one membership rule across the windowed engines

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -137,6 +137,10 @@ Read this section if you are comparing against older pg_gpu results.
   chromosome bounds. The old filter moved the bounds to the first and
   last surviving variant, which quietly changed the denominator of any
   span-normalized statistic computed afterwards.
+  ``exclude_missing_sites`` (and so every statistic under
+  ``missing_data='exclude'``) follows the same rule and also keeps the
+  accessibility mask: filtering sites changes neither the chromosome
+  extent nor which bases are accessible.
 * ``decomposition.pairwise_distance`` supports ``euclidean``,
   ``sqeuclidean``, and ``cityblock``. Other metrics now raise
   ``NotImplementedError``, and passing a ``GenotypeMatrix`` raises a

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -138,9 +138,10 @@ Read this section if you are comparing against older pg_gpu results.
   last surviving variant, which quietly changed the denominator of any
   span-normalized statistic computed afterwards.
   ``exclude_missing_sites`` (and so every statistic under
-  ``missing_data='exclude'``) follows the same rule and also keeps the
-  accessibility mask: filtering sites changes neither the chromosome
-  extent nor which bases are accessible.
+  ``missing_data='exclude'``) and ``filter_variants_by_missing`` follow
+  the same rule and also keep the accessibility mask: filtering sites
+  changes neither the chromosome extent nor which bases are
+  accessible.
 * ``decomposition.pairwise_distance`` supports ``euclidean``,
   ``sqeuclidean``, and ``cityblock``. Other metrics now raise
   ``NotImplementedError``, and passing a ``GenotypeMatrix`` raises a

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -1150,6 +1150,27 @@ class HaplotypeMatrix:
             accessible_mask=sliced_mask,
         )
 
+    def _keep_sites(self, keep) -> "HaplotypeMatrix":
+        """Subset to the given site indices, keeping the parent context.
+
+        Dropping sites changes neither the chromosome extent nor which
+        bases are accessible, so the child carries the parent's bounds,
+        accessibility mask, sample sets, and n_total_sites -- the rule
+        every same-region site filter follows. An empty selection routes
+        through get_subset, which builds a valid 0-variant matrix (the
+        constructor rejects empty arrays).
+        """
+        if len(keep) == 0:
+            return self.get_subset(keep)
+        return HaplotypeMatrix(
+            self.haplotypes[:, keep], self.positions[keep],
+            chrom_start=self.chrom_start,
+            chrom_end=self.chrom_end,
+            sample_sets=self._sample_sets,
+            n_total_sites=self.n_total_sites,
+            accessible_mask=self.accessible_mask,
+        )
+
     def restrict_to_biallelic(self) -> "HaplotypeMatrix":
         """Restrict to biallelic sites (drop >=3-allele), preserving allele codes.
 
@@ -1164,23 +1185,7 @@ class HaplotypeMatrix:
 
         ac, _ = allele_counts(self.haplotypes)
         biallelic, _ = _biallelic_and_alt(ac)
-        keep = cp.where(biallelic)[0]
-        if keep.shape[0] == 0:
-            # get_subset builds a valid 0-variant matrix; the constructor rejects empty
-            return self.get_subset(keep)
-        hap = self.haplotypes[:, keep]
-        positions = self.positions[keep]
-        # Dropping sites does not shrink the chromosome: keep the parent
-        # bounds so span-normalized statistics keep their denominator,
-        # like the GenotypeMatrix filters.
-        return HaplotypeMatrix(
-            hap, positions,
-            chrom_start=self.chrom_start,
-            chrom_end=self.chrom_end,
-            sample_sets=self._sample_sets,
-            n_total_sites=self.n_total_sites,
-            accessible_mask=self.accessible_mask,
-        )
+        return self._keep_sites(cp.where(biallelic)[0])
 
     def restrict_to_segregating(self) -> "HaplotypeMatrix":
         """Drop non-segregating (monomorphic) sites.
@@ -1193,23 +1198,7 @@ class HaplotypeMatrix:
         from ._memutil import allele_counts
 
         ac, _ = allele_counts(self.haplotypes)
-        keep = cp.where((ac > 0).sum(axis=1) >= 2)[0]
-        if keep.shape[0] == 0:
-            # get_subset builds a valid 0-variant matrix; the constructor rejects empty
-            return self.get_subset(keep)
-        hap = self.haplotypes[:, keep]
-        positions = self.positions[keep]
-        # Dropping sites does not shrink the chromosome: keep the parent
-        # bounds so span-normalized statistics keep their denominator,
-        # like the GenotypeMatrix filters.
-        return HaplotypeMatrix(
-            hap, positions,
-            chrom_start=self.chrom_start,
-            chrom_end=self.chrom_end,
-            sample_sets=self._sample_sets,
-            n_total_sites=self.n_total_sites,
-            accessible_mask=self.accessible_mask,
-        )
+        return self._keep_sites(cp.where((ac > 0).sum(axis=1) >= 2)[0])
 
     def _biallelic_indicator(self) -> cp.ndarray:
         """0/1 alt-indicator array for the current sites; -1 for missing.
@@ -1406,12 +1395,8 @@ class HaplotypeMatrix:
         Returns
         -------
         HaplotypeMatrix
-            Filtered matrix. Returns self if no missing data.
-
-        Raises
-        ------
-        ValueError
-            If no sites remain after filtering.
+            Filtered matrix. Returns self if no missing data, and a
+            matrix with zero variants when no site is complete.
         """
         if self.device == 'CPU':
             self.transfer_to_gpu()
@@ -1431,21 +1416,7 @@ class HaplotypeMatrix:
         valid = cp.where(~has_missing)[0]
         if len(valid) == hap.shape[1]:
             return self
-        if len(valid) == 0:
-            return self.get_subset(valid)
-        # Dropping incomplete sites does not shrink the chromosome or
-        # change its accessibility: keep the parent bounds and mask like
-        # the restrict_to_* filters, so span-normalized statistics keep
-        # their denominator. The no-missing path above returns self with
-        # the same context; get_subset alone would strip it.
-        return HaplotypeMatrix(
-            hap[:, valid], self.positions[valid],
-            chrom_start=self.chrom_start,
-            chrom_end=self.chrom_end,
-            sample_sets=self._sample_sets,
-            n_total_sites=self.n_total_sites,
-            accessible_mask=self.accessible_mask,
-        )
+        return self._keep_sites(valid)
 
     def filter_variants_by_missing(self, max_missing_freq=0.1):
         """
@@ -1461,15 +1432,10 @@ class HaplotypeMatrix:
         filtered : HaplotypeMatrix
             New HaplotypeMatrix with filtered variants
         """
+        if self.device == 'CPU':
+            self.transfer_to_gpu()
         missing_freq = self.count_missing(axis=0) / self.num_haplotypes
-        if self.device == 'GPU':
-            valid_mask = missing_freq <= max_missing_freq
-            valid_indices = cp.where(valid_mask)[0]
-            return self.get_subset(valid_indices)
-        else:
-            valid_mask = missing_freq <= max_missing_freq
-            valid_indices = np.where(valid_mask)[0]
-            return self.get_subset(valid_indices)
+        return self._keep_sites(cp.where(missing_freq <= max_missing_freq)[0])
 
     def filter(self, variants=None, genotypes=None,
                drop_all_missing: bool = True) -> "HaplotypeMatrix":

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -1433,7 +1433,19 @@ class HaplotypeMatrix:
             return self
         if len(valid) == 0:
             return self.get_subset(valid)
-        return self.get_subset(valid)
+        # Dropping incomplete sites does not shrink the chromosome or
+        # change its accessibility: keep the parent bounds and mask like
+        # the restrict_to_* filters, so span-normalized statistics keep
+        # their denominator. The no-missing path above returns self with
+        # the same context; get_subset alone would strip it.
+        return HaplotypeMatrix(
+            hap[:, valid], self.positions[valid],
+            chrom_start=self.chrom_start,
+            chrom_end=self.chrom_end,
+            sample_sets=self._sample_sets,
+            n_total_sites=self.n_total_sites,
+            accessible_mask=self.accessible_mask,
+        )
 
     def filter_variants_by_missing(self, max_missing_freq=0.1):
         """

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -2285,9 +2285,37 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
                                win_start, win_stop, n_windows, statistics,
                                results)
 
-    # Per-site stats binned into windows via scatter_add
-    bin_idx = cp.searchsorted(we_gpu, positions)
-    in_range = (bin_idx >= 0) & (bin_idx < n_windows)
+    # Per-site stats binned into windows via scatter_add. A variant belongs
+    # to window w iff ws[w] <= pos < we[w] -- the same right-open rule
+    # win_start / win_stop and n_variants use. Searching the window ENDS
+    # would put a variant sitting exactly on a boundary (pos == a window end
+    # == the next window's start) in the lower window, disagreeing with
+    # n_variants. Windows may also overlap (step < window), where a variant
+    # belongs to every window covering it, not just one. Both window
+    # families here have nondecreasing starts and ends, so the member
+    # windows of a variant are the consecutive run [k_lo, k_hi]: k_hi is
+    # the last window whose start is <= pos, k_lo the first whose end is
+    # > pos. Row j of site_win holds candidate k_hi - j; site_ok masks the
+    # rows outside the run. For contiguous windows the run has length one
+    # and the arrays stay (1, n_var).
+    if any(s in statistics for s in ('mean_nsl', 'daf_hist', 'mu_sfs')):
+        k_hi = cp.searchsorted(ws_gpu, positions, side='right') - 1
+        k_lo = cp.searchsorted(we_gpu, positions, side='right')
+        if positions.size:
+            n_per_var = max(1, int(cp.max(k_hi - k_lo).get()) + 1)
+        else:
+            n_per_var = 1
+        site_win = (k_hi[None, :]
+                    - cp.arange(n_per_var, dtype=cp.int64)[:, None])
+        site_ok = (site_win >= k_lo[None, :]) & (site_win < n_windows)
+        bin_idx = site_win.ravel()
+        in_range = site_ok.ravel()
+
+        def _per_site(v):
+            """Align a per-variant array with bin_idx / in_range."""
+            if n_per_var == 1:
+                return v
+            return cp.broadcast_to(v, (n_per_var, v.shape[0])).ravel()
 
     # Shared per-allele counts (used by daf_hist and mu_sfs). Per-derived-allele,
     # per-site n_valid -- the same convention as diversity.daf_histogram / mu_sfs,
@@ -2299,21 +2327,10 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
 
     if 'mean_nsl' in statistics:
         from . import selection as sel
-        # matrix is already population-subsetted upstream; don't re-subset.
-        # nSL is scanned once over this whole (eager) matrix, so each per-site
-        # score sees the full region before being binned into windows. Over a
-        # StreamingHaplotypeMatrix this runs per chunk, truncating the scan at
-        # chunk boundaries (see _stream_windowed_analysis).
-        # nsl() returns (n_var,) for biallelic data and (n_var, n_derived) when
-        # multiallelic focal sites are present; average every finite
-        # (site, allele) score falling in each window.
-        nsl_2d = cp.asarray(sel.nsl(matrix)).reshape(matrix.num_variants, -1)
-        m = nsl_2d.shape[1]
-        vals_flat = nsl_2d.reshape(-1)
-        bin_flat = cp.repeat(bin_idx, m)
-        inrange_flat = cp.repeat(in_range, m)
-        valid = cp.isfinite(vals_flat) & inrange_flat
-        results['mean_nsl'] = _windowed_mean(vals_flat, bin_flat, valid, n_windows)
+        # matrix is already population-subsetted (line 1533); don't re-subset
+        nsl_gpu = _per_site(cp.asarray(sel.nsl(matrix)))
+        valid = cp.isfinite(nsl_gpu) & in_range
+        results['mean_nsl'] = _windowed_mean(nsl_gpu, bin_idx, valid, n_windows)
 
     # SNP distance stats per window
     snp_dist_stats = {'snp_dist_mean', 'snp_dist_var', 'snp_dist_min',
@@ -2359,19 +2376,14 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
     # allele (freq = count / n_valid), scattered into (window, bin) and
     # normalized per window -- matching diversity.daf_histogram.
     if 'daf_hist' in statistics:
-        n_daf_bins = _DAF_N_BINS
-        derived = ac_daf[:, 1:]                                  # (n_var, K-1)
-        n_der = derived.shape[1]
-        nv = cp.maximum(nv_daf.astype(cp.float64), 1.0)[:, None]
-        freq = (derived.astype(cp.float64) / nv).reshape(-1)     # per (site, allele)
-        # keep present derived alleles at in-range, non-missing sites
-        keep = ((derived > 0) & (nv_daf[:, None] > 0)
-                & in_range[:, None]).reshape(-1)
-        bin_rep = cp.repeat(bin_idx, n_der)                      # site's window
-        composite = cp.where(keep, bin_rep * n_daf_bins
-                             + diversity._daf_bin_index(freq, n_daf_bins), 0)
-        flat = _scatter_sum(keep.astype(cp.float64), composite,
-                            n_windows * n_daf_bins)
+        n_daf_bins = 20
+        daf = dac_gpu.astype(cp.float64) / n_hap
+        daf_bin = cp.minimum((daf * n_daf_bins).astype(cp.int32), n_daf_bins - 1)
+        # Composite index: window * n_daf_bins + daf_bin
+        composite = bin_idx * n_daf_bins + _per_site(daf_bin)
+        valid_daf = in_range
+        flat = _scatter_sum(cp.ones_like(composite[valid_daf], dtype=cp.float64),
+                            composite[valid_daf], n_windows * n_daf_bins)
         hist_matrix = flat.get().reshape(n_windows, n_daf_bins)
         row_sum = hist_matrix.sum(axis=1, keepdims=True)
         hist_matrix = np.divide(hist_matrix, row_sum,
@@ -2383,22 +2395,14 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
     # muSFS: fraction of segregating (site, allele) entries at the SFS edges
     # (singleton or n_valid-1), per-site n_valid -- matching diversity.mu_sfs.
     if 'mu_sfs' in statistics:
-        derived = ac_daf[:, 1:]
-        n_der = derived.shape[1]
-        nvc = nv_daf[:, None]
-        is_seg = (derived > 0) & (derived < nvc) & in_range[:, None]
-        is_edge = is_seg & ((derived == 1) | (derived == nvc - 1))
-        keep = cp.repeat(in_range, n_der)
-        bin_safe = cp.where(keep, cp.repeat(bin_idx, n_der), 0)
-        seg_sum = _scatter_sum(is_seg.reshape(-1).astype(cp.float64),
-                               bin_safe, n_windows).get()
-        edge_sum = _scatter_sum(is_edge.reshape(-1).astype(cp.float64),
-                                bin_safe, n_windows).get()
-        # matches diversity.mu_sfs, which returns 0.0 when a window has no
-        # segregating (site, allele) entries (rather than NaN)
-        results['mu_sfs'] = np.divide(edge_sum, seg_sum,
-                                      out=np.zeros_like(edge_sum),
-                                      where=seg_sum > 0)
+        is_edge = _per_site(
+            ((dac_gpu == 1) | (dac_gpu == n_hap - 1)).astype(cp.float64))
+        edge_sum = _scatter_sum(is_edge[in_range], bin_idx[in_range], n_windows)
+        total_count = _bin_counts(bin_idx[in_range], n_windows)
+        edge_cpu = edge_sum.get()
+        count_cpu = total_count.get()
+        mu_sfs = np.where(count_cpu > 0, edge_cpu / count_cpu, np.nan)
+        results['mu_sfs'] = mu_sfs
 
     # Per-window pairwise stats (LD, distance moments)
     ld_pairwise = {'zns', 'omega', 'mu_ld'}

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -2294,10 +2294,13 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
     if any(s in statistics for s in _PER_SITE_SCATTER_STATS):
         k_hi = cp.searchsorted(ws_gpu, positions, side='right') - 1
         k_lo = cp.searchsorted(we_gpu, positions, side='right')
-        if positions.size:
-            n_per_var = max(1, int(cp.max(k_hi - k_lo).get()) + 1)
-        else:
-            n_per_var = 1
+        # n_per_var is grid geometry, not data: coverage depth (windows j
+        # with ws[j] <= x < we[j]) is maximized at a window start, and the
+        # window arrays are already on the host. An upper bound on any
+        # variant's run length; site_ok masks unused rows.
+        depth = (np.searchsorted(ws_cpu, ws_cpu, side='right')
+                 - np.searchsorted(we_cpu, ws_cpu, side='right'))
+        n_per_var = max(1, int(depth.max(initial=0)))
         site_win = (k_hi[None, :]
                     - cp.arange(n_per_var, dtype=cp.int64)[:, None])
         # site_win <= k_hi <= n_windows - 1 by construction, so k_lo is the

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -2315,18 +2315,26 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
     # Shared per-allele counts (used by daf_hist and mu_sfs). Per-derived-allele,
     # per-site n_valid -- the same convention as diversity.daf_histogram / mu_sfs,
     # so the windowed values equal the scalar over each window (include mode).
-    ac_daf = nv_daf = None
     if any(s in statistics for s in ('daf_hist', 'mu_sfs')):
         from ._memutil import allele_counts
         ac_daf, nv_daf = allele_counts(matrix.haplotypes)   # (n_var, K), (n_var,)
+        derived = ac_daf[:, 1:]                             # (n_var, K-1)
 
     if 'mean_nsl' in statistics:
         from . import selection as sel
-        # matrix is already population-subsetted (line 1533); don't re-subset
-        nsl_gpu = _expand(cp.asarray(sel.nsl(matrix)))
-        valid = cp.isfinite(nsl_gpu) & site_ok
-        results['mean_nsl'] = _windowed_mean(nsl_gpu, site_win, valid,
-                                             n_windows)
+        # matrix is already population-subsetted upstream; don't re-subset.
+        # nSL is scanned once over this whole (eager) matrix, so each per-site
+        # score sees the full region before being binned into windows. Over a
+        # StreamingHaplotypeMatrix this runs per chunk, truncating the scan at
+        # chunk boundaries (see _stream_windowed_analysis).
+        # nsl() returns (n_var,) for biallelic data and (n_var, n_derived)
+        # when multiallelic focal sites are present; average every finite
+        # (site, allele) score in every window the site belongs to.
+        nsl_2d = cp.asarray(sel.nsl(matrix)).reshape(matrix.num_variants, -1)
+        vals, wins = cp.broadcast_arrays(nsl_2d[None, :, :],
+                                         site_win[:, :, None])
+        valid = cp.isfinite(vals) & site_ok[:, :, None]
+        results['mean_nsl'] = _windowed_mean(vals, wins, valid, n_windows)
 
     # SNP distance stats per window
     snp_dist_stats = {'snp_dist_mean', 'snp_dist_var', 'snp_dist_min',
@@ -2372,30 +2380,45 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
     # allele (freq = count / n_valid), scattered into (window, bin) and
     # normalized per window -- matching diversity.daf_histogram.
     if 'daf_hist' in statistics:
-        daf = dac_gpu.astype(cp.float64) / n_hap
-        daf_bin = cp.minimum((daf * N_DAF_BINS).astype(cp.int32),
-                             N_DAF_BINS - 1)
-        # Composite index: window * N_DAF_BINS + daf_bin
-        composite = site_win * N_DAF_BINS + _expand(daf_bin)
-        member = composite[site_ok]
+        nv = cp.maximum(nv_daf.astype(cp.float64), 1.0)[:, None]
+        freq = derived.astype(cp.float64) / nv                   # per (site, allele)
+        dbin = diversity._daf_bin_index(freq, N_DAF_BINS)
+        # One entry per present derived allele at a non-missing site, in
+        # every window the site belongs to.
+        keep = (((derived > 0) & (nv_daf[:, None] > 0))[None, :, :]
+                & site_ok[:, :, None])
+        composite = site_win[:, :, None] * N_DAF_BINS + dbin[None, :, :]
+        member = composite[keep]
         flat = _scatter_sum(cp.ones_like(member, dtype=cp.float64),
                             member, n_windows * N_DAF_BINS)
         hist_matrix = flat.get().reshape(n_windows, N_DAF_BINS)
+        row_sum = hist_matrix.sum(axis=1, keepdims=True)
+        hist_matrix = np.divide(hist_matrix, row_sum,
+                                out=np.zeros_like(hist_matrix),
+                                where=row_sum > 0)
         for b in range(N_DAF_BINS):
             results[f'daf_bin_{b}'] = hist_matrix[:, b]
 
     # muSFS: fraction of segregating (site, allele) entries at the SFS edges
     # (singleton or n_valid-1), per-site n_valid -- matching diversity.mu_sfs.
     if 'mu_sfs' in statistics:
-        is_edge = _expand(
-            ((dac_gpu == 1) | (dac_gpu == n_hap - 1)).astype(cp.float64))
+        nvc = nv_daf[:, None]
+        is_seg = (derived > 0) & (derived < nvc)                 # (n_var, K-1)
+        is_edge = is_seg & ((derived == 1) | (derived == nvc - 1))
+        # The window index depends only on the site, so sum the per-allele
+        # counts per site first, then scatter into each membership.
+        seg_site = is_seg.sum(axis=1).astype(cp.float64)         # (n_var,)
+        edge_site = is_edge.sum(axis=1).astype(cp.float64)
         member_win = site_win[site_ok]
-        edge_sum = _scatter_sum(is_edge[site_ok], member_win, n_windows)
-        total_count = _bin_counts(member_win, n_windows)
-        edge_cpu = edge_sum.get()
-        count_cpu = total_count.get()
-        mu_sfs = np.where(count_cpu > 0, edge_cpu / count_cpu, np.nan)
-        results['mu_sfs'] = mu_sfs
+        seg_sum = _scatter_sum(_expand(seg_site)[site_ok], member_win,
+                               n_windows).get()
+        edge_sum = _scatter_sum(_expand(edge_site)[site_ok], member_win,
+                                n_windows).get()
+        # matches diversity.mu_sfs, which returns 0.0 when a window has no
+        # segregating (site, allele) entries (rather than NaN)
+        results['mu_sfs'] = np.divide(edge_sum, seg_sum,
+                                      out=np.zeros_like(edge_sum),
+                                      where=seg_sum > 0)
 
     # Per-window pairwise stats (LD, distance moments)
     ld_pairwise = {'zns', 'omega', 'mu_ld'}

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -62,9 +62,13 @@ def _compute_window_bases(haplotype_matrix, win_starts, win_stops,
 CANONICAL_WINDOW_PREFIX = (
     'chrom', 'start', 'end', 'center', 'n_variants', 'window_id')
 
-# Number of bins in the windowed daf_hist feature (columns daf_bin_0 ..
-# daf_bin_{_DAF_N_BINS - 1}) emitted by the fused engine.
-_DAF_N_BINS = 20
+# Fused stats scattered per variant into windows; they share the window
+# membership arrays built in windowed_statistics_fused, and the chunked
+# engine delegates them to the non-chunked function.
+_PER_SITE_SCATTER_STATS = ('mean_nsl', 'daf_hist', 'mu_sfs')
+
+# Frequency bins of the windowed daf_hist columns (daf_bin_0 .. daf_bin_19).
+N_DAF_BINS = 20
 
 
 def _init_window_results(chrom, win_starts_bp, win_stops_bp, n_variants):
@@ -370,45 +374,25 @@ class WindowIterator:
         else:
             raise ValueError(f"Unknown window type: {self.params.window_type}")
 
-    def _bp_window_bounds(self):
-        """Bounds of the bp window grid.
-
-        The matrix's chromosome coordinates win when set; the first and last
-        variant are the fallback. This is the same rule the fused engines
-        apply, so both engines tile the same grid for the same matrix --
-        anchoring at the first variant instead would shift every window of a
-        region- or subset-derived matrix whose chrom_start sits before its
-        first variant.
-        """
-        m = self.matrix
-        chrom_start = (int(m.chrom_start) if m.chrom_start is not None
-                       else int(self.positions_np[0]))
-        chrom_end = (int(m.chrom_end) if m.chrom_end is not None
-                     else int(self.positions_np[-1]))
-        return chrom_start, chrom_end
-
     def _iter_bp_windows(self) -> Iterator[WindowData]:
         """Iterate over fixed base pair windows."""
         # A matrix with no variants -- a region that covers none, for
         # example -- has no windows to yield, and no fallback bounds.
         if len(self.positions_np) == 0:
             return
-        chrom_start, chrom_end = self._bp_window_bounds()
+        chrom_start, chrom_end = _bp_grid_bounds(self.matrix,
+                                                 self.positions_np)
+        win_starts, win_stops = _bp_window_grid(
+            chrom_start, chrom_end,
+            self.params.window_size, self.params.step_size)
 
-        window_id = 0
-        start = chrom_start
-
-        while start < chrom_end:
-            end = start + self.params.window_size
-            center = (start + end) // 2
-
-            # Find variants in window
-            mask = (self.positions_np >= start) & (self.positions_np < end)
-            variant_indices = np.where(mask)[0]
-
-            if len(variant_indices) > 0:
+        for window_id, (start, end) in enumerate(zip(win_starts, win_stops)):
+            start, end = int(start), int(end)
+            # Variants in the right-open [start, end); positions are sorted.
+            lo, hi = np.searchsorted(self.positions_np, (start, end))
+            if hi > lo:
                 # Extract window matrix
-                window_matrix = self.matrix.get_subset(variant_indices)
+                window_matrix = self.matrix.get_subset(np.arange(lo, hi))
                 # Set correct chromosome coordinates for span normalization
                 window_matrix.chrom_start = start
                 window_matrix.chrom_end = end - 1  # end is exclusive in our window definition
@@ -418,14 +402,11 @@ class WindowIterator:
                     chrom=1,  # TODO: Handle multiple chromosomes
                     start=start,
                     end=end,
-                    center=center,
+                    center=(start + end) // 2,
                     matrix=window_matrix,
-                    n_variants=len(variant_indices),
+                    n_variants=hi - lo,
                     window_id=window_id
                 )
-
-            window_id += 1
-            start += self.params.step_size
 
     def _iter_snp_windows(self) -> Iterator[WindowData]:
         """Iterate over fixed SNP count windows."""
@@ -495,11 +476,12 @@ class WindowIterator:
         if self.params.window_type == 'bp':
             if len(self.positions_np) == 0:
                 return 0
-            chrom_start, chrom_end = self._bp_window_bounds()
-            # Candidate window starts: chrom_start, +step, ... while < chrom_end
-            # -- the exact set _iter_bp_windows walks.
-            span = chrom_end - chrom_start
-            return max(0, -(-span // self.params.step_size))
+            chrom_start, chrom_end = _bp_grid_bounds(self.matrix,
+                                                     self.positions_np)
+            win_starts, _ = _bp_window_grid(
+                chrom_start, chrom_end,
+                self.params.window_size, self.params.step_size)
+            return len(win_starts)
         elif self.params.window_type == 'snp':
             n_variants = len(self.positions_np)
             if n_variants <= self.params.window_size:
@@ -692,6 +674,34 @@ class WindowedAnalyzer:
                 yield pd.DataFrame(batch_results)
 
 
+def _bp_grid_bounds(matrix, positions):
+    """Bounds of the bp window grid.
+
+    The matrix's chromosome coordinates win when set; the first and last
+    variant are the fallback. Every windowed engine anchors with this one
+    rule, so they all tile the same grid for the same matrix -- anchoring
+    at the first variant instead would shift every window of a region- or
+    subset-derived matrix whose chrom_start sits before its first variant.
+    """
+    chrom_start = (int(matrix.chrom_start) if matrix.chrom_start is not None
+                   else int(positions[0]))
+    chrom_end = (int(matrix.chrom_end) if matrix.chrom_end is not None
+                 else int(positions[-1]))
+    return chrom_start, chrom_end
+
+
+def _bp_window_grid(chrom_start, chrom_end, window_size, step_size):
+    """Start/stop arrays of the bp window grid.
+
+    Starts run from chrom_start in steps of step_size while strictly below
+    chrom_end; each window spans window_size. Shared by every windowed
+    engine so the grids agree by construction.
+    """
+    win_starts = np.arange(int(chrom_start), int(chrom_end), step_size,
+                           dtype=np.float64)
+    return win_starts, win_starts + window_size
+
+
 def _build_scatter_indices(pos_cpu, chrom_start, chrom_end,
                            window_size, step_size):
     """Build window indices for scatter-add over (possibly overlapping) windows.
@@ -721,9 +731,8 @@ def _build_scatter_indices(pos_cpu, chrom_start, chrom_end,
     `values[:, None]` across n_per_var and raveling yields values aligned
     with win_idx_gpu / mask_gpu.
     """
-    win_starts = np.arange(int(chrom_start), int(chrom_end), step_size,
-                           dtype=np.float64)
-    win_stops = win_starts + window_size
+    win_starts, win_stops = _bp_window_grid(
+        chrom_start, chrom_end, window_size, step_size)
     n_windows = len(win_starts)
     n_per_var = int(np.ceil(window_size / step_size))
 
@@ -782,10 +791,7 @@ def _windowed_thetas_scatter(haplotype_matrix, window_size, step_size,
     else:
         pos_cpu = np.asarray(pos)
 
-    chrom_start = (matrix.chrom_start if matrix.chrom_start is not None
-                   else int(pos_cpu[0]))
-    chrom_end = (matrix.chrom_end if matrix.chrom_end is not None
-                 else int(pos_cpu[-1]))
+    chrom_start, chrom_end = _bp_grid_bounds(matrix, pos_cpu)
     (win_starts, win_stops, n_windows, n_per_var,
      k_safe, contains, win_idx_gpu, mask_gpu) = _build_scatter_indices(
         pos_cpu, chrom_start, chrom_end, window_size, step_size)
@@ -1005,12 +1011,7 @@ def _windowed_twopop_scatter(haplotype_matrix, window_size, step_size,
     else:
         pos_cpu = np.asarray(pos)
 
-    chrom_start = (haplotype_matrix.chrom_start
-                   if haplotype_matrix.chrom_start is not None
-                   else int(pos_cpu[0]))
-    chrom_end = (haplotype_matrix.chrom_end
-                 if haplotype_matrix.chrom_end is not None
-                 else int(pos_cpu[-1]))
+    chrom_start, chrom_end = _bp_grid_bounds(haplotype_matrix, pos_cpu)
     (win_starts, win_stops, n_windows, n_per_var,
      k_safe, contains, win_idx_gpu, mask_gpu) = _build_scatter_indices(
         pos_cpu, chrom_start, chrom_end, window_size, step_size)
@@ -1370,19 +1371,11 @@ def windowed_analysis(haplotype_matrix: HaplotypeMatrix,
             positions = positions.get()
         positions = np.asarray(positions)
 
-        chrom_start = haplotype_matrix.chrom_start
-        chrom_end = haplotype_matrix.chrom_end
-        if chrom_start is None:
-            chrom_start = int(positions[0])
-        if chrom_end is None:
-            chrom_end = int(positions[-1])
-        chrom_start = int(chrom_start)
-        chrom_end = int(chrom_end)
+        chrom_start, chrom_end = _bp_grid_bounds(haplotype_matrix, positions)
 
         # Build window start/stop arrays (supports overlapping windows)
-        win_starts = np.arange(chrom_start, chrom_end, step_size,
-                               dtype=np.float64)
-        win_stops = win_starts + window_size
+        win_starts, win_stops = _bp_window_grid(
+            chrom_start, chrom_end, window_size, step_size)
         # Build equivalent bp_bins for _compute_window_ranges
         bp_bins = np.concatenate([win_starts, [win_stops[-1]]])
 
@@ -2298,7 +2291,7 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
     # > pos. Row j of site_win holds candidate k_hi - j; site_ok masks the
     # rows outside the run. For contiguous windows the run has length one
     # and the arrays stay (1, n_var).
-    if any(s in statistics for s in ('mean_nsl', 'daf_hist', 'mu_sfs')):
+    if any(s in statistics for s in _PER_SITE_SCATTER_STATS):
         k_hi = cp.searchsorted(ws_gpu, positions, side='right') - 1
         k_lo = cp.searchsorted(we_gpu, positions, side='right')
         if positions.size:
@@ -2307,15 +2300,14 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
             n_per_var = 1
         site_win = (k_hi[None, :]
                     - cp.arange(n_per_var, dtype=cp.int64)[:, None])
-        site_ok = (site_win >= k_lo[None, :]) & (site_win < n_windows)
-        bin_idx = site_win.ravel()
-        in_range = site_ok.ravel()
+        # site_win <= k_hi <= n_windows - 1 by construction, so k_lo is the
+        # only bound that can exclude a candidate (k_lo >= 0 also rules out
+        # the negative rows below the first window).
+        site_ok = site_win >= k_lo[None, :]
 
-        def _per_site(v):
-            """Align a per-variant array with bin_idx / in_range."""
-            if n_per_var == 1:
-                return v
-            return cp.broadcast_to(v, (n_per_var, v.shape[0])).ravel()
+        def _expand(v):
+            """Zero-copy view of a per-variant array at site_win's shape."""
+            return cp.broadcast_to(v, site_win.shape)
 
     # Shared per-allele counts (used by daf_hist and mu_sfs). Per-derived-allele,
     # per-site n_valid -- the same convention as diversity.daf_histogram / mu_sfs,
@@ -2328,9 +2320,10 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
     if 'mean_nsl' in statistics:
         from . import selection as sel
         # matrix is already population-subsetted (line 1533); don't re-subset
-        nsl_gpu = _per_site(cp.asarray(sel.nsl(matrix)))
-        valid = cp.isfinite(nsl_gpu) & in_range
-        results['mean_nsl'] = _windowed_mean(nsl_gpu, bin_idx, valid, n_windows)
+        nsl_gpu = _expand(cp.asarray(sel.nsl(matrix)))
+        valid = cp.isfinite(nsl_gpu) & site_ok
+        results['mean_nsl'] = _windowed_mean(nsl_gpu, site_win, valid,
+                                             n_windows)
 
     # SNP distance stats per window
     snp_dist_stats = {'snp_dist_mean', 'snp_dist_var', 'snp_dist_min',
@@ -2376,29 +2369,26 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
     # allele (freq = count / n_valid), scattered into (window, bin) and
     # normalized per window -- matching diversity.daf_histogram.
     if 'daf_hist' in statistics:
-        n_daf_bins = 20
         daf = dac_gpu.astype(cp.float64) / n_hap
-        daf_bin = cp.minimum((daf * n_daf_bins).astype(cp.int32), n_daf_bins - 1)
-        # Composite index: window * n_daf_bins + daf_bin
-        composite = bin_idx * n_daf_bins + _per_site(daf_bin)
-        valid_daf = in_range
-        flat = _scatter_sum(cp.ones_like(composite[valid_daf], dtype=cp.float64),
-                            composite[valid_daf], n_windows * n_daf_bins)
-        hist_matrix = flat.get().reshape(n_windows, n_daf_bins)
-        row_sum = hist_matrix.sum(axis=1, keepdims=True)
-        hist_matrix = np.divide(hist_matrix, row_sum,
-                                out=np.zeros_like(hist_matrix),
-                                where=row_sum > 0)
-        for b in range(n_daf_bins):
+        daf_bin = cp.minimum((daf * N_DAF_BINS).astype(cp.int32),
+                             N_DAF_BINS - 1)
+        # Composite index: window * N_DAF_BINS + daf_bin
+        composite = site_win * N_DAF_BINS + _expand(daf_bin)
+        member = composite[site_ok]
+        flat = _scatter_sum(cp.ones_like(member, dtype=cp.float64),
+                            member, n_windows * N_DAF_BINS)
+        hist_matrix = flat.get().reshape(n_windows, N_DAF_BINS)
+        for b in range(N_DAF_BINS):
             results[f'daf_bin_{b}'] = hist_matrix[:, b]
 
     # muSFS: fraction of segregating (site, allele) entries at the SFS edges
     # (singleton or n_valid-1), per-site n_valid -- matching diversity.mu_sfs.
     if 'mu_sfs' in statistics:
-        is_edge = _per_site(
+        is_edge = _expand(
             ((dac_gpu == 1) | (dac_gpu == n_hap - 1)).astype(cp.float64))
-        edge_sum = _scatter_sum(is_edge[in_range], bin_idx[in_range], n_windows)
-        total_count = _bin_counts(bin_idx[in_range], n_windows)
+        member_win = site_win[site_ok]
+        edge_sum = _scatter_sum(is_edge[site_ok], member_win, n_windows)
+        total_count = _bin_counts(member_win, n_windows)
         edge_cpu = edge_sum.get()
         count_cpu = total_count.get()
         mu_sfs = np.where(count_cpu > 0, edge_cpu / count_cpu, np.nan)
@@ -2838,7 +2828,7 @@ def windowed_statistics_fused_chunked(haplotype_matrix: HaplotypeMatrix,
     # per-window).
     garud_stats = {'garud_h1', 'garud_h12', 'garud_h123', 'garud_h2h1',
                    'haplotype_count'}
-    scatter_stats = {'mean_nsl', 'daf_hist', 'mu_sfs', 'snp_dist_mean',
+    scatter_stats = {*_PER_SITE_SCATTER_STATS, 'snp_dist_mean',
                      'snp_dist_var', 'snp_dist_min', 'snp_dist_max',
                      'mu_var', 'zns', 'omega', 'mu_ld', 'dist_var',
                      'dist_skew', 'dist_kurt'}

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -694,12 +694,16 @@ def _bp_window_grid(chrom_start, chrom_end, window_size, step_size):
     """Start/stop arrays of the bp window grid.
 
     Starts run from chrom_start in steps of step_size while strictly below
-    chrom_end; each window spans window_size. Shared by every windowed
-    engine so the grids agree by construction.
+    chrom_end; each window spans window_size, and the trailing partial
+    window is clipped at chrom_end + 1: chrom_end is a base (the bounds
+    are inclusive), so the right-open trailing window keeps a variant
+    sitting exactly there and its span counts the bases that exist.
+    Shared by every windowed engine so the grids agree by construction.
     """
     win_starts = np.arange(int(chrom_start), int(chrom_end), step_size,
                            dtype=np.float64)
-    return win_starts, win_starts + window_size
+    return win_starts, np.minimum(win_starts + window_size,
+                                  int(chrom_end) + 1)
 
 
 def _build_scatter_indices(pos_cpu, chrom_start, chrom_end,
@@ -771,10 +775,20 @@ def _windowed_thetas_scatter(haplotype_matrix, window_size, step_size,
     else:
         matrix = haplotype_matrix
 
+    # Anchor the window grid before any missing-data filtering: the
+    # filtered subset carries no chromosome bounds and starts at its first
+    # complete site, which would hand every statistic in a mixed request
+    # its own grid.
+    pos_cpu = cp.asnumpy(matrix.positions)
+    chrom_start, chrom_end = _bp_grid_bounds(matrix, pos_cpu)
+    if chrom_end <= chrom_start:
+        return pd.DataFrame()
+
     if missing_data == 'exclude':
         matrix = matrix.exclude_missing_sites()
         if matrix.num_variants == 0:
             return pd.DataFrame()
+        pos_cpu = cp.asnumpy(matrix.positions)
 
     from .diversity import _prepare_allele_counts, _ac_contribution
     ac, n_valid, n_hap = _prepare_allele_counts(matrix)
@@ -785,13 +799,6 @@ def _windowed_thetas_scatter(haplotype_matrix, window_size, step_size,
     alleles_present = (ac > 0).sum(axis=1)
     mut = cp.where(has_data, cp.maximum(alleles_present - 1, 0), 0).astype(cp.float64)
 
-    pos = matrix.positions
-    if isinstance(pos, cp.ndarray):
-        pos_cpu = pos.get()
-    else:
-        pos_cpu = np.asarray(pos)
-
-    chrom_start, chrom_end = _bp_grid_bounds(matrix, pos_cpu)
     (win_starts, win_stops, n_windows, n_per_var,
      k_safe, contains, win_idx_gpu, mask_gpu) = _build_scatter_indices(
         pos_cpu, chrom_start, chrom_end, window_size, step_size)
@@ -810,7 +817,7 @@ def _windowed_thetas_scatter(haplotype_matrix, window_size, step_size,
     n_variants_per_window = np.bincount(
         k_safe[contains], minlength=n_windows)
     results = _init_window_results(
-        chrom, win_starts, np.minimum(win_stops, chrom_end),
+        chrom, win_starts, win_stops,
         n_variants=n_variants_per_window)
 
     # Span for normalization
@@ -824,7 +831,7 @@ def _windowed_thetas_scatter(haplotype_matrix, window_size, step_size,
             total_span = chrom_end - chrom_start
             spans = (win_stops - win_starts) * matrix.n_total_sites / total_span
         else:
-            spans = np.minimum(win_stops, chrom_end) - win_starts
+            spans = win_stops - win_starts
         # Windows with zero span (fully inaccessible) divide to NaN rather
         # than 0 — the per-base rate is undefined, not zero. Clamp for
         # safe division and carry the zero-span mask for post-processing.
@@ -994,6 +1001,13 @@ def _windowed_twopop_scatter(haplotype_matrix, window_size, step_size,
     mat1 = get_population_matrix(haplotype_matrix, pop1_name)
     mat2 = get_population_matrix(haplotype_matrix, pop2_name)
 
+    # Anchor the window grid before any missing-data filtering, so this
+    # engine tiles the same grid as every other statistic in the request.
+    pos_cpu = cp.asnumpy(haplotype_matrix.positions)
+    chrom_start, chrom_end = _bp_grid_bounds(haplotype_matrix, pos_cpu)
+    if chrom_end <= chrom_start:
+        return pd.DataFrame()
+
     if missing_data == 'exclude':
         haplotype_matrix = haplotype_matrix.exclude_missing_sites(
             populations=[pop1_name, pop2_name])
@@ -1001,17 +1015,11 @@ def _windowed_twopop_scatter(haplotype_matrix, window_size, step_size,
             return pd.DataFrame()
         mat1 = get_population_matrix(haplotype_matrix, pop1_name)
         mat2 = get_population_matrix(haplotype_matrix, pop2_name)
+        pos_cpu = cp.asnumpy(haplotype_matrix.positions)
 
     hap1 = mat1.haplotypes
     hap2 = mat2.haplotypes
 
-    pos = haplotype_matrix.positions
-    if isinstance(pos, cp.ndarray):
-        pos_cpu = pos.get()
-    else:
-        pos_cpu = np.asarray(pos)
-
-    chrom_start, chrom_end = _bp_grid_bounds(haplotype_matrix, pos_cpu)
     (win_starts, win_stops, n_windows, n_per_var,
      k_safe, contains, win_idx_gpu, mask_gpu) = _build_scatter_indices(
         pos_cpu, chrom_start, chrom_end, window_size, step_size)
@@ -1029,7 +1037,7 @@ def _windowed_twopop_scatter(haplotype_matrix, window_size, step_size,
     n_variants_per_window = np.bincount(
         k_safe[contains], minlength=n_windows)
     results = _init_window_results(
-        chrom, win_starts, np.minimum(win_stops, chrom_end),
+        chrom, win_starts, win_stops,
         n_variants=n_variants_per_window)
 
     # Span normalization
@@ -1042,7 +1050,7 @@ def _windowed_twopop_scatter(haplotype_matrix, window_size, step_size,
             total_span = chrom_end - chrom_start
             spans = (win_stops - win_starts) * haplotype_matrix.n_total_sites / total_span
         else:
-            spans = np.minimum(win_stops, chrom_end) - win_starts
+            spans = win_stops - win_starts
         # Windows with zero span (fully inaccessible) divide to NaN rather
         # than 0 — the per-base rate is undefined, not zero. Clamp for
         # safe division and carry the zero-span mask for post-processing.
@@ -1376,6 +1384,9 @@ def windowed_analysis(haplotype_matrix: HaplotypeMatrix,
         # Build window start/stop arrays (supports overlapping windows)
         win_starts, win_stops = _bp_window_grid(
             chrom_start, chrom_end, window_size, step_size)
+        # A zero-span matrix (one variant, no bounds) tiles no windows.
+        if len(win_starts) == 0:
+            return pd.DataFrame()
         # Build equivalent bp_bins for _compute_window_ranges
         bp_bins = np.concatenate([win_starts, [win_stops[-1]]])
 
@@ -2059,6 +2070,10 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
         _warn_fused_allele_cap(int((~cap_keep).sum()))
         hap = hap[cap_keep]
         positions = positions[cap_keep]
+        # Everything below that slices by variant-index ranges or counts
+        # per site (Garud, per-window LD, the per-site scatter stats) must
+        # see the same variant set the kernel arrays hold.
+        matrix = matrix.get_subset(cp.where(cap_keep)[0])
     else:
         cap_keep = None
     n_total_var = hap.shape[0]

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -370,15 +370,30 @@ class WindowIterator:
         else:
             raise ValueError(f"Unknown window type: {self.params.window_type}")
 
+    def _bp_window_bounds(self):
+        """Bounds of the bp window grid.
+
+        The matrix's chromosome coordinates win when set; the first and last
+        variant are the fallback. This is the same rule the fused engines
+        apply, so both engines tile the same grid for the same matrix --
+        anchoring at the first variant instead would shift every window of a
+        region- or subset-derived matrix whose chrom_start sits before its
+        first variant.
+        """
+        m = self.matrix
+        chrom_start = (int(m.chrom_start) if m.chrom_start is not None
+                       else int(self.positions_np[0]))
+        chrom_end = (int(m.chrom_end) if m.chrom_end is not None
+                     else int(self.positions_np[-1]))
+        return chrom_start, chrom_end
+
     def _iter_bp_windows(self) -> Iterator[WindowData]:
         """Iterate over fixed base pair windows."""
-        # Window bounds come from the first and last variant, so a matrix with
-        # no variants -- a region that covers none, for example -- has no
-        # windows to yield.
+        # A matrix with no variants -- a region that covers none, for
+        # example -- has no windows to yield, and no fallback bounds.
         if len(self.positions_np) == 0:
             return
-        chrom_start = int(self.positions_np[0])
-        chrom_end = int(self.positions_np[-1])
+        chrom_start, chrom_end = self._bp_window_bounds()
 
         window_id = 0
         start = chrom_start
@@ -480,10 +495,11 @@ class WindowIterator:
         if self.params.window_type == 'bp':
             if len(self.positions_np) == 0:
                 return 0
-            chrom_start = int(self.positions_np[0])
-            chrom_end = int(self.positions_np[-1])
-            return max(1, (chrom_end - chrom_start - self.params.window_size) //
-                      self.params.step_size + 1)
+            chrom_start, chrom_end = self._bp_window_bounds()
+            # Candidate window starts: chrom_start, +step, ... while < chrom_end
+            # -- the exact set _iter_bp_windows walks.
+            span = chrom_end - chrom_start
+            return max(0, -(-span // self.params.step_size))
         elif self.params.window_type == 'snp':
             n_variants = len(self.positions_np)
             if n_variants <= self.params.window_size:

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -775,10 +775,10 @@ def _windowed_thetas_scatter(haplotype_matrix, window_size, step_size,
     else:
         matrix = haplotype_matrix
 
-    # Anchor the window grid before any missing-data filtering: the
-    # filtered subset carries no chromosome bounds and starts at its first
-    # complete site, which would hand every statistic in a mixed request
-    # its own grid.
+    # Anchor the window grid before any missing-data filtering: a matrix
+    # without chromosome bounds falls back to its variant hull, which
+    # moves when a terminal site is incomplete, handing every statistic
+    # in a mixed request its own grid.
     pos_cpu = cp.asnumpy(matrix.positions)
     chrom_start, chrom_end = _bp_grid_bounds(matrix, pos_cpu)
     if chrom_end <= chrom_start:

--- a/tests/test_implementation_parity.py
+++ b/tests/test_implementation_parity.py
@@ -42,7 +42,7 @@ from pg_gpu.windowed_analysis import (
     _windowed_thetas_scatter,
     _windowed_twopop_scatter,
     windowed_statistics_fused,
-    _DAF_N_BINS,
+    N_DAF_BINS,
 )
 
 from .conftest import simulate_hm
@@ -463,7 +463,7 @@ def test_path_matches_scalar(request, condition, stat, path):
 
 @pytest.mark.parametrize("condition", list(_CONDITIONS))
 def test_daf_hist_matches_scalar(request, condition):
-    """daf_hist is vector-valued (daf_bin_0 .. daf_bin_{_DAF_N_BINS - 1}), so it
+    """daf_hist is vector-valued (daf_bin_0 .. daf_bin_{N_DAF_BINS - 1}), so it
     sits outside the scalar _STATS matrix. The fused engine computes it under
     missing_data='include'; check its whole-region histogram against
     diversity.daf_histogram.
@@ -475,11 +475,11 @@ def test_daf_hist_matches_scalar(request, condition):
         pytest.skip("windowed daf_hist is computed by the fused engine "
                     "(missing_data='include') only")
     hm = request.getfixturevalue(cond.fixture)
-    ref, _ = diversity.daf_histogram(hm, n_bins=_DAF_N_BINS, missing_data="include")
+    ref, _ = diversity.daf_histogram(hm, n_bins=N_DAF_BINS, missing_data="include")
 
     out = windowed_statistics_fused(hm, _whole_bp_bins(hm),
                                     statistics=("daf_hist",), per_base=False,
                                     missing_data="include", population=None)
     got_fused = np.array([np.asarray(out[f"daf_bin_{b}"])[0]
-                          for b in range(_DAF_N_BINS)])
+                          for b in range(N_DAF_BINS)])
     np.testing.assert_allclose(got_fused, ref, rtol=RTOL, atol=ATOL)

--- a/tests/test_missing_data_bias.py
+++ b/tests/test_missing_data_bias.py
@@ -201,3 +201,46 @@ class TestExcludeConsistency:
         dxy_inc = divergence.dxy(hm, "pop1", "pop2", missing_data='include')
         dxy_exc = divergence.dxy(hm, "pop1", "pop2", missing_data='exclude')
         assert abs(dxy_inc - dxy_exc) < 1e-10
+
+
+class TestExcludeKeepsMatrixContext:
+    """exclude_missing_sites keeps the parent chromosome bounds and
+    accessibility mask, like the restrict_to_* filters, so exclude-mode
+    span normalization divides by the chromosome, not the surviving
+    variant hull."""
+
+    def _hm(self):
+        rng = np.random.default_rng(17)
+        hap = rng.integers(0, 2, (10, 50), dtype=np.int8)
+        hap[0, 0] = -1            # first site incomplete (row in pop a)
+        hap[3, 49] = -1           # last site incomplete (row in pop a)
+        hap[8, 20] = -1           # mid site incomplete only in pop b
+        pos = (np.arange(50) * 190 + 200).astype(np.int64)  # 200..9510
+        return HaplotypeMatrix(hap, pos, 0, 10000)
+
+    def test_bounds_preserved(self):
+        h = self._hm()
+        ex = h.exclude_missing_sites()
+        assert ex.num_variants == 47
+        assert (ex.chrom_start, ex.chrom_end) == (0, 10000)
+
+    def test_bounds_preserved_with_populations(self):
+        h = self._hm()
+        h.sample_sets = {"a": list(range(6)), "b": list(range(6, 10))}
+        ex = h.exclude_missing_sites(populations=["a"])
+        assert ex.num_variants == 48   # only rows 0-5 checked
+        assert (ex.chrom_start, ex.chrom_end) == (0, 10000)
+
+    def test_mask_preserved(self):
+        from pg_gpu.accessible import AccessibleMask
+        h = self._hm()
+        h.set_accessible_mask(AccessibleMask(np.ones(10001, dtype=bool)))
+        ex = h.exclude_missing_sites()
+        assert ex.has_accessible_mask
+
+    def test_exclude_pi_uses_parent_span(self):
+        from pg_gpu import diversity
+        h = self._hm()
+        raw = diversity.pi(h, missing_data='exclude', span_normalize=False)
+        per_bp = diversity.pi(h, missing_data='exclude', span_normalize=True)
+        np.testing.assert_allclose(per_bp, raw / 10001, rtol=1e-12)

--- a/tests/test_missing_data_bias.py
+++ b/tests/test_missing_data_bias.py
@@ -238,6 +238,12 @@ class TestExcludeKeepsMatrixContext:
         ex = h.exclude_missing_sites()
         assert ex.has_accessible_mask
 
+    def test_filter_by_missing_keeps_context(self):
+        h = self._hm()
+        f = h.filter_variants_by_missing(max_missing_freq=0.05)
+        assert f.num_variants == 47
+        assert (f.chrom_start, f.chrom_end) == (0, 10000)
+
     def test_exclude_pi_uses_parent_span(self):
         from pg_gpu import diversity
         h = self._hm()

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -811,7 +811,7 @@ class TestWindowedDafMuSfsMatchesScalar:
     @pytest.mark.parametrize("kind", ["biallelic", "multiallelic"])
     @pytest.mark.parametrize("missing", [False, True])
     def test_whole_region_matches_scalar(self, kind, missing):
-        from pg_gpu.windowed_analysis import windowed_analysis, _DAF_N_BINS
+        from pg_gpu.windowed_analysis import windowed_analysis, N_DAF_BINS
         hap = self._hap(kind, missing)
         nv = hap.shape[1]
         pos = np.arange(nv) * 100
@@ -823,10 +823,10 @@ class TestWindowedDafMuSfsMatchesScalar:
                                missing_data='include')
         assert len(wa) == 1
         w_mu = wa['mu_sfs'].values[0]
-        w_hist = np.array([wa[f'daf_bin_{b}'].values[0] for b in range(_DAF_N_BINS)])
+        w_hist = np.array([wa[f'daf_bin_{b}'].values[0] for b in range(N_DAF_BINS)])
 
         sc_mu = diversity.mu_sfs(hm, missing_data='include')
-        sc_hist, _ = diversity.daf_histogram(hm, n_bins=_DAF_N_BINS, missing_data='include')
+        sc_hist, _ = diversity.daf_histogram(hm, n_bins=N_DAF_BINS, missing_data='include')
 
         if np.isnan(sc_mu):
             assert np.isnan(w_mu)
@@ -838,7 +838,7 @@ class TestWindowedDafMuSfsMatchesScalar:
         # A site that is monomorphic for the derived allele but has one missing
         # haplotype must not count as an SFS edge: classification uses the site's
         # own valid-sample count, not a global haplotype count.
-        from pg_gpu.windowed_analysis import windowed_analysis, _DAF_N_BINS
+        from pg_gpu.windowed_analysis import windowed_analysis, N_DAF_BINS
         n = 20
         hap = np.zeros((n, 4), dtype=np.int8)
         hap[:, :] = np.array([0, 1, 1, 1])  # sites 1..3 monomorphic-derived

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -1713,3 +1713,129 @@ class TestEngineGridAgreement:
         in2 = int(((pos >= 300_000) & (pos < 400_000)).sum())
         assert int(r1['n_variants'].sum()) == in1
         assert int(r2['n_variants'].sum()) == in2
+
+
+def _host(a):
+    return a.get() if hasattr(a, "get") else np.asarray(a)
+
+
+class TestOneGridAllModes:
+    """Every engine tiles the same grid whatever the missing-data mode, the
+    trailing window clips at the chromosome end (an inclusive base), and
+    degenerate inputs return empty results instead of crashing."""
+
+    def _two_pop_edge_missing(self):
+        rng = np.random.RandomState(11)
+        hap = rng.randint(0, 2, (12, 60)).astype(np.int8)
+        hap[0:6, 0:8] = -1     # pop1 missing at the left edge
+        hap[6:12, 52:] = -1    # pop2 missing at the right edge
+        pos = np.sort(rng.choice(np.arange(10, 9990), 60, replace=False))
+        hm = HaplotypeMatrix(hap, pos.astype(np.int64))
+        hm.sample_sets = {"p1": list(range(6)), "p2": list(range(6, 12))}
+        return hm
+
+    def test_mixed_exclude_asymmetric_missing_runs_on_one_grid(self):
+        hm = self._two_pop_edge_missing()
+        wa_ex = windowed_analysis(hm, window_size=1000, step_size=1000,
+                                  statistics=['pi', 'fst_hudson'],
+                                  populations=['p1', 'p2'],
+                                  missing_data='exclude')
+        wa_in = windowed_analysis(hm, window_size=1000, step_size=1000,
+                                  statistics=['pi', 'fst_hudson'],
+                                  populations=['p1', 'p2'],
+                                  missing_data='include')
+        assert list(wa_ex['start']) == list(wa_in['start'])
+        assert list(wa_ex['end']) == list(wa_in['end'])
+        assert 'fst_hudson' in wa_ex.columns and 'pi' in wa_ex.columns
+
+    def test_exclude_fst_lands_on_labeled_window(self):
+        from pg_gpu import divergence
+        hm = self._two_pop_edge_missing()
+        wa = windowed_analysis(hm, window_size=1000, step_size=1000,
+                               statistics=['fst_hudson'],
+                               populations=['p1', 'p2'],
+                               missing_data='exclude',
+                               span_normalize=False)
+        pos = _host(hm.positions)
+        complete = _host((hm.haplotypes >= 0).all(axis=0))
+        for _, row in wa.iterrows():
+            member = (pos >= row['start']) & (pos < row['end']) & complete
+            if member.sum() == 0:
+                continue
+            sub = hm.get_subset(np.where(member)[0])
+            sub.sample_sets = hm.sample_sets
+            expected = divergence.fst(sub, 'p1', 'p2')
+            got = row['fst_hudson']
+            if np.isnan(expected) and np.isnan(got):
+                continue
+            np.testing.assert_allclose(got, expected, rtol=1e-10,
+                                       err_msg=f"window {row['start']}")
+
+    def test_trailing_window_clips_across_engines(self):
+        from pg_gpu import diversity
+        rng = np.random.RandomState(7)
+        hap = rng.randint(0, 2, (10, 40)).astype(np.int8)
+        pos = np.sort(rng.choice(np.arange(1, 9990), 40, replace=False))
+        hm = HaplotypeMatrix(hap, pos.astype(np.int64), 0, 10000)
+        wa_f = windowed_analysis(hm, window_size=3000, step_size=3000,
+                                 statistics=['pi'])
+        assert int(wa_f['end'].iloc[-1]) == 10001
+        wa_it = WindowedAnalyzer(window_size=3000, step_size=3000,
+                                 statistics=['pi'],
+                                 progress_bar=False).compute(hm)
+        assert int(np.asarray(wa_it['end'])[-1]) == 10001
+        # per-base pi of the clipped window divides by the 1001 bases
+        # 9000..10000 that exist inside the inclusive bounds
+        member = (pos >= 9000) & (pos <= 10000)
+        sub = hm.get_subset(np.where(member)[0])
+        raw = diversity.pi(sub, span_normalize=False)
+        np.testing.assert_allclose(wa_f['pi'].iloc[-1], raw / 1001,
+                                   rtol=1e-10)
+
+    def test_allele_cap_drop_keeps_per_site_stats_aligned(self):
+        import warnings as _w
+        rng = np.random.RandomState(3)
+        hap = rng.randint(0, 2, (12, 40)).astype(np.int8)
+        hap[0, 5] = 9          # beyond the fused per-allele capacity
+        pos = (np.arange(40) * 100 + 50).astype(np.int64)
+        hm = HaplotypeMatrix(hap, pos, 0, 4000)
+        with _w.catch_warnings():
+            _w.simplefilter("ignore")
+            wa = windowed_analysis(hm, window_size=1000, step_size=1000,
+                                   statistics=['daf_hist', 'mu_sfs',
+                                               'mean_nsl'])
+        assert len(wa) == 4
+        assert np.isfinite(wa['mu_sfs']).all()
+        # the capped site is gone from its window's entries
+        from pg_gpu import diversity
+        sub = hm.get_subset(np.where((np.arange(40) != 5) & (pos < 1000))[0])
+        exp_mu = diversity.mu_sfs(sub)
+        np.testing.assert_allclose(wa['mu_sfs'].iloc[0], exp_mu, atol=1e-12)
+
+    def test_single_variant_no_bounds_returns_empty(self):
+        hm = HaplotypeMatrix(np.array([[0], [1], [1], [0]], dtype=np.int8),
+                             np.array([500], dtype=np.int64))
+        wa = windowed_analysis(hm, window_size=1000, step_size=1000,
+                               statistics=['pi'])
+        assert len(wa) == 0
+        wa_ex = windowed_analysis(hm, window_size=1000, step_size=1000,
+                                  statistics=['pi'],
+                                  missing_data='exclude')
+        assert len(wa_ex) == 0
+
+    def test_variant_at_chrom_end_membership(self):
+        # A variant at the inclusive chrom_end stays in a partial trailing
+        # window; on an aligned grid the right-open boundary excludes it.
+        hap = np.tile(np.array([[0], [1], [1], [0]], dtype=np.int8), (1, 5))
+        pos = np.array([100, 800, 1500, 2200, 2500], dtype=np.int64)
+        partial = HaplotypeMatrix(hap.copy(), pos, 0, 2500)
+        wa = windowed_analysis(partial, window_size=1000, step_size=1000,
+                               statistics=['pi'])
+        assert int(wa['n_variants'].sum()) == 5
+        assert int(wa['end'].iloc[-1]) == 2501
+        hap6 = np.tile(np.array([[0], [1], [1], [0]], dtype=np.int8), (1, 6))
+        pos6 = np.array([100, 800, 1500, 2200, 2500, 3000], dtype=np.int64)
+        aligned = HaplotypeMatrix(hap6, pos6, 0, 3000)
+        wa2 = windowed_analysis(aligned, window_size=1000, step_size=1000,
+                                statistics=['pi'])
+        assert int(wa2['n_variants'].sum()) == 5   # the 3000 variant is out

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -759,6 +759,19 @@ class TestFusedMissingData:
         self._compare_fused_vs_scatter(hm)
 
 
+def _leading_gap_hm(seq_len=100_000, first_pos=243):
+    """Haplotype matrix with chrom_start=0 and a first variant > 0."""
+    rng = np.random.RandomState(7)
+    positions = np.concatenate([
+        [first_pos],
+        np.sort(rng.choice(
+            np.arange(first_pos + 1, seq_len), size=499, replace=False)),
+    ])
+    hap = rng.randint(0, 2, (20, len(positions)), dtype=np.int8)
+    return HaplotypeMatrix(hap, positions,
+                           chrom_start=0, chrom_end=seq_len)
+
+
 class TestChromStartZero:
     """Windows must be anchored at chrom_start=0, not the first variant position.
 
@@ -770,16 +783,7 @@ class TestChromStartZero:
     """
 
     def _simple_hm(self, seq_len=100_000, first_pos=243):
-        """Haplotype matrix with chrom_start=0 and a first variant > 0."""
-        rng = np.random.RandomState(7)
-        positions = np.concatenate([
-            [first_pos],
-            np.sort(rng.choice(
-                np.arange(first_pos + 1, seq_len), size=499, replace=False)),
-        ])
-        hap = rng.randint(0, 2, (20, len(positions)), dtype=np.int8)
-        return HaplotypeMatrix(hap, positions,
-                               chrom_start=0, chrom_end=seq_len)
+        return _leading_gap_hm(seq_len, first_pos)
 
     def test_single_pop_windows_start_at_zero(self):
         hm = self._simple_hm()
@@ -1556,36 +1560,56 @@ class TestWindowedGarudCorrectness:
 
 
 class TestFusedPerSiteWindowMembership:
-    """Window assignment of the per-site scatter stats in the fused engine.
-
-    A variant belongs to the right-open [start, end) window -- the same rule
-    n_variants and the theta / divergence stats use -- so a variant sitting
-    exactly on an interior boundary (pos == a window end == the next
-    window's start) belongs to the upper window. When windows overlap
-    (step < window), a variant belongs to every window that covers it, not
-    just one. Each window's daf_hist / mu_sfs / mean_nsl must equal the
-    value recomputed from that window's own variant slice.
-    """
+    """Per-site scatter stats land in the right-open [start, end) window
+    that n_variants uses, and in every window covering them when windows
+    overlap. Each window must equal the value recomputed from its own
+    variant slice."""
 
     n_hap = 24
     n_var = 120
 
     @pytest.fixture
     def data(self):
+        from pg_gpu.windowed_analysis import N_DAF_BINS
         rng = np.random.RandomState(4)
         hap = rng.randint(0, 2, (self.n_hap, self.n_var)).astype(np.int8)
         # Evenly spaced positions put variants exactly on window boundaries
         # (3000, 6000, 9000 for 3 kb windows).
         pos = np.arange(self.n_var) * 100
         hm = HaplotypeMatrix(hap, pos, 0, self.n_var * 100)
-        return hm, hap, pos
-
-    def _check_windows(self, hm, hap, pos, window, step):
-        from pg_gpu import selection
         dac = hap.sum(axis=0)
-        # The fused engine's own binning formula; the subject here is
-        # membership, not binning.
-        daf_bin = np.minimum((dac / self.n_hap * 20).astype(int), 19)
+        # The engine's own binning formula; the subject here is membership,
+        # not binning.
+        daf_bin = np.minimum((dac / self.n_hap * N_DAF_BINS).astype(int),
+                             N_DAF_BINS - 1)
+        return hm, pos, dac, daf_bin
+
+    def _check_window(self, row_hist, row_mu, row_nsl, member,
+                      dac, daf_bin, nsl_all, label):
+        from pg_gpu.windowed_analysis import N_DAF_BINS
+        exp_hist = np.bincount(daf_bin[member],
+                               minlength=N_DAF_BINS).astype(float)
+        np.testing.assert_allclose(row_hist, exp_hist,
+                                   err_msg=f"daf_hist mismatch in {label}")
+        is_edge = (dac[member] == 1) | (dac[member] == self.n_hap - 1)
+        np.testing.assert_allclose(row_mu, is_edge.mean(), atol=1e-12,
+                                   err_msg=f"mu_sfs mismatch in {label}")
+        v = nsl_all[member]
+        v = v[np.isfinite(v)]
+        if len(v):
+            np.testing.assert_allclose(row_nsl, v.mean(), atol=1e-9,
+                                       err_msg=f"mean_nsl mismatch in {label}")
+
+    @pytest.mark.parametrize("window,step", [
+        pytest.param(3000, 3000, id="boundary-non-overlapping"),
+        pytest.param(100, 100, id="every-variant-on-a-boundary"),
+        pytest.param(2000, 1000, id="overlap-two-deep"),
+        pytest.param(3000, 1000, id="overlap-three-deep"),
+    ])
+    def test_window_matches_own_slice(self, data, window, step):
+        from pg_gpu import selection
+        from pg_gpu.windowed_analysis import N_DAF_BINS
+        hm, pos, dac, daf_bin = data
         nsl_all = np.asarray(selection.nsl(hm))
         wa = windowed_analysis(hm, window_size=window, step_size=step,
                                statistics=['mu_sfs', 'daf_hist',
@@ -1597,55 +1621,27 @@ class TestFusedPerSiteWindowMembership:
             assert int(member.sum()) == int(row['n_variants'])
             if not member.any():
                 continue
-            exp_hist = np.bincount(daf_bin[member], minlength=20).astype(float)
-            got_hist = np.array([row[f'daf_bin_{b}'] for b in range(20)])
-            np.testing.assert_allclose(
-                got_hist, exp_hist,
-                err_msg=f"daf_hist mismatch in [{s}, {e})")
-            is_edge = (dac[member] == 1) | (dac[member] == self.n_hap - 1)
-            np.testing.assert_allclose(
-                row['mu_sfs'], is_edge.mean(), atol=1e-12,
-                err_msg=f"mu_sfs mismatch in [{s}, {e})")
-            v = nsl_all[member]
-            v = v[np.isfinite(v)]
-            if len(v):
-                np.testing.assert_allclose(
-                    row['mean_nsl'], v.mean(), atol=1e-9,
-                    err_msg=f"mean_nsl mismatch in [{s}, {e})")
-
-    def test_boundary_variants_non_overlapping(self, data):
-        hm, hap, pos = data
-        self._check_windows(hm, hap, pos, 3000, 3000)
-
-    def test_every_variant_on_a_boundary(self, data):
-        # window == step == the position spacing: every variant sits
-        # exactly on a window start.
-        hm, hap, pos = data
-        self._check_windows(hm, hap, pos, 100, 100)
-
-    def test_overlapping_windows_two_deep(self, data):
-        hm, hap, pos = data
-        self._check_windows(hm, hap, pos, 2000, 1000)
-
-    def test_overlapping_windows_three_deep(self, data):
-        hm, hap, pos = data
-        self._check_windows(hm, hap, pos, 3000, 1000)
+            hist = np.array([row[f'daf_bin_{b}'] for b in range(N_DAF_BINS)])
+            self._check_window(hist, row['mu_sfs'], row['mean_nsl'],
+                               member, dac, daf_bin, nsl_all,
+                               f"[{s}, {e})")
 
     def test_direct_bp_bins_branch(self, data):
         # Calling the fused function with explicit contiguous bp_bins
         # exercises the branch without _win_starts/_win_stops.
-        from pg_gpu.windowed_analysis import windowed_statistics_fused
-        hm, hap, pos = data
-        dac = hap.sum(axis=0)
-        daf_bin = np.minimum((dac / self.n_hap * 20).astype(int), 19)
+        from pg_gpu.windowed_analysis import (windowed_statistics_fused,
+                                              N_DAF_BINS)
+        hm, pos, dac, daf_bin = data
         bp = np.array([0., 3000., 6000., 9000., 12000.])
         res = windowed_statistics_fused(
             hm, bp_bins=bp, statistics=('daf_hist', 'mu_sfs'),
             per_base=False)
         for wi in range(4):
             member = (pos >= bp[wi]) & (pos < bp[wi + 1])
-            exp_hist = np.bincount(daf_bin[member], minlength=20).astype(float)
-            got_hist = np.array([res[f'daf_bin_{b}'][wi] for b in range(20)])
+            exp_hist = np.bincount(daf_bin[member],
+                                   minlength=N_DAF_BINS).astype(float)
+            got_hist = np.array([res[f'daf_bin_{b}'][wi]
+                                 for b in range(N_DAF_BINS)])
             np.testing.assert_allclose(got_hist, exp_hist)
             is_edge = (dac[member] == 1) | (dac[member] == self.n_hap - 1)
             np.testing.assert_allclose(res['mu_sfs'][wi], is_edge.mean(),
@@ -1653,26 +1649,11 @@ class TestFusedPerSiteWindowMembership:
 
 
 class TestEngineGridAgreement:
-    """Both windowed engines tile the same grid for the same matrix.
-
-    The grid anchors at the matrix's chromosome coordinates when they are
-    set; the first and last variant are only the fallback. A region- or
-    subset-derived matrix whose chrom_start sits before its first variant
-    must not shift its windows.
-    """
-
-    def _hm(self):
-        rng = np.random.RandomState(7)
-        positions = np.concatenate([
-            [243],
-            np.sort(rng.choice(np.arange(244, 100_000), 499, replace=False)),
-        ])
-        hap = rng.randint(0, 2, (20, len(positions)), dtype=np.int8)
-        return HaplotypeMatrix(hap, positions,
-                               chrom_start=0, chrom_end=100_000)
+    """Both windowed engines tile the same grid for the same matrix,
+    anchored at the matrix chromosome bounds when they are set."""
 
     def test_iterator_anchors_at_chrom_start(self):
-        hm = self._hm()
+        hm = _leading_gap_hm()
         it = WindowedAnalyzer(window_size=10_000, step_size=10_000,
                               statistics=['pi'],
                               progress_bar=False).compute(hm)
@@ -1680,7 +1661,7 @@ class TestEngineGridAgreement:
         assert all(int(s) % 10_000 == 0 for s in it['start'])
 
     def test_iterator_grid_matches_fused(self):
-        hm = self._hm()
+        hm = _leading_gap_hm()
         fused = windowed_analysis(hm, window_size=10_000, step_size=10_000,
                                   statistics=['pi'])
         it = WindowedAnalyzer(window_size=10_000, step_size=10_000,
@@ -1718,7 +1699,7 @@ class TestEngineGridAgreement:
             rng.randint(0, 2, (20, n_var)).astype(np.int8),
             pos, 1, 999_999)
         wa = WindowedAnalyzer(window_size=20_000, step_size=20_000,
-                              statistics=['pi', 'n_variants'],
+                              statistics=['pi'],
                               progress_bar=False)
         r1 = wa.compute_region(hm, '1', 200_000, 300_000)
         r2 = wa.compute_region(hm, '1', 300_000, 400_000)

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -1584,16 +1584,20 @@ class TestFusedPerSiteWindowMembership:
                              N_DAF_BINS - 1)
         return hm, pos, dac, daf_bin
 
-    def _check_window(self, row_hist, row_mu, row_nsl, member,
-                      dac, daf_bin, nsl_all, label):
+    def _check_window(self, row_hist, row_mu, member, dac, daf_bin, label,
+                      row_nsl=None, nsl_all=None):
         from pg_gpu.windowed_analysis import N_DAF_BINS
         exp_hist = np.bincount(daf_bin[member],
                                minlength=N_DAF_BINS).astype(float)
+        if exp_hist.sum() > 0:
+            exp_hist = exp_hist / exp_hist.sum()   # daf_hist rows sum to 1
         np.testing.assert_allclose(row_hist, exp_hist,
                                    err_msg=f"daf_hist mismatch in {label}")
         is_edge = (dac[member] == 1) | (dac[member] == self.n_hap - 1)
         np.testing.assert_allclose(row_mu, is_edge.mean(), atol=1e-12,
                                    err_msg=f"mu_sfs mismatch in {label}")
+        if nsl_all is None:
+            return
         v = nsl_all[member]
         v = v[np.isfinite(v)]
         if len(v):
@@ -1622,9 +1626,9 @@ class TestFusedPerSiteWindowMembership:
             if not member.any():
                 continue
             hist = np.array([row[f'daf_bin_{b}'] for b in range(N_DAF_BINS)])
-            self._check_window(hist, row['mu_sfs'], row['mean_nsl'],
-                               member, dac, daf_bin, nsl_all,
-                               f"[{s}, {e})")
+            self._check_window(hist, row['mu_sfs'], member, dac, daf_bin,
+                               f"[{s}, {e})", row_nsl=row['mean_nsl'],
+                               nsl_all=nsl_all)
 
     def test_direct_bp_bins_branch(self, data):
         # Calling the fused function with explicit contiguous bp_bins
@@ -1638,14 +1642,10 @@ class TestFusedPerSiteWindowMembership:
             per_base=False)
         for wi in range(4):
             member = (pos >= bp[wi]) & (pos < bp[wi + 1])
-            exp_hist = np.bincount(daf_bin[member],
-                                   minlength=N_DAF_BINS).astype(float)
             got_hist = np.array([res[f'daf_bin_{b}'][wi]
                                  for b in range(N_DAF_BINS)])
-            np.testing.assert_allclose(got_hist, exp_hist)
-            is_edge = (dac[member] == 1) | (dac[member] == self.n_hap - 1)
-            np.testing.assert_allclose(res['mu_sfs'][wi], is_edge.mean(),
-                                       atol=1e-12)
+            self._check_window(got_hist, res['mu_sfs'][wi], member, dac,
+                               daf_bin, f"bp bin {wi}")
 
 
 class TestEngineGridAgreement:

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -1553,3 +1553,85 @@ class TestWindowedGarudCorrectness:
                                         err_msg=f"H123 window {w}")
             np.testing.assert_allclose(row["garud_h2h1"], h2h1_a, rtol=1e-9,
                                         err_msg=f"H2H1 window {w}")
+
+
+class TestEngineGridAgreement:
+    """Both windowed engines tile the same grid for the same matrix.
+
+    The grid anchors at the matrix's chromosome coordinates when they are
+    set; the first and last variant are only the fallback. A region- or
+    subset-derived matrix whose chrom_start sits before its first variant
+    must not shift its windows.
+    """
+
+    def _hm(self):
+        rng = np.random.RandomState(7)
+        positions = np.concatenate([
+            [243],
+            np.sort(rng.choice(np.arange(244, 100_000), 499, replace=False)),
+        ])
+        hap = rng.randint(0, 2, (20, len(positions)), dtype=np.int8)
+        return HaplotypeMatrix(hap, positions,
+                               chrom_start=0, chrom_end=100_000)
+
+    def test_iterator_anchors_at_chrom_start(self):
+        hm = self._hm()
+        it = WindowedAnalyzer(window_size=10_000, step_size=10_000,
+                              statistics=['pi'],
+                              progress_bar=False).compute(hm)
+        assert int(it['start'].iloc[0]) == 0
+        assert all(int(s) % 10_000 == 0 for s in it['start'])
+
+    def test_iterator_grid_matches_fused(self):
+        hm = self._hm()
+        fused = windowed_analysis(hm, window_size=10_000, step_size=10_000,
+                                  statistics=['pi'])
+        it = WindowedAnalyzer(window_size=10_000, step_size=10_000,
+                              statistics=['pi'],
+                              progress_bar=False).compute(hm)
+        # The fused engine reports every window; the iterator skips empty
+        # ones. Compare on the non-empty rows.
+        nonempty = fused[fused['n_variants'] > 0].reset_index(drop=True)
+        assert list(nonempty['start'].astype(int)) == \
+            list(it['start'].astype(int))
+        assert list(nonempty['end'].astype(int)) == \
+            list(it['end'].astype(int))
+        assert list(nonempty['n_variants'].astype(int)) == \
+            list(it['n_variants'].astype(int))
+        np.testing.assert_allclose(it['pi'].values, nonempty['pi'].values,
+                                   rtol=1e-9)
+
+    def test_positions_fallback_without_chrom_bounds(self):
+        rng = np.random.RandomState(3)
+        pos = np.sort(rng.choice(np.arange(5_000, 50_000), 200,
+                                 replace=False))
+        hap = rng.randint(0, 2, (12, len(pos)), dtype=np.int8)
+        hm = HaplotypeMatrix(hap, pos)
+        it = WindowedAnalyzer(window_size=5_000, step_size=5_000,
+                              statistics=['pi'],
+                              progress_bar=False).compute(hm)
+        assert int(it['start'].iloc[0]) == int(pos[0])
+
+    def test_compute_region_tiles_from_region_start(self):
+        rng = np.random.RandomState(0)
+        n_var = 400
+        pos = np.sort(rng.choice(np.arange(1, 1_000_000), n_var,
+                                 replace=False))
+        hm = HaplotypeMatrix(
+            rng.randint(0, 2, (20, n_var)).astype(np.int8),
+            pos, 1, 999_999)
+        wa = WindowedAnalyzer(window_size=20_000, step_size=20_000,
+                              statistics=['pi', 'n_variants'],
+                              progress_bar=False)
+        r1 = wa.compute_region(hm, '1', 200_000, 300_000)
+        r2 = wa.compute_region(hm, '1', 300_000, 400_000)
+        # Windows anchor at each region's start, so consecutive region
+        # calls tile without gaps or overlap.
+        assert list(r1['start'].astype(int)) == \
+            list(range(200_000, 300_000, 20_000))
+        assert list(r2['start'].astype(int)) == \
+            list(range(300_000, 400_000, 20_000))
+        in1 = int(((pos >= 200_000) & (pos < 300_000)).sum())
+        in2 = int(((pos >= 300_000) & (pos < 400_000)).sum())
+        assert int(r1['n_variants'].sum()) == in1
+        assert int(r2['n_variants'].sum()) == in2

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -1555,6 +1555,103 @@ class TestWindowedGarudCorrectness:
                                         err_msg=f"H2H1 window {w}")
 
 
+class TestFusedPerSiteWindowMembership:
+    """Window assignment of the per-site scatter stats in the fused engine.
+
+    A variant belongs to the right-open [start, end) window -- the same rule
+    n_variants and the theta / divergence stats use -- so a variant sitting
+    exactly on an interior boundary (pos == a window end == the next
+    window's start) belongs to the upper window. When windows overlap
+    (step < window), a variant belongs to every window that covers it, not
+    just one. Each window's daf_hist / mu_sfs / mean_nsl must equal the
+    value recomputed from that window's own variant slice.
+    """
+
+    n_hap = 24
+    n_var = 120
+
+    @pytest.fixture
+    def data(self):
+        rng = np.random.RandomState(4)
+        hap = rng.randint(0, 2, (self.n_hap, self.n_var)).astype(np.int8)
+        # Evenly spaced positions put variants exactly on window boundaries
+        # (3000, 6000, 9000 for 3 kb windows).
+        pos = np.arange(self.n_var) * 100
+        hm = HaplotypeMatrix(hap, pos, 0, self.n_var * 100)
+        return hm, hap, pos
+
+    def _check_windows(self, hm, hap, pos, window, step):
+        from pg_gpu import selection
+        dac = hap.sum(axis=0)
+        # The fused engine's own binning formula; the subject here is
+        # membership, not binning.
+        daf_bin = np.minimum((dac / self.n_hap * 20).astype(int), 19)
+        nsl_all = np.asarray(selection.nsl(hm))
+        wa = windowed_analysis(hm, window_size=window, step_size=step,
+                               statistics=['mu_sfs', 'daf_hist',
+                                           'mean_nsl', 'pi'])
+        assert len(wa) > 1
+        for _, row in wa.iterrows():
+            s, e = row['start'], row['end']
+            member = (pos >= s) & (pos < e)
+            assert int(member.sum()) == int(row['n_variants'])
+            if not member.any():
+                continue
+            exp_hist = np.bincount(daf_bin[member], minlength=20).astype(float)
+            got_hist = np.array([row[f'daf_bin_{b}'] for b in range(20)])
+            np.testing.assert_allclose(
+                got_hist, exp_hist,
+                err_msg=f"daf_hist mismatch in [{s}, {e})")
+            is_edge = (dac[member] == 1) | (dac[member] == self.n_hap - 1)
+            np.testing.assert_allclose(
+                row['mu_sfs'], is_edge.mean(), atol=1e-12,
+                err_msg=f"mu_sfs mismatch in [{s}, {e})")
+            v = nsl_all[member]
+            v = v[np.isfinite(v)]
+            if len(v):
+                np.testing.assert_allclose(
+                    row['mean_nsl'], v.mean(), atol=1e-9,
+                    err_msg=f"mean_nsl mismatch in [{s}, {e})")
+
+    def test_boundary_variants_non_overlapping(self, data):
+        hm, hap, pos = data
+        self._check_windows(hm, hap, pos, 3000, 3000)
+
+    def test_every_variant_on_a_boundary(self, data):
+        # window == step == the position spacing: every variant sits
+        # exactly on a window start.
+        hm, hap, pos = data
+        self._check_windows(hm, hap, pos, 100, 100)
+
+    def test_overlapping_windows_two_deep(self, data):
+        hm, hap, pos = data
+        self._check_windows(hm, hap, pos, 2000, 1000)
+
+    def test_overlapping_windows_three_deep(self, data):
+        hm, hap, pos = data
+        self._check_windows(hm, hap, pos, 3000, 1000)
+
+    def test_direct_bp_bins_branch(self, data):
+        # Calling the fused function with explicit contiguous bp_bins
+        # exercises the branch without _win_starts/_win_stops.
+        from pg_gpu.windowed_analysis import windowed_statistics_fused
+        hm, hap, pos = data
+        dac = hap.sum(axis=0)
+        daf_bin = np.minimum((dac / self.n_hap * 20).astype(int), 19)
+        bp = np.array([0., 3000., 6000., 9000., 12000.])
+        res = windowed_statistics_fused(
+            hm, bp_bins=bp, statistics=('daf_hist', 'mu_sfs'),
+            per_base=False)
+        for wi in range(4):
+            member = (pos >= bp[wi]) & (pos < bp[wi + 1])
+            exp_hist = np.bincount(daf_bin[member], minlength=20).astype(float)
+            got_hist = np.array([res[f'daf_bin_{b}'][wi] for b in range(20)])
+            np.testing.assert_allclose(got_hist, exp_hist)
+            is_edge = (dac[member] == 1) | (dac[member] == self.n_hap - 1)
+            np.testing.assert_allclose(res['mu_sfs'][wi], is_edge.mean(),
+                                       atol=1e-12)
+
+
 class TestEngineGridAgreement:
     """Both windowed engines tile the same grid for the same matrix.
 


### PR DESCRIPTION
Closes #179. Closes #166. Closes #208.

The two issues sit on different axes of the same module. A windowed engine makes two
decisions: where the window grid starts, and which window each variant belongs to.
#179 was a grid problem in the iterator engine; #166 was a membership problem in the
fused engine. One commit per issue.

## #179: iterator grid anchoring

`WindowIterator._iter_bp_windows` started the grid at the first variant and ignored
`chrom_start` / `chrom_end`, while every fused path anchors at the matrix bounds when
they are set. The engines tiled different grids for the same matrix whenever
`chrom_start` sits before the first variant: `from_ts` (chrom_start 0), a `from_vcf`
region load, or a `get_subset_from_range` subset. `compute_region` was the loudest
symptom -- its windows started at the first variant in the region, so neighbouring
region calls did not tile.

Fix: `_bp_window_bounds` applies the fused rule (matrix bounds when set, variants as
fallback) in both `_iter_bp_windows` and `count_windows`. `count_windows` now counts
the exact candidate starts the loop walks; the old formula under-counted whenever
step and window size differed (progress-bar total only).

## #166: fused per-site window membership

`bin_idx = searchsorted(we_gpu, positions)` assigned each variant to one window, with
a boundary variant (pos == a window end == the next window's start) going to the
lower window. Everything else in the same call -- `n_variants`, the theta and
divergence kernels, the per-window slice stats -- is right-open `[start, end)`. And
one window per variant means overlapping windows (step < window) silently dropped
each variant from every other window covering it. Affected: `daf_hist`, `mu_sfs`,
`mean_nsl`. The audit the issue asked for confirms the rest of the scatter set
(`snp_dist_*`, `mu_var`, `zns`, `omega`, `mu_ld`, `dist_*`) iterates
`win_start[wi]:win_stop[wi]` slices and was already correct.

Fix: membership is the consecutive run `[k_lo, k_hi]` -- `k_hi` the last window whose
start is <= pos, `k_lo` the first whose end is > pos. Both window families the engine
receives (contiguous `bp_bins`, uniform overlapping start/stop arrays) have
nondecreasing starts and ends, so the run is exact. Contiguous grids keep length-one
runs, so the common case keeps its old shape and cost. The chunked engine delegates
these stats to the fused function, so both paths are covered. This restores the
approach of the reverted df9716b and extends it to overlapping windows.

## Tests

Nine new tests; eight fail on main (the ninth pins the unchanged no-bounds fallback):

- per-window `daf_hist` / `mu_sfs` / `mean_nsl` equal the statistic recomputed from
  that window's own `[start, end)` slice, on a boundary-heavy grid (every variant on
  a window edge), on two- and three-deep overlapping grids, and through the direct
  `bp_bins` branch;
- the iterator anchors at `chrom_start`, its grid matches the fused engine, and two
  consecutive `compute_region` calls tile without gaps or overlap.

`pytest tests/ -n 10`: 895 passed, 64 skipped. `ruff`: clean.

## Notes

- The fused engine reports every window; the iterator skips empty ones. Pre-existing
  difference, unchanged here; the cross-engine test compares the non-empty rows.
- A variant exactly at the grid tail (pos == the last window end, when the span is an
  exact multiple of the step) falls outside all windows. Both engines agree on this
  and did before; unchanged.
- This will conflict lightly with the multiallelic branch, which reworks the daf /
  mu_sfs internals next to the membership block (and where df9716b was reverted to
  keep that branch scoped). The membership logic itself is orthogonal to those
  reworks.

## Rebase onto the multiallelic main

The rebase met #184's per-allele rewrite in the three per-site scatter
stats. A reconciliation commit combines both designs: `mean_nsl`,
`daf_hist`, and `mu_sfs` scatter one entry per present (site, allele)
pair -- main's multiallelic conventions (normalized `daf_hist` rows,
`mu_sfs` as edges over segregating entries) -- into every window
membership the shared grid assigns. An adversarial review confirmed the
combination against the scalar functions across 390+ windows and seven
grid geometries, with a first-principles numpy hand audit agreeing
bit-exactly, and found nothing lost from main in the resolution.

## One grid across missing-data modes

The same review showed the unification did not yet cover
`missing_data='exclude'`: the scatter engines computed grid bounds from
the already-filtered matrix, so a mixed request tiled one grid per
statistic -- the #208 crash, and silent wrong-window labels when the
filtered spans happened to agree. Both engines now anchor the grid
before filtering; the trailing window clips at `chrom_end + 1` in the
shared builder (an inclusive base, so the last loaded variant stays in
a partial trailing window and per-base values divide by the bases that
exist); the fused path's variant-domain consumers see the
allele-cap-filtered variant set; and a zero-span grid returns an empty
frame on every path. Twelve regression tests pin the reconciliation and
the grid behavior, each failing before its fix.

Verified at scale on ag1000g X (4.66M variants x 2940 haplotypes):
windowed totals conserve exactly, and the mixed exclude request runs on
the identical grid as include mode.

## Producer-side closure

`exclude_missing_sites` and `filter_variants_by_missing` now keep the
parent chromosome bounds and accessibility mask like the
`restrict_to_*` siblings -- a shared `_keep_sites` helper states the
policy once for all four same-region site filters -- so every
span-normalized exclude-mode statistic divides by the chromosome
rather than the surviving-variant hull, and the grid-anchor defect
class is closed at the producer as well as at the engines. Five tests
pin the preserved context and the denominator; changelog entry
included.

## Remaining, tracked outside this PR

The eager and streaming loaders still choose different bounds
conventions for the same store (the #159 residue; the engines agree
exactly once bounds agree). Unifying them should be decided together
with the region end-convention question in #224, since both define
what bounds a region string implies.


