### PR TITLE
Accumulate the pca Gram over variant chunks at any size

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -111,6 +111,9 @@ Read this section if you are comparing against older pg_gpu results.
   ``pca_dosage`` / ``randomized_pca_dosage``, which take a
   ``GenotypeMatrix``. The ``scaler`` argument is gone, and each
   function raises a ``TypeError`` on the wrong matrix type.
+  ``pca`` accumulates its Gram over variant chunks when the standardized
+  matrix would not fit in GPU memory, so the exact decomposition runs at
+  any matrix size.
   ``local_pca`` and ``lostruct`` changed the same way. They no longer
   match the R ``lostruct`` package number for number -- the eigenvalue
   scale differs -- though the component directions still agree closely,

--- a/pg_gpu/decomposition.py
+++ b/pg_gpu/decomposition.py
@@ -12,7 +12,10 @@ import numpy as np
 import cupy as cp
 import pandas as pd
 
+from cupy import cublas
+
 from .haplotype_matrix import HaplotypeMatrix
+from ._memutil import allele_counts, estimate_variant_chunk_size
 from ._utils import get_population_matrix as _get_population_matrix
 
 _GPU_MEM_BUDGET = 0.3
@@ -35,14 +38,35 @@ def _prepare_centered(haplotype_matrix, population=None, missing_data='include',
     False the count is not computed (returned as 0), avoiding its host sync on the
     per-window path (local PCA normalizes by ncol, not segregating sites).
     """
-    from ._memutil import allele_counts
+    hap, K = _gpu_hap(haplotype_matrix, population, n_alleles)
+    return _centered_block(hap, missing_data, K, need_segregating)
 
+
+def _gpu_hap(haplotype_matrix, population=None, n_alleles=None):
+    """Population-subset, move to the GPU, and resolve the allele width K.
+
+    ``n_alleles`` hoists K when the caller already knows it, avoiding the
+    per-call ``hap.max()`` host sync.
+    """
     matrix = (_get_population_matrix(haplotype_matrix, population)
               if population is not None else haplotype_matrix)
     if matrix.device == 'CPU':
         matrix.transfer_to_gpu()
-
     hap = matrix.haplotypes
+    if n_alleles is not None:
+        K = int(n_alleles)
+    else:
+        K = int(hap.max()) + 1 if hap.size else 1
+    return hap, K
+
+
+def _centered_block(hap, missing_data, K, need_segregating=True):
+    """Standardized block for one GPU variant slice; see _prepare_centered.
+
+    Every step is per-site (allele counts, centering, the missing-complete
+    filter, the segregating count), so slicing the variant axis and summing
+    the per-slice Grams reproduces the whole-matrix Gram exactly.
+    """
     n_samples, n_var = hap.shape
     if missing_data == 'exclude' and n_var:
         complete = cp.sum(hap >= 0, axis=0) == n_samples
@@ -51,10 +75,6 @@ def _prepare_centered(haplotype_matrix, population=None, missing_data='include',
     if hap.shape[1] == 0:
         return cp.zeros((n_samples, 0), dtype=cp.float64), 0
 
-    if n_alleles is not None:
-        K = int(n_alleles)                             # hoisted (avoids a per-call max sync)
-    else:
-        K = int(hap.max()) + 1 if hap.size else 1
     ac, n_valid = allele_counts(hap, n_alleles=K)     # (n_var, K), (n_var,)
     pairs = cp.argwhere(ac > 0)                        # present (site, allele), all alleles
     if pairs.shape[0] == 0:
@@ -74,6 +94,31 @@ def _prepare_centered(haplotype_matrix, population=None, missing_data='include',
     else:
         n_segregating = 0
     return X, n_segregating
+
+
+def _centered_gram_chunked(hap, missing_data, K, chunk_vars):
+    """Accumulate the centered Gram X @ X.T over variant chunks.
+
+    Never materializes the full standardized matrix: each chunk builds its
+    own (n_samples, chunk_cols) block and rank-k-updates the accumulator
+    with cublas syrk, which computes only the LOWER triangle (half the
+    flops of a full product; the upper triangle stays zero, which is the
+    triangle ``eigh`` reads). Returns (C, n_segregating, n_cols); the
+    chunk summation order differs from a dense product, so C matches it
+    to float accumulation error, not bit for bit.
+    """
+    n_samples, n_var = hap.shape
+    C = cp.zeros((n_samples, n_samples), dtype=cp.float64)
+    n_segregating = 0
+    n_cols = 0
+    for start in range(0, n_var, chunk_vars):
+        Xc, seg = _centered_block(
+            hap[:, start:start + chunk_vars], missing_data, K)
+        if Xc.shape[1]:
+            cublas.syrk('N', Xc, out=C, alpha=1.0, beta=1.0, lower=True)
+        n_segregating += seg
+        n_cols += Xc.shape[1]
+    return C, n_segregating, n_cols
 
 
 def _pca_from_gram(C, n_samples, n_components):
@@ -103,7 +148,9 @@ def pca(haplotype_matrix: HaplotypeMatrix,
     centered by its allele frequency with no variance scaling, and the
     sample-by-sample Gram X @ X.T is normalized by the number of segregating
     sites. Every haplotype is treated as its own sample, so this is
-    multiallelic-correct at any ploidy. For the diploid dosage PCA standardized by
+    multiallelic-correct at any ploidy. When the standardized matrix would
+    not fit in GPU memory, the Gram is accumulated over variant chunks
+    instead, so exact PCA runs at any matrix size. For the diploid dosage PCA standardized by
     binomial variance, use pca_dosage on a GenotypeMatrix.
 
     Parameters
@@ -132,11 +179,19 @@ def pca(haplotype_matrix: HaplotypeMatrix,
             "for the diploid dosage PCA standardized by binomial variance use "
             "pca_dosage on a GenotypeMatrix.")
 
-    X, n_segregating = _prepare_centered(haplotype_matrix, population, missing_data)
-    n_samples, n_cols = X.shape
-    n_components = min(n_components, n_samples, max(n_cols, 1))
+    hap, K = _gpu_hap(haplotype_matrix, population)
+    n_samples, n_var = hap.shape
 
-    C = X @ X.T
+    # One code path at any size: the accumulator sized by the shared
+    # chunk estimator degenerates to a single iteration when memory is
+    # ample. The standardization keeps ~3 float64 arrays of block size
+    # alive at peak, and K bounds the per-variant column expansion
+    # (at most K present alleles per site).
+    chunk_vars = estimate_variant_chunk_size(
+        n_samples, bytes_per_element=8, n_intermediates=3 * K)
+    C, n_segregating, n_cols = _centered_gram_chunked(
+        hap, missing_data, K, chunk_vars)
+    n_components = min(n_components, n_samples, max(n_cols, 1))
     if n_segregating > 0:
         C = C / n_segregating
     return _pca_from_gram(C, n_samples, n_components)

--- a/tests/test_decomposition_multiallelic.py
+++ b/tests/test_decomposition_multiallelic.py
@@ -139,3 +139,57 @@ class TestLocalPCAMultiallelic:
                                  window_size=3000, step_size=3000)
         valid = res.windows['n_variants'].values >= 6
         assert np.isfinite(se[valid]).all()
+
+
+class TestChunkedGram:
+    """The chunked Gram accumulator must reproduce the dense standardized
+    product: same per-site math on variant slices, summed. syrk fills the
+    lower triangle only, so comparisons symmetrize first."""
+
+    def _hap(self, seed=23, n_hap=30, n_var=61):
+        rng = np.random.default_rng(seed)
+        hap = rng.integers(0, 2, (n_hap, n_var), dtype=np.int8)
+        tri = rng.choice(n_var, 8, replace=False)
+        for j in tri:
+            carriers = np.where(hap[:, j] == 1)[0]
+            hap[carriers[: carriers.size // 2], j] = 2
+        miss = rng.random((n_hap, n_var)) < 0.05
+        hap[miss] = -1
+        hap[:, 11] = 0            # monomorphic site
+        hap[:, 17] = -1           # fully missing site
+        return cp.asarray(hap)
+
+    @pytest.mark.parametrize("missing_data", ["include", "exclude"])
+    @pytest.mark.parametrize("chunk_vars", [1, 7, 61])
+    def test_matches_dense(self, missing_data, chunk_vars):
+        from pg_gpu.decomposition import _centered_block, _centered_gram_chunked
+        hap = self._hap()
+        K = int(hap.max()) + 1
+        X, seg_dense = _centered_block(hap, missing_data, K)
+        C_dense = (X @ X.T).get()
+        C, seg, n_cols = _centered_gram_chunked(hap, missing_data, K, chunk_vars)
+        assert seg == seg_dense
+        assert n_cols == X.shape[1]
+        low = np.tril(C.get())
+        np.testing.assert_allclose(low + np.tril(low, -1).T, C_dense,
+                                   rtol=1e-10, atol=1e-10)
+
+    def test_pca_multichunk_matches_single_chunk(self, monkeypatch):
+        from pg_gpu import HaplotypeMatrix, decomposition
+        hap = self._hap(seed=5)
+        n_hap, n_var = hap.shape
+        pos = np.arange(1, n_var + 1, dtype=np.int64) * 50
+        hm = HaplotypeMatrix(hap, cp.asarray(pos))
+        coords_one, ratio_one = decomposition.pca(hm, n_components=5)
+        monkeypatch.setattr(decomposition, "estimate_variant_chunk_size",
+                            lambda *a, **k: 7)
+        coords_multi, ratio_multi = decomposition.pca(hm, n_components=5)
+        for j in range(coords_one.shape[1]):
+            k = np.argmax(np.abs(coords_one[:, j]))
+            if np.sign(coords_one[k, j]) != np.sign(coords_multi[k, j]):
+                coords_multi[:, j] = -coords_multi[:, j]
+        np.testing.assert_allclose(coords_multi, coords_one,
+                                   rtol=1e-8, atol=1e-8)
+        np.testing.assert_allclose(np.asarray(ratio_multi),
+                                   np.asarray(ratio_one),
+                                   rtol=1e-10, atol=1e-12)


### PR DESCRIPTION
Closes #221.

## Summary

The tskit-PCA migration deleted the memory-constrained PCA path (#221 has the history), so `pca` materialized the standardized matrix -- one float64 column per present (site, allele) pair -- and real chromosome arms (~600 GB in that layout for ag1000g X) died with a raw CuPy OutOfMemoryError. This restores exact PCA at any matrix size before #184 reaches main.

## Design

The standardization is per-site (allele counts, centering, the missing-complete filter, the segregating count), so slicing the variant axis and summing per-slice Gram updates reproduces the whole-matrix Gram. `pca` now always runs one chunked accumulation:

- `_centered_block` is the array-level core of the existing `_prepare_centered`, which keeps its exact signature for `randomized_pca` and `local_pca` (shared `_gpu_hap` prologue).
- Chunks are sized by the shared `_memutil.estimate_variant_chunk_size` -- the same estimator every other Gram loop uses -- with `3*K` intermediates so the per-variant column expansion cannot overshoot memory. With ample memory the loop is a single iteration.
- Each chunk rank-k-updates the accumulator with `cublas.syrk` (`beta=1`, lower triangle): half the flops of a full product, and `eigh` reads exactly that triangle.

A four-angle review pass shaped this: the first draft gated dense-vs-chunked on a footprint probe; three reviewers independently converged on deleting the gate (the single-iteration loop IS the dense path), and the fourth measured the syrk win (69.5 vs 122.6 ms per chunk on an A100). Routing through `relatedness.genetic_relatedness` was considered and rejected: its missing-data conventions differ from pca's impute-to-frequency, so a shared accumulator would change results.

## Verification

- Chunked-vs-dense equality tests across chunk sizes 1/7/61, both missing modes, with multiallelic, monomorphic, and fully-missing sites; a public-path test forces multi-chunk pca via the estimator and matches single-chunk to 1e-8.
- Real data (ag1000g X): 167k variants, forced chunking vs dispatched dense agree at 9.4e-13 (ratios 2.6e-14); 4.66M variants decompose in 7.3 s inside a 13.7 GB pool with sane leading ratios (7.2%, 3.6%).
- Full default suite: 1339 passed, 0 failed -- the syrk numerics hold against every existing pca pin. Ruff clean.

Streaming input and `randomized_pca` at scale are unchanged (pre-existing behavior); the `_centered_block` split makes both natural follow-ups, noted in #221.