### PR TITLE
Require a moments-popgen with the corrected pi2 term

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -51,8 +51,19 @@ ipykernel = ">=6.0"
 ruff = ">=0.4"
 htslib = ">=1.19"  # provides bgzip/tabix for VCF round-trip tests
 
+[feature.moments.dependencies]
+# moments-popgen caps both of these, and the conda solve wins over the pypi
+# one, so the caps have to be stated here or the environment silently
+# resolves to an older moments than required below. Scoped to this feature,
+# so only the parity-comparison environment is held back.
+mpmath = "<1.4"
+scipy = "<1.17"
+
 [feature.moments.pypi-dependencies]
-moments-popgen = "*"
+# Below 1.5.3 the cython genotype kernel has a sign error in the
+# single-population pi2 correction, so the unphased parity tests compare
+# against wrong reference values.
+moments-popgen = ">=1.5.3"
 demesdraw = "*"
 demes = "*"
 


### PR DESCRIPTION
## Problem

Two unphased parity cases in `tests/test_moments_ld.py` fail on the current
trunk:

- `TestFourPopLD::test_ld_sums_match[geno]`
- `TestAltCodedSiteParity::test_agree_on_plain_disagree_on_alt_coded[geno]`

Both mismatch only on `pi2_0_0_0_0` and `pi2_1_1_1_1`, the single-population
pi2 terms. Below moments-popgen 1.5.3 the cython genotype kernel carries a
sign error in the `pi2(i,i;i,i)` correction polynomial, so those tests were
comparing against wrong reference values. pg_gpu's kernel has the correct
term, so the failures were never a defect on our side. The environment was
resolving 1.5.0 because the dependency was unconstrained.

## Fix

Pin `moments-popgen >= 1.5.3`.

The pin alone does not solve. moments-popgen also caps `mpmath < 1.4` and
`scipy < 1.17`, and for both the conda solve takes precedence over the pypi
one, so the solve fails outright unless the caps are restated as conda
dependencies on the feature. They are scoped to `feature.moments`, so only
the parity-comparison environment is held back; the default environment is
unchanged.

## Verification

Local GPU run, since CI has no GPU:

- `pytest tests/test_moments_ld.py` (moments env): was 34 passed / 2 failed,
  now **36 passed, 6 skipped, 3 xfailed, 0 failed**
- `pytest tests/ -n 10` (default env): **1253 passed**, unchanged
- `ruff check pg_gpu/ tests/ examples/`: clean

Resolved versions in the moments environment: moments-popgen 1.6.0,
scipy 1.16.3, mpmath 1.3.0.