### PR TITLE
Teach the multiallelic ihs shape in the examples selection pipeline

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -138,13 +138,11 @@ Selection Scan Pipeline
 
    from pg_gpu import selection
 
-   # iHS with standardization by allele count
-   ihs_raw = selection.ihs(h)
-
-   # Derived-allele count per site: number of haplotypes carrying the alt
-   # allele. Counting carriers (rather than summing codes) is correct whether
-   # a site is coded {0,1} or {0,2}, and ignores missing (-1).
-   dac = np.sum(h.haplotypes.get() > 0, axis=0)
+   # Restrict to sites with two alleles in the sample, scan, then
+   # standardize the scores by each site's derived-allele count.
+   h_bi = h.restrict_to_biallelic()
+   ihs_raw = selection.ihs(h_bi)
+   dac = np.sum(h_bi.haplotypes.get() > 0, axis=0)
    ihs_std, bins = selection.standardize_by_allele_count(ihs_raw, dac)
 
    # Cross-population scans


### PR DESCRIPTION
Closes #197 (close manually at merge; trunk merges do not auto-fire).

## Summary

`examples.rst`'s selection pipeline passed `ihs` output straight into `standardize_by_allele_count`, which takes 1-D scores. On any matrix with an allele code above 1, `ihs` returns `(n_variants, K-1)` and the recipe raised `IndexError` -- the docs audit's only unfixed HIGH finding, and the last user-facing defect in the tree #184 ships.

The example now restricts to biallelic sites before the scan and keeps to the plain workflow: one imperative comment and four lines. The shape rule and the per-column recipe stay in the quickstart, the ihs docstring, and the skill file, where readers who need them look.

## Verification

Executed the corrected block on both inputs from the audit's repro: biallelic gives `ihs_raw(500,) -> ihs_std(500,)`; the multiallelic case that raised `IndexError` now drops its 60 triallelic sites and completes as a 440-site 1-D scan. `test_doc_examples.py` passes; full sphinx build clean; ruff clean.
