### PR TITLE
Tally allele counts in shared memory, not through global round trips

### DIFF
--- a/pg_gpu/_memutil.py
+++ b/pg_gpu/_memutil.py
@@ -168,10 +168,42 @@ extern "C" __global__
 void allele_counts(const signed char* hap, int n_hap, int n_var,
                    long long stride0, long long stride1, int K,
                    long long* out_ac, long long* out_n) {
+    // Per-thread histograms live in shared memory, laid out (allele, tid)
+    // so consecutive threads hit consecutive banks. Tallying in shared
+    // costs one 4-byte RMW per element where the old version paid a
+    // 16-byte global round trip -- that alone was a ~17x bandwidth
+    // amplification over the 1-byte reads.
+    extern __shared__ int cnt[];
+    int j = blockIdx.x * blockDim.x + threadIdx.x;
+    int tid = threadIdx.x;
+    for (int a = 0; a < K; a++) cnt[a * blockDim.x + tid] = 0;
+    if (j >= n_var) return;
+    int nv = 0;
+    for (int i = 0; i < n_hap; i++) {
+        signed char v = hap[i * stride0 + j * stride1];
+        if (v >= 0) {
+            nv++;
+            if (v < K) cnt[v * blockDim.x + tid]++;
+        }
+    }
+    long long base = (long long)j * K;
+    for (int a = 0; a < K; a++)
+        out_ac[base + a] = (long long)cnt[a * blockDim.x + tid];
+    out_n[j] = nv;
+}
+''', 'allele_counts')
+
+
+# Fallback for allele counts too wide for a shared-memory histogram (a
+# per-thread row would blow the 48 KB block budget). Same contract; the
+# output row doubles as the histogram, one global RMW per element.
+_allele_counts_kernel_widek = cp.RawKernel(r'''
+extern "C" __global__
+void allele_counts_widek(const signed char* hap, int n_hap, int n_var,
+                         long long stride0, long long stride1, int K,
+                         long long* out_ac, long long* out_n) {
     int j = blockIdx.x * blockDim.x + threadIdx.x;
     if (j >= n_var) return;
-    // One thread owns variant j's output row, so no atomics are needed:
-    // the row doubles as this thread's histogram. Zero it, then tally.
     long long base = (long long)j * K;
     for (int a = 0; a < K; a++) out_ac[base + a] = 0;
     int nv = 0;
@@ -179,12 +211,12 @@ void allele_counts(const signed char* hap, int n_hap, int n_var,
         signed char v = hap[i * stride0 + j * stride1];
         if (v >= 0) {
             nv++;
-            if (v < K) out_ac[base + v]++;  // v < K guaranteed when K == max+1
+            if (v < K) out_ac[base + v]++;
         }
     }
     out_n[j] = nv;
 }
-''', 'allele_counts')
+''', 'allele_counts_widek')
 
 
 def allele_counts(hap, n_alleles=None):
@@ -228,8 +260,15 @@ def allele_counts(hap, n_alleles=None):
     s0, s1 = hap.strides
     threads = _THREADS_PER_BLOCK
     blocks = (n_var + threads - 1) // threads
-    _allele_counts_kernel((blocks,), (threads,),
-                          (hap, n_hap, n_var, s0, s1, K, out_ac, out_n))
+    shared_bytes = K * threads * 4
+    if shared_bytes <= 48 * 1024:
+        _allele_counts_kernel((blocks,), (threads,),
+                              (hap, n_hap, n_var, s0, s1, K, out_ac, out_n),
+                              shared_mem=shared_bytes)
+    else:
+        _allele_counts_kernel_widek((blocks,), (threads,),
+                                    (hap, n_hap, n_var, s0, s1, K,
+                                     out_ac, out_n))
     return out_ac, out_n
 
 


### PR DESCRIPTION
Addresses the actionable core of #206.

The `allele_counts` kernel used each variant's output row as its
histogram: every 1-byte matrix element paid a 16-byte global-memory
read-modify-write, a ~17x bandwidth amplification. That one line, not
per-allele correctness, was most of the scalar slowdown the #184 A/B
measured. Per-thread histograms now live in shared memory
(bank-conflict-free `(allele, tid)` layout, single write-out); counts
too wide for the 48 KB budget fall back to the old pattern.

| Ag1000G X:1-6 Mb, 4.66M var x 2,940 hap | main | #206 before | after |
| --- | --- | --- | --- |
| allele_counts kernel (K=4) | ~17 ms | ~280 ms | **16.8 ms** |
| pi / theta_w / tajimas_d / sfs | 0.016-0.017 s | 0.28-0.30 s | 0.085-0.10 s |
| dxy / fst_hudson / joint_sfs | 0.21-0.22 s | 0.49 s | 0.29-0.30 s |
| windowed single-pop | 0.47 s | 0.73 s | **0.37 s (beats main)** |

Outputs are bit-identical (integer counts, no atomics), verified
against a numpy oracle on biallelic, K=8, wide-K fallback, and
strided-view inputs. Every consumer inherits the fix through the one
`allele_counts` entry point -- a sweep found no second site with the
global-RMW pattern. Full battery: 1314 passed, clean under
`-W error::UnpairedRowsWarning`; ruff clean.

The residual gap to main (~80 ms on a 4.7 M-site chromosome) is the
per-allele arithmetic itself plus the `max()` K-derivation -- real work
at absolute costs no workflow notices, recorded in #206. `fst_wc`'s
scalar cost is its ANOVA, not counting, and is unchanged.
