### PR TITLE
Reject a genotype stream in genetic_relatedness with the intended error

### DIFF
--- a/pg_gpu/relatedness.py
+++ b/pg_gpu/relatedness.py
@@ -64,7 +64,7 @@ def genetic_relatedness(haplotype_matrix, sample_sets=None, indexes=None, *,
         ``indexes``.
     """
     from ._memutil import estimate_variant_chunk_size
-    from .streaming_matrix import _StreamingMatrixBase
+    from .streaming_matrix import StreamingHaplotypeMatrix
     from .haplotype_matrix import HaplotypeMatrix
 
     # This list-of-row-lists parameter never passes the sample_sets setter,
@@ -73,13 +73,16 @@ def genetic_relatedness(haplotype_matrix, sample_sets=None, indexes=None, *,
     # rather than an error. Gate on the accepted input types so anything
     # else still reaches the dispatch below and its TypeError.
     if sample_sets is not None and isinstance(
-            haplotype_matrix, (_StreamingMatrixBase, HaplotypeMatrix)):
+            haplotype_matrix, (StreamingHaplotypeMatrix, HaplotypeMatrix)):
         from ._warnings import check_sample_set_rows
         for k, rows in enumerate(sample_sets):
             check_sample_set_rows(f"sample_sets[{k}]", list(rows),
                                   haplotype_matrix.num_haplotypes)
 
-    if isinstance(haplotype_matrix, _StreamingMatrixBase):
+    # Only the haplotype stream has the row semantics this statistic
+    # needs; a genotype stream must fall through to the TypeError below,
+    # the same way grm and ibs reject the wrong stream class.
+    if isinstance(haplotype_matrix, StreamingHaplotypeMatrix):
         return _stream_genetic_relatedness(
             haplotype_matrix, sample_sets=sample_sets, indexes=indexes,
             centre=centre, polarised=polarised, proportion=proportion,

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -38,6 +38,17 @@ def _stream_concat(streaming_hm):
 
 class TestStreamingFromZarr:
 
+    def test_genetic_relatedness_rejects_genotype_stream(self, vcz_store):
+        """A genotype stream must get the clean TypeError, not an
+        AttributeError from whichever haplotype attribute reads first."""
+        from pg_gpu import GenotypeMatrix, relatedness
+        path, _ = vcz_store
+        gs = GenotypeMatrix.from_zarr(path, streaming="always",
+                                      chunk_bp=5_000)
+        for kwargs in ({}, {'sample_sets': [[0, 1], [2, 3]]}):
+            with pytest.raises(TypeError, match="requires a HaplotypeMatrix"):
+                relatedness.genetic_relatedness(gs, **kwargs)
+
     def test_pop_assignment_yields_individual_row_sets(self, vcz_store,
                                                         tmp_path):
         """The stream stored pop-file sets in haplotype coordinates while


### PR DESCRIPTION
Fixes #203.

`genetic_relatedness` dispatched on the streaming base class while the
statistic and `_stream_genetic_relatedness` assume haplotype rows, so a
`StreamingGenotypeMatrix` died on `AttributeError` at whichever haplotype
attribute was read first -- where an eager `GenotypeMatrix` gets the
intended `TypeError`. The dispatch now accepts only the haplotype stream
and everything else falls through to that error, which is the same shape
`grm` and `ibs` already use to reject the wrong stream class. A sweep of
the package found no other dispatch site with the hole.

The regression test pins the clean `TypeError` with and without
`sample_sets`, covering both orders the AttributeError previously fired
in.

Suite: 1305 passed, 78 skipped, 25 xfailed, clean under
`-W error::UnpairedRowsWarning`; ruff clean.
