### PR TITLE
Route the rogers_huff estimator through diploid conversion

### DIFF
--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -1727,10 +1727,23 @@ class HaplotypeMatrix:
             biallelic sites only.
         """
         if estimator == 'rogers_huff':
+            from .genotype_matrix import GenotypeMatrix
             from .ld_statistics import _rogers_huff_pairwise_r
-            r_full = _rogers_huff_pairwise_r(self)
-            r2 = r_full ** 2
-            r2 = cp.where(cp.isnan(r2), 0.0, r2)
+
+            # Rogers-Huff r is a diploid-dosage correlation: pair adjacent
+            # haplotypes into 0/1/2 dosages. The conversion keeps sites with
+            # at most two distinct present alleles (the _biallelic_mask
+            # criterion) and drops the rest with a warning; dropped sites
+            # come back as NaN rows/columns, like the 'r2' branch.
+            keep = self._biallelic_mask()
+            gm = GenotypeMatrix.from_haplotype_matrix(self)
+            r2_kept = _rogers_huff_pairwise_r(gm) ** 2
+            if gm.num_variants == self.num_variants:
+                r2 = r2_kept
+            else:
+                idx = cp.where(keep)[0]
+                r2 = cp.full((self.num_variants, self.num_variants), cp.nan)
+                r2[cp.ix_(idx, idx)] = r2_kept
             cp.fill_diagonal(r2, 0)
             return r2
         if estimator != 'r2':
@@ -1835,7 +1848,9 @@ class HaplotypeMatrix:
             ``'r2'`` (default) -- naive haplotype r² from frequency
             counts. ``'rogers_huff'`` -- Rogers-Huff r² on diploid
             0/1/2 dosages obtained by pairing adjacent haplotypes;
-            matches :func:`scikit-allel.rogers_huff_r` ** 2.
+            sites with three or more present alleles are dropped
+            before binning. Matches
+            :func:`scikit-allel.rogers_huff_r` ** 2.
 
         Returns
         -------
@@ -1853,10 +1868,16 @@ class HaplotypeMatrix:
                     "windowed_r_squared(estimator='rogers_huff', pop=...) "
                     "is not yet implemented; pass the full matrix or "
                     "subset to the desired haplotypes first.")
+            from .genotype_matrix import GenotypeMatrix
             from pg_gpu.ld_statistics import _rogers_huff_pairwise_r
-            m = self.num_variants
-            pos = self.positions
-            r_full = _rogers_huff_pairwise_r(self)
+
+            # Pair adjacent haplotypes into 0/1/2 dosages; sites with three
+            # or more present alleles are dropped with a warning and vanish
+            # from the bins, like the 'r2' branch's biallelic restriction.
+            gm = GenotypeMatrix.from_haplotype_matrix(self)
+            m = gm.num_variants
+            pos = gm.positions
+            r_full = _rogers_huff_pairwise_r(gm)
             iu = cp.triu_indices(m, k=1)
             r2_vals = (r_full[iu]) ** 2
         elif estimator == 'r2':

--- a/tests/test_rogers_huff.py
+++ b/tests/test_rogers_huff.py
@@ -160,3 +160,113 @@ class TestEstimatorResolver:
     def test_unknown_estimator_raises(self):
         with pytest.raises(ValueError, match="Unknown estimator"):
             _resolve_ld_estimator('bogus', is_hap_matrix=True)
+
+
+# ---------------------------------------------------------------------------
+# HaplotypeMatrix methods that route through the dosage estimator
+# ---------------------------------------------------------------------------
+
+
+class TestHaplotypeMatrixEstimator:
+
+    def test_pairwise_r2_matches_module_function(self):
+        hm = _random_hm(n_diploids=30, n_var=40, seed=11)
+        r2_hm = hm.pairwise_r2(estimator='rogers_huff').get()
+        import scipy.spatial.distance as ssd
+        r2_gm = ssd.squareform(rogers_huff_r_squared(_gm(hm)).get())
+        finite = np.isfinite(r2_gm)
+        assert np.isfinite(r2_hm).sum() == finite.sum()
+        np.testing.assert_allclose(r2_hm[finite], r2_gm[finite], rtol=1e-12)
+
+    def test_pairwise_r2_matches_allel(self):
+        hm = _random_hm(n_diploids=40, n_var=50, seed=5)
+        r2_hm = hm.pairwise_r2(estimator='rogers_huff').get()
+        import scipy.spatial.distance as ssd
+        r_allel = ssd.squareform(_allel_r(hm).astype(np.float64))
+        r2_allel = r_allel ** 2
+        finite = np.isfinite(r2_allel) & np.isfinite(r2_hm)
+        np.fill_diagonal(finite, False)
+        np.testing.assert_allclose(
+            r2_hm[finite], r2_allel[finite], rtol=1e-5, atol=1e-5)
+
+    def test_pairwise_r2_multiallelic_site_is_nan(self):
+        hm = _random_hm(n_diploids=20, n_var=12, seed=7)
+        hap = np.array(cp.asnumpy(hm.haplotypes))
+        carriers = np.where(hap[:, 4] == 1)[0]
+        hap[carriers[: carriers.size // 2], 4] = 2
+        hm3 = HaplotypeMatrix(hap, cp.asnumpy(hm.positions), 0, 12 * 1000)
+        with pytest.warns(UserWarning, match="biallelic"):
+            r2 = hm3.pairwise_r2(estimator='rogers_huff').get()
+        assert r2.shape == (12, 12)
+        off = np.ones(12, dtype=bool)
+        off[4] = False
+        assert np.isnan(r2[4, off]).all() and np.isnan(r2[off, 4]).all()
+        assert r2[4, 4] == 0
+        kept = np.ix_(off, off)
+        assert np.isfinite(r2[kept]).any()
+
+    def test_pairwise_r2_monomorphic_site_is_nan(self):
+        hm = _random_hm(n_diploids=20, n_var=8, seed=9)
+        hap = np.array(cp.asnumpy(hm.haplotypes))
+        hap[:, 3] = 0
+        hm0 = HaplotypeMatrix(hap, cp.asnumpy(hm.positions), 0, 8 * 1000)
+        r2 = hm0.pairwise_r2(estimator='rogers_huff').get()
+        off = np.ones(8, dtype=bool)
+        off[3] = False
+        assert np.isnan(r2[3, off]).all()
+        assert r2[3, 3] == 0
+
+    def test_windowed_r_squared_runs_and_matches_manual(self):
+        hm = _random_hm(n_diploids=30, n_var=40, seed=13)
+        bins = [0, 10000, 20000, 40000]
+        res, counts = hm.windowed_r_squared(bins, percentile=50,
+                                            estimator='rogers_huff')
+        r = _allel_r(hm).astype(np.float64)
+        import scipy.spatial.distance as ssd
+        r2_full = ssd.squareform(r) ** 2
+        pos = cp.asnumpy(hm.positions)
+        ii, jj = np.triu_indices(40, k=1)
+        d = pos[jj] - pos[ii]
+        vals = r2_full[ii, jj]
+        for b in range(3):
+            sel = (d >= bins[b]) & (d < bins[b + 1]) & np.isfinite(vals)
+            assert counts[b] == sel.sum()
+            if sel.any():
+                np.testing.assert_allclose(res[b], np.percentile(vals[sel], 50),
+                                           rtol=1e-5, atol=1e-5)
+
+    def test_windowed_r_squared_drops_multiallelic_pairs(self):
+        hm = _random_hm(n_diploids=20, n_var=10, seed=15)
+        hap = np.array(cp.asnumpy(hm.haplotypes))
+        carriers = np.where(hap[:, 2] == 1)[0]
+        hap[carriers[: carriers.size // 2], 2] = 2
+        hm3 = HaplotypeMatrix(hap, cp.asnumpy(hm.positions), 0, 10 * 1000)
+        bins = [0, 10000]
+        with pytest.warns(UserWarning, match="biallelic"):
+            _, counts3 = hm3.windowed_r_squared(bins,
+                                                estimator='rogers_huff')
+        _, counts2 = hm.windowed_r_squared(bins, estimator='rogers_huff')
+        assert counts3[0] < counts2[0]
+
+    def test_windowed_r_squared_pop_raises(self):
+        hm = _random_hm(n_diploids=10, n_var=10, seed=17)
+        hm.sample_sets = {"p": list(range(10))}
+        with pytest.raises(NotImplementedError):
+            hm.windowed_r_squared([0, 10000], pop="p",
+                                  estimator='rogers_huff')
+
+    def test_missing_values_raise(self):
+        hm = _random_hm(n_diploids=10, n_var=10, seed=19)
+        hap = np.array(cp.asnumpy(hm.haplotypes))
+        hap[0, 0] = -1
+        hmm = HaplotypeMatrix(hap, cp.asnumpy(hm.positions), 0, 10 * 1000)
+        with pytest.raises(ValueError, match="missing"):
+            hmm.pairwise_r2(estimator='rogers_huff')
+
+    def test_odd_haplotype_count_raises(self):
+        rng = np.random.default_rng(21)
+        hap = rng.integers(0, 2, (9, 10), dtype=np.int8)
+        pos = np.arange(10, dtype=np.int64) * 1000
+        hm = HaplotypeMatrix(hap, pos, 0, 10 * 1000)
+        with pytest.raises(ValueError, match="even number"):
+            hm.pairwise_r2(estimator='rogers_huff')


### PR DESCRIPTION
## Summary

Three independent audit passes on #184 converged on the same defect: `HaplotypeMatrix.pairwise_r2(estimator='rogers_huff')` and `windowed_r_squared(estimator='rogers_huff')` raise `TypeError` on every call. Both pass `self` into `_dosage_from_matrix`, which #184 narrowed to `GenotypeMatrix`-only. The parameter is advertised in both docstrings and in `docs/source/tutorials/scikit_allel_comparison.rst`, and had zero test coverage, which is why the suite stayed green.

## Fix

Both methods now pair adjacent haplotypes with `GenotypeMatrix.from_haplotype_matrix` before the dosage computation, which is the conversion the error message itself prescribes. Consequences, all matching the documented contract of the `'r2'` branch:

- Sites with three or more present alleles are dropped with a `BiallelicOnlyWarning`. `pairwise_r2` returns them as NaN rows and columns (shape is unchanged); `windowed_r_squared` drops their pairs from the bins.
- Undefined pairs (constant dosage) stay NaN instead of the old silent 0.
- The conversion handles `{0,2}` and reference-absent `{1,2}` codings correctly; main's raw `h1 + h2` sum produced nonsense dosages there.
- Missing calls and odd haplotype counts raise `ValueError`, as before.

The tutorial rst needs no change: its calls become valid again with this fix.

## Verification

Nine new tests: parity with the module-level `rogers_huff_r_squared` (rtol 1e-12) and with `scikit-allel.rogers_huff_r ** 2` (float32 floor), NaN placement for multiallelic and monomorphic sites, bin counts against a hand-built oracle, the multiallelic pair drop, and the error paths. Eight of nine fail on the unfixed trunk (the ninth is the `pop=` guard, which fires before the broken call). Full default suite on the fixed tree: 1323 passed, 0 failed. Ruff clean.