### PR TITLE
Give haplotype rows one order across the package

### DIFF
--- a/debug/bench_3L_validate.py
+++ b/debug/bench_3L_validate.py
@@ -33,12 +33,12 @@ def load():
     n_s = hm.num_haplotypes // 2  # diploid sample count
 
     # Map diploid sample indices to haplotype indices:
-    # diploid i -> haplotype i (allele 1) and haplotype i + n_samples (allele 2)
+    # diploid i -> haplotypes 2i (allele 1) and 2i + 1 (allele 2)
     def dip_to_hap(dip_indices):
         hap = []
         for i in dip_indices:
-            hap.append(i)
-            hap.append(i + n_s)
+            hap.append(2 * i)
+            hap.append(2 * i + 1)
         return hap
 
     hm.sample_sets = {

--- a/debug/stress_test_ag1000g.py
+++ b/debug/stress_test_ag1000g.py
@@ -110,8 +110,8 @@ def load_data(skip_allel=False):
     assert ploidy == 2
 
     haplotypes = np.empty((n_variants, 2 * n_samples), dtype=gt.dtype)
-    haplotypes[:, :n_samples] = gt[:, :, 0]
-    haplotypes[:, n_samples:] = gt[:, :, 1]
+    haplotypes[:, 0::2] = gt[:, :, 0]
+    haplotypes[:, 1::2] = gt[:, :, 1]
     haplotypes = haplotypes.T
 
     chrom_start = REGION_START if REGION_START is not None else int(positions[0])

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -49,6 +49,17 @@ Results that change even for two-allele data
 
 Read this section if you are comparing against older pg_gpu results.
 
+* Haplotype rows now follow one order everywhere: sample ``i`` owns rows
+  ``2i`` and ``2i + 1``. ``from_ts`` already used this order, while
+  ``from_vcf`` and ``from_zarr`` grouped all of the first gametes ahead of
+  the second ones. Statistics that reconstruct individuals -- ``ibs``,
+  ``grm``, ``fst_weir_cockerham``, ``heterozygosity_observed``,
+  ``GenotypeMatrix.from_haplotype_matrix``, and genotype-mode LD -- now
+  read the same order the loaders write, so their values change for data
+  loaded from VCF or zarr. Statistics that treat rows as independent
+  gametes are unaffected. ``sample_sets`` built by ``load_pop_file`` now
+  lists ``2i`` and ``2i + 1`` for each member, and hand-written index
+  lists that assumed the previous order need updating.
 * Frequency spectra: sites where nothing varies no longer contribute,
   folded spectra are returned as ``float64`` rather than integers, and
   ``joint_sfs_folded`` returns a full ``(n1 + 1, n2 + 1)`` grid folded

--- a/pg_gpu/_gpu_genotype_prep.py
+++ b/pg_gpu/_gpu_genotype_prep.py
@@ -4,10 +4,9 @@ and GenotypeMatrix.
 The VCZ ``call_genotype`` array is ``(n_var, n_dip, 2)`` int8. The two matrix
 classes consume it differently:
 
-* ``HaplotypeMatrix`` wants ``(n_hap, n_var)`` int8 with haps
-  ``0..n_dip-1`` carrying ploidy 0 and haps ``n_dip..2*n_dip-1`` carrying
-  ploidy 1. ``build_haplotype_matrix`` does the ploidy interleave +
-  transpose on the GPU.
+* ``HaplotypeMatrix`` wants ``(n_hap, n_var)`` int8 in the canonical row
+  order: hap ``2i`` carries sample i's ploidy 0 and hap ``2i+1`` its ploidy
+  1. ``build_haplotype_matrix`` does that interleave + transpose on the GPU.
 * ``GenotypeMatrix`` wants ``(n_indiv, n_var)`` int8 dosages (0/1/2 with
   ``-1`` for missing). ``build_genotype_matrix`` counts each site's alt
   allele on the GPU and propagates missing.
@@ -67,13 +66,12 @@ def build_haplotype_matrix(gt, pos, *,
     n_var, n_dip, _ = gt.shape
     gt_gpu = cp.asarray(gt)
 
-    # transpose (n_var, n_dip, 2) -> (2, n_dip, n_var) puts ploidy outermost,
-    # then the reshape concatenates: hap[0..n_dip-1] = ploidy 0 samples,
-    # hap[n_dip..2*n_dip-1] = ploidy 1 samples. This matches the layout
-    # HaplotypeMatrix.load_pop_file builds, so sample_sets indices line up
-    # without a permutation.
+    # The ploidy axis is last and varies fastest, so reshaping to
+    # (n_var, 2 * n_dip) interleaves the two gametes of each sample; the
+    # transpose then yields the canonical row order, individual i at rows
+    # 2i and 2i+1.
     haps = cp.ascontiguousarray(
-        gt_gpu.transpose(2, 1, 0).reshape(2 * n_dip, n_var)
+        gt_gpu.reshape(n_var, 2 * n_dip).T
     )
     del gt_gpu
 

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -151,6 +151,19 @@ class HaplotypeMatrix:
     labels. Supports GPU-accelerated computation of diversity, divergence,
     selection, and LD statistics.
 
+    Row order
+    ---------
+    Rows are gametes, and for diploid data the two gametes of one sample are
+    adjacent: sample ``i`` owns rows ``2i`` and ``2i + 1``. Every loader
+    produces this order and every consumer that reconstructs individuals --
+    ``GenotypeMatrix.from_haplotype_matrix``, ``relatedness.ibs``,
+    ``divergence.fst_weir_cockerham``, ``diversity.heterozygosity_observed``,
+    the ``to_zarr`` writer -- assumes it. ``sample_sets`` therefore lists both
+    gametes of each member, e.g. sample 3 contributes ``[6, 7]``.
+
+    Statistics that treat rows as independent gametes are unaffected by the
+    order; only the ones above pair rows.
+
     Parameters
     ----------
     genotypes : ndarray, shape (n_haplotypes, n_variants)
@@ -483,10 +496,11 @@ class HaplotypeMatrix:
                                source=f"VCF '{path}'")
         num_variants, num_samples, _ = genotypes.shape
 
-        haplotypes = np.empty((num_variants, 2 * num_samples), dtype=genotypes.dtype)
-        haplotypes[:, :num_samples] = genotypes[:, :, 0]
-        haplotypes[:, num_samples:] = genotypes[:, :, 1]
-        haplotypes = haplotypes.T
+        # Ploidy is the fastest-varying axis of (n_var, n_samples, 2), so
+        # merging the trailing axes interleaves each sample's two gametes and
+        # lands directly on the canonical row order.
+        haplotypes = np.asarray(genotypes).reshape(
+            num_variants, 2 * num_samples).T
 
         positions = np.array(vcf['variants/POS'])
         sample_names = list(vcf['samples'])
@@ -821,8 +835,8 @@ class HaplotypeMatrix:
         n_hap, n_var = hap.shape
         n_samples = n_hap // 2
         gt = np.empty((n_var, n_samples, 2), dtype=hap.dtype)
-        gt[:, :, 0] = hap[:n_samples, :].T
-        gt[:, :, 1] = hap[n_samples:, :].T
+        gt[:, :, 0] = hap[0::2, :].T
+        gt[:, :, 1] = hap[1::2, :].T
         return gt
 
     def load_pop_file(self, pop_assignment, pops: list = None):
@@ -842,11 +856,16 @@ class HaplotypeMatrix:
             labels.
         pops : list of str, optional
             Populations to include. If None, includes all found populations.
+
+        Notes
+        -----
+        Each population's entry lists haplotype rows, not samples, so a member
+        contributes both of its gametes (sample ``i`` gives ``2i`` and
+        ``2i + 1``).
         """
         if self.samples is None:
             raise ValueError("No sample names stored. Use from_vcf() to load data.")
 
-        n_samples = len(self.samples)
         if isinstance(pop_assignment, dict):
             pop_map = {str(k): str(v) for k, v in pop_assignment.items() if v}
         else:
@@ -862,19 +881,15 @@ class HaplotypeMatrix:
         if pops is None:
             pops = sorted(found_pops)
 
-        # Block ordering: ploidy-0 indices first, then ploidy-1 indices.
-        # _get_genotype_data and _get_diploid_genotypes split the
-        # haplotype axis at hap.shape[0] // 2 to recover diploid pairs,
-        # which only gives correct pairing under this layout. Matches
-        # what ZarrGenotypeSource produces from a pop file too, so the
-        # streaming and eager paths agree.
+        # Canonical row order: sample i owns haplotype rows 2i and 2i+1, so a
+        # population's index list holds both gametes of each of its samples.
         pop_dips = {p: [] for p in pops}
         for i, name in enumerate(self.samples):
             pop = pop_map.get(name)
             if pop in pop_dips:
                 pop_dips[pop].append(i)
         pop_sets = {
-            p: dips + [d + n_samples for d in dips]
+            p: [h for d in dips for h in (2 * d, 2 * d + 1)]
             for p, dips in pop_dips.items()
         }
 
@@ -1464,10 +1479,10 @@ class HaplotypeMatrix:
         # haplotype matrix so the original is untouched.
         if genotypes_arr is not None:
             # (n_var, n_samples) -> (2 * n_samples, n_var): both
-            # haplotype rows for a sample share its genotype mask.
+            # haplotype rows for a sample share its genotype mask, and under
+            # the canonical row order those rows are adjacent.
             per_sample_keep = genotypes_arr.T  # (n_samples, n_var)
-            hap_keep = xp.concatenate([per_sample_keep, per_sample_keep],
-                                      axis=0)
+            hap_keep = xp.repeat(per_sample_keep, 2, axis=0)
             haps = xp.where(hap_keep, haps_src, np.int8(-1))
         else:
             haps = haps_src

--- a/pg_gpu/relatedness.py
+++ b/pg_gpu/relatedness.py
@@ -532,8 +532,8 @@ def _get_genotype_data(matrix, population=None):
     elif isinstance(matrix, HaplotypeMatrix):
         hap = matrix.haplotypes
         n_ind = hap.shape[0] // 2
-        h1 = hap[:n_ind, :]
-        h2 = hap[n_ind:, :]
+        h1 = hap[0:2 * n_ind:2, :]
+        h2 = hap[1:2 * n_ind:2, :]
         missing = (h1 < 0) | (h2 < 0)
         geno = (cp.maximum(h1, 0) + cp.maximum(h2, 0)).astype(cp.int8)
         geno[missing] = -1
@@ -541,83 +541,6 @@ def _get_genotype_data(matrix, population=None):
     else:
         raise TypeError(f"Expected HaplotypeMatrix or GenotypeMatrix, got {type(matrix)}")
 
-
-def _get_haplotype_data(matrix, population=None):
-    """Get haplotype matrix and number of diploid individuals.
-
-    Returns the raw haplotype matrix on GPU (no genotype conversion)
-    so callers can build diploid genotypes per-chunk.
-    """
-    from .haplotype_matrix import HaplotypeMatrix
-    from .genotype_matrix import GenotypeMatrix
-    from ._utils import get_population_matrix
-
-    if population is not None:
-        matrix = get_population_matrix(matrix, population)
-
-    if hasattr(matrix, 'device') and matrix.device == 'CPU':
-        matrix.transfer_to_gpu()
-
-    if isinstance(matrix, GenotypeMatrix):
-        # Convert genotypes back to haplotype layout for uniform processing
-        geno = matrix.genotypes  # (n_ind, n_var)
-        n_ind = geno.shape[0]
-        # Fake haplotype layout: allele1 = geno // 2, allele2 = geno - allele1
-        # This is approximate for het sites but correct for IBS/GRM counting
-        h1 = cp.where(geno >= 0, geno // 2, -1).astype(cp.int8)
-        h2 = cp.where(geno >= 0, geno - geno // 2, -1).astype(cp.int8)
-        hap = cp.concatenate([h1, h2], axis=0)
-        return hap, n_ind
-    elif isinstance(matrix, HaplotypeMatrix):
-        n_ind = matrix.num_haplotypes // 2
-        return matrix.haplotypes, n_ind
-    else:
-        raise TypeError(f"Expected HaplotypeMatrix or GenotypeMatrix, got {type(matrix)}")
-
-
-def _get_diploid_genotypes(matrix, population=None):
-    """Extract diploid genotype matrix (n_individuals, n_variants) on GPU.
-
-    If input is HaplotypeMatrix, pairs consecutive haplotypes into diploid
-    genotypes (hap[0]+hap[1], hap[2]+hap[3], ...).
-    """
-    from .haplotype_matrix import HaplotypeMatrix
-    from .genotype_matrix import GenotypeMatrix
-    from ._utils import get_population_matrix
-
-    if population is not None:
-        matrix = get_population_matrix(matrix, population)
-
-    if hasattr(matrix, 'device') and matrix.device == 'CPU':
-        matrix.transfer_to_gpu()
-
-    if isinstance(matrix, GenotypeMatrix):
-        return matrix.genotypes
-    elif isinstance(matrix, HaplotypeMatrix):
-        hap = matrix.haplotypes
-        n_hap = hap.shape[0]
-        n_ind = n_hap // 2
-        # Pair consecutive haplotypes: first n_ind are allele 1,
-        # next n_ind are allele 2 (pg_gpu convention)
-        geno = hap[:n_ind, :].astype(cp.int8) + hap[n_ind:, :].astype(cp.int8)
-        # Mark as missing (-1) if either haplotype is missing
-        missing = (hap[:n_ind, :] < 0) | (hap[n_ind:, :] < 0)
-        geno[missing] = -1
-        return geno
-    else:
-        raise TypeError(f"Expected HaplotypeMatrix or GenotypeMatrix, got {type(matrix)}")
-
-
-# ---------------------------------------------------------------------------
-# Streaming IBS: variant-axis stream + indiv-axis row-block tile
-# ---------------------------------------------------------------------------
-#
-# The three accumulators (ibs2, ibs1, n_joint) are each (n_ind, n_ind) and
-# decompose by sum over variants, so the variant axis can be streamed
-# chunk-by-chunk. The output itself can exceed GPU memory (80 GB at 100k
-# diploids), so the individual axis is tiled into row blocks and the
-# accumulators live on host -- only one row-block's (block_size, n_ind)
-# matmul output sits on the GPU at a time.
 
 def _stream_ibs(streaming_matrix, *, population, missing_data,
                 block_size=None):

--- a/pg_gpu/relatedness.py
+++ b/pg_gpu/relatedness.py
@@ -511,13 +511,13 @@ def _relatedness_columns(hap, sample_sets, n_alleles, centre=True):
 # ---------------------------------------------------------------------------
 
 def _get_genotype_data(matrix, population=None):
-    """Get diploid genotype matrix (n_individuals, n_variants) on GPU.
+    """Get the diploid dosage matrix (n_individuals, n_variants) on GPU.
 
-    Returns genotypes directly from GenotypeMatrix, or builds them from
-    HaplotypeMatrix by summing paired haplotypes. Avoids the memory cost
-    of round-tripping through an intermediate haplotype representation.
+    Callers reach here only with a GenotypeMatrix: ``grm`` and ``ibs`` reject
+    haplotype input up front, so haplotypes become dosages through the one
+    conversion in ``GenotypeMatrix.from_haplotype_matrix``, which counts the
+    alt allele and drops sites carrying more than two.
     """
-    from .haplotype_matrix import HaplotypeMatrix
     from .genotype_matrix import GenotypeMatrix
     from ._utils import get_population_matrix
 
@@ -529,17 +529,7 @@ def _get_genotype_data(matrix, population=None):
 
     if isinstance(matrix, GenotypeMatrix):
         return matrix.genotypes, matrix.genotypes.shape[0]
-    elif isinstance(matrix, HaplotypeMatrix):
-        hap = matrix.haplotypes
-        n_ind = hap.shape[0] // 2
-        h1 = hap[0:2 * n_ind:2, :]
-        h2 = hap[1:2 * n_ind:2, :]
-        missing = (h1 < 0) | (h2 < 0)
-        geno = (cp.maximum(h1, 0) + cp.maximum(h2, 0)).astype(cp.int8)
-        geno[missing] = -1
-        return geno, n_ind
-    else:
-        raise TypeError(f"Expected HaplotypeMatrix or GenotypeMatrix, got {type(matrix)}")
+    raise TypeError(f"Expected GenotypeMatrix, got {type(matrix)}")
 
 
 def _stream_ibs(streaming_matrix, *, population, missing_data,

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -606,14 +606,10 @@ class _StreamingMatrixBase:
                     f"got {n_hap}."
                 )
             n_dip_sub = n_hap // 2
-            # The subsample ploidy ordering matches the source's
-            # convention: haps 0..n_dip-1 = ploidy 0, n_dip..2*n_dip-1
-            # = ploidy 1. Assemble the (n_var, n_dip', 2) layout in
-            # cupy so we don't round-trip through a multi-GB host buffer.
-            gt = cp.empty((n_var, n_dip_sub, 2), dtype=gm_gpu.dtype)
-            gt[:, :, 0] = gm_gpu[:, :n_dip_sub]
-            gt[:, :, 1] = gm_gpu[:, n_dip_sub:]
-            del gm_gpu
+            # Canonical row order puts a sample's two gametes adjacent, so the
+            # haplotype axis is already the flattened (n_dip', 2) layout and
+            # the split is a view rather than a copy.
+            gt = gm_gpu.reshape(n_var, n_dip_sub, 2)
 
         return self._build_chunk(
             gt, pos,

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -576,6 +576,15 @@ class _StreamingMatrixBase:
         sample_subset : sequence of int, optional
             Haplotype-axis indices to keep. ``None`` keeps every
             haplotype.
+
+            Sample ``i`` is rows ``2i`` and ``2i + 1``. Ask for both to
+            keep whole samples. Ask for only one and the rows you get
+            back still sit side by side, but a neighbouring pair is no
+            longer one sample. Do not feed such a matrix to anything
+            that works per individual -- ``grm``, ``ibs``,
+            ``fst_weir_cockerham``, ``heterozygosity_observed``, or
+            ``GenotypeMatrix.from_haplotype_matrix``. Statistics that
+            read each row on its own are fine either way.
         """
         if region is None:
             left, right = self.chrom_start, self.chrom_end

--- a/pg_gpu/zarr_source.py
+++ b/pg_gpu/zarr_source.py
@@ -226,9 +226,8 @@ class ZarrGenotypeSource:
                     np.empty(0, np.int64))
         zlo, zhi = self._zarr_row_range(lo, hi)
 
-        is_p1 = hap_cols >= self.num_diploids
-        dip_idx = np.where(is_p1, hap_cols - self.num_diploids, hap_cols)
-        ploidy = is_p1.astype(np.int64)
+        dip_idx = hap_cols // 2
+        ploidy = hap_cols % 2
         unique_dips, inv = np.unique(dip_idx, return_inverse=True)
 
         # Group sorted unique_dips into contiguous diploid-axis runs.
@@ -301,15 +300,14 @@ class ZarrGenotypeSource:
             return empty, np.empty(0, np.int64)
         zlo, zhi = self._zarr_row_range(lo, hi)
 
-        # The haplotype axis indexes a flat (n_dip * 2) layout where hap j
-        # = (ploidy j // n_dip, dip j % n_dip). VCZ stores (n_var, n_dip, 2)
-        # so we have to translate each requested hap index into (dip, ploidy)
+        # Haplotype rows follow the canonical order, so hap j belongs to
+        # dip j // 2 at ploidy j % 2. VCZ stores (n_var, n_dip, 2) so we have
+        # to translate each requested hap index into (dip, ploidy)
         # and feed unique dips through oindex (zarr's oindex on a 3-D axis
         # does not de-duplicate, and requesting the same dip twice would
         # double-decompress its sample chunk).
-        is_p1 = hap_cols >= self.num_diploids
-        dip_idx = np.where(is_p1, hap_cols - self.num_diploids, hap_cols)
-        ploidy = is_p1.astype(np.int64)
+        dip_idx = hap_cols // 2
+        ploidy = hap_cols % 2
         unique_dips, inv = np.unique(dip_idx, return_inverse=True)
 
         block_host = np.asarray(
@@ -391,12 +389,12 @@ class ZarrGenotypeSource:
                 continue
             pop_to_dips.setdefault(pop, []).append(i)
 
-        # Map diploid indices to haplotype-axis indices: dip i lives at
-        # haps i (ploidy 0) and i + num_diploids (ploidy 1). Matches the
-        # layout build_haplotype_matrix produces and load_pop_file expects.
-        n_dip = self.num_diploids
+        # Map diploid indices to haplotype-axis indices: under the canonical
+        # row order dip i lives at haps 2i (ploidy 0) and 2i+1 (ploidy 1),
+        # which is what build_haplotype_matrix produces and load_pop_file
+        # expects.
         pop_cols = {}
         for pop, dips in pop_to_dips.items():
             dips = np.asarray(sorted(dips), dtype=np.int64)
-            pop_cols[pop] = np.concatenate([dips, dips + n_dip])
+            pop_cols[pop] = np.stack([2 * dips, 2 * dips + 1], axis=1).ravel()
         return pop_cols

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,3 +157,19 @@ def multiallelic_hm(multiallelic_ts):
     """(ts, hm) pair for the multiallelic tree sequence; hm on GPU."""
     from pg_gpu import HaplotypeMatrix
     return multiallelic_ts, HaplotypeMatrix.from_ts(multiallelic_ts, device="GPU")
+
+
+def canonical_hap_rows(call_genotype):
+    """Reference (n_hap, n_var) rows for a ``(n_var, n_dip, 2)`` block.
+
+    Spelled as explicit per-ploidy column slices rather than a reshape so it
+    stays an independent statement of the canonical row order -- sample i at
+    rows 2i and 2i+1 -- rather than a mirror of the loader implementation.
+    """
+    import numpy as np
+
+    n_var, n_dip, _ = call_genotype.shape
+    haps = np.empty((n_var, 2 * n_dip), dtype=call_genotype.dtype)
+    haps[:, 0::2] = call_genotype[:, :, 0]
+    haps[:, 1::2] = call_genotype[:, :, 1]
+    return haps.T

--- a/tests/test_gpu_genotype_prep.py
+++ b/tests/test_gpu_genotype_prep.py
@@ -3,6 +3,8 @@ GPU-side prep of (n_var, n_dip, 2) blocks."""
 
 import numpy as np
 import pytest
+
+from .conftest import canonical_hap_rows
 import cupy as cp
 
 from pg_gpu._gpu_genotype_prep import (
@@ -12,13 +14,8 @@ from pg_gpu._gpu_genotype_prep import (
 
 def _reference_reshape(gt):
     """Host-only equivalent of build_haplotype_matrix's reshape, used as
-    ground truth in equivalence tests. Matches the layout
-    HaplotypeMatrix.load_pop_file expects (ploidy 0 first, then ploidy 1)."""
-    n_var, n_dip, _ = gt.shape
-    haps = np.empty((n_var, 2 * n_dip), dtype=gt.dtype)
-    haps[:, :n_dip] = gt[:, :, 0]
-    haps[:, n_dip:] = gt[:, :, 1]
-    return haps.T
+    ground truth in equivalence tests."""
+    return canonical_hap_rows(gt)
 
 
 @pytest.fixture

--- a/tests/test_haplotype_counting.py
+++ b/tests/test_haplotype_counting.py
@@ -70,8 +70,8 @@ class TestHaplotypeCounting:
 
             # Define populations
             pop_sets = {
-                "pop0": [0, 1, 4, 5],  # ind0 and ind1 haplotypes
-                "pop1": [2, 3, 6, 7]   # ind2 and ind3 haplotypes
+                "pop0": [0, 1, 2, 3],  # ind0 and ind1 haplotypes
+                "pop1": [4, 5, 6, 7]   # ind2 and ind3 haplotypes
             }
             h_gpu.sample_sets = pop_sets
 

--- a/tests/test_loader_parity.py
+++ b/tests/test_loader_parity.py
@@ -15,6 +15,8 @@ import pytest
 from pg_gpu import BiallelicOnlyWarning, GenotypeMatrix
 from pg_gpu.zarr_io import write_vcz
 
+from .conftest import canonical_hap_rows
+
 
 def _host(a):
     return a.get() if hasattr(a, "get") else np.asarray(a)
@@ -176,3 +178,170 @@ class TestMultiallelicParity:
         assert len(chunks) >= 2   # the sites really did split across chunks
         bo = [w for w in rec if issubclass(w.category, BiallelicOnlyWarning)]
         assert len(bo) == 1
+
+
+class TestHaplotypeRowOrder:
+    """Every loader must place a sample's two gametes at rows 2i and 2i+1.
+
+    The loaders used to disagree: from_ts emitted that order while the VCF and
+    zarr paths emitted ploidy-0 rows followed by ploidy-1 rows. Whichever
+    convention a consumer assumed, data from the other loader was paired across
+    individuals -- silently, since a mispaired matrix is still well formed.
+    """
+
+    @pytest.fixture(scope="class")
+    def ts_and_vcf(self, tmp_path_factory):
+        """A diploid tree sequence and the VCF written from it."""
+        msprime = pytest.importorskip("msprime")
+        ts = msprime.sim_ancestry(samples=8, population_size=1e4,
+                                  sequence_length=2e4, recombination_rate=1e-8,
+                                  random_seed=11, ploidy=2)
+        ts = msprime.sim_mutations(ts, rate=1e-7, random_seed=11,
+                                   model="binary")
+        assert ts.num_sites > 0
+        path = str(tmp_path_factory.mktemp("rows") / "ts.vcf")
+        with open(path, "w") as fh:
+            ts.write_vcf(fh, individual_names=[f"s{i}" for i
+                                               in range(ts.num_individuals)])
+        return ts, path
+
+    def test_vcf_and_zarr_agree_with_canonical_order(self, tmp_path):
+        from pg_gpu import HaplotypeMatrix
+
+        cg, pos = _BIALLELIC_CG, _BIALLELIC_POS
+        vcf = str(tmp_path / "rows.vcf")
+        _write_vcf_from_cg(vcf, cg, pos, _SAMPLES)
+        vcz = str(tmp_path / "rows.vcz.zarr")
+        write_vcz(vcz, cg, pos, samples=_SAMPLES, contig_name="1")
+
+        expected = canonical_hap_rows(cg)
+        np.testing.assert_array_equal(_host(HaplotypeMatrix.from_vcf(vcf).haplotypes),
+                                      expected)
+        np.testing.assert_array_equal(_host(HaplotypeMatrix.from_zarr(vcz).haplotypes),
+                                      expected)
+
+    def test_from_ts_matches_the_vcf_loader(self, ts_and_vcf):
+        """A tree sequence and the VCF written from it load identically."""
+        from pg_gpu import HaplotypeMatrix
+
+        ts, vcf = ts_and_vcf
+        hm_ts = HaplotypeMatrix.from_ts(ts)
+        hm_vcf = HaplotypeMatrix.from_vcf(vcf)
+        np.testing.assert_array_equal(_host(hm_ts.haplotypes),
+                                      _host(hm_vcf.haplotypes))
+
+        # tskit sample nodes 2i / 2i+1 are individual i, so summing adjacent
+        # rows is the per-individual dosage the loaders must reproduce.
+        g = ts.genotype_matrix()
+        truth = np.stack([g[:, 2 * i] + g[:, 2 * i + 1]
+                          for i in range(ts.num_individuals)], axis=1).T
+        gm = GenotypeMatrix.from_haplotype_matrix(hm_ts)
+        np.testing.assert_array_equal(_host(gm.genotypes), truth)
+
+    def test_consumers_read_the_canonical_order(self, ts_and_vcf):
+        """Statistics that rebuild individuals agree with a host reference.
+
+        Loader-against-loader would prove nothing once the rows are known to be
+        byte-identical, so each statistic is checked against a value computed
+        directly from the tree sequence instead.
+        """
+        from pg_gpu import HaplotypeMatrix, diversity, relatedness
+
+        ts, vcf = ts_and_vcf
+        hm = HaplotypeMatrix.from_vcf(vcf)
+        g = ts.genotype_matrix()
+        dosage = np.stack([g[:, 2 * i] + g[:, 2 * i + 1]
+                           for i in range(ts.num_individuals)], axis=1).T
+
+        ho = float(np.nanmean(_host(diversity.heterozygosity_observed(hm))))
+        assert ho == pytest.approx(float((dosage == 1).mean()), rel=1e-12)
+
+        # For ibs and grm, build the reference GenotypeMatrix straight from the
+        # tree sequence dosages so the comparison isolates the pairing without
+        # restating either statistic's formula.
+        pos = np.asarray([s.position for s in ts.sites()], dtype=np.int64)
+        ref = GenotypeMatrix(dosage.astype(np.int8), pos,
+                             int(pos[0]), int(pos[-1]))
+        via_loader = GenotypeMatrix.from_haplotype_matrix(hm)
+        np.testing.assert_allclose(_host(relatedness.ibs(via_loader)),
+                                   _host(relatedness.ibs(ref)), rtol=1e-12)
+        np.testing.assert_allclose(_host(relatedness.grm(via_loader)),
+                                   _host(relatedness.grm(ref)), rtol=1e-12)
+
+    def test_to_zarr_round_trip_preserves_pairing(self, tmp_path):
+        """The writer must read the same row order the loaders emit."""
+        from pg_gpu import HaplotypeMatrix
+
+        cg, pos = _BIALLELIC_CG, _BIALLELIC_POS
+        vcz = str(tmp_path / "in.vcz.zarr")
+        write_vcz(vcz, cg, pos, samples=_SAMPLES, contig_name="1")
+        hm = HaplotypeMatrix.from_zarr(vcz)
+
+        out = str(tmp_path / "out.vcz.zarr")
+        hm.to_zarr(out, format="vcz", contig_name="1")
+        np.testing.assert_array_equal(_host(HaplotypeMatrix.from_zarr(out).haplotypes),
+                                      _host(hm.haplotypes))
+
+    def test_populations_pair_within_their_own_subset(self, tmp_path):
+        """Pairing must survive subsetting to a population.
+
+        Statistics like fst_weir_cockerham pair consecutive rows *within* the
+        population subset, a second pairing step layered on the row order. The
+        populations here alternate through the samples, so each one's rows are
+        non-contiguous in the full matrix and the subset has to carry the
+        adjacency with it.
+        """
+        from pg_gpu import HaplotypeMatrix, divergence, diversity
+
+        rng = np.random.default_rng(4)
+        n_var, n_dip = 40, 6
+        cg = rng.integers(0, 2, size=(n_var, n_dip, 2)).astype(np.int8)
+        pos = np.arange(1, n_var + 1) * 100
+        names = [f"s{i}" for i in range(n_dip)]
+
+        vcf = str(tmp_path / "multipop.vcf")
+        _write_vcf_from_cg(vcf, cg, pos, names)
+        pop_file = tmp_path / "multipop.tsv"
+        pop_file.write_text("".join(
+            f"s{i}\t{'p1' if i % 2 == 0 else 'p2'}\n" for i in range(n_dip)))
+
+        hm = HaplotypeMatrix.from_vcf(vcf)
+        hm.load_pop_file(str(pop_file))
+        # p1 = samples 0, 2, 4 -> both gametes of each, still adjacent in pairs
+        assert sorted(hm.sample_sets["p1"]) == [0, 1, 4, 5, 8, 9]
+        assert sorted(hm.sample_sets["p2"]) == [2, 3, 6, 7, 10, 11]
+
+        def only(dips):
+            """A matrix holding just these samples, in canonical order."""
+            return HaplotypeMatrix(canonical_hap_rows(cg[:, dips, :]), pos,
+                                   int(pos[0]), int(pos[-1]))
+
+        # Per-population statistic against a matrix of just that population.
+        for pop, dips in (("p1", [0, 2, 4]), ("p2", [1, 3, 5])):
+            got = float(np.nanmean(_host(
+                diversity.heterozygosity_observed(hm, population=pop))))
+            ref = float(np.nanmean(_host(
+                diversity.heterozygosity_observed(only(dips)))))
+            assert got == pytest.approx(ref, rel=1e-12), pop
+
+        # Two-population statistic against the same populations laid out
+        # contiguously, which must give the identical estimate.
+        stacked = only([0, 2, 4, 1, 3, 5])
+        stacked.sample_sets = {"p1": list(range(6)), "p2": list(range(6, 12))}
+        assert float(divergence.fst_weir_cockerham(hm, "p1", "p2")) == pytest.approx(
+            float(divergence.fst_weir_cockerham(stacked, "p1", "p2")), rel=1e-12)
+
+    def test_load_pop_file_lists_both_gametes(self, tmp_path):
+        """Population sets must hold rows 2i and 2i+1 for each member."""
+        from pg_gpu import HaplotypeMatrix
+
+        cg, pos = _BIALLELIC_CG, _BIALLELIC_POS
+        vcf = str(tmp_path / "pops.vcf")
+        _write_vcf_from_cg(vcf, cg, pos, _SAMPLES)
+        pop_file = tmp_path / "pops.tsv"
+        pop_file.write_text("s0\tp1\ns1\tp1\ns2\tp2\n")
+
+        hm = HaplotypeMatrix.from_vcf(vcf)
+        hm.load_pop_file(str(pop_file))
+        assert sorted(hm.sample_sets["p1"]) == [0, 1, 2, 3]
+        assert sorted(hm.sample_sets["p2"]) == [4, 5]

--- a/tests/test_moments_ld.py
+++ b/tests/test_moments_ld.py
@@ -588,21 +588,15 @@ class TestHaplotypeMatrixGenotypePath:
     through ``GenotypeMatrix.from_haplotype_matrix``, so the conversion has to
     recover the same individuals the VCF loader would have built.
 
-    pg_gpu pairs haplotypes into diploids two contradictory ways (issue #148):
-    consecutive rows ``(2i, 2i+1)``, which ``from_haplotype_matrix`` uses, and
-    split-half rows ``(i, i + n_ind)``, which the VCF/zarr loaders produce and
-    ``load_pop_file`` documents. Whichever order is eventually made canonical,
-    one VCF loaded two ways has to yield the same individuals -- so these
-    comparisons hold either way, and the fixture is VCF-loaded to keep them
-    independent of that decision.
+    Haplotype rows are ordered so that sample ``i`` owns rows ``2i`` and
+    ``2i + 1``, and every loader emits that order, so one VCF loaded two ways
+    yields the same individuals.
 
     Getting it wrong builds each "individual" from two different people's
     chromosomes and scrambles the population assignment with it, which no
     downstream statistic can detect.
     """
 
-    @pytest.mark.xfail(reason="haplotype->diploid pairing, issue #148",
-                       strict=False)
     def test_conversion_matches_vcf_genotypes(self, plain_vcf):
         vcf, _ = plain_vcf
         direct = GenotypeMatrix.from_vcf(vcf)
@@ -612,8 +606,6 @@ class TestHaplotypeMatrixGenotypePath:
         np.testing.assert_array_equal(
             _to_numpy(converted.genotypes), _to_numpy(direct.genotypes))
 
-    @pytest.mark.xfail(reason="haplotype->diploid pairing, issue #148",
-                       strict=False)
     def test_conversion_preserves_sample_sets(self, plain_vcf):
         vcf, pop_file = plain_vcf
         direct = GenotypeMatrix.from_vcf(vcf)
@@ -624,8 +616,6 @@ class TestHaplotypeMatrixGenotypePath:
         for pop in SMALL_VCF_POPS:
             assert sorted(converted.sample_sets[pop]) == sorted(direct.sample_sets[pop])
 
-    @pytest.mark.xfail(reason="haplotype->diploid pairing, issue #148",
-                       strict=False)
     def test_ld_sums_match_the_vcf_path(self, plain_vcf):
         vcf, pop_file = plain_vcf
         hm = HaplotypeMatrix.from_vcf(vcf)

--- a/tests/test_ploidy_check.py
+++ b/tests/test_ploidy_check.py
@@ -179,8 +179,8 @@ def test_normal_vcf_loads_without_warning(simple_vcf_file):
 
 def _to_vcz(hap, tmp_path, name="store.vcz"):
     """Write a (n_hap, n_var) haplotype matrix to a VCZ store and return its
-    path. The matrix is paired into diploids as (hap[i], hap[i + n_samples]),
-    so a first half equal to the second half yields homozygous individuals."""
+    path. The matrix is paired into diploids as (hap[2i], hap[2i + 1]), so
+    equal adjacent rows yield homozygous individuals."""
     path = str(tmp_path / name)
     hm = HaplotypeMatrix(np.asarray(hap, dtype=np.int8),
                          np.arange(1, hap.shape[1] + 1) * 100, 100,
@@ -192,10 +192,10 @@ def _to_vcz(hap, tmp_path, name="store.vcz"):
 
 @pytest.fixture
 def pseudo_diploid_vcz(tmp_path):
-    # First half of rows == second half -> every individual is homozygous;
-    # the alternate allele is present, so it is polymorphic but never het.
+    # Each row repeated adjacently -> every individual is homozygous; the
+    # alternate allele is present, so it is polymorphic but never het.
     block = _i8([[1, 0], [0, 1], [1, 1]])  # 3 samples, 2 variants
-    return _to_vcz(np.vstack([block, block]), tmp_path)
+    return _to_vcz(np.repeat(block, 2, axis=0), tmp_path)
 
 
 def test_haplotype_from_zarr_warns_pseudo_diploid(pseudo_diploid_vcz):

--- a/tests/test_qc_fields.py
+++ b/tests/test_qc_fields.py
@@ -315,16 +315,16 @@ class TestHaplotypeMatrixFilter:
         # The variant axis stays put when only genotypes= is applied
         # without drop_all_missing.
         assert filtered.haplotypes.shape == loaded.haplotypes.shape
-        # Sample s rejected at variant v means both haplotype rows (s, v)
-        # and (s + n_samples, v) are -1.
+        # Sample s rejected at variant v means both of its haplotype rows,
+        # (2s, v) and (2s + 1, v), are -1.
         n_samples = loaded.haplotypes.shape[0] // 2
         haps_host = _host(filtered._haplotypes)
         gt_keep_host = np.asarray(gt_keep)
         for v in range(haps_host.shape[1]):
             for s in range(n_samples):
                 if not gt_keep_host[v, s]:
-                    assert haps_host[s, v] == -1
-                    assert haps_host[s + n_samples, v] == -1
+                    assert haps_host[2 * s, v] == -1
+                    assert haps_host[2 * s + 1, v] == -1
 
     def test_drop_all_missing_kicks_in(self, tmp_path):
         hm = _simulate_hm()

--- a/tests/test_zarr_source.py
+++ b/tests/test_zarr_source.py
@@ -8,6 +8,8 @@ import zarr
 from pg_gpu import HaplotypeMatrix
 from pg_gpu.zarr_source import ZarrGenotypeSource
 
+from .conftest import canonical_hap_rows
+
 
 def _simulate_hm(n_samples=20, seq_length=50_000, seed=42):
     """Build a HaplotypeMatrix with msprime, matching test_zarr_io.py's style."""
@@ -128,12 +130,9 @@ class TestSliceRegion:
         path, hm = vcz_store
         src = ZarrGenotypeSource(path)
         gt, pos = src.slice_region(0, src.mappable_hi)
-        # Reproduce the existing eager from_zarr layout (ploidy 0 then ploidy 1
-        # along the hap axis); compare to the original HaplotypeMatrix bytes.
-        n_dip = src.num_diploids
-        haps = np.empty((gt.shape[0], 2 * n_dip), dtype=gt.dtype)
-        haps[:, :n_dip] = gt[:, :, 0]
-        haps[:, n_dip:] = gt[:, :, 1]
+        # Reproduce the canonical row order and compare to the original
+        # HaplotypeMatrix bytes.
+        haps = canonical_hap_rows(gt).T
         np.testing.assert_array_equal(haps.T, np.asarray(hm.haplotypes))
 
     def test_empty_region(self, vcz_store):
@@ -152,18 +151,15 @@ class TestSliceSubsample:
         src = ZarrGenotypeSource(path)
         gt_full, _ = src.slice_region(0, src.mappable_hi)
 
-        # Pick a haplotype subset that crosses the ploidy-0/ploidy-1
-        # boundary so we exercise the (dip, ploidy) translation.
-        n_dip = src.num_diploids
-        cols = np.array([0, 1, 2, n_dip, n_dip + 1], dtype=np.int64)
+        # Mix both gametes of some samples with a single gamete of another so
+        # the (dip, ploidy) translation is exercised in both parities.
+        cols = np.array([0, 1, 2, 5, 8], dtype=np.int64)
 
         gm_sub, _ = src.slice_subsample(0, src.mappable_hi, cols)
         # Build the expected (n_var, len(cols)) from gt_full.
         expected = np.empty((gt_full.shape[0], len(cols)), dtype=gt_full.dtype)
         for j, c in enumerate(cols):
-            ploidy = 1 if c >= n_dip else 0
-            dip = c - n_dip if c >= n_dip else c
-            expected[:, j] = gt_full[:, dip, ploidy]
+            expected[:, j] = gt_full[:, c // 2, c % 2]
         np.testing.assert_array_equal(gm_sub, expected)
 
     def test_empty_region(self, vcz_store):
@@ -178,8 +174,7 @@ class TestSliceSubsample:
         import cupy as cp
         path, _ = vcz_store
         src = ZarrGenotypeSource(path)
-        n_dip = src.num_diploids
-        cols = np.array([0, 1, 2, n_dip, n_dip + 1], dtype=np.int64)
+        cols = np.array([0, 1, 2, 5, 8], dtype=np.int64)
         gm_host, pos_host = src.slice_subsample(
             0, src.mappable_hi, cols, to_gpu=False
         )
@@ -230,9 +225,8 @@ class TestPopAssignmentResolution:
         path, _ = vcz_store
         src = ZarrGenotypeSource(path, pop_assignment=pop_tsv)
         assert set(src.pop_cols.keys()) == {"pop1", "pop2"}
-        n_dip = src.num_diploids
-        # pop1 = first 10 diploids -> haps [0..10) plus [n_dip..n_dip+10)
-        expected1 = np.concatenate([np.arange(10), np.arange(10) + n_dip])
+        # pop1 = first 10 diploids -> haps [0..20), both gametes of each
+        expected1 = np.arange(2 * 10)
         np.testing.assert_array_equal(np.sort(src.pop_cols["pop1"]), expected1)
 
     def test_auto_load_companion(self, vcz_store, pop_tsv, tmp_path, capsys):
@@ -272,9 +266,8 @@ class TestPopAssignmentResolution:
                                   for i in range(20)},
         )
         assert set(src.pop_cols.keys()) == {"pop1", "pop2"}
-        # pop1 = first 5 diploids -> haps [0..5) plus [n_dip..n_dip+5)
-        n_dip = src.num_diploids
-        expected1 = np.concatenate([np.arange(5), np.arange(5) + n_dip])
+        # pop1 = first 5 diploids -> haps [0..10), both gametes of each
+        expected1 = np.arange(2 * 5)
         np.testing.assert_array_equal(np.sort(src.pop_cols["pop1"]),
                                        expected1)
 
@@ -284,8 +277,7 @@ class TestPopAssignmentResolution:
         labels = np.array(["pop1"] * 12 + ["pop2"] * 8)
         src = ZarrGenotypeSource(path, pop_assignment=labels)
         assert set(src.pop_cols.keys()) == {"pop1", "pop2"}
-        n_dip = src.num_diploids
-        expected1 = np.concatenate([np.arange(12), np.arange(12) + n_dip])
+        expected1 = np.arange(2 * 12)
         np.testing.assert_array_equal(np.sort(src.pop_cols["pop1"]),
                                        expected1)
 


### PR DESCRIPTION
Closes #148.

## Problem

A `HaplotypeMatrix` had no single row order. `from_ts` placed a sample's two
gametes adjacent (rows `2i`, `2i+1`); `from_vcf` and `from_zarr` grouped all
of the first gametes ahead of the second ones. Consumers split the same way:

| assumed adjacent rows | assumed the halved layout |
| --- | --- |
| `GenotypeMatrix.from_haplotype_matrix` | `relatedness._get_genotype_data` (`ibs`, `grm`) |
| `divergence.fst_weir_cockerham` | `HaplotypeMatrix._haplotypes_to_gt` (the `to_zarr` writer) |
| `diversity.heterozygosity_observed` | `load_pop_file`'s population index lists |

So for any matrix at least one consumer paired gametes from two different
samples, and which one depended only on where the data came from. Nothing
failed loudly, because a mispaired matrix is still well formed.

## Fix

Adjacent rows are canonical, stated on the `HaplotypeMatrix` docstring.
Producers emit it (`from_vcf`, `build_haplotype_matrix`, `load_pop_file`,
the zarr source's population columns) and the consumers that assumed the
halved layout read it.

Four of the sites are index-space translators rather than array slices, and
are easy to miss when grepping for slicing patterns:

- `zarr_source.slice_subsample` / `slice_subsample_gpu` map a haplotype index
  back to `(sample, ploidy)`. This is the inverse of the population-column
  mapping a few lines away, so leaving it alone would have broken
  `materialize(sample_subset=...)` -- the path `examples/biobank_streaming_scan.py`
  uses.
- `streaming_matrix.materialize` reassembles a subsample into `(n_var, n_dip, 2)`.
  Under the canonical order that split is a free reshape rather than two
  strided writes.
- `HaplotypeMatrix.filter(genotypes=...)` expands a per-sample mask to rows.
- `relatedness._get_haplotype_data`, dead and still carrying the old layout,
  is removed along with the already-dead `_get_diploid_genotypes`.

`from_vcf` now reshapes instead of writing two strided halves: ploidy is the
fastest-varying axis, so merging the trailing axes already interleaves. That
also drops a full copy of the matrix.

## Verification

`TestHaplotypeRowOrder` in `tests/test_loader_parity.py` checks against
outside references rather than pg_gpu against itself:

- `from_ts` and `from_vcf` produce byte-identical matrices, and their
  per-individual genotypes match the tree sequence they came from.
- `ibs` and `grm` match a `GenotypeMatrix` built straight from tskit
  dosages, bypassing haplotype pairing entirely.
- Populations that alternate through the samples, so each one's rows are
  non-contiguous, still pair correctly once subset -- `fst_weir_cockerham`
  pairs consecutive rows *within* the population subset, which is a second
  pairing step layered on the row order.
- A `to_zarr` round trip preserves the order.

Five of the six new cases fail without this change. The three `moments_ld`
cases that were xfailed against this bug now pass, so their marks are gone.

Suites: 1259 passed, 28 xfailed; moments 39 passed with no xfails; ruff clean.

## Results that change

Recorded in the changelog. Statistics that reconstruct individuals from VCF-
or zarr-loaded data -- `ibs`, `grm`, `fst_weir_cockerham`,
`heterozygosity_observed`, `GenotypeMatrix.from_haplotype_matrix`, and
genotype-mode LD -- change value. Statistics that treat rows as independent
gametes are unaffected. Hand-written `sample_sets` index lists that assumed
the previous order need updating.

## Note

Interleaved was the order agreed on the issue. One case is deliberately not
guarded: a hand-written `sample_sets` that separates a sample's two gametes
(e.g. `[0, 4, 1, 5]`) will still mispair, since pairing reads position within
the subset. Every list the library produces is correct; say the word if
`fst_weir_cockerham` should reject that shape instead.