### PR TITLE
Compute moments_ld heterozygosity on the LD site set and indicator

### DIFF
--- a/pg_gpu/moments_ld.py
+++ b/pg_gpu/moments_ld.py
@@ -384,25 +384,40 @@ def _compute_heterozygosity(mat, pops, use_genotypes=False):
     """Compute H_i_j statistics on GPU for N populations (moments convention).
 
     Works with both haplotype and genotype data by converting to allele
-    counts with the haploid sample size convention.
+    counts with the haploid sample size convention. The haplotype branch
+    restricts to the same exactly-two-present-allele site set as
+    ``_compute_ld_sums`` and counts the alt allele on the 0/1 indicator, so
+    every allele coding ({0,1}, {0,2}, reference-absent {1,2}) gives the same
+    H, and a missing call leaves both the alt count and the per-site sample
+    size, matching the genotype branch's valid mask.
     """
     num_pops = len(pops)
+
+    if not use_genotypes:
+        # _biallelic_indicator transfers a CPU-resident matrix to the GPU,
+        # so it must run before allele_counts sees mat.haplotypes.
+        indicator = mat._biallelic_indicator()
+        from ._memutil import allele_counts
+        ac, _ = allele_counts(mat.haplotypes)
+        keep_idx = cp.where((ac > 0).sum(axis=1) == 2)[0]
+        indicator = indicator[:, keep_idx]
 
     alt_counts = []
     ref_counts = []
     hap_sizes = []
     for pop in pops:
         pidx = mat.sample_sets[pop]
+        if isinstance(pidx, list):
+            pidx = cp.array(pidx, dtype=cp.int32)
         if use_genotypes:
-            if isinstance(pidx, list):
-                pidx = cp.array(pidx, dtype=cp.int32)
             pop_data = mat.genotypes[pidx, :]
             valid = pop_data >= 0
             alt = cp.sum(cp.where(valid, pop_data, 0).astype(cp.int32), axis=0).astype(cp.float64)
             n_hap = 2.0 * cp.sum(valid, axis=0).astype(cp.float64)
         else:
-            alt = cp.sum(cp.maximum(mat.haplotypes[pidx, :], 0).astype(cp.int32), axis=0).astype(cp.float64)
-            n_hap = cp.float64(len(pidx)) * cp.ones_like(alt)
+            pop_ind = indicator[pidx, :]
+            alt = cp.sum(pop_ind == 1, axis=0).astype(cp.float64)
+            n_hap = cp.sum(pop_ind >= 0, axis=0).astype(cp.float64)
         alt_counts.append(alt)
         ref_counts.append(n_hap - alt)
         hap_sizes.append(n_hap)

--- a/tests/test_ld_missing_data_degenerate.py
+++ b/tests/test_ld_missing_data_degenerate.py
@@ -157,3 +157,68 @@ def test_heterozygosity_zero_sample_pop_site_is_finite():
     gm.sample_sets = {"A": [0, 1, 2], "B": [3, 4, 5, 6]}
     het = _compute_heterozygosity(gm, ["A", "B"], use_genotypes=True)
     assert all(np.isfinite(v) for v in het.values())
+
+
+# ---------------------------------------------------------------------------
+# Haplotype-path heterozygosity: coding invariance, site set, missing calls
+# ---------------------------------------------------------------------------
+
+
+class TestHaplotypeHeterozygosity:
+    """The hap branch of ``_compute_heterozygosity`` must count the alt allele
+    on the same exactly-two-present-allele, indicator-recoded site set as the
+    LD sums, whatever the allele coding, and drop missing calls from the
+    per-site sample size."""
+
+    def _hm(self, hap, sets=None):
+        from pg_gpu import HaplotypeMatrix
+        hap = np.asarray(hap, dtype=np.int8)
+        n_var = hap.shape[1]
+        pos = np.arange(1, n_var + 1, dtype=np.int64) * 100
+        hm = HaplotypeMatrix(hap, pos, 0, (n_var + 1) * 100)
+        hm.sample_sets = sets or {"A": list(range(hap.shape[0]))}
+        hm.transfer_to_gpu()
+        return hm
+
+    BASE = np.array([[0, 1, 0],
+                     [1, 1, 0],
+                     [1, 0, 1],
+                     [1, 0, 0]], dtype=np.int8)
+
+    def test_oracle_value(self):
+        # per-site alt carriers a of n=4: 2*a*(n-a)/(n*(n-1))
+        # cols: a=3 -> 0.5, a=2 -> 2/3, a=1 -> 0.5
+        het = _compute_heterozygosity(self._hm(self.BASE), ["A"])
+        assert het["H_0_0"] == pytest.approx(0.5 + 2 / 3 + 0.5)
+
+    def test_coding_invariance(self):
+        h01 = _compute_heterozygosity(self._hm(self.BASE), ["A"])
+        h02 = _compute_heterozygosity(self._hm(self.BASE * 2), ["A"])
+        h12 = _compute_heterozygosity(self._hm(self.BASE + 1), ["A"])
+        assert h02 == pytest.approx(h01)
+        assert h12 == pytest.approx(h01)
+
+    def test_coding_invariance_two_pops(self):
+        sets = {"A": [0, 1], "B": [2, 3]}
+        h01 = _compute_heterozygosity(self._hm(self.BASE, sets), ["A", "B"])
+        h02 = _compute_heterozygosity(self._hm(self.BASE * 2, sets),
+                                      ["A", "B"])
+        assert set(h01) == {"H_0_0", "H_0_1", "H_1_1"}
+        assert h02 == pytest.approx(h01)
+        # cross term, per site: (ref_A*alt_B + alt_A*ref_B) / (n_A*n_B)
+        # cols (a_A, a_B) of n=2 each: (1,2) -> 0.5, (2,0) -> 1.0, (0,1) -> 0.5
+        assert h01["H_0_1"] == pytest.approx(0.5 + 1.0 + 0.5)
+
+    def test_multiallelic_site_excluded(self):
+        tri = np.hstack([self.BASE,
+                         np.array([[0], [1], [2], [0]], dtype=np.int8)])
+        h_base = _compute_heterozygosity(self._hm(self.BASE), ["A"])
+        h_tri = _compute_heterozygosity(self._hm(tri), ["A"])
+        assert h_tri == pytest.approx(h_base)
+
+    def test_missing_call_leaves_site_sample_size(self):
+        # one alt carrier among three valid calls; counting the missing call
+        # as ref (n=4, a=1) would give 0.5 instead
+        col = np.array([[1], [0], [0], [-1]], dtype=np.int8)
+        het = _compute_heterozygosity(self._hm(col), ["A"])
+        assert het["H_0_0"] == pytest.approx(2 * 1 * 2 / (3 * 2))


### PR DESCRIPTION
## Summary

The referee audit of #184 found the two halves of one `compute_ld_statistics` output disagreeing. `_compute_heterozygosity`'s haplotype branch summed raw allele codes over every site with a constant sample size, while `_compute_ld_sums` restricts to exactly-two-present-allele sites recoded through `_biallelic_indicator`. Measured consequences:

- A `{0,2}`-coded site counts each carrier twice; `ref = n - alt` goes negative, so H can go negative (a 4-haplotype site with 3 carriers gives H = -2.0; correct is 0.5).
- A reference-absent `{1,2}` site counts reference carriers as alt.
- Multiallelic sites enter H but not the LD sums.
- A missing call counts as a reference allele at full sample size.

This is a #184 regression on the VCF entry path: main reduced everything to `{0,1}` there with `apply_biallelic_filter()`, which #184 removed. The module docstring's claim that `{0,2}` and `{1,2}` sites are kept and recoded was true only for the LD half.

## Fix

The haplotype branch now uses the same site set and 0/1 indicator as `_compute_ld_sums`, and drops missing calls from both the alt count and the per-site sample size, matching the genotype branch's valid mask. On complete `{0,1}` data the values are bit-unchanged.

## Verification

- New default-env tests in `test_ld_missing_data_degenerate.py`: oracle value, coding invariance for one and two populations, multiallelic exclusion, missing-call sample size. Four of five fail on the unfixed trunk (the oracle case was always correct on `{0,1}` data).
- Moments parity suite in the moments env: 39 passed, 0 failed.
- Full default suite: 1319 passed, 0 failed. Ruff clean.