### PR TITLE
Compute windowed fst_wc with the diploid per-allele ANOVA

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -372,7 +372,7 @@ Two-population (one kernel launch for all):
 
 - ``fst`` -- Hudson's FST (ratio of averages)
 - ``fst_hudson`` -- alias for ``fst``
-- ``fst_wc`` -- Weir-Cockerham FST (haploid)
+- ``fst_wc`` -- Weir-Cockerham FST
 - ``dxy`` -- absolute divergence
 - ``da`` -- net divergence (Dxy - mean within-pop pi)
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -61,6 +61,13 @@ Read this section if you are comparing against older pg_gpu results.
   ``sample_sets`` built by ``load_pop_file`` now lists ``2i`` and
   ``2i + 1`` for each member, and hand-written index lists that assumed
   the previous order need updating.
+* Windowed ``fst_wc`` now gives the same estimate as
+  ``divergence.fst_weir_cockerham``. It used to treat the data as haploid
+  and lump every alternate allele together, so it returned a different
+  number from the plain function on the same variants. Expect windowed
+  values to move: the old ones were off by a small fixed amount, which is
+  under a few percent once FST is above about 0.02 and much larger when
+  FST is near zero. The plain function is unchanged.
 * Frequency spectra: sites where nothing varies no longer contribute,
   folded spectra are returned as ``float64`` rather than integers, and
   ``joint_sfs_folded`` returns a full ``(n1 + 1, n2 + 1)`` grid folded

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -598,7 +598,7 @@ falls back to a slower route that produces the same numbers.
    * - ``fst``, ``fst_hudson``
      - Hudson's FST per window
    * - ``fst_wc``
-     - Weir-Cockerham FST per window (treats data as haploid; see below)
+     - Weir-Cockerham FST per window
    * - ``dxy``
      - Absolute divergence per window
    * - ``da``
@@ -627,12 +627,9 @@ falls back to a slower route that produces the same numbers.
 
 The rule to expect is that a windowed statistic gives the same answer
 as calling the plain function on just that window's variants. Alleles
-are counted separately here too, the same as everywhere else. There are
-two known exceptions:
+are counted separately here too, the same as everywhere else. There is
+one known exception:
 
-* Windowed ``fst_wc`` treats the data as haploid, so it will not match
-  the plain ``fst_weir_cockerham``, which treats it as diploid. This
-  holds even for two-allele data.
 * When data is missing, the windowed neutrality tests (``tajimas_d``,
   ``normalized_fay_wu_h``, ``zeng_e``, ``zeng_dh``) use the full sample
   size in their variance formula, while the plain versions use an

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -495,7 +495,7 @@ same values, so your results do not change -- only the speed.
 
 A windowed statistic should give you the same number as calling the
 plain function on just that window's variants. See :doc:`features` for
-the two cases where that is not quite true.
+the one case where that is not quite true.
 
 For advanced usage with custom bin edges, use ``windowed_statistics_fused()``
 directly:

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -1396,7 +1396,21 @@ def windowed_analysis(haplotype_matrix: HaplotypeMatrix,
         span_normalize=span_normalize,
         **kwargs
     )
-    return analyzer.compute(haplotype_matrix)
+    df = analyzer.compute(haplotype_matrix)
+    # The analyzer names two-population columns "<stat>_<pop1>_<pop2>"
+    # because it computes every pair. The fused and scatter engines name
+    # them after the statistic alone when exactly two populations are
+    # given, and the same request must return the same columns whichever
+    # engine serves it. With one pair the bare name is unambiguous, so
+    # rename on the way out; direct analyzer use keeps the suffixed form.
+    if populations is not None and len(populations) == 2:
+        p1, p2 = populations
+        df = df.rename(columns={
+            f"{stat}_{p1}_{p2}": stat
+            for stat in statistics
+            if isinstance(stat, str) and f"{stat}_{p1}_{p2}" in df.columns
+        })
+    return df
 
 
 # Helper functions for built-in statistics

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -1331,7 +1331,14 @@ def windowed_analysis(haplotype_matrix: HaplotypeMatrix,
     requested = set(statistics)
 
     can_fuse = (missing_data == 'include'
-                and requested <= fused_all)
+                and requested <= fused_all
+                # A two-population statistic with anything other than exactly
+                # two populations must not reach the fused engine, which
+                # computes the first pair only and names the column after the
+                # bare statistic. The per-window fallback computes every pair
+                # and suffixes the names, the same as missing_data='exclude'.
+                and (not (requested & fused_two)
+                     or len(populations or []) == 2))
 
     if can_fuse:
         if haplotype_matrix.device == 'CPU':
@@ -1400,9 +1407,10 @@ def windowed_analysis(haplotype_matrix: HaplotypeMatrix,
     # The analyzer names two-population columns "<stat>_<pop1>_<pop2>"
     # because it computes every pair. The fused and scatter engines name
     # them after the statistic alone when exactly two populations are
-    # given, and the same request must return the same columns whichever
-    # engine serves it. With one pair the bare name is unambiguous, so
-    # rename on the way out; direct analyzer use keeps the suffixed form.
+    # given, and a two-population request must name those columns the
+    # same whichever engine serves it. With one pair the bare name is
+    # unambiguous, so rename on the way out; direct analyzer use and
+    # requests with three or more populations keep the suffixed form.
     if populations is not None and len(populations) == 2:
         p1, p2 = populations
         df = df.rename(columns={

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -1668,11 +1668,11 @@ void fused_windowed_twopop(const signed char* hap1_t,
     for (int vi = threadIdx.x; vi < n_vars; vi += blockDim.x) {
         int v = v_start + vi;
 
-        // Haploid per-allele counts (cnt) over every non-missing call, plus
-        // the diploid tallies Weir-Cockerham needs: consecutive rows are one
-        // individual, dip[] counts allele copies carried by complete
-        // individuals, and het[] counts individuals holding exactly one copy
-        // of an allele. One pass per population covers both.
+        // One pass per population gives three counts for each allele a:
+        // hom[a] is individuals with two copies, het[a] is individuals with
+        // one copy, and half[a] is lone gametes whose partner is missing.
+        // Weir-Cockerham below uses hom and het. The allele frequencies use
+        // all three.
         int hom1[MAX_ALLELES], het1[MAX_ALLELES], half1[MAX_ALLELES];
         int hom2[MAX_ALLELES], het2[MAX_ALLELES], half2[MAX_ALLELES];
         int valid1 = 0, nind1 = 0, valid2 = 0, nind2 = 0;

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -2640,11 +2640,16 @@ def windowed_statistics_fused_chunked(haplotype_matrix: HaplotypeMatrix,
         # bounds-check, so applying these rows to the subset would silently
         # read the wrong haplotypes. Read the rows from the original matrix,
         # and select the same variant columns the cap filter kept.
+        # A population is a sample_sets name or a row list, the same as the
+        # single-shot engine accepts via get_population_matrix.
+        def pop_rows_of(pop):
+            rows = (haplotype_matrix.sample_sets[pop]
+                    if isinstance(pop, str) else list(pop))
+            return cp.asarray(rows, dtype=cp.int64)
+
         orig_hap = haplotype_matrix.haplotypes
-        pop1_rows = cp.asarray(haplotype_matrix.sample_sets[pop1],
-                               dtype=cp.int64)
-        pop2_rows = cp.asarray(haplotype_matrix.sample_sets[pop2],
-                               dtype=cp.int64)
+        pop1_rows = pop_rows_of(pop1)
+        pop2_rows = pop_rows_of(pop2)
         n1 = len(pop1_rows)
         n2 = len(pop2_rows)
         # Chunk size based on the larger population

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -1598,11 +1598,23 @@ _fused_windowed_twopop_kernel = cp.RawKernel(r'''
    the bounds checks stay because that filter is derived from the
    single-population subset (or the whole matrix), neither of which need cover
    both of pop1 and pop2. */
-__device__ inline void tally_pop(const signed char* row, int n_hap,
+__device__ inline void tally_pop(const signed char* row, int n_hap, int need_wc,
                                  int* hom, int* het, int* half,
                                  int* out_valid, int* out_nind) {
     for (int a = 0; a < MAX_ALLELES; a++) { hom[a] = 0; het[a] = 0; half[a] = 0; }
     int valid = 0, nind = 0;
+    if (!need_wc) {
+        /* Only gamete counts are wanted. Putting every gamete in half[] keeps
+           the 2*hom + het + half sum right while touching one array per
+           gamete instead of three. */
+        for (int i = 0; i < n_hap; i++) {
+            signed char g = row[i];
+            if (g >= 0) { valid++; if (g < MAX_ALLELES) half[g]++; }
+        }
+        *out_valid = valid;
+        *out_nind = 0;
+        return;
+    }
     int i = 0;
     for (; i + 1 < n_hap; i += 2) {
         signed char x = row[i];
@@ -1672,13 +1684,14 @@ void fused_windowed_twopop(const signed char* hap1_t,
         // hom[a] is individuals with two copies, het[a] is individuals with
         // one copy, and half[a] is lone gametes whose partner is missing.
         // Weir-Cockerham below uses hom and het. The allele frequencies use
-        // all three.
+        // all three. Without Weir-Cockerham only the frequencies are needed,
+        // so the tally skips the pairing and fills half[] alone.
         int hom1[MAX_ALLELES], het1[MAX_ALLELES], half1[MAX_ALLELES];
         int hom2[MAX_ALLELES], het2[MAX_ALLELES], half2[MAX_ALLELES];
         int valid1 = 0, nind1 = 0, valid2 = 0, nind2 = 0;
-        tally_pop(hap1_t + (long long)v * n_hap1, n_hap1,
+        tally_pop(hap1_t + (long long)v * n_hap1, n_hap1, need_wc,
                   hom1, het1, half1, &valid1, &nind1);
-        tally_pop(hap2_t + (long long)v * n_hap2, n_hap2,
+        tally_pop(hap2_t + (long long)v * n_hap2, n_hap2, need_wc,
                   hom2, het2, half2, &valid2, &nind2);
 
         if (valid1 == 0 || valid2 == 0) continue;

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -1471,7 +1471,7 @@ def _warn_fused_allele_cap(n_over):
         MultiallelicCapWarning, stacklevel=3)
 
 
-def _filter_fused_allele_cap_raw(hap_raw, positions):
+def _filter_fused_allele_cap_raw(hap_raw, positions, cap_source=None):
     """Cap filter for the chunked path's un-transposed (n_hap, n_var) matrix.
 
     Reduces over the haplotype axis (axis 0) to get per-variant max allele
@@ -1481,12 +1481,19 @@ def _filter_fused_allele_cap_raw(hap_raw, positions):
     never triggers the cap. (The non-chunked single-pass path filters inline,
     capturing the keep mask so the two-pop kernel's hap1/hap2 align.)
 
+    ``cap_source`` is the matrix the reduction runs over; it defaults to
+    ``hap_raw`` but must be the original matrix whenever the kernels will
+    read rows beyond ``hap_raw`` -- otherwise an over-cap allele in those
+    rows survives the filter and is silently dropped from the tallies. It
+    must share ``hap_raw``'s variant axis.
+
     Also returns the kept variants' column indices into the unfiltered
     matrix, or ``None`` when nothing was dropped. The two-population block
     reads rows from the original matrix, so it needs these to select the
     same variants the filtered axis holds.
     """
-    overcap = hap_raw.max(axis=0) >= _FUSED_MAX_ALLELES
+    src = hap_raw if cap_source is None else cap_source
+    overcap = src.max(axis=0) >= _FUSED_MAX_ALLELES
     n_over = int(overcap.sum())
     keep_idx = None
     if n_over:
@@ -1625,10 +1632,10 @@ _fused_windowed_twopop_kernel = cp.RawKernel(r'''
    half[] holds gametes whose partner is missing (and a trailing unpaired
    gamete), which count toward allele frequencies but form no individual.
 
-   Sites carrying an allele index >= MAX_ALLELES are dropped on the host, but
-   the bounds checks stay because that filter is derived from the
-   single-population subset (or the whole matrix), neither of which need cover
-   both of pop1 and pop2. */
+   Sites carrying an allele index >= MAX_ALLELES are dropped on the host,
+   which derives the filter from the whole matrix whenever two-population
+   statistics are requested, so it covers pop1 and pop2. The bounds checks
+   stay as a guard for direct kernel callers. */
 __device__ inline void tally_pop(const signed char* row, int n_hap, int need_wc,
                                  int* hom, int* het, int* half,
                                  int* out_valid, int* out_nind) {
@@ -2024,7 +2031,16 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
     # variant-index ranges are computed against the retained sites. Capture the
     # keep mask so the two-pop path can slice hap1/hap2 to the same variants
     # (positions/window indices are computed against the filtered set below).
-    cap_keep = hap.max(axis=1) < _FUSED_MAX_ALLELES if hap.shape[0] else None
+    # When two-population statistics are requested the kernel reads pop1 and
+    # pop2 rows of the original matrix, which the single-population subset
+    # need not cover, so the reduction runs over the original.
+    if any(s in ('fst', 'fst_hudson', 'fst_wc', 'dxy', 'da')
+           for s in statistics):
+        cap_src = haplotype_matrix.haplotypes
+        cap_keep = (cap_src.max(axis=0) < _FUSED_MAX_ALLELES
+                    if cap_src.shape[1] else None)
+    else:
+        cap_keep = hap.max(axis=1) < _FUSED_MAX_ALLELES if hap.shape[0] else None
     if cap_keep is not None and not bool(cap_keep.all()):
         _warn_fused_allele_cap(int((~cap_keep).sum()))
         hap = hap[cap_keep]
@@ -2467,9 +2483,15 @@ def windowed_statistics_fused_chunked(haplotype_matrix: HaplotypeMatrix,
         positions = cp.asarray(positions)
 
     # Drop sites the fused kernel's per-allele capacity can't represent. Must
-    # precede window indexing so variant-index ranges match the retained sites.
+    # precede window indexing so variant-index ranges match the retained
+    # sites. When two-population statistics are requested the kernels read
+    # pop1 and pop2 rows of the original matrix, which the single-population
+    # subset need not cover, so the cap reduction runs over the original.
+    two_pop_stats = {'fst', 'fst_hudson', 'fst_wc', 'dxy', 'da'}
+    two_pop_requested = any(s in statistics for s in two_pop_stats)
     hap_raw, positions, cap_keep_idx = _filter_fused_allele_cap_raw(
-        hap_raw, positions)
+        hap_raw, positions,
+        cap_source=haplotype_matrix.haplotypes if two_pop_requested else None)
     n_total_var = hap_raw.shape[1]
 
     # Window ranges (same setup as non-chunked)
@@ -2628,8 +2650,8 @@ def windowed_statistics_fused_chunked(haplotype_matrix: HaplotypeMatrix,
             results['max_daf'] = max_daf_arr
 
     # ── Two-pop stats via chunked fused kernel ───────────────────────────
-    two_pop_stats = {'fst', 'fst_hudson', 'fst_wc', 'dxy', 'da'}
-    two_pop_requested = any(s in statistics for s in two_pop_stats)
+    # two_pop_requested was computed above, before the cap filter, which
+    # needs it to pick its reduction source.
     if two_pop_requested:
         if pop1 is None or pop2 is None:
             raise ValueError("pop1 and pop2 required for fst/dxy/da")

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -1458,15 +1458,24 @@ def _filter_fused_allele_cap_raw(hap_raw, positions):
     >= _FUSED_MAX_ALLELES and emits a ``MultiallelicCapWarning``; missing (-1)
     never triggers the cap. (The non-chunked single-pass path filters inline,
     capturing the keep mask so the two-pop kernel's hap1/hap2 align.)
+
+    Also returns the kept variants' column indices into the unfiltered
+    matrix, or ``None`` when nothing was dropped. The two-population block
+    reads rows from the original matrix, so it needs these to select the
+    same variants the filtered axis holds.
     """
     overcap = hap_raw.max(axis=0) >= _FUSED_MAX_ALLELES
     n_over = int(overcap.sum())
+    keep_idx = None
     if n_over:
         _warn_fused_allele_cap(n_over)
         keep = ~overcap
         hap_raw = hap_raw[:, keep]
         positions = positions[keep]
-    return hap_raw, positions
+        # int32 is enough: the kernel already receives the variant count as
+        # an int32, so a matrix this path accepts cannot exceed that range.
+        keep_idx = cp.where(keep)[0].astype(cp.int32)
+    return hap_raw, positions, keep_idx
 
 
 _fused_windowed_kernel_v2 = cp.RawKernel(r'''
@@ -2437,7 +2446,8 @@ def windowed_statistics_fused_chunked(haplotype_matrix: HaplotypeMatrix,
 
     # Drop sites the fused kernel's per-allele capacity can't represent. Must
     # precede window indexing so variant-index ranges match the retained sites.
-    hap_raw, positions = _filter_fused_allele_cap_raw(hap_raw, positions)
+    hap_raw, positions, cap_keep_idx = _filter_fused_allele_cap_raw(
+        hap_raw, positions)
     n_total_var = hap_raw.shape[1]
 
     # Window ranges (same setup as non-chunked)
@@ -2602,11 +2612,19 @@ def windowed_statistics_fused_chunked(haplotype_matrix: HaplotypeMatrix,
         if pop1 is None or pop2 is None:
             raise ValueError("pop1 and pop2 required for fst/dxy/da")
 
-        # Get population haplotype indices from the original (unsubsetted) matrix
-        pop1_idx = haplotype_matrix.sample_sets[pop1]
-        pop2_idx = haplotype_matrix.sample_sets[pop2]
-        n1 = len(pop1_idx)
-        n2 = len(pop2_idx)
+        # The population row numbers index the original matrix, but hap_raw
+        # can be the single-population subset (the dispatcher passes
+        # population=pop1 alongside pop1/pop2). CuPy fancy indexing does not
+        # bounds-check, so applying these rows to the subset would silently
+        # read the wrong haplotypes. Read the rows from the original matrix,
+        # and select the same variant columns the cap filter kept.
+        orig_hap = haplotype_matrix.haplotypes
+        pop1_rows = cp.asarray(haplotype_matrix.sample_sets[pop1],
+                               dtype=cp.int64)
+        pop2_rows = cp.asarray(haplotype_matrix.sample_sets[pop2],
+                               dtype=cp.int64)
+        n1 = len(pop1_rows)
+        n2 = len(pop2_rows)
         # Chunk size based on the larger population
         twopop_chunk = estimate_fused_chunk_size(max(n1, n2))
         twopop_chunk = max(twopop_chunk, max_win_variants + 1)
@@ -2632,10 +2650,17 @@ def windowed_statistics_fused_chunked(haplotype_matrix: HaplotypeMatrix,
             clipped_stop = cp.minimum(win_stop[w_idx], c_end) - c_start
             n_overlap = len(w_idx)
 
-            hap1_t = cp.ascontiguousarray(
-                hap_raw[pop1_idx, c_start:c_end].T.astype(cp.int8))
-            hap2_t = cp.ascontiguousarray(
-                hap_raw[pop2_idx, c_start:c_end].T.astype(cp.int8))
+            def pop_chunk_t(rows):
+                # Chunk columns count filtered variants; map them back to
+                # original columns when the cap filter dropped sites.
+                if cap_keep_idx is None:
+                    blk = orig_hap[rows, c_start:c_end]
+                else:
+                    blk = orig_hap[cp.ix_(rows, cap_keep_idx[c_start:c_end])]
+                return cp.ascontiguousarray(blk.T.astype(cp.int8))
+
+            hap1_t = pop_chunk_t(pop1_rows)
+            hap2_t = pop_chunk_t(pop2_rows)
             n_chunk_var = c_end - c_start
 
             out_fst_num = cp.zeros(n_overlap, dtype=cp.float64)

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -1582,6 +1582,54 @@ void fused_windowed_stats_v2(const signed char* hap_t,
 # Two-population fused kernel for FST and Dxy
 _fused_windowed_twopop_kernel = cp.RawKernel(r'''
 #define MAX_ALLELES 8   /* keep in sync with _FUSED_MAX_ALLELES (host guard) */
+
+/* Tally one population at one site, pairing consecutive rows into diploid
+   individuals. Counting by individual class rather than by gamete keeps the
+   per-allele tallies to one update for a homozygote and two for a
+   heterozygote, and both consumers derive what they need:
+
+       gamete copies of allele a  = 2*hom[a] + het[a] + half[a]
+       copies within individuals  = 2*hom[a] + het[a]
+
+   half[] holds gametes whose partner is missing (and a trailing unpaired
+   gamete), which count toward allele frequencies but form no individual.
+
+   Sites carrying an allele index >= MAX_ALLELES are dropped on the host, but
+   the bounds checks stay because that filter is derived from the
+   single-population subset (or the whole matrix), neither of which need cover
+   both of pop1 and pop2. */
+__device__ inline void tally_pop(const signed char* row, int n_hap,
+                                 int* hom, int* het, int* half,
+                                 int* out_valid, int* out_nind) {
+    for (int a = 0; a < MAX_ALLELES; a++) { hom[a] = 0; het[a] = 0; half[a] = 0; }
+    int valid = 0, nind = 0;
+    int i = 0;
+    for (; i + 1 < n_hap; i += 2) {
+        signed char x = row[i];
+        signed char y = row[i + 1];
+        if (x >= 0 && y >= 0) {
+            valid += 2;
+            nind++;
+            if (x == y) {
+                if (x < MAX_ALLELES) hom[x]++;
+            } else {
+                if (x < MAX_ALLELES) het[x]++;
+                if (y < MAX_ALLELES) het[y]++;
+            }
+        } else if (x >= 0) {
+            valid++; if (x < MAX_ALLELES) half[x]++;
+        } else if (y >= 0) {
+            valid++; if (y < MAX_ALLELES) half[y]++;
+        }
+    }
+    if (i < n_hap) {   /* odd count: the trailing gamete has no partner */
+        signed char x = row[i];
+        if (x >= 0) { valid++; if (x < MAX_ALLELES) half[x]++; }
+    }
+    *out_valid = valid;
+    *out_nind = nind;
+}
+
 extern "C" __global__
 void fused_windowed_twopop(const signed char* hap1_t,
                            const signed char* hap2_t,
@@ -1589,13 +1637,14 @@ void fused_windowed_twopop(const signed char* hap1_t,
                            const long long* win_stop,
                            int n_hap1, int n_hap2,
                            int n_total_var, int n_windows,
+                           int need_wc,
                            double* out_fst_num,
                            double* out_fst_den,
                            double* out_dxy_sum,
                            double* out_pi1_sum,
                            double* out_pi2_sum,
                            double* out_wc_a_sum,
-                           double* out_wc_ab_sum) {
+                           double* out_wc_abc_sum) {
     int wid = blockIdx.x;
     if (wid >= n_windows) return;
 
@@ -1607,49 +1656,85 @@ void fused_windowed_twopop(const signed char* hap1_t,
             out_fst_num[wid] = 0.0;  out_fst_den[wid] = 0.0;
             out_dxy_sum[wid] = 0.0;  out_pi1_sum[wid] = 0.0;
             out_pi2_sum[wid] = 0.0;  out_wc_a_sum[wid] = 0.0;
-            out_wc_ab_sum[wid] = 0.0;
+            out_wc_abc_sum[wid] = 0.0;
         }
         return;
     }
 
     double t_fst_num = 0.0, t_fst_den = 0.0;
     double t_dxy = 0.0, t_pi1 = 0.0, t_pi2 = 0.0;
-    double t_wc_a = 0.0, t_wc_ab = 0.0;
+    double t_wc_a = 0.0, t_wc_abc = 0.0;
 
     for (int vi = threadIdx.x; vi < n_vars; vi += blockDim.x) {
         int v = v_start + vi;
 
-        // Per-allele counts over non-missing calls (shared cnt width for both
-        // pops). Sites with an allele index >= MAX_ALLELES are filtered on the
-        // host before launch, so every allele fits in cnt[].
-        int cnt1[MAX_ALLELES];
-        int cnt2[MAX_ALLELES];
-        for (int a = 0; a < MAX_ALLELES; a++) { cnt1[a] = 0; cnt2[a] = 0; }
-        int valid1 = 0;
-        const signed char* row1 = hap1_t + (long long)v * n_hap1;
-        for (int h = 0; h < n_hap1; h++) {
-            signed char a = row1[h];
-            if (a >= 0) { valid1++; if (a < MAX_ALLELES) cnt1[a]++; }
-        }
-        int valid2 = 0;
-        const signed char* row2 = hap2_t + (long long)v * n_hap2;
-        for (int h = 0; h < n_hap2; h++) {
-            signed char a = row2[h];
-            if (a >= 0) { valid2++; if (a < MAX_ALLELES) cnt2[a]++; }
-        }
+        // Haploid per-allele counts (cnt) over every non-missing call, plus
+        // the diploid tallies Weir-Cockerham needs: consecutive rows are one
+        // individual, dip[] counts allele copies carried by complete
+        // individuals, and het[] counts individuals holding exactly one copy
+        // of an allele. One pass per population covers both.
+        int hom1[MAX_ALLELES], het1[MAX_ALLELES], half1[MAX_ALLELES];
+        int hom2[MAX_ALLELES], het2[MAX_ALLELES], half2[MAX_ALLELES];
+        int valid1 = 0, nind1 = 0, valid2 = 0, nind2 = 0;
+        tally_pop(hap1_t + (long long)v * n_hap1, n_hap1,
+                  hom1, het1, half1, &valid1, &nind1);
+        tally_pop(hap2_t + (long long)v * n_hap2, n_hap2,
+                  hom2, het2, half2, &valid2, &nind2);
 
         if (valid1 == 0 || valid2 == 0) continue;
 
         double dn1 = (double)valid1;
         double dn2 = (double)valid2;
 
+        // Weir-Cockerham, mirroring divergence.fst_weir_cockerham (see its
+        // NOTE): a per-allele one-vs-rest ANOVA over diploid individuals whose
+        // components are between-population (a), between-individual-within-
+        // population (b), and between-gamete-within-individual (c), giving
+        // FST = sum(a) / sum(a + b + c) over alleles and sites. Absent alleles
+        // contribute zero to each, so the loop can run the full width. With
+        // r = 2 the scalar's (r-1)*s2/r folds to s2/2 and its nc to n_C.
+        double di1 = (double)nind1;
+        double di2 = (double)nind2;
+        double n_tot = di1 + di2;
+        double n_bar = n_tot / 2.0;
+        // n_C reduces to 2*di1*di2/n_tot, so it is positive exactly when both
+        // populations have a complete individual; n_bar > 1 implies n_tot > 2.
+        if (need_wc && n_bar > 1.0) {
+            double n_C = n_tot - (di1 * di1 + di2 * di2) / n_tot;
+            if (n_C > 0.0) {
+                // Divisors that do not vary across alleles, reciprocated once.
+                double inv_2di1 = 0.5 / di1;
+                double inv_2di2 = 0.5 / di2;
+                double inv_ntot = 1.0 / n_tot;
+                double inv_nbar = 1.0 / n_bar;
+                double inv_nbar_m1 = 1.0 / (n_bar - 1.0);
+                double nbar_over_nC = n_bar / n_C;
+                double nbar_ratio = n_bar * inv_nbar_m1;
+                double hb_coef = (2.0 * n_bar - 1.0) * 0.25 * inv_nbar;
+                for (int a = 0; a < MAX_ALLELES; a++) {
+                    double p1a = (double)(2 * hom1[a] + het1[a]) * inv_2di1;
+                    double p2a = (double)(2 * hom2[a] + het2[a]) * inv_2di2;
+                    double p_bar = (di1 * p1a + di2 * p2a) * inv_ntot;
+                    double s2 = (di1 * (p1a - p_bar) * (p1a - p_bar) +
+                                 di2 * (p2a - p_bar) * (p2a - p_bar)) * inv_nbar;
+                    double hb = (double)(het1[a] + het2[a]) * inv_ntot;
+                    double base = p_bar * (1.0 - p_bar) - s2 * 0.5;
+                    double av = nbar_over_nC *
+                        (s2 - inv_nbar_m1 * (base - hb * 0.25));
+                    double bv = nbar_ratio * (base - hb_coef * hb);
+                    t_wc_a += av;
+                    t_wc_abc += av + bv + hb * 0.5;
+                }
+            }
+        }
+
         // Per-allele within-pop mean pairwise difference (same pairs summed over
         // alleles) and between-pop difference (per-allele cross term) -- mirrors
         // divergence._hudson_fst_from_counts / dxy, multiallelic-correct.
         double same1 = 0.0, same2 = 0.0, between_same = 0.0;
         for (int a = 0; a < MAX_ALLELES; a++) {
-            double c1 = (double)cnt1[a];
-            double c2 = (double)cnt2[a];
+            double c1 = (double)(2 * hom1[a] + het1[a] + half1[a]);
+            double c2 = (double)(2 * hom2[a] + het2[a] + half2[a]);
             same1 += c1 * (c1 - 1.0);
             same2 += c2 * (c2 - 1.0);
             between_same += c1 * c2;
@@ -1659,37 +1744,11 @@ void fused_windowed_twopop(const signed char* hap1_t,
         double within = (mpd1 + mpd2) / 2.0;
         double between = 1.0 - between_same / (dn1 * dn2);
 
-        // Total non-reference copy counts (all alt alleles collapsed) retained
-        // for the HAPLOID Weir-Cockerham block below, which is deliberately
-        // unchanged -- the fused fst_wc haploid/diploid mismatch is tracked
-        // separately and is out of scope here.
-        double d_ac1_1 = dn1 - (double)cnt1[0];
-        double d_ac2_1 = dn2 - (double)cnt2[0];
-
         t_fst_num += between - within;
         t_fst_den += between;
         t_dxy += between;
         t_pi1 += mpd1;
         t_pi2 += mpd2;
-
-        // Weir-Cockerham (haploid, h_bar=0, r=2, per-site sample sizes)
-        double n_total = dn1 + dn2;
-        double n_bar = n_total / 2.0;
-        double n_C = (n_total - (dn1*dn1 + dn2*dn2) / n_total);
-        double p1 = d_ac1_1 / dn1;
-        double p2 = d_ac2_1 / dn2;
-        double p_bar = (dn1 * p1 + dn2 * p2) / n_total;
-        double s2 = (dn1 * (p1 - p_bar) * (p1 - p_bar) +
-                     dn2 * (p2 - p_bar) * (p2 - p_bar)) / n_bar;
-        double pq = p_bar * (1.0 - p_bar);
-
-        double a_val = 0.0, b_val = 0.0;
-        if (n_bar > 1.0 && n_C > 0.0) {
-            a_val = (n_bar / n_C) * (s2 - (1.0 / (n_bar - 1.0)) * (pq - s2 / 2.0));
-            b_val = (n_bar / (n_bar - 1.0)) * (pq - s2 / 2.0);
-        }
-        t_wc_a += a_val;
-        t_wc_ab += a_val + b_val;
     }
 
     // Block reduction (7 values)
@@ -1701,7 +1760,7 @@ void fused_windowed_twopop(const signed char* hap1_t,
     smem[768 + tid]    = t_pi1;
     smem[1024 + tid]   = t_pi2;
     smem[1280 + tid]   = t_wc_a;
-    smem[1536 + tid]   = t_wc_ab;
+    smem[1536 + tid]   = t_wc_abc;
     __syncthreads();
 
     for (int s = blockDim.x / 2; s > 0; s >>= 1) {
@@ -1724,7 +1783,7 @@ void fused_windowed_twopop(const signed char* hap1_t,
         out_pi1_sum[wid]  = smem[768];
         out_pi2_sum[wid]  = smem[1024];
         out_wc_a_sum[wid] = smem[1280];
-        out_wc_ab_sum[wid]= smem[1536];
+        out_wc_abc_sum[wid] = smem[1536];
     }
 }
 ''', 'fused_windowed_twopop')
@@ -2073,7 +2132,8 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
         out_pi1 = cp.zeros(n_windows, dtype=cp.float64)
         out_pi2 = cp.zeros(n_windows, dtype=cp.float64)
         out_wc_a = cp.zeros(n_windows, dtype=cp.float64)
-        out_wc_ab = cp.zeros(n_windows, dtype=cp.float64)
+        out_wc_abc = cp.zeros(n_windows, dtype=cp.float64)
+        need_wc = 'fst_wc' in statistics
 
         block = 256
         grid = n_windows
@@ -2083,8 +2143,9 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
             (hap1, hap2, win_start, win_stop,
              np.int32(n1), np.int32(n2),
              np.int32(n_total_var), np.int32(n_windows),
+             np.int32(need_wc),
              out_fst_num, out_fst_den, out_dxy, out_pi1, out_pi2,
-             out_wc_a, out_wc_ab))
+             out_wc_a, out_wc_abc))
 
         # Post-process on GPU, single .get() per result
         if 'fst' in statistics or 'fst_hudson' in statistics:
@@ -2096,8 +2157,8 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
                 results['fst_hudson'] = hudson_fst
 
         if 'fst_wc' in statistics:
-            results['fst_wc'] = cp.where(out_wc_ab > 0,
-                                          out_wc_a / out_wc_ab, cp.nan).get()
+            results['fst_wc'] = cp.where(out_wc_abc > 0,
+                                          out_wc_a / out_wc_abc, cp.nan).get()
 
         if 'dxy' in statistics:
             if per_base:
@@ -2543,7 +2604,8 @@ def windowed_statistics_fused_chunked(haplotype_matrix: HaplotypeMatrix,
         acc_pi1 = cp.zeros(n_windows, dtype=cp.float64)
         acc_pi2 = cp.zeros(n_windows, dtype=cp.float64)
         acc_wc_a = cp.zeros(n_windows, dtype=cp.float64)
-        acc_wc_ab = cp.zeros(n_windows, dtype=cp.float64)
+        acc_wc_abc = cp.zeros(n_windows, dtype=cp.float64)
+        need_wc = 'fst_wc' in statistics
 
         for c_start in range(0, n_total_var, twopop_chunk):
             c_end = min(c_start + twopop_chunk, n_total_var)
@@ -2569,23 +2631,25 @@ def windowed_statistics_fused_chunked(haplotype_matrix: HaplotypeMatrix,
             out_pi1 = cp.zeros(n_overlap, dtype=cp.float64)
             out_pi2 = cp.zeros(n_overlap, dtype=cp.float64)
             out_wc_a = cp.zeros(n_overlap, dtype=cp.float64)
-            out_wc_ab = cp.zeros(n_overlap, dtype=cp.float64)
+            out_wc_abc = cp.zeros(n_overlap, dtype=cp.float64)
 
             _fused_windowed_twopop_kernel(
                 (int(n_overlap),), (256,),
                 (hap1_t, hap2_t, clipped_start, clipped_stop,
                  np.int32(n1), np.int32(n2),
                  np.int32(n_chunk_var), np.int32(n_overlap),
+                 np.int32(need_wc),
                  out_fst_num, out_fst_den, out_dxy, out_pi1, out_pi2,
-                 out_wc_a, out_wc_ab))
+                 out_wc_a, out_wc_abc))
 
             cp.add.at(acc_fst_num, w_idx, out_fst_num)
             cp.add.at(acc_fst_den, w_idx, out_fst_den)
             cp.add.at(acc_dxy, w_idx, out_dxy)
             cp.add.at(acc_pi1, w_idx, out_pi1)
             cp.add.at(acc_pi2, w_idx, out_pi2)
-            cp.add.at(acc_wc_a, w_idx, out_wc_a)
-            cp.add.at(acc_wc_ab, w_idx, out_wc_ab)
+            if need_wc:
+                cp.add.at(acc_wc_a, w_idx, out_wc_a)
+                cp.add.at(acc_wc_abc, w_idx, out_wc_abc)
 
             del hap1_t, hap2_t
             free_gpu_pool()
@@ -2600,8 +2664,8 @@ def windowed_statistics_fused_chunked(haplotype_matrix: HaplotypeMatrix,
                 results['fst_hudson'] = hudson_fst
 
         if 'fst_wc' in statistics:
-            results['fst_wc'] = cp.where(acc_wc_ab > 0,
-                                          acc_wc_a / acc_wc_ab, cp.nan).get()
+            results['fst_wc'] = cp.where(acc_wc_abc > 0,
+                                          acc_wc_a / acc_wc_abc, cp.nan).get()
 
         if 'dxy' in statistics:
             if per_base:

--- a/tests/test_implementation_parity.py
+++ b/tests/test_implementation_parity.py
@@ -368,10 +368,6 @@ _SCATTER_VARIANCE = (
     "rather than per-site valid counts, diverging from the scalar under "
     "missing data. #135"
 )
-_FST_WC_FUSED = (
-    "the fused fst_wc kernel was not converted to the per-allele one-vs-rest "
-    "Weir-Cockerham ANOVA the scalar/python-loop path now uses. #135"
-)
 _DA_SCATTER_EXCLUDE = (
     "under missing_data='exclude' the scatter da's within-population pi terms "
     "use a different site set than the scalar (dxy agrees), so da diverges. #135"
@@ -410,9 +406,6 @@ _XFAILS = {
     ("theta_w", "fs"): [(_FS_MULTIALLELIC, _WHEN_MULTIALLELIC)],
     ("segregating_sites", "fs"): [(_FS_MULTIALLELIC, _WHEN_MULTIALLELIC)],
     ("fay_wu_h", "fs"): [(_FS_MULTIALLELIC, _WHEN_MULTIALLELIC)],
-
-    # fused fst_wc kernel not updated to the per-allele WC ANOVA (all conditions).
-    ("fst_wc", "fused"): [(_FST_WC_FUSED, None)],
 
     # scatter da within-pop pi term uses a different site set under exclude.
     ("da", "scatter"): [(_DA_SCATTER_EXCLUDE, _WHEN_EXCLUDE)],

--- a/tests/test_multiallelic.py
+++ b/tests/test_multiallelic.py
@@ -544,6 +544,40 @@ class TestDivergenceVsTskit:
         fst_pg = divergence.fst_weir_cockerham(hm, 'A', 'B')
         np.testing.assert_allclose(fst_pg, fst_allel, rtol=1e-9)
 
+    def test_windowed_fst_wc_matches_allel(self, multiallelic_ts):
+        # The fused kernel against the same independent reference, per
+        # window. The parity suite only ties the kernel to the scalar, so
+        # without this the kernel never meets a reference outside the
+        # package.
+        from pg_gpu.windowed_analysis import windowed_statistics_fused
+        ts = multiallelic_ts
+        G = ts.genotype_matrix()
+        nsites, n_nodes = G.shape
+        n_ind = n_nodes // 2
+        half = n_ind // 2
+        gd = allel.GenotypeArray(G.reshape(nsites, n_ind, 2))
+        a, b, c = allel.weir_cockerham_fst(
+            gd, [list(range(half)), list(range(half, n_ind))])
+
+        hm = HaplotypeMatrix.from_ts(ts, device="GPU")
+        hm.sample_sets = {'A': list(range(2 * half)),
+                          'B': list(range(2 * half, n_nodes))}
+        pos = hm.positions
+        pos = pos.get() if hasattr(pos, 'get') else np.asarray(pos)
+
+        W = 20_000
+        bp = np.arange(0, int(ts.sequence_length) + W, W, dtype=float)
+        r = windowed_statistics_fused(
+            hm, bp_bins=bp, statistics=('fst_wc',), pop1='A', pop2='B',
+            per_base=False, chrom='1')
+        for w, (start, stop) in enumerate(zip(bp[:-1], bp[1:])):
+            m = (pos >= start) & (pos < stop)
+            if not m.any():
+                continue
+            ref = np.nansum(a[m]) / np.nansum(a[m] + b[m] + c[m])
+            np.testing.assert_allclose(r['fst_wc'][w], ref, rtol=1e-9,
+                                       err_msg=f"window {w}")
+
     def test_pbs_matches_allel(self, multiallelic_ts):
         # PBS composes three per-allele Hudson FSTs; matches allel.pbs.
         from pg_gpu import divergence

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -523,6 +523,32 @@ class TestChunkedFused:
             assert len(r[k]) > 0
 
 
+class TestTwoPopColumnNaming:
+    """One request, one column set, whichever engine serves it (#193)."""
+
+    def test_two_pop_columns_match_across_modes(self):
+        rng = np.random.RandomState(7)
+        n_hap, n_var = 40, 400
+        hap = rng.randint(0, 2, (n_hap, n_var)).astype(np.int8)
+        pos = np.arange(1, n_var + 1) * 100
+        hm = HaplotypeMatrix(hap, pos, 0, (n_var + 1) * 100)
+        hm.sample_sets = {"p1": list(range(20)), "p2": list(range(20, 40))}
+
+        # 'include' routes fst_wc to the fused engine, 'exclude' to the
+        # per-window fallback; both must name the column after the
+        # statistic alone.
+        frames = {
+            mode: windowed_analysis(
+                hm, window_size=10_000, step_size=10_000,
+                statistics=['fst_wc'], populations=['p1', 'p2'],
+                missing_data=mode)
+            for mode in ('include', 'exclude')
+        }
+        for mode, df in frames.items():
+            assert 'fst_wc' in df.columns, f"no bare fst_wc under {mode!r}"
+        assert list(frames['include'].columns) == list(frames['exclude'].columns)
+
+
 class TestFusedMissingData:
     """Fused two-pop kernel must use per-site valid counts under missingness."""
 

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -548,6 +548,30 @@ class TestTwoPopColumnNaming:
             assert 'fst_wc' in df.columns, f"no bare fst_wc under {mode!r}"
         assert list(frames['include'].columns) == list(frames['exclude'].columns)
 
+    def test_three_pop_request_returns_every_pair(self):
+        """Three populations must yield all pairs under both modes, never a
+        bare column silently holding the first pair only."""
+        rng = np.random.RandomState(8)
+        n_hap, n_var = 60, 400
+        hap = rng.randint(0, 2, (n_hap, n_var)).astype(np.int8)
+        pos = np.arange(1, n_var + 1) * 100
+        hm = HaplotypeMatrix(hap, pos, 0, (n_var + 1) * 100)
+        hm.sample_sets = {"p1": list(range(20)), "p2": list(range(20, 40)),
+                          "p3": list(range(40, 60))}
+
+        frames = {
+            mode: windowed_analysis(
+                hm, window_size=10_000, step_size=10_000,
+                statistics=['fst'], populations=['p1', 'p2', 'p3'],
+                missing_data=mode)
+            for mode in ('include', 'exclude')
+        }
+        for mode, df in frames.items():
+            assert 'fst' not in df.columns, f"bare fst under {mode!r}"
+            for pair in ('fst_p1_p2', 'fst_p1_p3', 'fst_p2_p3'):
+                assert pair in df.columns, f"missing {pair} under {mode!r}"
+        assert list(frames['include'].columns) == list(frames['exclude'].columns)
+
 
 class TestFusedMissingData:
     """Fused two-pop kernel must use per-site valid counts under missingness."""

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -531,6 +531,45 @@ class TestChunkedFused:
                                        equal_nan=True,
                                        err_msg=f"Mismatch in {k}")
 
+    def test_over_cap_allele_in_pop2_drops_site_with_warning(self):
+        """An over-cap allele only pop2 carries must drop the site, warned.
+
+        The cap filter used to reduce over the population= subset (always
+        pop1 from the dispatcher), so a site with an allele index >= 8 in
+        pop2 alone survived it; the kernel's bounds checks then dropped
+        those gametes from the tallies while the valid count kept them,
+        skewing every statistic with no warning.
+        """
+        from pg_gpu.windowed_analysis import (
+            windowed_statistics_fused,
+            windowed_statistics_fused_chunked,
+        )
+        from pg_gpu._warnings import MultiallelicCapWarning
+
+        rng = np.random.RandomState(5)
+        n_hap, n_var = 40, 300
+        hap = rng.randint(0, 2, (n_hap, n_var)).astype(np.int8)
+        hap[25, 40] = 9                       # pop2 row only
+        pos = np.arange(1, n_var + 1) * 100
+        hm = HaplotypeMatrix(hap, pos, 0, (n_var + 1) * 100)
+        hm.sample_sets = {"p1": list(range(20)), "p2": list(range(20, 40))}
+        hm.transfer_to_gpu()
+
+        # Scalar reference on the sites the cap keeps.
+        keep = np.ones(n_var, dtype=bool)
+        keep[40] = False
+        ref_hm = HaplotypeMatrix(hap[:, keep], pos[keep], 0, (n_var + 1) * 100)
+        ref_hm.sample_sets = hm.sample_sets
+        ref = divergence.fst_weir_cockerham(ref_hm, 'p1', 'p2')
+
+        bp = np.array([0.0, (n_var + 1) * 100.0])
+        for fn in (windowed_statistics_fused, windowed_statistics_fused_chunked):
+            with pytest.warns(MultiallelicCapWarning):
+                r = fn(hm, bp_bins=bp, statistics=('fst_wc',),
+                       population='p1', pop1='p1', pop2='p2')
+            np.testing.assert_allclose(r['fst_wc'][0], ref, rtol=1e-9,
+                                       err_msg=fn.__name__)
+
     def test_mixed_single_twopop_chunked(self, matrix_with_pops):
         """Mixed single+two-pop stats should not crash (KeyError regression)."""
         from pg_gpu.windowed_analysis import windowed_statistics_fused_chunked

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -426,7 +426,8 @@ class TestChunkedFused:
             _memutil.estimate_fused_chunk_size = orig
 
         for k in ('pi', 'theta_w', 'tajimas_d', 'segregating_sites'):
-            np.testing.assert_allclose(r1[k], r2[k], rtol=1e-12, equal_nan=True,
+            np.testing.assert_allclose(r1[k], r2[k], rtol=1e-10, atol=1e-14,
+                                       equal_nan=True,
                                        err_msg=f"Mismatch in {k}")
 
     def test_two_pop_chunked_matches_fused(self, matrix_with_pops):
@@ -457,7 +458,8 @@ class TestChunkedFused:
             _memutil.estimate_fused_chunk_size = orig
 
         for k in ('fst', 'fst_wc', 'dxy', 'da'):
-            np.testing.assert_allclose(r1[k], r2[k], rtol=1e-12, equal_nan=True,
+            np.testing.assert_allclose(r1[k], r2[k], rtol=1e-10, atol=1e-14,
+                                       equal_nan=True,
                                        err_msg=f"Mismatch in {k}")
 
     def test_two_pop_chunked_with_population_subset(self, matrix_with_pops):
@@ -495,7 +497,38 @@ class TestChunkedFused:
             _memutil.estimate_fused_chunk_size = orig
 
         for k in stats:
-            np.testing.assert_allclose(r1[k], r2[k], rtol=1e-12, equal_nan=True,
+            np.testing.assert_allclose(r1[k], r2[k], rtol=1e-10, atol=1e-14,
+                                       equal_nan=True,
+                                       err_msg=f"Mismatch in {k}")
+
+    def test_two_pop_chunked_accepts_row_lists(self, matrix_with_pops):
+        """Row-list populations work in both engines, not only names."""
+        from pg_gpu.windowed_analysis import (
+            windowed_statistics_fused,
+            windowed_statistics_fused_chunked,
+        )
+        from pg_gpu import _memutil
+
+        hm = matrix_with_pops
+        hm.transfer_to_gpu()
+        n = hm.num_haplotypes
+        l1, l2 = list(range(n // 2)), list(range(n // 2, n))
+
+        bp_bins = np.arange(0, 500_001, 50_000, dtype=np.float64)
+        r1 = windowed_statistics_fused(
+            hm, bp_bins=bp_bins, statistics=('fst', 'fst_wc'),
+            pop1=l1, pop2=l2)
+        orig = _memutil.estimate_fused_chunk_size
+        _memutil.estimate_fused_chunk_size = lambda n, memory_fraction=0.35: 500
+        try:
+            r2 = windowed_statistics_fused_chunked(
+                hm, bp_bins=bp_bins, statistics=('fst', 'fst_wc'),
+                pop1=l1, pop2=l2)
+        finally:
+            _memutil.estimate_fused_chunk_size = orig
+        for k in ('fst', 'fst_wc'):
+            np.testing.assert_allclose(r1[k], r2[k], rtol=1e-10, atol=1e-14,
+                                       equal_nan=True,
                                        err_msg=f"Mismatch in {k}")
 
     def test_mixed_single_twopop_chunked(self, matrix_with_pops):

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -460,6 +460,44 @@ class TestChunkedFused:
             np.testing.assert_allclose(r1[k], r2[k], rtol=1e-12, equal_nan=True,
                                        err_msg=f"Mismatch in {k}")
 
+    def test_two_pop_chunked_with_population_subset(self, matrix_with_pops):
+        """Chunked two-pop values must not depend on the population= subset.
+
+        The dispatcher passes population=pop1 alongside pop1/pop2, so the
+        chunked engine holds the pop1 subset while the sample_sets row
+        numbers index the original matrix. The engine must read the rows
+        from the original matrix; indexing the subset selected the wrong
+        haplotypes without raising (#189).
+        """
+        from pg_gpu.windowed_analysis import (
+            windowed_statistics_fused,
+            windowed_statistics_fused_chunked,
+        )
+        from pg_gpu import _memutil
+
+        hm = matrix_with_pops
+        hm.transfer_to_gpu()
+
+        bp_bins = np.arange(0, 500_001, 50_000, dtype=np.float64)
+        stats = ('pi', 'fst', 'fst_wc', 'dxy', 'da')
+
+        r1 = windowed_statistics_fused(
+            hm, bp_bins=bp_bins, statistics=stats,
+            population='pop1', pop1='pop1', pop2='pop2')
+
+        orig = _memutil.estimate_fused_chunk_size
+        _memutil.estimate_fused_chunk_size = lambda n, memory_fraction=0.35: 500
+        try:
+            r2 = windowed_statistics_fused_chunked(
+                hm, bp_bins=bp_bins, statistics=stats,
+                population='pop1', pop1='pop1', pop2='pop2')
+        finally:
+            _memutil.estimate_fused_chunk_size = orig
+
+        for k in stats:
+            np.testing.assert_allclose(r1[k], r2[k], rtol=1e-12, equal_nan=True,
+                                       err_msg=f"Mismatch in {k}")
+
     def test_mixed_single_twopop_chunked(self, matrix_with_pops):
         """Mixed single+two-pop stats should not crash (KeyError regression)."""
         from pg_gpu.windowed_analysis import windowed_statistics_fused_chunked

--- a/tests/test_windowed_analysis.py
+++ b/tests/test_windowed_analysis.py
@@ -1115,18 +1115,16 @@ class TestMultiallelicTwoPop:
                 assert np.isclose(fst_w, fst_ref, rtol=1e-9, atol=1e-12)
 
     def test_fused_dxy_fst_da_match_scalar(self, sim_hm):
-        """Fused CUDA two-pop kernel: dxy/fst_hudson/da per window == scalar.
-        (fst_wc is excluded: the fused kernel's WC is a haploid estimator that
-        differs from the scalar diploid fst_weir_cockerham, a separate issue.)"""
+        """Fused CUDA two-pop kernel: dxy/fst_hudson/fst_wc/da per window == scalar."""
         from pg_gpu.windowed_analysis import windowed_statistics_fused
         window_size = 25_000
         bp = np.arange(0, int(sim_hm.chrom_end) + window_size, window_size,
                        dtype=float)
         r = windowed_statistics_fused(
-            sim_hm, bp_bins=bp, statistics=('dxy', 'fst_hudson', 'da'),
+            sim_hm, bp_bins=bp, statistics=('dxy', 'fst_hudson', 'fst_wc', 'da'),
             pop1='p1', pop2='p2', per_base=False, chrom='1')
-        for start, dxy_w, fst_w, da_w in zip(
-                r['start'], r['dxy'], r['fst_hudson'], r['da']):
+        for start, dxy_w, fst_w, wc_w, da_w in zip(
+                r['start'], r['dxy'], r['fst_hudson'], r['fst_wc'], r['da']):
             stop = start + window_size
             if stop > sim_hm.chrom_end:
                 continue
@@ -1139,11 +1137,12 @@ class TestMultiallelicTwoPop:
             assert np.isclose(da_w,
                               divergence.da(sub, 'p1', 'p2', span_normalize=False),
                               rtol=1e-9, atol=1e-12)
-            fst_ref = divergence.fst_hudson(sub, 'p1', 'p2')
-            if np.isnan(fst_w) or np.isnan(fst_ref):
-                assert np.isnan(fst_w) and np.isnan(fst_ref)
-            else:
-                assert np.isclose(fst_w, fst_ref, rtol=1e-9, atol=1e-12)
+            for got, ref in ((fst_w, divergence.fst_hudson(sub, 'p1', 'p2')),
+                             (wc_w, divergence.fst_weir_cockerham(sub, 'p1', 'p2'))):
+                if np.isnan(got) or np.isnan(ref):
+                    assert np.isnan(got) and np.isnan(ref)
+                else:
+                    assert np.isclose(got, ref, rtol=1e-9, atol=1e-12)
 
     def test_per_variant_dxy_fst_match_scalar(self, sim_hm):
         """Per-variant engine (windowed_statistics): two-pop dxy/fst per window


### PR DESCRIPTION
## Problem

The scalar `fst_weir_cockerham` is a per-allele one-vs-rest ANOVA over diploid
individuals. The fused two-population kernel still used the older form: every
haplotype treated as an independent gamete, all alternate alleles collapsed
into one, and `h_bar` fixed at 0 so the `c` component vanished.

The fused engine serves `missing_data='include'`, which is the default, so
windowed `fst_wc` and the plain function disagreed for most callers. The
per-window Python fallback (`missing_data='exclude'`) matched the scalar, so
which answer you got depended on engine dispatch.

Fixes #133.

The error is a roughly constant **absolute** offset -- at most 0.0012 across 44
datasets spanning true FST 0.0003 to 0.31, median 0.00033. As a fraction that
is under 3% for FST above 0.02 and under 0.1% above 0.15, but it swamps the
near-zero-FST fixtures the parity tests use, where the old kernel ran 67% to
93% low. On biallelic data the old `fst_wc` also agreed with the fused Hudson
FST to ~1e-12, so it was effectively a second copy of the `fst` column.

## Fix

The kernel pairs consecutive haplotypes into individuals, tallies per-allele
copies and per-allele heterozygotes, and runs the same ANOVA as the scalar,
including the `c` term. Both fused entry points share this kernel, so the
chunked engine converts with it.

## Verification

Local GPU runs, since CI has no GPU. Windowed vs scalar, max relative
difference:

| case | fused | chunked |
| --- | --- | --- |
| biallelic | 5.6e-16 | 5.6e-16 |
| multiallelic (JC69, 2597 sites with 3+ alleles) | 4.7e-16 | 4.7e-16 |
| synthetic 6-allele | 1.7e-14 | 1.8e-14 |
| 6-allele + 30% missing | 5.2e-15 | 5.2e-15 |
| half-missing individuals | 2.3e-15 | 2.8e-15 |
| structured A/B split, 15% missing | 2.8e-16 | 2.7e-16 |

Also checked: 1 / 2 / 4 / 100 / 1000 windows (max 6.1e-14), odd-sized
populations, non-contiguous populations, reversed row order, and `from_ts` /
`from_vcf` / `from_zarr` giving identical values.

Both the new kernel and the scalar match scikit-allel's `weir_cockerham_fst`
bit-for-bit on biallelic, multiallelic and odd-count inputs, and on missing
data whenever genotypes are called or missing as whole units. Half-called
genotypes are a convention difference, not a disagreement: allel counts the
lone gamete in its allele frequencies with `n = an // 2`, while pg_gpu's
scalar and both fused engines use complete individuals only -- and all
three pg_gpu paths agree with each other in every case.

Suites after the rebase: 1264 passed, 78 skipped, 25 xfailed (three `fst_wc`
parity cells flip from xfail to pass); moments 39 passed; ruff clean.

## Cost

The kernel does more work per variant, so the ANOVA and the diploid tally are
both skipped when `fst_wc` is not requested. Kernel time against the kernel
this replaces:

| shape | pre-PR | fst_wc not requested | fst_wc requested |
| --- | --- | --- | --- |
| 200 hap x 500k var | 1.17 ms | 1.48 ms | 1.93 ms |
| 800 hap x 300k var | 2.79 ms | 3.14 ms | 3.93 ms |
| 2000 hap x 150k var | 3.58 ms | 3.89 ms | 4.92 ms |

The skip path stays 9% to 26% above the old kernel. That residue is the
register and local-memory footprint of code that is compiled in but not run
(95 registers / 192 B versus 64 / 64 B), which only a separately compiled
variant would remove. `dxy`, `fst_hudson` and `da` are bit-identical with the
skip on or off.

For scale: reaching this kernel without asking for `fst_wc` means pairing a
two-population statistic with a garud/nSL/diploSHIC one, and the kernel is a
few percent of wall time at ordinary window spacing, more when windows overlap
heavily.

## Also in this change

The divergence was recorded in four places and all four are now consistent: the
strict xfail in `test_implementation_parity.py`, the "known exceptions" bullet
in `features.rst`, and the two "(haploid)" annotations in `features.rst` and
`api.rst`. `test_fused_dxy_fst_da_match_scalar` now covers `fst_wc` alongside
`dxy`, `fst` and `da` -- the parity suite compares a single whole-region window,
so that is the only per-window check across many windows.

Follow-up filed as #187: Weir-Cockerham still lacks the shared per-site CuPy
decomposition that `_ac_contribution` and `_twopop_site_components` give the
other statistics, which is why `fst_wc` cannot be computed by the scatter
engine.

## Picked up while landing this

Rebased on the trunk after #191 and #198. The pairing question from review
is settled by #191: every loader now writes sample ``i`` to rows ``2i`` and
``2i + 1`` and ``load_pop_file`` emits that order, so the kernel's
consecutive-row pairing is the package convention, not a one-off. A
pair-preserving shuffle of the population lists changes the result by
exactly zero.

Two bugs in the same dispatch path are fixed here, because windowed
``fst_wc`` cannot be trusted without them:

* #189 -- the chunked engine subsetted the matrix to the single-population
  argument, then indexed that subset with row numbers from the original
  matrix. The dispatcher always passes ``population=pop1`` next to
  ``pop1``/``pop2``, so every chunked two-population scan read wrong
  haplotypes, silently, because CuPy fancy indexing does not bounds-check.
  The rows now come from the original matrix. The old chunked test missed
  this because it never passed ``population=``; the new test mirrors the
  dispatcher's call and fails on the unfixed engine.

* #193 -- the same request named the column ``fst_wc`` under
  ``missing_data='include'`` but ``fst_wc_<p1>_<p2>`` under ``'exclude'``.
  The dispatcher now returns the bare name whenever exactly two
  populations are requested, whichever engine serves it.

## From the adversarial audit

Three review agents (route enumeration, numeric probing, diff review) went
over every path that can emit an FST number. Verdict on the core: sound --
the kernel is a term-for-term transcription of the scalar ANOVA, chunked
equals single-shot to machine precision under adversarial chunking, the
`need_wc` skip is bit-identical for the other statistics, and the streaming
route matches the eager frame exactly. Three surrounding defects they
found, all pre-existing, are fixed here because each can put a wrong or
misleading FST number in front of a user:

* Three or more populations reached the fused engine, which computed the
  first pair only and named the column after the bare statistic -- a
  three-population scan reported `fst` for p1 against p2 and said nothing
  about the rest. Such requests now take the per-window fallback, which
  computes every pair and suffixes the names, matching `'exclude'`.

* The chunked engine looked populations up as `sample_sets` keys, so the
  row-list form the single-shot engine accepts raised `TypeError` -- and
  engine choice depends on free GPU memory, so the same call worked or
  crashed depending on what else was on the card.

* Both fused engines derived the over-cap site filter from the pop1
  subset, so a site with an allele index of 8 or more only in pop2
  survived it and was silently mis-tallied: measured 9.5% off on `fst_wc`
  and 23% on Hudson `fst`, no warning. The cap now reduces over the
  original matrix whenever two-population statistics are requested, so
  the site is dropped and the warning fires. Nucleotide data cannot hit
  this; indel and microsatellite VCFs can.

Known and deliberately left open, all predating this PR: `include` and
`exclude` still disagree on the undefined-FST sentinel (NaN from the fused
engines, 0.0 from the scalar-backed fallback) and on single-population
column names in mixed requests; windowed `da` computes the composite on
the sites both populations have data for, while the scalar `da` lets each
pi term keep its own population's sites, so the two disagree when a site
is entirely missing in one population (the FST flavors and `dxy` are
unaffected); and under `'exclude'` the two serving engines anchor their
window grids differently (#179's family), which the trunk does not yet
have the fix for. Each needs its own decision.

#133, #189 and #193 need closing by hand after merge -- the base branch is
not the default, so the keywords will not fire.
