### PR TITLE
Post-audit cleanup: dead code, invariant comments, small fixes

### DIFF
--- a/debug/stress_test_ag1000g.py
+++ b/debug/stress_test_ag1000g.py
@@ -253,8 +253,8 @@ def main():
     benchmarks.append(("diversity.inbreeding_coefficient",
         lambda: diversity.inbreeding_coefficient(hm, population="pop1"),
         allel_fn(['g'], lambda: np.nanmean(allel.inbreeding_coefficient(_allel_cache['g'].subset(sel1=list(range(N_DIP_PER_POP))))))))
-    benchmarks.append(("diversity.allele_freq_spectrum",
-        lambda: diversity.allele_frequency_spectrum(hm, population="pop1"),
+    benchmarks.append(("sfs.sfs",
+        lambda: sfs.sfs(hm, population="pop1"),
         allel_fn(['g'], lambda: allel.sfs(_allel_cache['g'].count_alleles(subpop=pop1_dip)[:, 1]))))
     benchmarks.append(("diversity.segregating_sites",
         lambda: diversity.segregating_sites(hm, population="pop1"),
@@ -355,7 +355,7 @@ def main():
     # --- Decomposition ---
     # randomized_pca needs O(n_hap * n_var * 8) intermediates; OOM at full-arm scale
     benchmarks.append(("decomposition.randomized_pca",
-        lambda: decomposition.randomized_pca(hm, n_components=4, scaler="patterson"),
+        lambda: decomposition.randomized_pca(hm, n_components=4),
         None))
 
     # --- Relatedness ---

--- a/debug/stress_test_ag1000g.py
+++ b/debug/stress_test_ag1000g.py
@@ -35,7 +35,7 @@ from pg_gpu import (
 from pg_gpu.genotype_matrix import GenotypeMatrix
 
 # ── Config ───────────────────────────────────────────────────────────────
-ZARR_PATH = "/sietch_colab/data_share/Ag1000G/Ag3.0/vcf/AgamP3.phased.zarr"
+ZARR_PATH = "/sietch_colab/data_share/Ag1000G/Ag3.0/vcf/phased_vcf/AgamP3.phased.zarr"
 ACC_PATH = "/sietch_colab/data_share/Ag1000G/Ag3.0/vcf/agp3.is_accessible.txt.npz"
 CHROM = "3R"
 REGION_START = None  # None = full arm
@@ -150,6 +150,7 @@ def bench(fn, n_iter=N_ITER, n_warmup=1, sync_gpu=True):
         try:
             fn()
         except Exception:
+            traceback.print_exc()
             return None
         if sync_gpu:
             cp.cuda.Stream.null.synchronize()
@@ -162,6 +163,7 @@ def bench(fn, n_iter=N_ITER, n_warmup=1, sync_gpu=True):
         try:
             fn()
         except Exception:
+            traceback.print_exc()
             return None
         if sync_gpu:
             cp.cuda.Stream.null.synchronize()

--- a/pg_gpu/_gpu_genotype_prep.py
+++ b/pg_gpu/_gpu_genotype_prep.py
@@ -109,10 +109,10 @@ def build_genotype_matrix(gt, pos, *,
         when either ploidy on that variant was missing. A site with three or
         more distinct alleles present in the sample cannot be a 0/1/2 dosage,
         so its whole row is set to ``-1`` (present but fully missing), keeping
-        the row/chunk alignment the streaming path relies on. The number of
-        such recoded sites is
-        stashed on the result as ``_n_multiallelic_recoded`` for the caller
-        to surface as a BiallelicOnlyWarning (once per load).
+        the row/chunk alignment the streaming path relies on. The number
+        of such recoded sites is stashed on the result as
+        ``_n_multiallelic_recoded`` for the caller to surface as a
+        BiallelicOnlyWarning (once per load).
     """
     from .genotype_matrix import GenotypeMatrix, _biallelic_and_alt
     from ._memutil import allele_counts

--- a/pg_gpu/_memutil.py
+++ b/pg_gpu/_memutil.py
@@ -87,81 +87,6 @@ def free_gpu_pool():
     cp.get_default_memory_pool().free_all_blocks()
 
 
-def chunked_sum_int32(hap, axis=0):
-    """Sum haplotype matrix along axis 0 using int32 chunks.
-
-    Avoids creating a full int32 copy of the matrix by processing
-    variant columns in chunks.
-
-    Parameters
-    ----------
-    hap : cupy.ndarray, int8, shape (n_hap, n_var)
-
-    Returns
-    -------
-    cupy.ndarray, int64, shape (n_var,)
-    """
-    n_hap, n_var = hap.shape
-    chunk_size = estimate_variant_chunk_size(n_hap, bytes_per_element=4,
-                                             n_intermediates=1)
-    result = cp.empty(n_var, dtype=cp.int64)
-    for start in range(0, n_var, chunk_size):
-        end = min(start + chunk_size, n_var)
-        result[start:end] = cp.sum(hap[:, start:end].astype(cp.int32), axis=0)
-    return result
-
-
-_dac_and_n_kernel = cp.RawKernel(r'''
-extern "C" __global__
-void dac_and_n(const signed char* hap, int n_hap, int n_var,
-               long long stride0, long long stride1,
-               long long* out_dac, long long* out_n) {
-    int j = blockIdx.x * blockDim.x + threadIdx.x;
-    if (j >= n_var) return;
-    int d = 0, nv = 0;
-    for (int i = 0; i < n_hap; i++) {
-        signed char v = hap[i * stride0 + j * stride1];
-        if (v >= 0) nv++;
-        if (v > 0) d++;
-    }
-    out_dac[j] = d;
-    out_n[j] = nv;
-}
-''', 'dac_and_n')
-
-
-def dac_and_n(hap):
-    """Compute derived allele counts and valid counts via fused CUDA kernel.
-
-    Single-pass kernel: reads each element once, no intermediate arrays.
-    Counts non-reference alleles (hap > 0) as derived, handling
-    multiallelic sites correctly.
-
-    Parameters
-    ----------
-    hap : cupy.ndarray, int8, shape (n_hap, n_var)
-
-    Returns
-    -------
-    dac : cupy.ndarray, int64, shape (n_var,)
-        Derived (non-reference) allele count per site.
-    n_valid : cupy.ndarray, int64, shape (n_var,)
-        Number of non-missing haplotypes per site.
-    """
-    n_hap, n_var = hap.shape
-    out_dac = cp.empty(n_var, dtype=cp.int64)
-    out_n = cp.empty(n_var, dtype=cp.int64)
-    s0, s1 = hap.strides
-    threads = _THREADS_PER_BLOCK
-    blocks = (n_var + threads - 1) // threads
-    _dac_and_n_kernel((blocks,), (threads,),
-                      (hap, n_hap, n_var, s0, s1, out_dac, out_n))
-    return out_dac, out_n
-
-
-# Backward-compatible alias
-chunked_dac_and_n = dac_and_n
-
 
 _allele_counts_kernel = cp.RawKernel(r'''
 extern "C" __global__
@@ -170,9 +95,8 @@ void allele_counts(const signed char* hap, int n_hap, int n_var,
                    long long* out_ac, long long* out_n) {
     // Per-thread histograms live in shared memory, laid out (allele, tid)
     // so consecutive threads hit consecutive banks. Tallying in shared
-    // costs one 4-byte RMW per element where the old version paid a
-    // 16-byte global round trip -- that alone was a ~17x bandwidth
-    // amplification over the 1-byte reads.
+    // costs one 4-byte RMW per element; a global int64 tally would pay a
+    // 16-byte round trip per 1-byte read, a ~17x bandwidth amplification.
     extern __shared__ int cnt[];
     int j = blockIdx.x * blockDim.x + threadIdx.x;
     int tid = threadIdx.x;
@@ -224,10 +148,10 @@ def allele_counts(hap, n_alleles=None):
 
     Single-pass kernel: one thread per variant reads each element once and
     tallies a per-allele histogram directly into its own output row (no
-    intermediate array, no atomics). This is the per-allele analogue of
-    ``dac_and_n`` and the multiallelic-correct primitive: allele ``a`` at a
-    site gets its own count, rather than all non-reference alleles being
-    collapsed into one derived class.
+    intermediate array, no atomics). This is the multiallelic-correct
+    counting primitive: allele ``a`` at a site gets its own count, rather
+    than all non-reference alleles being collapsed into one derived
+    class.
 
     Parameters
     ----------
@@ -272,35 +196,3 @@ def allele_counts(hap, n_alleles=None):
     return out_ac, out_n
 
 
-def chunked_matmul_accumulate(X, chunk_size=None):
-    """Compute X @ X.T by accumulating partial outer products.
-
-    Splits X along columns (variant axis) to control memory.
-    Result is exact (no approximation).
-
-    Parameters
-    ----------
-    X : cupy.ndarray, shape (n, m)
-    chunk_size : int, optional
-        Columns per chunk. Auto-estimated if None.
-
-    Returns
-    -------
-    cupy.ndarray, shape (n, n)
-    """
-    n, m = X.shape
-    if chunk_size is None:
-        free = cp.cuda.Device().mem_info[0]
-        # Each chunk needs (n, chunk) working memory + (n, n) output
-        output_bytes = n * n * 8  # float64
-        budget = int(free * 0.4) - output_bytes
-        per_col = n * 8  # float64
-        chunk_size = max(1, budget // per_col)
-
-    result = cp.zeros((n, n), dtype=cp.float64)
-    for start in range(0, m, chunk_size):
-        end = min(start + chunk_size, m)
-        chunk = X[:, start:end]
-        result += chunk @ chunk.T
-
-    return result

--- a/pg_gpu/_warnings.py
+++ b/pg_gpu/_warnings.py
@@ -219,19 +219,22 @@ class BiallelicOnlyWarning(UserWarning):
     """
 
 
-def _warn_biallelic_only(n_dropped, *, context, stacklevel=3):
-    """Emit ``BiallelicOnlyWarning`` that ``context`` dropped ``n_dropped`` sites.
+def _warn_biallelic_only(n_dropped, *, context, stacklevel=3, action="dropped"):
+    """Emit ``BiallelicOnlyWarning`` that ``context`` handled ``n_dropped`` sites.
 
     A no-op when ``n_dropped`` is 0, so callers can pass a raw count
     unconditionally. ``context`` names the operation that restricted to biallelic
-    (e.g. ``"GenotypeMatrix.from_vcf"``, ``"patterson_d"``) and leads the message.
+    (e.g. ``"GenotypeMatrix.from_vcf"``, ``"patterson_d"``) and leads the
+    message. ``action`` says what happened to the sites: the default
+    ``"dropped"`` fits filtering paths; the zarr loaders pass
+    ``"recoded to all-missing rows"`` because they keep every row.
     """
     n_dropped = int(n_dropped)
     if n_dropped <= 0:
         return
     warnings.warn(
-        f"{context} is defined on biallelic sites; dropped {n_dropped} "
-        f"multiallelic site(s). To silence:\n"
+        f"{context} is defined on biallelic sites; {n_dropped} "
+        f"multiallelic site(s) {action}. To silence:\n"
         "    import warnings\n"
         "    from pg_gpu import BiallelicOnlyWarning\n"
         "    warnings.filterwarnings('ignore', category=BiallelicOnlyWarning)",

--- a/pg_gpu/admixture.py
+++ b/pg_gpu/admixture.py
@@ -277,9 +277,8 @@ def _patterson_d_gpu(haplotype_matrix, pop_a, pop_b, pop_c, pop_d,
     from ._warnings import _warn_biallelic_only
     _warn_biallelic_only(int((~biallelic).sum()), context="patterson_d")
 
-    # Alt allele = highest-index present allele (== allele 1 for a {0,1} site,
-    # so this reduces to the previous behaviour on standard biallelic data);
-    # D is invariant to which of the two alleles is chosen.
+    # Alt allele = highest-index present allele (allele 1 for a {0,1}
+    # site); D is invariant to which of the two alleles is chosen.
     k = xa.shape[1]
     alt = cp.where(present, cp.arange(k)[None, :], -1).argmax(axis=1)[:, None]
 

--- a/pg_gpu/decomposition.py
+++ b/pg_gpu/decomposition.py
@@ -166,7 +166,9 @@ def randomized_pca(haplotype_matrix: HaplotypeMatrix,
     population : str or list, optional
         Population subset.
     n_iter : int
-        Number of power iterations for accuracy.
+        Number of power iterations. The default trades accuracy for
+        speed on flat spectra; raise it (10-20) when leading eigenvalues
+        are close.
     random_state : int, optional
         Random seed for reproducibility.
     missing_data : str
@@ -189,14 +191,14 @@ def randomized_pca(haplotype_matrix: HaplotypeMatrix,
     n_samples, n_variants = X.shape
     n_components = min(n_components, n_samples, max(n_variants, 1))
 
-    # randomized SVD on GPU
-    if random_state is not None:
-        cp.random.seed(random_state)
+    # randomized SVD on GPU; a local generator leaves the process-global
+    # CuPy RNG untouched when a seed is given
+    rng = cp.random.RandomState(random_state) if random_state is not None else cp.random
 
     # random projection
     k = n_components + 10  # oversampling
     k = min(k, min(n_samples, max(n_variants, 1)))
-    Omega = cp.random.randn(n_variants, k, dtype=cp.float64)
+    Omega = rng.randn(n_variants, k, dtype=cp.float64)
     Y = X @ Omega
 
     # power iteration for accuracy
@@ -211,8 +213,8 @@ def randomized_pca(haplotype_matrix: HaplotypeMatrix,
     Uhat, S, Vt = cp.linalg.svd(B, full_matrices=False)
     U = Q @ Uhat
 
-    # S are singular values of X; the pca Gram is X @ X.T / n_segregating
-    # (proportion=True), so coords scale by 1 / sqrt(n_segregating).
+    # S are singular values of X; the Gram is X @ X.T / n_segregating,
+    # so coords scale by 1 / sqrt(n_segregating).
     coords = U[:, :n_components] * S[:n_components]
     if n_segregating > 0:
         coords = coords / cp.sqrt(n_segregating)
@@ -240,9 +242,8 @@ def _prepare_dosage(genotype_matrix, population=None, missing_data='include'):
         matrix.transfer_to_gpu()
 
     geno = matrix.genotypes
-    # Subset individuals inline (the shared get_population_matrix is haplotype
-    # granularity; genotype/haplotype population subsetting is unified in the
-    # type-domain-consistency follow-up).
+    # Subset individuals inline: the shared get_population_matrix speaks
+    # haplotype rows, not individual rows.
     if population is not None:
         if isinstance(population, str):
             if matrix.sample_sets is None or population not in matrix.sample_sets:
@@ -340,7 +341,9 @@ def randomized_pca_dosage(genotype_matrix,
     population : str or list, optional
         Population subset.
     n_iter : int
-        Number of power iterations for accuracy.
+        Number of power iterations. The default trades accuracy for
+        speed on flat spectra; raise it (10-20) when leading eigenvalues
+        are close.
     random_state : int, optional
         Random seed for reproducibility.
     missing_data : str
@@ -363,12 +366,13 @@ def randomized_pca_dosage(genotype_matrix,
     n_samples, n_variants = X.shape
     n_components = min(n_components, n_samples, max(n_variants, 1))
 
-    if random_state is not None:
-        cp.random.seed(random_state)
+    # A local generator leaves the process-global CuPy RNG untouched when
+    # a seed is given.
+    rng = cp.random.RandomState(random_state) if random_state is not None else cp.random
 
     # random projection
     k = min(n_components + 10, n_samples, max(n_variants, 1))
-    Omega = cp.random.randn(n_variants, k, dtype=cp.float64)
+    Omega = rng.randn(n_variants, k, dtype=cp.float64)
     Y = X @ Omega
 
     # power iteration for accuracy
@@ -462,8 +466,7 @@ def pairwise_distance(haplotype_matrix: HaplotypeMatrix,
 
     # Scale the mismatch count to the full variant span when missing sites reduce
     # the jointly-valid count (raw * n_var / n_joint). With no missing data
-    # joint_valid == n_var, so d == m. On biallelic {0,1} data m equals the old
-    # raw sum, so this is bit-identical to the previous per-metric formula.
+    # joint_valid == n_var, so d == m, the plain mismatch count.
     d = cp.where(joint_valid > 0, m * n_var / joint_valid, 0.0)
     if metric == 'euclidean':
         d = cp.sqrt(d)
@@ -738,8 +741,7 @@ def _local_pca_streaming(matrix, iterator, k, missing_data,
     """
     n_samples = matrix.num_haplotypes
     # Global allele width, computed once, so the per-window standardization does
-    # not pay an int(hap.max()) host sync per window (keeps the streaming sync
-    # footprint at the pre-reframe level).
+    # not pay an int(hap.max()) host sync per window.
     n_alleles_all = int(matrix.haplotypes.max()) + 1 if matrix.num_variants else 1
 
     if tile_size is None:

--- a/pg_gpu/distance_stats.py
+++ b/pg_gpu/distance_stats.py
@@ -68,8 +68,8 @@ def _pairwise_diffs_matrix_gpu(hap, missing_data='include',
     chunk_size = estimate_variant_chunk_size(n_hap, bytes_per_element=8,
                                              n_intermediates=3)
 
-    # One-hot Hamming over K allele values. K matmuls/chunk (vs 1 for the old
-    # binary-only gram trick); K is the number of allele values, typically small.
+    # One-hot Hamming over K allele values, K matmuls per chunk; K is the
+    # number of distinct allele values, typically small.
     max_allele = int(hap.max()) if hap.size else -1
     n_alleles = max(max_allele + 1, 0)
 

--- a/pg_gpu/diversity.py
+++ b/pg_gpu/diversity.py
@@ -187,86 +187,6 @@ def _achaz_variance(w1_name, w2_name, n, S):
     return alpha_n * S / a1 + beta_n * S * (S - 1) / (a1 ** 2 + a2)
 
 
-def _site_contribution(name, d, n_safe, seg, n_valid, n_hap, dac=None):
-    """Compute per-site contribution for a theta estimator on GPU.
-
-    LEGACY (collapsed, biallelic) path: derived alleles are lumped into a single
-    ``dac`` count, so this is not multiallelic-correct. The scalar diversity path
-    now uses the per-allele ``_ac_contribution``; this function is retained only
-    for ``windowed_analysis``, which still imports it.
-
-    Parameters
-    ----------
-    name : str
-        Estimator name.
-    d, n_safe : cupy.ndarray, float64
-        Derived allele count (float) and safe sample size per site.
-    seg : cupy.ndarray, bool
-        Segregating site mask.
-    n_valid : cupy.ndarray, int64
-        Per-site valid sample count (for watterson lookup).
-    n_hap : int
-        Total haplotype count (for harmonic number lookup).
-    dac : cupy.ndarray, int64, optional
-        Integer derived allele count (for exact comparisons like == 1).
-        If None, uses d cast to int64.
-
-    Returns
-    -------
-    cupy.ndarray, float64, shape (n_variants,)
-        Per-site contribution (zero for non-segregating sites).
-    """
-    if dac is None:
-        dac = d.astype(cp.int64)
-
-    if name in ('pi', 'theta_pi'):
-        return cp.where(seg, 2 * d * (n_safe - d) / (n_safe * (n_safe - 1)), 0.0)
-    elif name in ('watterson', 'theta_s'):
-        a1_inv = _get_a1_inv(n_hap)
-        return cp.where(seg, a1_inv[n_valid], 0.0)
-    elif name == 'theta_h':
-        return cp.where(seg, 2 * d * d / (n_safe * (n_safe - 1)), 0.0)
-    elif name == 'theta_l':
-        return cp.where(seg, d / (n_safe - 1), 0.0)
-    elif name == 'eta1':
-        # Singletons only: dac == 1
-        a1_inv = _get_a1_inv(n_hap)
-        return cp.where(seg & (dac == 1), a1_inv[n_valid], 0.0)
-    elif name == 'eta1_star':
-        # Singletons + (n-1)-tons
-        a1_inv = _get_a1_inv(n_hap)
-        is_edge = (dac == 1) | (dac == n_valid - 1)
-        return cp.where(seg & is_edge, a1_inv[n_valid], 0.0)
-    elif name == 'minus_eta1':
-        not_sing = dac >= 2
-        a1m1_gpu = _get_minus_eta1_norm(n_hap)
-        return cp.where(seg & not_sing, a1m1_gpu[n_valid], 0.0)
-    elif name == 'minus_eta1_star':
-        interior = (dac >= 2) & (dac <= n_valid - 2)
-        norm_gpu = _get_minus_eta1_star_norm(n_hap)
-        return cp.where(seg & interior, norm_gpu[n_valid], 0.0)
-    else:
-        raise ValueError(f"Unknown estimator: {name}. Use FrequencySpectrum "
-                         f"for custom weight functions.")
-
-
-def _prepare_dac(matrix):
-    """Compute dac, n_valid, and derived quantities on GPU.
-
-    Returns (dac, n_valid, d, n_safe, seg, n_hap) — the shared
-    intermediate arrays used by all theta estimator paths.
-    """
-    if matrix.device == 'CPU':
-        matrix.transfer_to_gpu()
-    from ._memutil import dac_and_n
-    dac, n_valid = dac_and_n(matrix.haplotypes)
-    n = n_valid.astype(cp.float64)
-    d = dac.astype(cp.float64)
-    seg = (dac > 0) & (dac < n_valid) & (n_valid >= 2)
-    n_safe = cp.maximum(n, 2.0)
-    return dac, n_valid, d, n_safe, seg, matrix.num_haplotypes
-
-
 def _prepare_allele_counts(matrix):
     """Compute per-allele counts and valid counts on GPU.
 
@@ -545,8 +465,9 @@ def project_sfs(sfs, n_from, n_to):
 # FrequencySpectrum: power-user class for SFS analysis
 # ---------------------------------------------------------------------------
 
-# Weight functions for SFS dot-product path (used by FrequencySpectrum.theta
-# for custom callables; built-in names use _site_contribution instead).
+# Weight functions for the SFS dot-product path, used by
+# FrequencySpectrum.theta for custom callables; the built-in estimator
+# names go through the per-allele _ac_contribution path.
 def _weights_watterson(n):
     w = np.zeros(n + 1)
     a1 = np.sum(1.0 / np.arange(1, n))
@@ -1541,9 +1462,8 @@ def max_daf(haplotype_matrix: HaplotypeMatrix,
     if ac.shape[1] < 2:  # no derived alleles present anywhere
         return 0.0
     n_valid = n_valid_i.astype(cp.float64)
-    # Per-allele DAF: the frequency of each individual derived allele. NOTE
-    # (issue #100): "max DAF" is the frequency of the single most common derived
-    # allele, not the total non-ancestral fraction of the sample.
+    # Per-allele DAF: "max DAF" is the frequency of the single most common
+    # derived allele, not the total non-ancestral fraction of the sample.
     freq = ac[:, 1:].astype(cp.float64) / cp.maximum(n_valid[:, None], 1.0)
     present = ac[:, 1:] > 0
     if missing_data == 'exclude':
@@ -1641,10 +1561,9 @@ def daf_histogram(matrix, n_bins: int = 20,
     from ._memutil import allele_counts
     ac, n_valid_i = allele_counts(matrix.haplotypes)
     n_valid = n_valid_i.astype(cp.float64)
-    # Per-allele DAF: each derived allele contributes its own frequency. NOTE
-    # (issue #100): this histograms individual derived-allele frequencies (was
-    # the per-site total non-ancestral fraction), and only present derived
-    # alleles are binned (no 0-frequency spike from monomorphic sites).
+    # Per-allele DAF: each derived allele contributes its own frequency,
+    # and only present derived alleles are binned (no 0-frequency spike
+    # from monomorphic sites).
     freq = ac[:, 1:].astype(cp.float64) / cp.maximum(n_valid[:, None], 1.0)
     present = ac[:, 1:] > 0
     if missing_data == 'exclude':
@@ -1818,9 +1737,8 @@ def heterozygosity_expected(haplotype_matrix: HaplotypeMatrix,
     n = matrix.haplotypes.shape[0]
     ac_f = ac.astype(cp.float64)
 
-    # He = 1 - sum_a p_a^2 over ALL alleles (per-allele; reduces to 2p(1-p) for
-    # biallelic). The old 2p(1-p) with p = total-derived collapsed multiallelic
-    # alleles into one class (issue #100).
+    # He = 1 - sum_a p_a^2 over ALL alleles; reduces to 2p(1-p) on
+    # biallelic sites.
     if missing_data == 'include':
         p_sq = (ac_f ** 2).sum(axis=1) / cp.maximum(n_valid, 1.0) ** 2
         he = cp.where(n_valid >= 2, 1.0 - p_sq, cp.nan)

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -618,6 +618,7 @@ class GenotypeMatrix:
         )
         from ._warnings import _warn_biallelic_only
         _warn_biallelic_only(gm._n_multiallelic_recoded,
+                             action="recoded to all-missing rows",
                              context="GenotypeMatrix.from_zarr")
         if fields:
             gm.fields = read_qc_fields(

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -13,9 +13,9 @@ from .accessible import AccessibleMask, resolve_accessible_mask
 
 
 def _biallelic_and_alt(ac):
-    """Per-site biallelic mask and alt-allele index from an (n_var, K) allele-count
-    matrix (any array namespace).
+    """Per-site biallelic mask and alt-allele index from allele counts.
 
+    ``ac`` is an ``(n_var, K)`` allele-count matrix in any array namespace.
     Biallelic = at most two distinct present alleles. Allele 0 is the reference;
     ``alt`` is the highest-index present allele > 0, which the 0/1/2 dosage counts --
     code-independent, so {0,2} and reference-absent {1,2} sites work, while {0,1}
@@ -46,9 +46,9 @@ class GenotypeMatrix:
     ``from_haplotype_matrix`` keep sites with at most two distinct present
     alleles -- so {0,1}, {0,2}, and reference-absent {1,2} are all kept, with the
     dosage counting the alt allele -- and drop sites with three or more distinct
-    present alleles, emitting a ``BiallelicOnlyWarning`` with the dropped-site
-    count. For
-    multiallelic data use the allele-index ``HaplotypeMatrix``.
+    present alleles, emitting a ``BiallelicOnlyWarning`` with the
+    dropped-site count. For multiallelic data use the allele-index
+    ``HaplotypeMatrix``.
 
     Parameters
     ----------
@@ -884,23 +884,18 @@ class GenotypeMatrix:
         -------
         GenotypeMatrix
         """
-        xp = cp if self._device == 'GPU' else np
+        if self._device == 'CPU':
+            self.transfer_to_gpu()
         geno = self.genotypes
         valid = geno >= 0
-        geno_clean = xp.where(valid, geno, 0)
-        alt_counts = xp.sum(geno_clean, axis=0)
-        n_valid = xp.sum(valid, axis=0)
+        geno_clean = cp.where(valid, geno, 0)
+        alt_counts = cp.sum(geno_clean, axis=0)
+        n_valid = cp.sum(valid, axis=0)
         max_alt = 2 * n_valid
         keep = (alt_counts > 0) & (alt_counts < max_alt) & (n_valid >= 2)
-
-        if self._device == 'GPU':
-            keep_idx = cp.where(keep)[0]
-            new_geno = self.genotypes[:, keep_idx]
-            new_pos = self.positions[keep_idx]
-        else:
-            keep_np = keep if isinstance(keep, np.ndarray) else keep.get()
-            new_geno = self.genotypes[:, keep_np]
-            new_pos = self.positions[keep_np]
+        keep_idx = cp.where(keep)[0]
+        new_geno = self.genotypes[:, keep_idx]
+        new_pos = self.positions[keep_idx]
 
         return GenotypeMatrix(new_geno, new_pos,
                               self.chrom_start, self.chrom_end,

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -596,8 +596,8 @@ class HaplotypeMatrix:
             (suitable for large-scale stores that do not fit
             entirely in GPU memory). ``'always'`` forces streaming;
             ``'never'`` forces a single-shot load (and raises
-            ``MemoryError`` if the matrix would not fit in free GPU
-            memory). ``'auto'`` (default) checks the projected
+            ``MemoryError`` when the matrix would exceed half the
+            free GPU memory -- the same check ``'auto'`` uses). ``'auto'`` (default) checks the projected
             footprint of the haplotype matrix against free GPU
             memory and picks streaming when the full matrix would
             consume more than half the device. Scikit-allel-formatted

--- a/pg_gpu/moments_ld.py
+++ b/pg_gpu/moments_ld.py
@@ -48,7 +48,8 @@ def compute_ld_statistics(
 ):
     """GPU LD statistics in the moments.LD.Parsing.compute_ld_statistics output format.
 
-    Accepts the same arguments as the moments version, but restricts to biallelic
+    Accepts the same arguments as the moments version, minus ``ac_filter``:
+    this pipeline always restricts to biallelic
     segregating sites with arbitrary allele coding (two present alleles): {0,2}
     and reference-absent {1,2} sites are kept and recoded, whereas moments'
     is_biallelic_01 drops them. Results match moments only when the input is

--- a/pg_gpu/selection.py
+++ b/pg_gpu/selection.py
@@ -320,7 +320,8 @@ def nsl(haplotype_matrix: HaplotypeMatrix,
         derived allele ``j+1`` (NaN where that allele or the ancestral allele
         is absent at a site). ``standardize_by_allele_count`` takes 1-D input,
         so standardize each derived-allele column separately, pairing column
-        ``j`` with that allele's per-site derived count.
+        ``j`` with that allele's per-site derived count. A matrix with no
+        alternate allele at all gives ``(n_variants,)``, all NaN.
 
     Notes
     -----
@@ -356,9 +357,9 @@ def nsl(haplotype_matrix: HaplotypeMatrix,
         return np.full(matrix.num_variants, np.nan)
 
     # One pair-walk scores every derived allele at once -- the shared-suffix
-    # state never depends on the focal choice, so the per-allele passes this
-    # replaced were re-buying the same O(pairs x variants) traffic to change
-    # one comparison.
+    # state never depends on the focal choice, so separate per-allele passes
+    # would repeat the same O(pairs x variants) traffic to change one
+    # comparison.
     nsl0_fwd, nsla_fwd = _nsl01_scan_gpu(hap, max_focal=max_allele)
     nsl0_rev, nsla_rev = _nsl01_scan_gpu(hap[::-1], max_focal=max_allele)
     nsl0 = nsl0_fwd + nsl0_rev[::-1]
@@ -485,7 +486,9 @@ def ihs(haplotype_matrix: HaplotypeMatrix,
         derived allele ``j+1`` (NaN where that allele or the ancestral allele
         is absent, or the allele is MAF-filtered). ``standardize_by_allele_count``
         takes 1-D input, so standardize each derived-allele column separately,
-        pairing column ``j`` with that allele's per-site derived count.
+        pairing column ``j`` with that allele's per-site derived count. A
+        matrix with no alternate allele at all gives ``(n_variants,)``,
+        all NaN.
 
     Notes
     -----
@@ -538,9 +541,9 @@ def ihs(haplotype_matrix: HaplotypeMatrix,
     # Biallelic data has a single derived allele and returns a 1-D array
     # identical to the classic iHS.
     # One pair-walk scores every derived allele at once -- the shared-suffix
-    # state never depends on the focal choice, so the per-allele passes this
-    # replaced were re-buying the same O(pairs x variants) traffic to change
-    # one comparison.
+    # state never depends on the focal choice, so separate per-allele passes
+    # would repeat the same O(pairs x variants) traffic to change one
+    # comparison.
     ihh0_fwd, ihha_fwd = _ihh01_scan_hist_gpu(
         hap, gaps_gpu, ac, min_ehh, include_edges)
     ihh0_rev, ihha_rev = _ihh01_scan_hist_gpu(
@@ -549,8 +552,8 @@ def ihs(haplotype_matrix: HaplotypeMatrix,
     ihha = ihha_fwd + ihha_rev[::-1, :]
     scores = cp.log(ihha / ihh0[:, None])
 
-    # Per-allele MAF, formerly applied inside each scan pass: the focal
-    # allele's own frequency among valid haplotypes. Reduces to
+    # Per-allele MAF gate on the focal allele's own frequency among valid
+    # haplotypes. Reduces to
     # min(n0, n1)/(n0 + n1) on biallelic sites and makes a common allele
     # with index >= 2 visible to the filter.
     nv = cp.maximum(n_valid.astype(cp.float64), 1.0)

--- a/pg_gpu/sfs.py
+++ b/pg_gpu/sfs.py
@@ -21,8 +21,7 @@ def _per_allele_counts(matrix, n_alleles=None):
     K defaults to the site-local maximum allele index + 1; pass ``n_alleles``
     for a fixed/global width (e.g. to align populations for the joint SFS).
     Multiallelic-correct: each allele is counted separately. This is the sole
-    counting primitive for every SFS in this module (the old collapsed
-    ``dac_and_n`` wrappers were removed once all variants went per-allele).
+    counting primitive for every SFS in this module.
     """
     if matrix.device == 'CPU':
         matrix.transfer_to_gpu()

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -750,6 +750,10 @@ class StreamingHaplotypeMatrix(_StreamingMatrixBase):
     Returned by ``HaplotypeMatrix.from_zarr`` when the requested
     matrix does not fit eagerly on the GPU. See ``_StreamingMatrixBase``
     for the iteration / materialize / sample_sets contract.
+
+    Every statistic call walks the region from disk again, so N calls
+    cost N full passes; batch work into one pass where possible, or
+    ``materialize`` a sub-region for repeated calls on the same data.
     """
 
     @property
@@ -857,8 +861,14 @@ class StreamingGenotypeMatrix(_StreamingMatrixBase):
             m._sample_sets = sets
         if m._n_multiallelic_recoded and not self._biallelic_warned:
             from ._warnings import _warn_biallelic_only
-            _warn_biallelic_only(m._n_multiallelic_recoded,
-                                 context="GenotypeMatrix.from_zarr (streaming)")
+            # The count covers only the chunk that trips the latch; a full
+            # region count would need a whole extra pass over the store.
+            _warn_biallelic_only(
+                m._n_multiallelic_recoded,
+                context="GenotypeMatrix.from_zarr (streaming; count is for "
+                        "the first affected chunk, later chunks recode "
+                        "silently)",
+                action="recoded to all-missing rows")
             self._biallelic_warned = True
         return m
 

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -838,8 +838,6 @@ class StreamingGenotypeMatrix(_StreamingMatrixBase):
         # The pop file resolves to haplotype columns, but this stream's
         # rows are individuals. Both of a sample's gametes floor-divide to
         # its individual, so the unique halves are the individual rows.
-        # Before this mapping the chunks carried haplotype-numbered sets
-        # that indexed past the individual axis.
         return {p: np.unique(np.asarray(cols) // 2)
                 for p, cols in pop_cols.items()}
 

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -63,8 +63,7 @@ CANONICAL_WINDOW_PREFIX = (
     'chrom', 'start', 'end', 'center', 'n_variants', 'window_id')
 
 # Number of bins in the windowed daf_hist feature (columns daf_bin_0 ..
-# daf_bin_{_DAF_N_BINS - 1}) emitted by the fused engine. Fixed for now; making
-# it a caller parameter is deferred.
+# daf_bin_{_DAF_N_BINS - 1}) emitted by the fused engine.
 _DAF_N_BINS = 20
 
 
@@ -2025,7 +2024,6 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
 
     hap_raw = matrix.haplotypes
     n_hap = hap_raw.shape[0]
-    n_total_var = hap_raw.shape[1]
     # transpose for coalesced kernel access: (n_total_var, n_hap)
     hap = cp.ascontiguousarray(hap_raw.T.astype(cp.int8))
 
@@ -2285,7 +2283,7 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
 
     if 'mean_nsl' in statistics:
         from . import selection as sel
-        # matrix is already population-subsetted (line 1533); don't re-subset.
+        # matrix is already population-subsetted upstream; don't re-subset.
         # nSL is scanned once over this whole (eager) matrix, so each per-site
         # score sees the full region before being binned into windows. Over a
         # StreamingHaplotypeMatrix this runs per chunk, truncating the scan at
@@ -3322,9 +3320,9 @@ def windowed_statistics(haplotype_matrix: HaplotypeMatrix,
         results['segregating_sites'] = seg_count.get().astype(int)
 
     if 'singletons' in statistics:
-        # Per-allele: derived alleles observed exactly once (unfolded, ==
-        # scalar singleton_count). The old (dac==1)|(dac==n-1) also counted
-        # ancestral-allele singletons (folded).
+        # Per-allele: derived alleles observed exactly once, matching the
+        # unfolded scalar singleton_count; ancestral-allele singletons do
+        # not count.
         n_sing = ((derived == 1).sum(axis=1) if derived.shape[1]
                   else cp.zeros(ac.shape[0], dtype=cp.int64))
         sing = cp.where(has_data, n_sing, 0).astype(cp.float64)
@@ -3342,8 +3340,7 @@ def windowed_statistics(haplotype_matrix: HaplotypeMatrix,
 
     if 'tajimas_d' in statistics:
         # numerator = pi - theta_w (per-allele sums); Achaz (2009) variance from
-        # a single n_hap and mutation-count S, matching the scatter engine. (The
-        # effective-n-under-missing-data question is tracked separately.)
+        # a single n_hap and mutation-count S, matching the scatter engine.
         pi_sum_td = _scatter_sum(pi_contrib, bin_idx, n_windows)
         watt_sum_td = _scatter_sum(watt_contrib, bin_idx, n_windows)
         S = seg_count.get()

--- a/tests/test_biallelic_only_warning.py
+++ b/tests/test_biallelic_only_warning.py
@@ -63,12 +63,12 @@ def test_is_userwarning_subclass():
 
 
 def test_helper_warns_with_count_and_context():
-    with pytest.warns(BiallelicOnlyWarning, match=r"foo\.bar .*dropped 3 multiallelic"):
+    with pytest.warns(BiallelicOnlyWarning, match=r"foo\.bar .*3 multiallelic site\(s\) dropped"):
         _warn_biallelic_only(3, context="foo.bar")
 
 
 def test_helper_accepts_numpy_scalar_count():
-    with pytest.warns(BiallelicOnlyWarning, match="dropped 7 multiallelic"):
+    with pytest.warns(BiallelicOnlyWarning, match="7 multiallelic site.s. dropped"):
         _warn_biallelic_only(np.int64(7), context="ctx")
 
 
@@ -92,7 +92,7 @@ class TestFromVcfWarns:
             "1\t200\t.\tA\tT,G\t.\tPASS\t.\tGT\t2|1\t0|0",   # triallelic -> dropped
             "1\t300\t.\tA\tT\t.\tPASS\t.\tGT\t0|1\t1|0",     # biallelic
         ])
-        with pytest.warns(BiallelicOnlyWarning, match="dropped 1 multiallelic"):
+        with pytest.warns(BiallelicOnlyWarning, match="1 multiallelic site.s. dropped"):
             gm = GenotypeMatrix.from_vcf(vcf)
         assert gm.num_variants == 2   # the multiallelic site is dropped
 
@@ -117,7 +117,7 @@ class TestFromVcfWarns:
             "1\t400\t.\tA\tT\t.\tPASS\t.\tGT\t0|0\t0|0",       # mono {0} -> 0, 0
             "1\t500\t.\tA\tT,G\t.\tPASS\t.\tGT\t0|1\t2|0",     # {0,1,2} -> dropped
         ])
-        with pytest.warns(BiallelicOnlyWarning, match="dropped 1 multiallelic"):
+        with pytest.warns(BiallelicOnlyWarning, match="1 multiallelic site.s. dropped"):
             gm = GenotypeMatrix.from_vcf(vcf)
         assert gm.num_variants == 4
         np.testing.assert_array_equal(_host(gm.positions), [100, 200, 300, 400])
@@ -135,7 +135,7 @@ class TestFromHaplotypeMatrixWarns:
                         [0, 2, 0],
                         [1, 0, 0]], dtype=np.int8)
         hm = HaplotypeMatrix(hap, np.array([100, 200, 300]), 0, 400)
-        with pytest.warns(BiallelicOnlyWarning, match="dropped 1 multiallelic"):
+        with pytest.warns(BiallelicOnlyWarning, match="1 multiallelic site.s. dropped"):
             gm = GenotypeMatrix.from_haplotype_matrix(hm)
         assert gm.num_variants == 2
         # paired sums of the two retained {0,1} sites; no bogus >2 dosage
@@ -240,7 +240,7 @@ class TestPattersonDWarns:
             [0, 1, 2, 0, 1, 0, 1, 0],   # triallelic (0,1,2) -> dropped
             [1, 0, 1, 0, 1, 0, 1, 0],   # biallelic
         ])
-        with pytest.warns(BiallelicOnlyWarning, match="dropped 1 multiallelic"):
+        with pytest.warns(BiallelicOnlyWarning, match="1 multiallelic site.s. dropped"):
             admixture.patterson_d(hm, "A", "B", "C", "D")
 
     def test_no_warn_when_biallelic(self):
@@ -267,4 +267,4 @@ class TestPattersonDWarns:
             admixture.moving_patterson_d(hm, "A", "B", "C", "D", size=2)
         bo = [w for w in rec if issubclass(w.category, BiallelicOnlyWarning)]
         assert len(bo) == 1
-        assert "dropped 2 multiallelic" in str(bo[0].message)
+        assert "2 multiallelic site(s) dropped" in str(bo[0].message)

--- a/tests/test_loader_parity.py
+++ b/tests/test_loader_parity.py
@@ -133,10 +133,12 @@ class TestMultiallelicParity:
         path = str(tmp_path / "m.vcz.zarr")
         write_vcz(path, _MULTI_CG, _MULTI_POS, samples=_SAMPLES, contig_name="1")
 
-        with pytest.warns(BiallelicOnlyWarning, match="dropped 1 multiallelic"):
+        with pytest.warns(BiallelicOnlyWarning,
+                          match="1 multiallelic site.s. recoded"):
             eager = GenotypeMatrix.from_zarr(path, streaming="never")
         streaming = GenotypeMatrix.from_zarr(path, streaming="always")
-        with pytest.warns(BiallelicOnlyWarning, match="dropped 1 multiallelic"):
+        with pytest.warns(BiallelicOnlyWarning,
+                          match="first affected chunk"):
             strm = streaming.materialize()
 
         np.testing.assert_array_equal(_host(eager.genotypes), expected)
@@ -148,7 +150,8 @@ class TestMultiallelicParity:
     def test_from_vcf_drops_the_site(self, tmp_path):
         vcf = _write_vcf_from_cg(
             tmp_path / "m.vcf", _MULTI_CG, _MULTI_POS, _SAMPLES)
-        with pytest.warns(BiallelicOnlyWarning, match="dropped 1 multiallelic"):
+        with pytest.warns(BiallelicOnlyWarning,
+                          match="1 multiallelic site.s. dropped"):
             from_vcf = GenotypeMatrix.from_vcf(vcf)
         # from_vcf drops the multiallelic site entirely (5 kept, not 6)...
         assert from_vcf.num_variants == 5

--- a/tests/test_local_pca_parity.py
+++ b/tests/test_local_pca_parity.py
@@ -46,13 +46,16 @@ CORNERS_PATH = DATA_DIR / "lostruct_reference_corners.json"
 # centering) that shifts the eigenvalue scale and perturbs eigenvector VALUES at
 # the ~1e-3 level; the top-k eigenvector DIRECTIONS still match R to |corr| >~
 # 0.999 (see test_parity_eigenvectors_subspace_corr, which is kept live). The
-# bit-tight value/scale pins below are xfailed pending a decision in review on
-# whether to keep the all-allele lostruct or restore strict R-lostruct parity.
+# bit-tight value/scale pins below are xfailed: they compare against frozen R
+# references generated under R-lostruct's binary standardization, which the
+# all-allele form cannot reproduce bit-tight.
 _R_PARITY_XFAIL = pytest.mark.xfail(
-    reason="lostruct moved to the all-allele centered (tskit) standardization; "
-           "the frozen R references match in subspace but not in eigenvalue "
-           "scale / bit-tight eigenvector values. Revisit in review.",
-    strict=False,
+    reason="lostruct uses the all-allele centered (tskit) standardization; "
+           "the frozen R references agree in subspace (corr > 0.999) but "
+           "not in eigenvalue scale or bit-tight eigenvector values, and "
+           "will not until they are regenerated for the new "
+           "standardization.",
+    strict=True,
 )
 
 
@@ -172,7 +175,6 @@ def test_parity_eigenvectors_sign_aligned(pg_local_pca_result):
 # conventions are nearly orthogonal (|corr| ~ 0.1), a genuine divergence rather
 # than a scale/noise artifact. For genealogical structure (e.g. a simulated
 # sweep) the two agree to |corr| ~ 1; the divergence is structure-type-dependent.
-# See the PR discussion.
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The full-diff read of #184 flagged stranded code, comments that narrate project history instead of stating invariants, and a set of small hygiene defects. This applies the survivors.

## Dead code (first commit)

`_site_contribution` and `_prepare_dac` lost their last caller when scalar diversity moved to `_ac_contribution` (the docstring claiming `windowed_analysis` still imports it was false at tip). Transitively dead and removed: `dac_and_n`, its kernel and `chunked_dac_and_n` alias, `chunked_sum_int32`, and `chunked_matmul_accumulate` (no callers on main or trunk). Stale references in the `allele_counts` docstring and SFS weight comment rewritten.

## Comments and docstrings (second commit)

Sixteen sites that referenced replaced code, prior behavior, issue numbers, or deferred plans now state what the code does. The R-parity xfail reason is standalone and `strict=True` (verified: all eight fail deterministically). Three mid-clause docstring wraps fixed. `ihs`/`nsl` document the all-NaN no-alternate-allele return; `moments_ld` no longer claims full argument parity with moments; randomized PCA documents the `n_iter` accuracy trade.

## Code fixes

- Randomized PCA uses a local `cp.random.RandomState` instead of reseeding the process-global generator, so a seeded PCA no longer perturbs later `cp.random` draws. Same-seed outputs change (different draw path), determinism is unchanged.
- `GenotypeMatrix.restrict_to_segregating` forces GPU transfer like every other filter, dropping its numpy branch.
- Dead `n_total_var` assignment in the fused windowed setup removed.
- `debug/stress_test_ag1000g.py` calls current API (`sfs.sfs`, `randomized_pca` without `scaler`); its two pre-existing `allel` lint errors are untouched (out of lint scope).

## Deliberately skipped

- The duplicated fused allele-cap filter (helper + inline copy): refactoring the hot dispatch path is not worth the risk this week; the helper's docstring documents the duplication.
- Function-local `allele_counts` imports (24 sites, 11 files): pure churn, no behavior.
- Promoting `BiallelicOnlyWarning` to a CI error: measured blast radius is 28 failing tests needing per-site judgment; better as its own pass.
- The `.gitignore`-vs-tracked-files question (`.claude/`, `plans/`, `debug/`): policy call, surfaced separately.

## Verification

Full default suite: 1314 passed, 0 failed, 25 xfailed (the 8 parity tests still xfail under strict). Ruff clean on the standard scope.