### PR TITLE
Reject sample_sets row lists no matrix can serve

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -61,12 +61,16 @@ Read this section if you are comparing against older pg_gpu results.
   ``sample_sets`` built by ``load_pop_file`` now lists ``2i`` and
   ``2i + 1`` for each member, and hand-written index lists that assumed
   the previous order need updating.
-* ``sample_sets`` now rejects row lists no matrix can serve: an
-  out-of-range or duplicated row raises ``ValueError`` instead of
+* Row lists are validated at assignment and at resolution: assigning
+  ``sample_sets`` and passing a row list as a population argument both
+  raise ``ValueError`` for out-of-range or duplicated rows instead of
   silently producing wrong numbers. The statistics that pair rows into
   individuals (``fst_weir_cockerham``, ``heterozygosity_observed``,
-  windowed ``fst_wc``) warn when a list does not carry each sample's two
-  rows adjacently; gamete statistics accept any list, as before.
+  windowed ``fst_wc``, and ``GenotypeMatrix.from_haplotype_matrix``)
+  warn when a list does not carry each sample's two rows adjacently;
+  gamete statistics accept any list, as before. Streaming loads with a
+  pop file validate once at stream construction, and the genotype
+  stream's sets now hold individual rows rather than haplotype columns.
 * Windowed ``fst_wc`` now gives the same estimate as
   ``divergence.fst_weir_cockerham``. It used to treat the data as haploid
   and lump every alternate allele together, so it returned a different

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -61,6 +61,12 @@ Read this section if you are comparing against older pg_gpu results.
   ``sample_sets`` built by ``load_pop_file`` now lists ``2i`` and
   ``2i + 1`` for each member, and hand-written index lists that assumed
   the previous order need updating.
+* ``sample_sets`` now rejects row lists no matrix can serve: an
+  out-of-range or duplicated row raises ``ValueError`` instead of
+  silently producing wrong numbers. The statistics that pair rows into
+  individuals (``fst_weir_cockerham``, ``heterozygosity_observed``,
+  windowed ``fst_wc``) warn when a list does not carry each sample's two
+  rows adjacently; gamete statistics accept any list, as before.
 * Windowed ``fst_wc`` now gives the same estimate as
   ``divergence.fst_weir_cockerham``. It used to treat the data as haploid
   and lump every alternate allele together, so it returned a different

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -78,7 +78,10 @@ Read this section if you are comparing against older pg_gpu results.
   ``sample_sets`` and ``materialize(sample_subset=...)`` both speak
   haplotype rows on a haplotype stream and individual rows on a genotype
   stream, so ``materialize(sample_subset=stream.sample_sets[pop])``
-  works on either class. The genotype stream's sets previously held
+  works on either class. This changes what a genotype stream's
+  ``sample_subset`` means: it took haplotype columns before and takes
+  individual rows now, so callers that passed columns must halve their
+  values. The genotype stream's sets previously held
   haplotype columns that indexed past its individual axis. Assigning
   ``sample_sets`` on a stream validates like the eager classes, and pop
   files validate once at stream construction.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -68,9 +68,20 @@ Read this section if you are comparing against older pg_gpu results.
   individuals (``fst_weir_cockerham``, ``heterozygosity_observed``,
   windowed ``fst_wc``, and ``GenotypeMatrix.from_haplotype_matrix``)
   warn when a list does not carry each sample's two rows adjacently;
-  gamete statistics accept any list, as before. Streaming loads with a
-  pop file validate once at stream construction, and the genotype
-  stream's sets now hold individual rows rather than haplotype columns.
+  gamete statistics accept any list, as before. An empty set also
+  raises -- a population must name at least one row, matching tskit --
+  and ``load_pop_file`` drops a population with no member in the matrix
+  instead of storing it empty. Duplicates are a hard error, so
+  bootstrapping over individuals by repeating rows in a set is not
+  possible; resample windows or blocks instead.
+* Streaming matrices follow one row space end to end: a stream's
+  ``sample_sets`` and ``materialize(sample_subset=...)`` both speak
+  haplotype rows on a haplotype stream and individual rows on a genotype
+  stream, so ``materialize(sample_subset=stream.sample_sets[pop])``
+  works on either class. The genotype stream's sets previously held
+  haplotype columns that indexed past its individual axis. Assigning
+  ``sample_sets`` on a stream validates like the eager classes, and pop
+  files validate once at stream construction.
 * Windowed ``fst_wc`` now gives the same estimate as
   ``divergence.fst_weir_cockerham``. It used to treat the data as haploid
   and lump every alternate allele together, so it returned a different

--- a/pg_gpu/__init__.py
+++ b/pg_gpu/__init__.py
@@ -69,10 +69,10 @@ from .decomposition import (
 from .resampling import block_jackknife, block_bootstrap
 from ._warnings import (
     BadlyChunkedWarning, HaploidDataWarning, MemoryLimitedWarning,
-    MultiallelicCapWarning, BiallelicOnlyWarning,
+    MultiallelicCapWarning, BiallelicOnlyWarning, UnpairedRowsWarning,
 )
 
-__all__ = ['ld_statistics', 'diversity', 'divergence', 'windowed_analysis', 'selection', 'sfs', 'admixture', 'decomposition', 'plotting', 'distance_stats', 'resampling', 'HaplotypeMatrix', 'GenotypeMatrix', 'WindowedAnalyzer', 'windowed_analysis', 'AccessibleMask', 'bed_to_mask', 'parse_bed', 'LocalPCAResult', 'LostructResult', 'pca', 'randomized_pca', 'pca_dosage', 'randomized_pca_dosage', 'local_pca', 'local_pca_jackknife', 'lostruct', 'pc_dist', 'corners', 'block_jackknife', 'block_bootstrap', 'MemoryLimitedWarning', 'HaploidDataWarning', 'BadlyChunkedWarning', 'MultiallelicCapWarning', 'BiallelicOnlyWarning']
+__all__ = ['ld_statistics', 'diversity', 'divergence', 'windowed_analysis', 'selection', 'sfs', 'admixture', 'decomposition', 'plotting', 'distance_stats', 'resampling', 'HaplotypeMatrix', 'GenotypeMatrix', 'WindowedAnalyzer', 'windowed_analysis', 'AccessibleMask', 'bed_to_mask', 'parse_bed', 'LocalPCAResult', 'LostructResult', 'pca', 'randomized_pca', 'pca_dosage', 'randomized_pca_dosage', 'local_pca', 'local_pca_jackknife', 'lostruct', 'pc_dist', 'corners', 'block_jackknife', 'block_bootstrap', 'MemoryLimitedWarning', 'HaploidDataWarning', 'BadlyChunkedWarning', 'MultiallelicCapWarning', 'BiallelicOnlyWarning', 'UnpairedRowsWarning']
 
 # Version is derived from the git tag at build time (hatch-vcs) and read here
 # from the installed package metadata, so there is no hardcoded string to keep

--- a/pg_gpu/_utils.py
+++ b/pg_gpu/_utils.py
@@ -33,6 +33,12 @@ def get_population_matrix(matrix, population: Union[str, list]):
         pop_indices = matrix.sample_sets[population]
     else:
         pop_indices = list(population)
+        # Direct row-list arguments never pass the sample_sets setter, so
+        # the same range and duplicate rules apply here before the rows
+        # reach CuPy's unchecked fancy indexing.
+        from ._warnings import check_sample_set_rows
+        check_sample_set_rows("population row list", pop_indices,
+                              matrix.shape[0])
 
     subset_sets = {'all': list(range(len(pop_indices)))}
     if isinstance(matrix, GenotypeMatrix):

--- a/pg_gpu/_warnings.py
+++ b/pg_gpu/_warnings.py
@@ -84,6 +84,98 @@ class MultiallelicCapWarning(UserWarning):
     """
 
 
+class UnpairedRowsWarning(UserWarning):
+    """Emitted when a diploid statistic pairs a row list that does not pair.
+
+    Statistics that reconstruct individuals pair consecutive entries of a
+    population's row list, and every loader writes sample ``i`` to rows
+    ``2i`` and ``2i + 1``. A list whose length is odd, or whose consecutive
+    entries span two individuals -- one gamete per individual
+    (``[0, 2, 4, ...]``) is the classic case -- is silently mis-paired, so
+    those statistics compute something other than what the set describes.
+    Gamete statistics accept any list, which is why this fires from the
+    pairing consumers rather than from the ``sample_sets`` setter. Silence
+    with::
+
+        import warnings
+        from pg_gpu import UnpairedRowsWarning
+        warnings.filterwarnings("ignore", category=UnpairedRowsWarning)
+    """
+
+
+def check_sample_set_rows(name, rows, n_rows):
+    """Reject a sample_sets row list no matrix can serve.
+
+    CuPy fancy indexing does not bounds-check, so an out-of-range row
+    silently reads whatever memory it lands on, and a duplicated row counts
+    one gamete twice in every statistic. Neither has a valid meaning, so
+    both raise. Empty lists pass: subsetting code builds them legitimately.
+
+    A set is a list, a tuple, or a one-dimensional integer array (the
+    streaming loaders build arrays).
+    """
+    if isinstance(rows, (list, tuple)):
+        arr = np.asarray(rows)
+    elif isinstance(rows, np.ndarray):
+        arr = rows
+    else:
+        raise ValueError(
+            f"sample_sets[{name!r}] must be a list, tuple, or 1-D integer "
+            f"array; got {type(rows).__name__}")
+    if arr.ndim != 1:
+        raise ValueError(
+            f"sample_sets[{name!r}] must be one-dimensional; "
+            f"got shape {arr.shape}")
+    if arr.size == 0:
+        return
+    if not np.issubdtype(arr.dtype, np.integer):
+        raise ValueError(
+            f"sample_sets[{name!r}] must hold integer row numbers; "
+            f"got dtype {arr.dtype}")
+    lo, hi = int(arr.min()), int(arr.max())
+    if lo < 0 or hi >= n_rows:
+        offender = lo if lo < 0 else hi
+        raise ValueError(
+            f"sample_sets[{name!r}] holds row {offender}, but the matrix "
+            f"has rows 0..{n_rows - 1}")
+    if np.unique(arr).size != arr.size:
+        raise ValueError(
+            f"sample_sets[{name!r}] holds duplicate rows, which would "
+            f"count the same gamete more than once")
+
+
+def check_paired_rows(rows, context):
+    """Warn when a population row list cannot pair into diploid individuals.
+
+    The caller pairs consecutive entries, so the check mirrors that
+    exactly: even length, and each consecutive pair drawn from one
+    individual (``row // 2`` equal). Order inside a pair and the order of
+    pairs in the list are both free.
+    """
+    n = len(rows)
+    problem = None
+    if n % 2:
+        problem = f"has {n} rows, so pairing drops the last one"
+    else:
+        arr = np.asarray(rows)
+        first = arr[0::2] // 2
+        second = arr[1::2] // 2
+        bad = np.nonzero(first != second)[0]
+        if bad.size:
+            k = int(bad[0])
+            a, b = int(arr[2 * k]), int(arr[2 * k + 1])
+            problem = (f"pairs rows {a} and {b}, which belong to "
+                       f"individuals {a // 2} and {b // 2}")
+    if problem is not None:
+        warnings.warn(
+            f"{context}: the population row list {problem}. Statistics "
+            f"that reconstruct individuals pair consecutive list entries, "
+            f"and every loader writes sample i to rows 2i and 2i + 1, so "
+            f"this set gives them something other than the individuals it "
+            f"describes.",
+            UnpairedRowsWarning, stacklevel=3)
+
+
 class BiallelicOnlyWarning(UserWarning):
     """Emitted when a biallelic-only statistic or loader drops multiallelic sites.
 

--- a/pg_gpu/_warnings.py
+++ b/pg_gpu/_warnings.py
@@ -103,61 +103,75 @@ class UnpairedRowsWarning(UserWarning):
     """
 
 
-def check_sample_set_rows(name, rows, n_rows):
-    """Reject a sample_sets row list no matrix can serve.
+def _rows_as_numpy(rows):
+    """Row numbers as a host numpy array.
+
+    Accepts lists, tuples, numpy arrays, cupy arrays, and sequences of
+    numpy or cupy integer scalars (``list(cp.arange(4))`` produces the
+    last kind).
+    """
+    if hasattr(rows, 'get') and not isinstance(rows, np.ndarray):
+        rows = rows.get()
+    try:
+        return np.asarray(rows)
+    except (TypeError, ValueError):
+        return np.asarray([int(r) for r in rows])
+
+
+def check_sample_set_rows(label, rows, n_rows):
+    """Reject a row list no matrix can serve.
 
     CuPy fancy indexing does not bounds-check, so an out-of-range row
     silently reads whatever memory it lands on, and a duplicated row counts
     one gamete twice in every statistic. Neither has a valid meaning, so
     both raise. Empty lists pass: subsetting code builds them legitimately.
 
-    A set is a list, a tuple, or a one-dimensional integer array (the
-    streaming loaders build arrays).
+    A set is a list, a tuple, or a one-dimensional integer array (numpy or
+    cupy; the streaming loaders build arrays). ``label`` is interpolated
+    verbatim into the messages, e.g. ``"sample_sets['p1']"`` or
+    ``"population row list"``.
     """
-    if isinstance(rows, (list, tuple)):
-        arr = np.asarray(rows)
-    elif isinstance(rows, np.ndarray):
-        arr = rows
+    if isinstance(rows, (list, tuple, np.ndarray)) or hasattr(rows, 'get'):
+        arr = _rows_as_numpy(rows)
     else:
         raise ValueError(
-            f"sample_sets[{name!r}] must be a list, tuple, or 1-D integer "
-            f"array; got {type(rows).__name__}")
+            f"{label} must be a list, tuple, or 1-D integer array; "
+            f"got {type(rows).__name__}")
     if arr.ndim != 1:
         raise ValueError(
-            f"sample_sets[{name!r}] must be one-dimensional; "
-            f"got shape {arr.shape}")
+            f"{label} must be one-dimensional; got shape {arr.shape}")
     if arr.size == 0:
         return
     if not np.issubdtype(arr.dtype, np.integer):
         raise ValueError(
-            f"sample_sets[{name!r}] must hold integer row numbers; "
-            f"got dtype {arr.dtype}")
+            f"{label} must hold integer row numbers; got dtype {arr.dtype}")
     lo, hi = int(arr.min()), int(arr.max())
     if lo < 0 or hi >= n_rows:
         offender = lo if lo < 0 else hi
         raise ValueError(
-            f"sample_sets[{name!r}] holds row {offender}, but the matrix "
-            f"has rows 0..{n_rows - 1}")
+            f"{label} holds row {offender}, but the matrix has rows "
+            f"0..{n_rows - 1}")
     if np.unique(arr).size != arr.size:
         raise ValueError(
-            f"sample_sets[{name!r}] holds duplicate rows, which would "
-            f"count the same gamete more than once")
+            f"{label} holds duplicate rows, which would count the same "
+            f"gamete more than once")
 
 
-def check_paired_rows(rows, context):
+def check_paired_rows(rows, context, stacklevel=3):
     """Warn when a population row list cannot pair into diploid individuals.
 
     The caller pairs consecutive entries, so the check mirrors that
     exactly: even length, and each consecutive pair drawn from one
     individual (``row // 2`` equal). Order inside a pair and the order of
-    pairs in the list are both free.
+    pairs in the list are both free. ``stacklevel`` points the warning at
+    the caller's caller by default; call sites nested one deeper pass 4.
     """
     n = len(rows)
     problem = None
     if n % 2:
         problem = f"has {n} rows, so pairing drops the last one"
     else:
-        arr = np.asarray(rows)
+        arr = _rows_as_numpy(rows)
         first = arr[0::2] // 2
         second = arr[1::2] // 2
         bad = np.nonzero(first != second)[0]
@@ -173,7 +187,7 @@ def check_paired_rows(rows, context):
             f"and every loader writes sample i to rows 2i and 2i + 1, so "
             f"this set gives them something other than the individuals it "
             f"describes.",
-            UnpairedRowsWarning, stacklevel=3)
+            UnpairedRowsWarning, stacklevel=stacklevel)
 
 
 class BiallelicOnlyWarning(UserWarning):

--- a/pg_gpu/_warnings.py
+++ b/pg_gpu/_warnings.py
@@ -147,8 +147,7 @@ def check_sample_set_rows(label, rows, n_rows):
         raise ValueError(
             f"{label} must be one-dimensional; got shape {arr.shape}")
     if arr.size == 0:
-        raise ValueError(f"{label} holds no rows; a population must "
-                         f"name at least one")
+        raise ValueError(f"{label} holds no rows; at least one is required")
     if not np.issubdtype(arr.dtype, np.integer):
         raise ValueError(
             f"{label} must hold integer row numbers; got dtype {arr.dtype}")
@@ -178,7 +177,14 @@ def check_paired_rows(rows, context, stacklevel=3):
     if n % 2:
         problem = f"has {n} rows, so pairing drops the last one"
     else:
-        arr = _rows_as_numpy(rows)
+        try:
+            arr = _rows_as_numpy(rows)
+        except (TypeError, ValueError):
+            return
+        if arr.ndim != 1 or not np.issubdtype(arr.dtype, np.integer):
+            # Malformed input has no pairing to speak about; the
+            # validating chokepoints raise the proper error for it.
+            return
         first = arr[0::2] // 2
         second = arr[1::2] // 2
         bad = np.nonzero(first != second)[0]

--- a/pg_gpu/_warnings.py
+++ b/pg_gpu/_warnings.py
@@ -110,7 +110,7 @@ def _rows_as_numpy(rows):
     numpy or cupy integer scalars (``list(cp.arange(4))`` produces the
     last kind).
     """
-    if hasattr(rows, 'get') and not isinstance(rows, np.ndarray):
+    if hasattr(rows, '__cuda_array_interface__'):
         rows = rows.get()
     try:
         return np.asarray(rows)
@@ -124,15 +124,21 @@ def check_sample_set_rows(label, rows, n_rows):
     CuPy fancy indexing does not bounds-check, so an out-of-range row
     silently reads whatever memory it lands on, and a duplicated row counts
     one gamete twice in every statistic. Neither has a valid meaning, so
-    both raise. Empty lists pass: subsetting code builds them legitimately.
+    both raise, and so does an empty set -- a population must name at
+    least one row, which is also the reference tskit behavior.
 
     A set is a list, a tuple, or a one-dimensional integer array (numpy or
     cupy; the streaming loaders build arrays). ``label`` is interpolated
     verbatim into the messages, e.g. ``"sample_sets['p1']"`` or
     ``"population row list"``.
     """
-    if isinstance(rows, (list, tuple, np.ndarray)) or hasattr(rows, 'get'):
-        arr = _rows_as_numpy(rows)
+    if (isinstance(rows, (list, tuple, np.ndarray))
+            or hasattr(rows, '__cuda_array_interface__')):
+        try:
+            arr = _rows_as_numpy(rows)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"{label} must hold integer row numbers") from None
     else:
         raise ValueError(
             f"{label} must be a list, tuple, or 1-D integer array; "
@@ -141,7 +147,8 @@ def check_sample_set_rows(label, rows, n_rows):
         raise ValueError(
             f"{label} must be one-dimensional; got shape {arr.shape}")
     if arr.size == 0:
-        return
+        raise ValueError(f"{label} holds no rows; a population must "
+                         f"name at least one")
     if not np.issubdtype(arr.dtype, np.integer):
         raise ValueError(
             f"{label} must hold integer row numbers; got dtype {arr.dtype}")

--- a/pg_gpu/divergence.py
+++ b/pg_gpu/divergence.py
@@ -753,7 +753,14 @@ def _get_population_indices(haplotype_matrix: HaplotypeMatrix,
             raise ValueError(f"Population {pop} not found in sample_sets")
         return haplotype_matrix.sample_sets[pop]
     else:
-        return list(pop)
+        indices = list(pop)
+        # Direct row-list arguments never pass the sample_sets setter, so
+        # the same range and duplicate rules apply here before the rows
+        # reach CuPy's unchecked fancy indexing.
+        from ._warnings import check_sample_set_rows
+        check_sample_set_rows("population row list", indices,
+                              haplotype_matrix.haplotypes.shape[0])
+        return indices
 
 
 def _hudson_fst_from_counts(ac1, nv1, ac2, nv2):

--- a/pg_gpu/divergence.py
+++ b/pg_gpu/divergence.py
@@ -316,6 +316,14 @@ def fst_weir_cockerham(haplotype_matrix,
 
     pop1_idx = _get_population_indices(haplotype_matrix, pop1)
     pop2_idx = _get_population_indices(haplotype_matrix, pop2)
+    # WC pairs consecutive rows of each subset into individuals, so a row
+    # list that does not carry each individual's two rows adjacently gives
+    # a wrong answer with no error. Gamete statistics accept such lists,
+    # which is why the check lives here and warns rather than raises.
+    from ._warnings import check_paired_rows
+    for pop, idx in ((pop1, pop1_idx), (pop2, pop2_idx)):
+        label = pop if isinstance(pop, str) else "row list"
+        check_paired_rows(idx, f"fst_weir_cockerham({label})")
     pop1_haps = haplotype_matrix.haplotypes[pop1_idx, :]
     pop2_haps = haplotype_matrix.haplotypes[pop2_idx, :]
 

--- a/pg_gpu/diversity.py
+++ b/pg_gpu/diversity.py
@@ -1863,6 +1863,10 @@ def heterozygosity_observed(haplotype_matrix: HaplotypeMatrix,
     """
 
     if population is not None:
+        if not isinstance(population, str):
+            # One materialization serves the check and the subset below, so
+            # generators and arrays behave like lists.
+            population = list(population)
         # Consecutive subset rows become one individual below, so warn on
         # a row list that does not carry each individual's rows adjacently.
         from ._warnings import check_paired_rows

--- a/pg_gpu/diversity.py
+++ b/pg_gpu/diversity.py
@@ -1871,10 +1871,14 @@ def heterozygosity_observed(haplotype_matrix: HaplotypeMatrix,
         # a row list that does not carry each individual's rows adjacently.
         from ._warnings import check_paired_rows
         if ploidy == 2:
-            rows = (haplotype_matrix.sample_sets[population]
+            # .get: an unknown name skips the check and reaches
+            # _get_population_matrix below for its proper ValueError.
+            rows = (haplotype_matrix.sample_sets.get(population)
                     if isinstance(population, str) else population)
-            label = population if isinstance(population, str) else "row list"
-            check_paired_rows(rows, f"heterozygosity_observed({label})")
+            if rows is not None:
+                label = (population if isinstance(population, str)
+                         else "row list")
+                check_paired_rows(rows, f"heterozygosity_observed({label})")
         matrix = _get_population_matrix(haplotype_matrix, population)
     else:
         matrix = haplotype_matrix

--- a/pg_gpu/diversity.py
+++ b/pg_gpu/diversity.py
@@ -1863,6 +1863,14 @@ def heterozygosity_observed(haplotype_matrix: HaplotypeMatrix,
     """
 
     if population is not None:
+        # Consecutive subset rows become one individual below, so warn on
+        # a row list that does not carry each individual's rows adjacently.
+        from ._warnings import check_paired_rows
+        if ploidy == 2:
+            rows = (haplotype_matrix.sample_sets[population]
+                    if isinstance(population, str) else population)
+            label = population if isinstance(population, str) else "row list"
+            check_paired_rows(rows, f"heterozygosity_observed({label})")
         matrix = _get_population_matrix(haplotype_matrix, population)
     else:
         matrix = haplotype_matrix

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -168,7 +168,8 @@ class GenotypeMatrix:
 
         Each value must be a list of individual row numbers within the
         matrix, without duplicates. Rows are individuals here, so no
-        pairing applies.
+        pairing applies. The dict is stored as given, not copied; mutating
+        it afterwards is not re-validated.
         """
         if sample_sets is None:
             self._sample_sets = None
@@ -178,7 +179,7 @@ class GenotypeMatrix:
         from ._warnings import check_sample_set_rows
         n_rows = self._genotypes.shape[0]
         for key, value in sample_sets.items():
-            check_sample_set_rows(key, value, n_rows)
+            check_sample_set_rows(f"sample_sets[{key!r}]", value, n_rows)
         self._sample_sets = sample_sets
 
     @property
@@ -365,8 +366,14 @@ class GenotypeMatrix:
         # remap sample_sets: haplotype indices -> individual indices
         new_sample_sets = None
         if hap_matrix._sample_sets is not None:
+            from ._warnings import check_paired_rows
             new_sample_sets = {}
             for name, indices in hap_matrix._sample_sets.items():
+                # The i // 2 collapse assumes each set carries whole
+                # individuals; a set holding one gamete of a sample would
+                # silently become that whole individual here.
+                check_paired_rows(
+                    indices, f"GenotypeMatrix.from_haplotype_matrix({name})")
                 # map haplotype indices to individual indices
                 ind_indices = sorted(set(i // 2 for i in indices))
                 new_sample_sets[name] = ind_indices

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -87,7 +87,7 @@ class GenotypeMatrix:
         self._accessible_mask = None
         self.chrom_start = chrom_start
         self.chrom_end = chrom_end
-        self._sample_sets = sample_sets
+        self.sample_sets = sample_sets   # property setter validates
         self.n_total_sites = n_total_sites
         self.samples = samples
         # See HaplotypeMatrix.fields for the shape contract.
@@ -163,6 +163,22 @@ class GenotypeMatrix:
 
     @sample_sets.setter
     def sample_sets(self, sample_sets):
+        """
+        Set the sample sets.
+
+        Each value must be a list of individual row numbers within the
+        matrix, without duplicates. Rows are individuals here, so no
+        pairing applies.
+        """
+        if sample_sets is None:
+            self._sample_sets = None
+            return
+        if not isinstance(sample_sets, dict):
+            raise ValueError("sample_sets must be a dictionary")
+        from ._warnings import check_sample_set_rows
+        n_rows = self._genotypes.shape[0]
+        for key, value in sample_sets.items():
+            check_sample_set_rows(key, value, n_rows)
         self._sample_sets = sample_sets
 
     @property

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -860,7 +860,15 @@ class GenotypeMatrix:
 
         # A population with no member in this matrix resolves empty --
         # routine when the matrix holds a sample subset of the pop file's
-        # cohort. Drop it rather than fail the whole load.
+        # cohort. Drop it rather than fail the whole load, but say so: a
+        # silently vanishing population sends the user's next error to the
+        # statistic call instead of here.
+        dropped = sorted(p for p, rows in pop_sets.items() if not rows)
+        if dropped:
+            import warnings
+            warnings.warn(
+                f"pop file populations with no member in this matrix "
+                f"dropped: {', '.join(dropped)}", stacklevel=2)
         self.sample_sets = {p: rows for p, rows in pop_sets.items() if rows}
 
     def restrict_to_segregating(self):

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -166,7 +166,8 @@ class GenotypeMatrix:
         """
         Set the sample sets.
 
-        Each value must be a list of individual row numbers within the
+        Each value must be a list, tuple, or one-dimensional integer
+        array of individual row numbers within the
         matrix, without duplicates. Rows are individuals here, so no
         pairing applies. The dict is stored as given, not copied; mutating
         it afterwards is not re-validated.
@@ -857,7 +858,10 @@ class GenotypeMatrix:
             if pop in pop_sets:
                 pop_sets[pop].append(i)
 
-        self.sample_sets = pop_sets
+        # A population with no member in this matrix resolves empty --
+        # routine when the matrix holds a sample subset of the pop file's
+        # cohort. Drop it rather than fail the whole load.
+        self.sample_sets = {p: rows for p, rows in pop_sets.items() if rows}
 
     def restrict_to_segregating(self):
         """Drop monomorphic (non-segregating) sites.

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -315,7 +315,8 @@ class HaplotypeMatrix:
         matrix, without duplicates. Lists that do not pair rows into
         individuals are accepted here -- gamete statistics take any list --
         and the statistics that reconstruct individuals warn when they
-        meet one.
+        meet one. The dict is stored as given, not copied; mutating it
+        afterwards is not re-validated.
         """
         if sample_sets is None:
             self._sample_sets = None
@@ -325,7 +326,7 @@ class HaplotypeMatrix:
         from ._warnings import check_sample_set_rows
         n_rows = self._haplotypes.shape[0]
         for key, value in sample_sets.items():
-            check_sample_set_rows(key, value, n_rows)
+            check_sample_set_rows(f"sample_sets[{key!r}]", value, n_rows)
         self._sample_sets = sample_sets
 
     @property

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -311,7 +311,8 @@ class HaplotypeMatrix:
         """
         Set the sample sets.
 
-        Each value must be a list of haplotype row numbers within the
+        Each value must be a list, tuple, or one-dimensional integer
+        array of haplotype row numbers within the
         matrix, without duplicates. Lists that do not pair rows into
         individuals are accepted here -- gamete statistics take any list --
         and the statistics that reconstruct individuals warn when they
@@ -904,7 +905,10 @@ class HaplotypeMatrix:
             for p, dips in pop_dips.items()
         }
 
-        self.sample_sets = pop_sets
+        # A population with no member in this matrix resolves empty --
+        # routine when the matrix holds a sample subset of the pop file's
+        # cohort. Drop it rather than fail the whole load.
+        self.sample_sets = {p: rows for p, rows in pop_sets.items() if rows}
 
     @classmethod
     def from_ts(cls, ts: tskit.TreeSequence, device: str = 'CPU',

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -219,7 +219,7 @@ class HaplotypeMatrix:
         self._accessible_mask = None
         self.chrom_start = chrom_start
         self.chrom_end = chrom_end
-        self._sample_sets = sample_sets
+        self.sample_sets = sample_sets   # property setter validates
         self.n_total_sites = n_total_sites
         self.samples = samples  # diploid sample names from VCF
         # Optional per-variant (n_var,) and per-genotype (n_var, n_samples)
@@ -310,13 +310,22 @@ class HaplotypeMatrix:
     def sample_sets(self, sample_sets: dict):
         """
         Set the sample sets.
+
+        Each value must be a list of haplotype row numbers within the
+        matrix, without duplicates. Lists that do not pair rows into
+        individuals are accepted here -- gamete statistics take any list --
+        and the statistics that reconstruct individuals warn when they
+        meet one.
         """
+        if sample_sets is None:
+            self._sample_sets = None
+            return
         if not isinstance(sample_sets, dict):
             raise ValueError("sample_sets must be a dictionary")
-        # check that the values are lists
+        from ._warnings import check_sample_set_rows
+        n_rows = self._haplotypes.shape[0]
         for key, value in sample_sets.items():
-            if not isinstance(value, list):
-                raise ValueError("values in sample_sets must be lists")
+            check_sample_set_rows(key, value, n_rows)
         self._sample_sets = sample_sets
 
     @property

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -907,7 +907,15 @@ class HaplotypeMatrix:
 
         # A population with no member in this matrix resolves empty --
         # routine when the matrix holds a sample subset of the pop file's
-        # cohort. Drop it rather than fail the whole load.
+        # cohort. Drop it rather than fail the whole load, but say so: a
+        # silently vanishing population sends the user's next error to the
+        # statistic call instead of here.
+        dropped = sorted(p for p, rows in pop_sets.items() if not rows)
+        if dropped:
+            import warnings
+            warnings.warn(
+                f"pop file populations with no member in this matrix "
+                f"dropped: {', '.join(dropped)}", stacklevel=2)
         self.sample_sets = {p: rows for p, rows in pop_sets.items() if rows}
 
     @classmethod

--- a/pg_gpu/relatedness.py
+++ b/pg_gpu/relatedness.py
@@ -67,6 +67,16 @@ def genetic_relatedness(haplotype_matrix, sample_sets=None, indexes=None, *,
     from .streaming_matrix import _StreamingMatrixBase
     from .haplotype_matrix import HaplotypeMatrix
 
+    # This list-of-row-lists parameter never passes the sample_sets setter,
+    # so apply the same range and duplicate rules here. Without them an
+    # invalid row was silently dropped from the tally -- wrong membership
+    # rather than an error.
+    if sample_sets is not None:
+        from ._warnings import check_sample_set_rows
+        for k, rows in enumerate(sample_sets):
+            check_sample_set_rows(f"sample_sets[{k}]", list(rows),
+                                  haplotype_matrix.num_haplotypes)
+
     if isinstance(haplotype_matrix, _StreamingMatrixBase):
         return _stream_genetic_relatedness(
             haplotype_matrix, sample_sets=sample_sets, indexes=indexes,

--- a/pg_gpu/relatedness.py
+++ b/pg_gpu/relatedness.py
@@ -70,8 +70,10 @@ def genetic_relatedness(haplotype_matrix, sample_sets=None, indexes=None, *,
     # This list-of-row-lists parameter never passes the sample_sets setter,
     # so apply the same range and duplicate rules here. Without them an
     # invalid row was silently dropped from the tally -- wrong membership
-    # rather than an error.
-    if sample_sets is not None:
+    # rather than an error. Gate on the accepted input types so anything
+    # else still reaches the dispatch below and its TypeError.
+    if sample_sets is not None and isinstance(
+            haplotype_matrix, (_StreamingMatrixBase, HaplotypeMatrix)):
         from ._warnings import check_sample_set_rows
         for k, rows in enumerate(sample_sets):
             check_sample_set_rows(f"sample_sets[{k}]", list(rows),

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -433,8 +433,19 @@ class _StreamingMatrixBase:
         )
         # Mirror the eager classes' idiom: store the explicit value
         # (or None) and let the property fall back to a default 'all'
-        # set when no pop file resolved at source construction.
-        self._sample_sets = source.pop_cols
+        # set when no pop file resolved at source construction. The pop
+        # file resolves to haplotype columns; _sets_in_row_space puts them
+        # in this stream's own row space. Validate once here -- every
+        # chunk shares the stream's row space, so chunks carry the sets
+        # without re-checking.
+        sets = source.pop_cols
+        if sets:
+            sets = self._sets_in_row_space(sets)
+            from ._warnings import check_sample_set_rows
+            n_rows = self._sample_axis_size()
+            for name, rows in sets.items():
+                check_sample_set_rows(f"sample_sets[{name!r}]", rows, n_rows)
+        self._sample_sets = sets
         # Span-normalization metadata, mirroring the eager HaplotypeMatrix.
         # None when no accessible BED was supplied at load; see get_span.
         self.accessible_mask = accessible_mask
@@ -663,6 +674,15 @@ class _StreamingMatrixBase:
     def _build_chunk(self, gt, pos, **kwargs):  # pragma: no cover -- abstract
         raise NotImplementedError
 
+    def _sets_in_row_space(self, pop_cols):
+        """Pop-file sets in this stream's row space.
+
+        The pop file resolves to haplotype columns, which already are the
+        rows of a haplotype stream; the genotype stream overrides this to
+        map gametes to individuals.
+        """
+        return pop_cols
+
     def __repr__(self):
         return (
             f"{type(self).__name__}(num_variants={self.num_variants}, "
@@ -705,7 +725,15 @@ class StreamingHaplotypeMatrix(_StreamingMatrixBase):
         return self.num_haplotypes
 
     def _build_chunk(self, gt, pos, **kwargs):
-        return build_haplotype_matrix(gt, pos, **kwargs)
+        # The stream validated sample_sets once at construction and every
+        # chunk shares the stream's row space, so skip the setter's
+        # re-validation -- np.unique per population per chunk adds up to
+        # minutes over a biobank-scale walk.
+        sets = kwargs.pop('sample_sets', None)
+        m = build_haplotype_matrix(gt, pos, **kwargs)
+        if sets is not None:
+            m._sample_sets = sets
+        return m
 
     def _repr_sample_axis(self):
         return f"num_haplotypes={self.num_haplotypes}"
@@ -758,8 +786,22 @@ class StreamingGenotypeMatrix(_StreamingMatrixBase):
     def _sample_axis_size(self):
         return self.num_individuals
 
+    def _sets_in_row_space(self, pop_cols):
+        # The pop file resolves to haplotype columns, but this stream's
+        # rows are individuals. Both of a sample's gametes floor-divide to
+        # its individual, so the unique halves are the individual rows.
+        # Before this mapping the chunks carried haplotype-numbered sets
+        # that indexed past the individual axis.
+        return {p: np.unique(np.asarray(cols) // 2)
+                for p, cols in pop_cols.items()}
+
     def _build_chunk(self, gt, pos, **kwargs):
+        # Same skip as the haplotype stream: the sets were validated once
+        # at construction, in this stream's own (individual) row space.
+        sets = kwargs.pop('sample_sets', None)
         m = build_genotype_matrix(gt, pos, **kwargs)
+        if sets is not None:
+            m._sample_sets = sets
         if m._n_multiallelic_recoded and not self._biallelic_warned:
             from ._warnings import _warn_biallelic_only
             _warn_biallelic_only(m._n_multiallelic_recoded,

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -441,11 +441,10 @@ class _StreamingMatrixBase:
         sets = source.pop_cols
         if sets:
             sets = self._sets_in_row_space(sets)
-            from ._warnings import check_sample_set_rows
-            n_rows = self._sample_axis_size()
-            for name, rows in sets.items():
-                check_sample_set_rows(f"sample_sets[{name!r}]", rows, n_rows)
-        self._sample_sets = sets
+            # A pop-file population with no member in the store resolves
+            # empty; drop it rather than fail the whole load.
+            sets = {p: rows for p, rows in sets.items() if len(rows)}
+        self.sample_sets = sets or None
         # Span-normalization metadata, mirroring the eager HaplotypeMatrix.
         # None when no accessible BED was supplied at load; see get_span.
         self.accessible_mask = accessible_mask
@@ -539,6 +538,26 @@ class _StreamingMatrixBase:
 
     @sample_sets.setter
     def sample_sets(self, value):
+        """
+        Set the sample sets.
+
+        Each value must name rows in this stream's own row space --
+        haplotype rows on a haplotype stream, individual rows on a
+        genotype stream -- as a list, tuple, or one-dimensional integer
+        array, without duplicates. Every chunk carries these sets, so an
+        invalid assignment would put garbage rows in front of each
+        chunk's statistics. The dict is stored as given, not copied;
+        mutating it afterwards is not re-validated.
+        """
+        if value is None:
+            self._sample_sets = None
+            return
+        if not isinstance(value, dict):
+            raise ValueError("sample_sets must be a dictionary")
+        from ._warnings import check_sample_set_rows
+        n_rows = self._sample_axis_size()
+        for key, rows in value.items():
+            check_sample_set_rows(f"sample_sets[{key!r}]", rows, n_rows)
         self._sample_sets = value
 
     def iter_gpu_chunks(self):
@@ -585,23 +604,26 @@ class _StreamingMatrixBase:
             exclusive. ``None`` materializes the full mappable range,
             which on a biobank-scale store will OOM.
         sample_subset : sequence of int, optional
-            Haplotype-axis indices to keep. ``None`` keeps every
-            haplotype.
+            Rows to keep, in this stream's own row space -- the same
+            space ``sample_sets`` uses, so
+            ``materialize(sample_subset=stream.sample_sets[pop])`` works
+            on either class. ``None`` keeps everything. The subset obeys
+            the same rules as a ``sample_sets`` value: rows within the
+            matrix, no duplicates.
 
-            Sample ``i`` is rows ``2i`` and ``2i + 1``. Ask for both to
-            keep whole samples. Ask for only one and the rows you get
-            back still sit side by side, but a neighbouring pair is no
-            longer one sample. Do not feed such a matrix to anything
-            that works per individual -- ``grm``, ``ibs``,
-            ``fst_weir_cockerham``, ``heterozygosity_observed``, or
-            ``GenotypeMatrix.from_haplotype_matrix``. Statistics that
-            read each row on its own are fine either way.
+            On a haplotype stream rows are gametes: sample ``i`` is rows
+            ``2i`` and ``2i + 1``, and asking for one gamete of a pair
+            gives back rows that sit side by side without being one
+            sample -- do not feed such a matrix to anything that works
+            per individual (``grm``, ``ibs``, ``fst_weir_cockerham``,
+            ``heterozygosity_observed``,
+            ``GenotypeMatrix.from_haplotype_matrix``). On a genotype
+            stream rows are individuals, so whole samples are the only
+            thing it is possible to ask for.
 
             The stream's ``sample_sets`` are renumbered into the subset:
             each population keeps the members the subset retains, and a
-            population with none left is dropped. On a genotype stream
-            the sets hold individual rows, so an individual survives only
-            when the subset keeps both of its gametes as one pair.
+            population with none left is dropped.
         """
         if region is None:
             left, right = self.chrom_start, self.chrom_end
@@ -611,6 +633,15 @@ class _StreamingMatrixBase:
         if sample_subset is None:
             gt, pos = self._source.slice_region(left, right)
         else:
+            # The subset names rows in this stream's own row space and
+            # obeys the same rules as a sample_sets value; the store read
+            # below wants haplotype columns, which _subset_hap_columns
+            # supplies per class.
+            from ._warnings import check_sample_set_rows
+            sample_subset = list(sample_subset)
+            check_sample_set_rows("sample_subset", sample_subset,
+                                  self._sample_axis_size())
+            hap_cols = self._subset_hap_columns(sample_subset)
             # If the fetcher uses kvikio, decompress through it: at
             # biobank-scale sample subsets the host-side oindex codec
             # pipeline that ``slice_subsample`` would use is minutes per
@@ -618,11 +649,11 @@ class _StreamingMatrixBase:
             # fall back to the host stage with the gather on GPU.
             if isinstance(self._fetcher, KvikioChunkFetcher):
                 gm_gpu, pos = self._read_subsample_via_kvikio(
-                    left, right, sample_subset
+                    left, right, hap_cols
                 )
             else:
                 gm_gpu, pos = self._source.slice_subsample(
-                    left, right, sample_subset, to_gpu=True
+                    left, right, hap_cols, to_gpu=True
                 )
             n_var, n_hap = gm_gpu.shape
             if n_hap % 2 != 0:
@@ -646,7 +677,7 @@ class _StreamingMatrixBase:
         if sample_subset is not None and sets:
             sets = {p: rows for p, rows in
                     self._renumber_sets(sets, sample_subset).items()
-                    if len(rows)} or None
+                    if len(rows)}
 
         return self._build_chunk(
             gt, pos,
@@ -656,11 +687,17 @@ class _StreamingMatrixBase:
 
     def _renumber_sets(self, sets, sample_subset):
         """Sets renumbered into the subset's row space; rows the subset
-        does not retain are dropped. Rows here are haplotypes; the
-        genotype stream overrides to renumber individuals."""
+        does not retain are dropped. The subset and the sets share this
+        stream's row space, so one mapping serves both classes."""
         new_row = {int(r): i for i, r in enumerate(sample_subset)}
         return {p: [new_row[int(r)] for r in rows if int(r) in new_row]
                 for p, rows in sets.items()}
+
+    def _subset_hap_columns(self, sample_subset):
+        """The store's haplotype columns for a subset given in this
+        stream's row space. Identity for a haplotype stream; the genotype
+        stream expands each individual to its two gametes."""
+        return sample_subset
 
     def _read_subsample_via_kvikio(self, left, right, sample_subset):
         """Open the fetcher's GDSStore-backed ``call_genotype`` array
@@ -736,8 +773,8 @@ class StreamingHaplotypeMatrix(_StreamingMatrixBase):
         return self.num_haplotypes
 
     def _build_chunk(self, gt, pos, **kwargs):
-        # The stream validated sample_sets once at construction and every
-        # chunk shares the stream's row space, so skip the setter's
+        # The stream's setter validated these sets in the stream's row
+        # space, which every chunk shares, so skip the eager setter's
         # re-validation -- np.unique per population per chunk adds up to
         # minutes over a biobank-scale walk.
         sets = kwargs.pop('sample_sets', None)
@@ -806,21 +843,12 @@ class StreamingGenotypeMatrix(_StreamingMatrixBase):
         return {p: np.unique(np.asarray(cols) // 2)
                 for p, cols in pop_cols.items()}
 
-    def _renumber_sets(self, sets, sample_subset):
-        # The subset names haplotype columns, but this stream's sets hold
-        # individual rows. Subset individual j is the column pair
-        # (subset[2j], subset[2j + 1]); an individual survives when its
-        # two gametes form one such pair. Split pairs dissolve their
-        # individual, so its members drop from the sets, matching the
-        # materialize docstring's whole-samples guidance.
-        new_ind = {}
-        for j in range(len(sample_subset) // 2):
-            a = int(sample_subset[2 * j])
-            b = int(sample_subset[2 * j + 1])
-            if a // 2 == b // 2:
-                new_ind[a // 2] = j
-        return {p: [new_ind[int(r)] for r in rows if int(r) in new_ind]
-                for p, rows in sets.items()}
+    def _subset_hap_columns(self, sample_subset):
+        # This stream's rows are individuals; the store's columns are
+        # gametes. Sample i owns columns 2i and 2i + 1, and the pair
+        # lands adjacently, so the (n_dip, 2) reshape below recovers
+        # exactly the requested individuals in order.
+        return [c for i in sample_subset for c in (2 * int(i), 2 * int(i) + 1)]
 
     def _build_chunk(self, gt, pos, **kwargs):
         # Same skip as the haplotype stream: the sets were validated once

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -441,10 +441,9 @@ class _StreamingMatrixBase:
         sets = source.pop_cols
         if sets:
             sets = self._sets_in_row_space(sets)
-            # A pop-file population with no member in the store resolves
-            # empty; drop it rather than fail the whole load.
-            sets = {p: rows for p, rows in sets.items() if len(rows)}
-        self.sample_sets = sets or None
+        # None means no pop file; {} means a pop file matched nothing.
+        # Keeping the difference mirrors the eager loaders.
+        self.sample_sets = sets
         # Span-normalization metadata, mirroring the eager HaplotypeMatrix.
         # None when no accessible BED was supplied at load; see get_span.
         self.accessible_mask = accessible_mask
@@ -695,9 +694,10 @@ class _StreamingMatrixBase:
 
     def _subset_hap_columns(self, sample_subset):
         """The store's haplotype columns for a subset given in this
-        stream's row space. Identity for a haplotype stream; the genotype
-        stream expands each individual to its two gametes."""
-        return sample_subset
+        stream's row space. Host ints for a haplotype stream (a cupy
+        subset arrives as device scalars); the genotype stream expands
+        each individual to its two gametes."""
+        return [int(i) for i in sample_subset]
 
     def _read_subsample_via_kvikio(self, left, right, sample_subset):
         """Open the fetcher's GDSStore-backed ``call_genotype`` array

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -585,6 +585,10 @@ class _StreamingMatrixBase:
             ``fst_weir_cockerham``, ``heterozygosity_observed``, or
             ``GenotypeMatrix.from_haplotype_matrix``. Statistics that
             read each row on its own are fine either way.
+
+            The stream's ``sample_sets`` are renumbered into the subset:
+            each population keeps the members the subset retains, and a
+            population with none left is dropped.
         """
         if region is None:
             left, right = self.chrom_start, self.chrom_end
@@ -620,10 +624,20 @@ class _StreamingMatrixBase:
             # the split is a view rather than a copy.
             gt = gm_gpu.reshape(n_var, n_dip_sub, 2)
 
+        # sample_subset renumbers the rows, so full-matrix sample_sets no
+        # longer apply. Keep each population's surviving members, renumbered
+        # into the subset; a population with no member left is dropped.
+        sets = self._sample_sets
+        if sample_subset is not None and sets:
+            new_row = {int(r): i for i, r in enumerate(sample_subset)}
+            sets = {p: [new_row[int(r)] for r in rows if int(r) in new_row]
+                    for p, rows in sets.items()}
+            sets = {p: rows for p, rows in sets.items() if rows} or None
+
         return self._build_chunk(
             gt, pos,
             chrom_start=left, chrom_end=right,
-            sample_sets=self._sample_sets,
+            sample_sets=sets,
         )
 
     def _read_subsample_via_kvikio(self, left, right, sample_subset):

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -599,7 +599,9 @@ class _StreamingMatrixBase:
 
             The stream's ``sample_sets`` are renumbered into the subset:
             each population keeps the members the subset retains, and a
-            population with none left is dropped.
+            population with none left is dropped. On a genotype stream
+            the sets hold individual rows, so an individual survives only
+            when the subset keeps both of its gametes as one pair.
         """
         if region is None:
             left, right = self.chrom_start, self.chrom_end
@@ -637,19 +639,28 @@ class _StreamingMatrixBase:
 
         # sample_subset renumbers the rows, so full-matrix sample_sets no
         # longer apply. Keep each population's surviving members, renumbered
-        # into the subset; a population with no member left is dropped.
+        # into the subset; a population with no member left is dropped. The
+        # renumbering is per-class: the subset is haplotype columns, and the
+        # genotype stream's sets hold individual rows.
         sets = self._sample_sets
         if sample_subset is not None and sets:
-            new_row = {int(r): i for i, r in enumerate(sample_subset)}
-            sets = {p: [new_row[int(r)] for r in rows if int(r) in new_row]
-                    for p, rows in sets.items()}
-            sets = {p: rows for p, rows in sets.items() if rows} or None
+            sets = {p: rows for p, rows in
+                    self._renumber_sets(sets, sample_subset).items()
+                    if len(rows)} or None
 
         return self._build_chunk(
             gt, pos,
             chrom_start=left, chrom_end=right,
             sample_sets=sets,
         )
+
+    def _renumber_sets(self, sets, sample_subset):
+        """Sets renumbered into the subset's row space; rows the subset
+        does not retain are dropped. Rows here are haplotypes; the
+        genotype stream overrides to renumber individuals."""
+        new_row = {int(r): i for i, r in enumerate(sample_subset)}
+        return {p: [new_row[int(r)] for r in rows if int(r) in new_row]
+                for p, rows in sets.items()}
 
     def _read_subsample_via_kvikio(self, left, right, sample_subset):
         """Open the fetcher's GDSStore-backed ``call_genotype`` array
@@ -794,6 +805,22 @@ class StreamingGenotypeMatrix(_StreamingMatrixBase):
         # that indexed past the individual axis.
         return {p: np.unique(np.asarray(cols) // 2)
                 for p, cols in pop_cols.items()}
+
+    def _renumber_sets(self, sets, sample_subset):
+        # The subset names haplotype columns, but this stream's sets hold
+        # individual rows. Subset individual j is the column pair
+        # (subset[2j], subset[2j + 1]); an individual survives when its
+        # two gametes form one such pair. Split pairs dissolve their
+        # individual, so its members drop from the sets, matching the
+        # materialize docstring's whole-samples guidance.
+        new_ind = {}
+        for j in range(len(sample_subset) // 2):
+            a = int(sample_subset[2 * j])
+            b = int(sample_subset[2 * j + 1])
+            if a // 2 == b // 2:
+                new_ind[a // 2] = j
+        return {p: [new_ind[int(r)] for r in rows if int(r) in new_ind]
+                for p, rows in sets.items()}
 
     def _build_chunk(self, gt, pos, **kwargs):
         # Same skip as the haplotype stream: the sets were validated once

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -2679,12 +2679,21 @@ def windowed_statistics_fused_chunked(haplotype_matrix: HaplotypeMatrix,
         def pop_rows_of(pop):
             rows = (haplotype_matrix.sample_sets[pop]
                     if isinstance(pop, str) else list(pop))
+            if not isinstance(pop, str):
+                # Direct row lists never pass the sample_sets setter; apply
+                # the same range and duplicate rules before the gather.
+                from ._warnings import check_sample_set_rows
+                check_sample_set_rows("population row list", rows,
+                                      haplotype_matrix.haplotypes.shape[0])
             if need_wc:
                 # The kernel pairs consecutive rows into individuals for
                 # Weir-Cockerham; the gamete statistics take any row list.
+                # stacklevel 4: this closure adds a frame over the direct
+                # call sites the default points past.
                 from ._warnings import check_paired_rows
                 label = pop if isinstance(pop, str) else "row list"
-                check_paired_rows(rows, f"windowed fst_wc({label})")
+                check_paired_rows(rows, f"windowed fst_wc({label})",
+                                  stacklevel=4)
             return cp.asarray(rows, dtype=cp.int64)
 
         orig_hap = haplotype_matrix.haplotypes

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -2173,8 +2173,12 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
             # Weir-Cockerham; the gamete statistics take any row list.
             from ._warnings import check_paired_rows
             for pop in (pop1, pop2):
-                rows = (haplotype_matrix.sample_sets[pop]
+                # .get: an unknown name skips the check and reaches
+                # get_population_matrix below for its proper ValueError.
+                rows = (haplotype_matrix.sample_sets.get(pop)
                         if isinstance(pop, str) else list(pop))
+                if rows is None:
+                    continue
                 label = pop if isinstance(pop, str) else "row list"
                 check_paired_rows(rows, f"windowed fst_wc({label})")
 
@@ -2677,8 +2681,15 @@ def windowed_statistics_fused_chunked(haplotype_matrix: HaplotypeMatrix,
         # A population is a sample_sets name or a row list, the same as the
         # single-shot engine accepts via get_population_matrix.
         def pop_rows_of(pop):
-            rows = (haplotype_matrix.sample_sets[pop]
-                    if isinstance(pop, str) else list(pop))
+            if isinstance(pop, str):
+                rows = haplotype_matrix.sample_sets.get(pop)
+                if rows is None:
+                    # Match get_population_matrix's error for unknown names,
+                    # so the chunked and single-shot engines agree.
+                    raise ValueError(
+                        f"Population {pop} not found in sample_sets")
+            else:
+                rows = list(pop)
             if not isinstance(pop, str):
                 # Direct row lists never pass the sample_sets setter; apply
                 # the same range and duplicate rules before the gather.

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -2168,6 +2168,16 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
         if pop1 is None or pop2 is None:
             raise ValueError("pop1 and pop2 required for fst/dxy/da")
 
+        if 'fst_wc' in statistics:
+            # The kernel pairs consecutive subset rows into individuals for
+            # Weir-Cockerham; the gamete statistics take any row list.
+            from ._warnings import check_paired_rows
+            for pop in (pop1, pop2):
+                rows = (haplotype_matrix.sample_sets[pop]
+                        if isinstance(pop, str) else list(pop))
+                label = pop if isinstance(pop, str) else "row list"
+                check_paired_rows(rows, f"windowed fst_wc({label})")
+
         # Use the original (unsubsetted) matrix for population lookup
         m1 = get_population_matrix(haplotype_matrix, pop1)
         m2 = get_population_matrix(haplotype_matrix, pop2)
@@ -2662,11 +2672,19 @@ def windowed_statistics_fused_chunked(haplotype_matrix: HaplotypeMatrix,
         # bounds-check, so applying these rows to the subset would silently
         # read the wrong haplotypes. Read the rows from the original matrix,
         # and select the same variant columns the cap filter kept.
+        need_wc = 'fst_wc' in statistics
+
         # A population is a sample_sets name or a row list, the same as the
         # single-shot engine accepts via get_population_matrix.
         def pop_rows_of(pop):
             rows = (haplotype_matrix.sample_sets[pop]
                     if isinstance(pop, str) else list(pop))
+            if need_wc:
+                # The kernel pairs consecutive rows into individuals for
+                # Weir-Cockerham; the gamete statistics take any row list.
+                from ._warnings import check_paired_rows
+                label = pop if isinstance(pop, str) else "row list"
+                check_paired_rows(rows, f"windowed fst_wc({label})")
             return cp.asarray(rows, dtype=cp.int64)
 
         orig_hap = haplotype_matrix.haplotypes
@@ -2685,7 +2703,6 @@ def windowed_statistics_fused_chunked(haplotype_matrix: HaplotypeMatrix,
         acc_pi2 = cp.zeros(n_windows, dtype=cp.float64)
         acc_wc_a = cp.zeros(n_windows, dtype=cp.float64)
         acc_wc_abc = cp.zeros(n_windows, dtype=cp.float64)
-        need_wc = 'fst_wc' in statistics
 
         for c_start in range(0, n_total_var, twopop_chunk):
             c_end = min(c_start + twopop_chunk, n_total_var)

--- a/tests/test_haplotype_matrix.py
+++ b/tests/test_haplotype_matrix.py
@@ -384,9 +384,20 @@ class TestSampleSetsValidation:
         hm = self._hm()
         # Overlap across keys is allowed; only within-set duplication is not.
         hm.sample_sets = {'p1': [0, 1, 2, 3], 'p2': [2, 3, 4, 5]}
-        hm.sample_sets = {'p': []}
         hm.sample_sets = None
         assert list(hm.sample_sets) == ['all']
+
+    def test_empty_set_raises(self):
+        hm = self._hm()
+        with pytest.raises(ValueError, match="at least one"):
+            hm.sample_sets = {'p': []}
+
+    def test_dict_value_gets_clean_error(self):
+        hm = self._hm()
+        with pytest.raises(ValueError, match="list, tuple, or 1-D"):
+            hm.sample_sets = {'p': {'a': 1}}
+        with pytest.raises(ValueError, match="integer row numbers"):
+            hm.sample_sets = {'p': [[0, 1], [2]]}
 
     def test_genotype_matrix_validates_individual_rows(self):
         from pg_gpu.genotype_matrix import GenotypeMatrix
@@ -559,3 +570,46 @@ class TestDirectListValidation:
         with pytest.raises(ValueError, match="rows 0"):
             relatedness.genetic_relatedness(
                 hm, sample_sets=[[0, 1], [2, 999999]])
+
+    def test_unknown_population_name_gives_value_error(self):
+        """Every engine agrees on the unknown-name error, not KeyError."""
+        from pg_gpu import diversity
+        from pg_gpu.windowed_analysis import (
+            windowed_statistics_fused,
+            windowed_statistics_fused_chunked,
+        )
+        hm = self._hm()
+        hm.sample_sets = {'p1': [0, 1, 2, 3], 'p2': [8, 9, 10, 11]}
+        hm.transfer_to_gpu()
+        with pytest.raises(ValueError, match="not found"):
+            diversity.heterozygosity_observed(hm, population='nope')
+        bp = np.array([0.0, 700.0])
+        for fn in (windowed_statistics_fused, windowed_statistics_fused_chunked):
+            with pytest.raises(ValueError, match="not found"):
+                fn(hm, bp_bins=bp, statistics=('fst_wc',),
+                   pop1='p1', pop2='nope')
+
+    def test_genetic_relatedness_wrong_type_gives_type_error(self):
+        """Validation must not shadow the dispatch TypeError."""
+        from pg_gpu import relatedness
+        from pg_gpu.genotype_matrix import GenotypeMatrix
+        gm = GenotypeMatrix(np.zeros((4, 5), dtype=np.int8),
+                            np.arange(1, 6), 0, 6)
+        with pytest.raises(TypeError, match="requires a HaplotypeMatrix"):
+            relatedness.genetic_relatedness(gm, sample_sets=[[0, 1], [2, 3]])
+
+    def test_genetic_relatedness_empty_set_gives_value_error(self):
+        from pg_gpu import relatedness
+        hm = self._hm()
+        hm.transfer_to_gpu()
+        with pytest.raises(ValueError, match="at least one"):
+            relatedness.genetic_relatedness(hm, sample_sets=[[0, 1], []])
+
+    def test_load_pop_file_drops_absent_population(self):
+        from pg_gpu import divergence
+        hm = self._hm()
+        hm.samples = [f's{i}' for i in range(6)]
+        hm.load_pop_file({'s0': 'p1', 's1': 'p1', 's2': 'p2', 's3': 'p2',
+                          'zz': 'ghost'})
+        assert 'ghost' not in hm.sample_sets
+        assert sorted(hm.sample_sets) == ['p1', 'p2']

--- a/tests/test_haplotype_matrix.py
+++ b/tests/test_haplotype_matrix.py
@@ -551,3 +551,11 @@ class TestDirectListValidation:
         hm.transfer_to_gpu()
         with pytest.warns(UnpairedRowsWarning):
             GenotypeMatrix.from_haplotype_matrix(hm)
+
+    def test_genetic_relatedness_list_of_lists_validated(self):
+        from pg_gpu import relatedness
+        hm = self._hm()
+        hm.transfer_to_gpu()
+        with pytest.raises(ValueError, match="rows 0"):
+            relatedness.genetic_relatedness(
+                hm, sample_sets=[[0, 1], [2, 999999]])

--- a/tests/test_haplotype_matrix.py
+++ b/tests/test_haplotype_matrix.py
@@ -19,7 +19,7 @@ def sample_vcf():
         random_seed=42,
         ploidy=2
     )
-    ts = msprime.sim_mutations(ts, rate=0.01)
+    ts = msprime.sim_mutations(ts, rate=0.01, random_seed=42)
     # Create a temporary file
     with tempfile.NamedTemporaryFile(suffix='.vcf', delete=False) as tmp:
         # Write VCF to temporary file
@@ -489,3 +489,65 @@ class TestUnpairedRowsWarning:
                           for i in range(6)})
         self._assert_quiet(
             lambda: divergence.fst_weir_cockerham(hm, 'p1', 'p2'))
+
+
+class TestDirectListValidation:
+    """Row lists passed as population arguments are validated at resolution,
+    not only at sample_sets assignment."""
+
+    def _hm(self, n_hap=12, n_var=60, seed=3):
+        rng = np.random.RandomState(seed)
+        hap = rng.randint(0, 2, (n_hap, n_var)).astype(np.int8)
+        return HaplotypeMatrix(hap, np.arange(1, n_var + 1) * 10, 0,
+                               (n_var + 1) * 10)
+
+    def test_out_of_range_direct_lists_raise(self):
+        from pg_gpu import diversity, divergence
+        hm = self._hm()
+        with pytest.raises(ValueError, match="rows 0"):
+            diversity.pi(hm, population=[0, 1, 999999])
+        with pytest.raises(ValueError, match="rows 0"):
+            divergence.fst_hudson(hm, [0, 1], [2, 999999])
+
+    def test_duplicate_direct_list_raises(self):
+        from pg_gpu import divergence
+        hm = self._hm()
+        with pytest.raises(ValueError, match="duplicate"):
+            divergence.fst_weir_cockerham(hm, [0, 0, 1, 1], [8, 9, 10, 11])
+
+    def test_cupy_array_populations_work(self):
+        from pg_gpu import divergence
+        hm = self._hm()
+        hm.transfer_to_gpu()
+        v = divergence.fst_weir_cockerham(hm, cp.arange(4), cp.arange(8, 12))
+        ref = divergence.fst_weir_cockerham(hm, [0, 1, 2, 3], [8, 9, 10, 11])
+        assert np.isclose(v, ref)
+
+    def test_generator_population_works(self):
+        from pg_gpu import diversity
+        hm = self._hm()
+        v = diversity.heterozygosity_observed(hm,
+                                              population=(i for i in range(4)))
+        ref = diversity.heterozygosity_observed(hm, population=[0, 1, 2, 3])
+        assert cp.allclose(cp.asarray(v), cp.asarray(ref))
+
+    def test_chunked_windowed_fst_wc_warns_on_stride(self):
+        from pg_gpu.windowed_analysis import windowed_statistics_fused_chunked
+        from pg_gpu._warnings import UnpairedRowsWarning
+        hm = self._hm()
+        hm.sample_sets = {'p1': [0, 2, 4, 6], 'p2': [8, 9, 10, 11]}
+        hm.transfer_to_gpu()
+        bp = np.array([0.0, 700.0])
+        with pytest.warns(UnpairedRowsWarning):
+            windowed_statistics_fused_chunked(hm, bp_bins=bp,
+                                              statistics=('fst_wc',),
+                                              pop1='p1', pop2='p2')
+
+    def test_from_haplotype_matrix_warns_on_gamete_set(self):
+        from pg_gpu.genotype_matrix import GenotypeMatrix
+        from pg_gpu._warnings import UnpairedRowsWarning
+        hm = self._hm()
+        hm.sample_sets = {'p1': [0, 2, 4, 6]}
+        hm.transfer_to_gpu()
+        with pytest.warns(UnpairedRowsWarning):
+            GenotypeMatrix.from_haplotype_matrix(hm)

--- a/tests/test_haplotype_matrix.py
+++ b/tests/test_haplotype_matrix.py
@@ -348,3 +348,144 @@ def test_pairwise_LD_v_transfers():
     assert isinstance(D, cp.ndarray)
     # Check that D is symmetric (D should equal its transpose).
     assert cp.allclose(D, D.T)
+
+
+class TestSampleSetsValidation:
+    """sample_sets rejects lists no matrix can serve (#201)."""
+
+    def _hm(self, n_hap=8, n_var=10):
+        hap = np.zeros((n_hap, n_var), dtype=np.int8)
+        return HaplotypeMatrix(hap, np.arange(1, n_var + 1), 0, n_var + 1)
+
+    def test_out_of_range_raises(self):
+        hm = self._hm()
+        with pytest.raises(ValueError, match="rows 0..7"):
+            hm.sample_sets = {'p': [0, 1, 999]}
+        with pytest.raises(ValueError, match="row -1"):
+            hm.sample_sets = {'p': [-1, 0]}
+
+    def test_duplicates_raise(self):
+        hm = self._hm()
+        with pytest.raises(ValueError, match="duplicate"):
+            hm.sample_sets = {'p': [0, 0, 1, 2]}
+
+    def test_non_integer_raises(self):
+        hm = self._hm()
+        with pytest.raises(ValueError, match="integer"):
+            hm.sample_sets = {'p': [0.5, 1.5]}
+
+    def test_constructor_validates_too(self):
+        hap = np.zeros((4, 5), dtype=np.int8)
+        with pytest.raises(ValueError, match="rows 0..3"):
+            HaplotypeMatrix(hap, np.arange(1, 6), 0, 6,
+                            sample_sets={'p': [99]})
+
+    def test_legitimate_assignments_pass(self):
+        hm = self._hm()
+        # Overlap across keys is allowed; only within-set duplication is not.
+        hm.sample_sets = {'p1': [0, 1, 2, 3], 'p2': [2, 3, 4, 5]}
+        hm.sample_sets = {'p': []}
+        hm.sample_sets = None
+        assert list(hm.sample_sets) == ['all']
+
+    def test_genotype_matrix_validates_individual_rows(self):
+        from pg_gpu.genotype_matrix import GenotypeMatrix
+        gm = GenotypeMatrix(np.zeros((4, 5), dtype=np.int8),
+                            np.arange(1, 6), 0, 6)
+        with pytest.raises(ValueError, match="rows 0..3"):
+            gm.sample_sets = {'p': [0, 7]}
+        gm.sample_sets = {'p': [0, 3]}
+
+
+class TestUnpairedRowsWarning:
+    """Pairing consumers warn on lists that do not pair into individuals."""
+
+    def _hm(self, n_hap=12, n_var=60, seed=3):
+        rng = np.random.RandomState(seed)
+        hap = rng.randint(0, 2, (n_hap, n_var)).astype(np.int8)
+        hm = HaplotypeMatrix(hap, np.arange(1, n_var + 1) * 10, 0,
+                             (n_var + 1) * 10)
+        return hm
+
+    def _assert_quiet(self, fn):
+        import warnings as w
+        from pg_gpu._warnings import UnpairedRowsWarning
+        with w.catch_warnings(record=True) as rec:
+            w.simplefilter("always")
+            fn()
+        assert not [r for r in rec if issubclass(r.category,
+                                                 UnpairedRowsWarning)]
+
+    def test_scalar_wc_warns_on_gamete_stride(self):
+        from pg_gpu import divergence
+        from pg_gpu._warnings import UnpairedRowsWarning
+        hm = self._hm()
+        hm.sample_sets = {'p1': [0, 2, 4, 6], 'p2': [8, 9, 10, 11]}
+        with pytest.warns(UnpairedRowsWarning, match="individuals 0 and 1"):
+            divergence.fst_weir_cockerham(hm, 'p1', 'p2')
+
+    def test_scalar_wc_warns_on_odd_list(self):
+        from pg_gpu import divergence
+        from pg_gpu._warnings import UnpairedRowsWarning
+        hm = self._hm()
+        hm.sample_sets = {'p1': [0, 1, 2], 'p2': [8, 9, 10, 11]}
+        with pytest.warns(UnpairedRowsWarning, match="drops the last one"):
+            divergence.fst_weir_cockerham(hm, 'p1', 'p2')
+
+    def test_scalar_wc_warns_on_cross_pairing(self):
+        # Sorted parity would pass this list; consumer-order pairing must not.
+        from pg_gpu import divergence
+        from pg_gpu._warnings import UnpairedRowsWarning
+        hm = self._hm()
+        hm.sample_sets = {'p1': [0, 2, 1, 3], 'p2': [8, 9, 10, 11]}
+        with pytest.warns(UnpairedRowsWarning):
+            divergence.fst_weir_cockerham(hm, 'p1', 'p2')
+
+    def test_scalar_wc_quiet_on_correct_pairings(self):
+        from pg_gpu import divergence
+        hm = self._hm()
+        # Adjacent pairs in any pair order, and swapped within a pair, are
+        # all the same partition.
+        for p1 in ([0, 1, 2, 3], [2, 3, 0, 1], [1, 0, 3, 2]):
+            hm.sample_sets = {'p1': p1, 'p2': [8, 9, 10, 11]}
+            self._assert_quiet(
+                lambda: divergence.fst_weir_cockerham(hm, 'p1', 'p2'))
+
+    def test_gamete_statistics_stay_quiet(self):
+        from pg_gpu import divergence
+        hm = self._hm()
+        hm.sample_sets = {'p1': [0, 2, 4, 6], 'p2': [8, 9, 10, 11]}
+        self._assert_quiet(lambda: divergence.fst_hudson(hm, 'p1', 'p2'))
+        self._assert_quiet(lambda: divergence.dxy(hm, 'p1', 'p2'))
+
+    def test_het_observed_warns_on_gamete_stride(self):
+        from pg_gpu import diversity
+        from pg_gpu._warnings import UnpairedRowsWarning
+        hm = self._hm()
+        hm.sample_sets = {'p1': [0, 2, 4, 6]}
+        with pytest.warns(UnpairedRowsWarning):
+            diversity.heterozygosity_observed(hm, population='p1')
+
+    def test_windowed_fst_wc_warns_and_fst_alone_does_not(self):
+        from pg_gpu.windowed_analysis import windowed_statistics_fused
+        from pg_gpu._warnings import UnpairedRowsWarning
+        hm = self._hm()
+        hm.sample_sets = {'p1': [0, 2, 4, 6], 'p2': [8, 9, 10, 11]}
+        hm.transfer_to_gpu()
+        bp = np.array([0.0, 700.0])
+        with pytest.warns(UnpairedRowsWarning):
+            windowed_statistics_fused(hm, bp_bins=bp, statistics=('fst_wc',),
+                                      pop1='p1', pop2='p2')
+        self._assert_quiet(
+            lambda: windowed_statistics_fused(hm, bp_bins=bp,
+                                              statistics=('fst',),
+                                              pop1='p1', pop2='p2'))
+
+    def test_load_pop_file_output_is_quiet(self):
+        from pg_gpu import divergence
+        hm = self._hm()
+        hm.samples = [f's{i}' for i in range(6)]
+        hm.load_pop_file({f's{i}': ('p1' if i < 3 else 'p2')
+                          for i in range(6)})
+        self._assert_quiet(
+            lambda: divergence.fst_weir_cockerham(hm, 'p1', 'p2'))

--- a/tests/test_haplotype_matrix.py
+++ b/tests/test_haplotype_matrix.py
@@ -605,11 +605,26 @@ class TestDirectListValidation:
         with pytest.raises(ValueError, match="at least one"):
             relatedness.genetic_relatedness(hm, sample_sets=[[0, 1], []])
 
-    def test_load_pop_file_drops_absent_population(self):
-        from pg_gpu import divergence
+    def test_load_pop_file_drops_absent_population_with_warning(self):
         hm = self._hm()
         hm.samples = [f's{i}' for i in range(6)]
-        hm.load_pop_file({'s0': 'p1', 's1': 'p1', 's2': 'p2', 's3': 'p2',
-                          'zz': 'ghost'})
+        with pytest.warns(UserWarning, match="dropped: ghost"):
+            hm.load_pop_file({'s0': 'p1', 's1': 'p1', 's2': 'p2',
+                              's3': 'p2', 'zz': 'ghost'})
         assert 'ghost' not in hm.sample_sets
         assert sorted(hm.sample_sets) == ['p1', 'p2']
+
+    def test_nested_list_population_gets_clean_error(self):
+        """The pairing check stays silent on malformed input so the
+        validating chokepoint raises the proper error, at every site."""
+        from pg_gpu import diversity
+        from pg_gpu.windowed_analysis import windowed_statistics_fused
+        hm = self._hm()
+        hm.sample_sets = {'p2': [8, 9, 10, 11]}
+        hm.transfer_to_gpu()
+        with pytest.raises(ValueError, match="one-dimensional"):
+            diversity.heterozygosity_observed(hm, population=[[0, 1], [2, 3]])
+        with pytest.raises(ValueError, match="one-dimensional"):
+            windowed_statistics_fused(hm, bp_bins=np.array([0.0, 700.0]),
+                                      statistics=('fst_wc',),
+                                      pop1=[[0, 1], [2, 3]], pop2='p2')

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -38,6 +38,43 @@ def _stream_concat(streaming_hm):
 
 class TestStreamingFromZarr:
 
+    def test_pop_assignment_yields_individual_row_sets(self, vcz_store,
+                                                        tmp_path):
+        """The stream stored pop-file sets in haplotype coordinates while
+        its chunks hold individual rows, so chunk construction raised once
+        sample_sets grew validation."""
+        from pg_gpu import GenotypeMatrix
+        path, hm = vcz_store
+        n_dip = hm.num_haplotypes // 2
+        half = n_dip // 2
+        popfile = tmp_path / "pops.tsv"
+        lines = ["sample\tpop"] + [
+            f"s{i}\t{'p1' if i < half else 'p2'}" for i in range(n_dip)]
+        popfile.write_text("\n".join(lines) + "\n")
+
+        stream = GenotypeMatrix.from_zarr(path, streaming="always",
+                                          chunk_bp=5_000,
+                                          pop_assignment=str(popfile))
+        sets = stream.sample_sets
+        assert sorted(int(i) for i in sets['p1']) == list(range(half))
+        assert sorted(int(i) for i in sets['p2']) == list(range(half, n_dip))
+        for _, _, chunk in stream.iter_gpu_chunks():
+            assert max(int(i) for i in chunk.sample_sets['p2']) < n_dip
+            break
+
+    def test_grm_runs_with_pop_assignment(self, vcz_store, tmp_path):
+        from pg_gpu import GenotypeMatrix, relatedness
+        path, hm = vcz_store
+        n_dip = hm.num_haplotypes // 2
+        popfile = tmp_path / "pops.tsv"
+        lines = ["sample\tpop"] + [f"s{i}\tp1" for i in range(n_dip)]
+        popfile.write_text("\n".join(lines) + "\n")
+        stream = GenotypeMatrix.from_zarr(path, streaming="always",
+                                          chunk_bp=5_000,
+                                          pop_assignment=str(popfile))
+        g = relatedness.grm(stream)
+        assert g.shape == (n_dip, n_dip)
+
     def test_streaming_always_returns_streaming_class(self, vcz_store):
         path, _ = vcz_store
         hm = HaplotypeMatrix.from_zarr(path, streaming="always", chunk_bp=5_000)
@@ -274,6 +311,41 @@ class TestMaterialize:
         with pytest.raises(ValueError, match="even count"):
             stream.materialize(region=(10_000, 20_000),
                                sample_subset=[0, 1, 2])  # odd
+
+
+class TestMaterializeSampleSetRenumbering:
+    """materialize(sample_subset=...) renumbers sample_sets into the
+    subset; it used to carry full-matrix row numbers onto a smaller
+    matrix."""
+
+    def _stream_with_pops(self, vcz_store, tmp_path):
+        path, hm = vcz_store
+        n_dip = hm.num_haplotypes // 2
+        half = n_dip // 2
+        popfile = tmp_path / "pops.tsv"
+        lines = ["sample\tpop"] + [
+            f"s{i}\t{'p1' if i < half else 'p2'}" for i in range(n_dip)]
+        popfile.write_text("\n".join(lines) + "\n")
+        stream = HaplotypeMatrix.from_zarr(path, streaming="always",
+                                           chunk_bp=5_000,
+                                           pop_assignment=str(popfile))
+        return stream, half
+
+    def test_subset_sets_are_renumbered(self, vcz_store, tmp_path):
+        stream, half = self._stream_with_pops(vcz_store, tmp_path)
+        # Samples 0 and 1 from p1, sample `half` from p2, whole samples.
+        sub = [0, 1, 2, 3, 2 * half, 2 * half + 1]
+        m = stream.materialize(sample_subset=sub)
+        assert m.num_haplotypes == 6
+        assert sorted(int(i) for i in m.sample_sets['p1']) == [0, 1, 2, 3]
+        assert sorted(int(i) for i in m.sample_sets['p2']) == [4, 5]
+
+    def test_population_absent_from_subset_is_dropped(self, vcz_store,
+                                                      tmp_path):
+        stream, half = self._stream_with_pops(vcz_store, tmp_path)
+        m = stream.materialize(sample_subset=[0, 1, 2, 3])
+        assert 'p2' not in m.sample_sets
+        assert sorted(int(i) for i in m.sample_sets['p1']) == [0, 1, 2, 3]
 
 
 class TestChunkFetcherABC:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -75,6 +75,33 @@ class TestStreamingFromZarr:
         g = relatedness.grm(stream)
         assert g.shape == (n_dip, n_dip)
 
+    def test_materialize_subset_renumbers_individual_sets(self, vcz_store,
+                                                          tmp_path):
+        """The subset names haplotype columns while this stream's sets
+        hold individual rows; the renumbering used to key on haplotype
+        coordinates and produce out-of-range individual sets, silently
+        after chunk construction stopped re-validating."""
+        from pg_gpu import GenotypeMatrix
+        path, hm = vcz_store
+        n_dip = hm.num_haplotypes // 2
+        half = n_dip // 2
+        popfile = tmp_path / "pops.tsv"
+        lines = ["sample\tpop"] + [
+            f"s{i}\t{'p1' if i < half else 'p2'}" for i in range(n_dip)]
+        popfile.write_text("\n".join(lines) + "\n")
+        stream = GenotypeMatrix.from_zarr(path, streaming="always",
+                                          chunk_bp=5_000,
+                                          pop_assignment=str(popfile))
+
+        # Whole samples 0, 1 (p1) and `half` (p2), as haplotype columns.
+        sub = [0, 1, 2, 3, 2 * half, 2 * half + 1]
+        m = stream.materialize(sample_subset=sub)
+        assert m.num_individuals == 3
+        assert sorted(int(i) for i in m.sample_sets['p1']) == [0, 1]
+        assert sorted(int(i) for i in m.sample_sets['p2']) == [2]
+        for rows in m.sample_sets.values():
+            assert max(int(i) for i in rows) < m.num_individuals
+
     def test_streaming_always_returns_streaming_class(self, vcz_store):
         path, _ = vcz_store
         hm = HaplotypeMatrix.from_zarr(path, streaming="always", chunk_bp=5_000)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -75,12 +75,13 @@ class TestStreamingFromZarr:
         g = relatedness.grm(stream)
         assert g.shape == (n_dip, n_dip)
 
-    def test_materialize_subset_renumbers_individual_sets(self, vcz_store,
-                                                          tmp_path):
-        """The subset names haplotype columns while this stream's sets
-        hold individual rows; the renumbering used to key on haplotype
-        coordinates and produce out-of-range individual sets, silently
-        after chunk construction stopped re-validating."""
+    def test_materialize_subset_speaks_individual_rows(self, vcz_store,
+                                                       tmp_path):
+        """A genotype stream's subset and its sample_sets share the
+        individual row space, so feeding a population's own rows back as
+        the subset is the supported idiom. Both used to disagree: the
+        sets moved to individual rows while the subset still meant
+        haplotype columns, silently selecting the wrong samples."""
         from pg_gpu import GenotypeMatrix
         path, hm = vcz_store
         n_dip = hm.num_haplotypes // 2
@@ -93,14 +94,49 @@ class TestStreamingFromZarr:
                                           chunk_bp=5_000,
                                           pop_assignment=str(popfile))
 
-        # Whole samples 0, 1 (p1) and `half` (p2), as haplotype columns.
-        sub = [0, 1, 2, 3, 2 * half, 2 * half + 1]
-        m = stream.materialize(sample_subset=sub)
-        assert m.num_individuals == 3
-        assert sorted(int(i) for i in m.sample_sets['p1']) == [0, 1]
-        assert sorted(int(i) for i in m.sample_sets['p2']) == [2]
+        # The documented idiom: a population's rows as the subset.
+        m = stream.materialize(sample_subset=list(stream.sample_sets['p2']))
+        assert m.num_individuals == n_dip - half
+        assert sorted(int(i) for i in m.sample_sets['p2']) == list(
+            range(n_dip - half))
+        assert 'p1' not in m.sample_sets
         for rows in m.sample_sets.values():
             assert max(int(i) for i in rows) < m.num_individuals
+
+    def test_materialize_subset_is_validated(self, vcz_store, tmp_path):
+        """The subset obeys the same rules as a sample_sets value."""
+        from pg_gpu import GenotypeMatrix
+        path, hm = vcz_store
+        stream_h = HaplotypeMatrix.from_zarr(path, streaming="always",
+                                             chunk_bp=5_000)
+        with pytest.raises(ValueError, match="duplicate"):
+            stream_h.materialize(sample_subset=[0, 1, 0, 1])
+        with pytest.raises(ValueError, match="rows 0"):
+            stream_h.materialize(sample_subset=[0, 10**6])
+        stream_g = GenotypeMatrix.from_zarr(path, streaming="always",
+                                            chunk_bp=5_000)
+        with pytest.raises(ValueError, match="duplicate"):
+            stream_g.materialize(sample_subset=[0, 0, 2, 3])
+
+    def test_stream_setter_validates_in_own_row_space(self, vcz_store):
+        """Assigning sample_sets on a stream validates like the eager
+        classes; the bare assignment used to carry garbage into every
+        chunk and out through materialize."""
+        from pg_gpu import GenotypeMatrix
+        path, hm = vcz_store
+        n_dip = hm.num_haplotypes // 2
+        stream_h = HaplotypeMatrix.from_zarr(path, streaming="always",
+                                             chunk_bp=5_000)
+        with pytest.raises(ValueError, match="rows 0"):
+            stream_h.sample_sets = {'p': [0, 10**6]}
+        stream_h.sample_sets = {'p': [0, 1, 2, 3]}
+
+        stream_g = GenotypeMatrix.from_zarr(path, streaming="always",
+                                            chunk_bp=5_000)
+        # Individual rows: n_dip is one past the end for this stream.
+        with pytest.raises(ValueError, match=f"rows 0..{n_dip - 1}"):
+            stream_g.sample_sets = {'p': [0, n_dip]}
+        stream_g.sample_sets = {'p': [0, 1]}
 
     def test_streaming_always_returns_streaming_class(self, vcz_store):
         path, _ = vcz_store

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -118,6 +118,18 @@ class TestStreamingFromZarr:
         with pytest.raises(ValueError, match="duplicate"):
             stream_g.materialize(sample_subset=[0, 0, 2, 3])
 
+    def test_cupy_sample_subset_works_on_both_classes(self, vcz_store):
+        from pg_gpu import GenotypeMatrix
+        path, _ = vcz_store
+        hs = HaplotypeMatrix.from_zarr(path, streaming="always",
+                                       chunk_bp=5_000)
+        m = hs.materialize(sample_subset=cp.arange(4))
+        assert m.num_haplotypes == 4
+        gs = GenotypeMatrix.from_zarr(path, streaming="always",
+                                      chunk_bp=5_000)
+        m = gs.materialize(sample_subset=cp.arange(4))
+        assert m.num_individuals == 4
+
     def test_stream_setter_validates_in_own_row_space(self, vcz_store):
         """Assigning sample_sets on a stream validates like the eager
         classes; the bare assignment used to carry garbage into every


### PR DESCRIPTION
Fixes #201.

`sample_sets` accepted index lists that cannot mean anything, and every
consumer computed silently wrong results from them -- out-of-range rows
read arbitrary memory through CuPy's unchecked fancy indexing, duplicates
counted a gamete twice, and lists that do not pair rows into individuals
fed the diploid statistics mis-paired data.

### Hard errors, in the setter

Rows outside the matrix, duplicates within a set, and non-integer values
raise `ValueError` on both matrix classes. The constructors route through
the setter, so loader-built sets are validated too. Lists, tuples and
one-dimensional integer arrays are accepted -- the streaming loaders build
arrays. Overlap across different sets stays legal, as do empty sets and
`None`.

### Pairing warning, at the consumers

The statistics that reconstruct individuals -- `fst_weir_cockerham`,
`heterozygosity_observed`, and windowed `fst_wc` in both fused engines --
warn (`UnpairedRowsWarning`, exported at package level) when a list does
not carry each sample's two rows adjacently. The check mirrors the
consumers exactly: consecutive entries must belong to one individual, with
pair order and within-pair order free, so `[2, 3, 0, 1]` and `[1, 0, 3, 2]`
are quiet while `[0, 2, 4, ...]`, odd-length lists, and cross-pairing
`[0, 2, 1, 3]` warn. It deliberately does not live in the setter: gamete
statistics accept any list, and the changelog says so.

The measured motivation, from #201 (12 diploids per pop, scalar WC,
baseline +0.019, previously no signal in any case): one gamete per
individual flipped the sign to -0.024; an odd list gave +0.029; duplicates
gave +0.034; row 999999 returned a garbage-shaped array.

### What the validation caught immediately

`StreamingHaplotypeMatrix.materialize(sample_subset=...)` carried the
stream's full-matrix `sample_sets` on a matrix holding only the subset's
rows -- the exact hazard class, previously documented as a docstring
warning. The sets are now renumbered into the subset, each population
keeping the members the subset retains. That commit comes first so both
commits test green independently.

Suite state is reported per review round below; every round runs with
`-W error::UnpairedRowsWarning` to confirm no test trips the new warning
outside its own assertions, plus ruff over the full repo.

## After adversarial review

An adversarial pass over the first two commits found one regression and
a ring of hardening gaps; two more commits close all of them.

* The genotype stream stored pop-file sets in haplotype columns while
  its chunks hold individual rows, so the new validation turned a
  documented silently-wrong carry into a crash on every chunk -- and no
  test covered `GenotypeMatrix.from_zarr(streaming=..., pop_assignment=...)`.
  Each stream now puts the sets in its own row space at construction,
  which is the contract the streaming test class had documented all
  along, and makes `materialize(sample_subset=...)` renumber coherently
  for both classes. Covered by four new streaming tests.

* Per-chunk re-validation would have cost up to ~20 minutes of
  `np.unique` over a biobank-scale walk. Streams validate once at
  construction; chunks share the row space and skip the setter.
  Verified: two validation calls at construction, zero during the walk.

* Row lists passed directly as population arguments bypassed the setter
  entirely, so `fst_hudson(hm, [0, 1], [2, 999999])` still read garbage.
  The same range and duplicate rules now run at resolution --
  `get_population_matrix`, divergence's index resolution, and the
  chunked engine's row gather -- and the changelog states the scope
  honestly.

* cupy arrays and cupy-scalar sequences as populations raised TypeError
  where they previously worked; generators were consumed before the
  subset was built; the chunked engine's warning pointed at library
  internals instead of the caller; and
  `GenotypeMatrix.from_haplotype_matrix` silently collapsed a lone
  gamete into a whole individual. All fixed, all tested.

Left as documented behavior: a `sample_subset` keeping one gamete per
sample renumbers into a set that passes every check -- the materialize
docstring is the guard, as before. Suite after the round: 1292 passed,
78 skipped, 25 xfailed, clean under `-W error::UnpairedRowsWarning`;
ruff clean. A shared-fixture seed also rides along in the first
hardening commit so the variant count is deterministic.

A verification pass by the same reviewer confirmed all eight findings
fixed and caught one issue the fixes created between them: the subset
renumbering in `materialize` still keyed on haplotype columns after the
genotype stream's sets moved to individual rows, and the validate-once
change meant nothing caught the out-of-range result. The renumbering is
a per-class hook now -- a genotype-stream individual survives the subset
when both its gametes are kept as one pair -- with a test pinning the
row bound. `genetic_relatedness`'s list-of-row-lists parameter, which
passes neither the setter nor a population-argument chokepoint, gets the
same range and duplicate rules; an invalid row there was silently
dropped from the tally. Final: 1294 passed, clean under the escalated
warning, ruff clean.

## After an independent cold review

A second, independent reviewer -- forbidden from reading the first
review's work, instructed to falsify this description's claims -- found
two blockers in the streaming half and a ring of error-contract
regressions. Two more commits close all of them:

* Assigning `sample_sets` on a stream ran no validation at all, and
  chunks route around the eager setter -- one assignment put garbage
  rows into every chunk and out through `materialize`, reopening on the
  streaming path exactly the hole the eager setter closed. Streams now
  validate assignments in their own row space.

* `materialize(sample_subset=...)` still spoke haplotype columns after
  the genotype stream's sets moved to individual rows, so
  `materialize(sample_subset=stream.sample_sets[pop])` silently selected
  the wrong samples on a genotype stream. The subset now shares the
  stream's row space on both classes, obeys the same rules as a
  `sample_sets` value (duplicates and out-of-range entries raise), and
  populations emptied by the subset no longer revert the result to the
  default `'all'` set.

* Error contracts unified: unknown population names raise the same
  ValueError from every engine instead of KeyError from the new lookups;
  `genetic_relatedness` keeps its TypeError for wrong input types
  instead of an AttributeError from the new validation; a dict or ragged
  value gets the intended ValueError rather than a raw TypeError.

* Empty sets now raise, matching tskit, with `load_pop_file` dropping
  populations that have no member in the matrix -- routine when the
  matrix holds a sample subset of the pop file's cohort.

The reviewer also confirmed by execution that nothing in the package
resamples rows with replacement, so the duplicate rule breaks no
existing pg_gpu workflow; it does forbid the external idiom of
bootstrapping over individuals via repeated rows, which the changelog
now states.

The reviewer's verification pass on those fixes returned approve --
both blockers confirmed genuinely closed, subset-read data parity
verified cell by cell, and the per-class row space endorsed as the right
contract -- with four small follow-ups, all applied: the pairing check
stays silent on malformed input so the validating chokepoint owns the
error at every site; dropping a pop-file population that matches nothing
in the matrix now warns by name, and a fully unmatched pop file yields
an empty dict on streams as well as eager matrices; a cupy
`sample_subset` works on both stream classes; and the changelog states
plainly that a genotype stream's `sample_subset` changed meaning from
haplotype columns to individual rows.

Known and disclosed rather than fixed: mutating the stored sample_sets
dict in place is not re-validated (documented identically on eager and
streaming classes), and `genetic_relatedness` on a streaming
GenotypeMatrix hits a pre-existing AttributeError rather than a clean
TypeError -- present before this PR, worth its own issue.

Final: 1304 passed, 78 skipped, 25 xfailed, clean under the escalated
warning; ruff clean. 36 test functions added across the PR, none
removed.
