### PR TITLE
Make region strings end-inclusive, as in samtools

### DIFF
--- a/.claude/SKILL.md
+++ b/.claude/SKILL.md
@@ -58,7 +58,7 @@ set it for analysis runs.
 # Basic load
 h = HaplotypeMatrix.from_vcf("data.vcf.gz")
 
-# Specific region (requires .tbi index)
+# Specific region; both ends inclusive, as in samtools (requires .tbi index)
 h = HaplotypeMatrix.from_vcf("data.vcf.gz", region="chr1:1000000-2000000")
 
 # Subset of samples

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -57,6 +57,8 @@ diploid genotypes; haploid and polyploid stores are rejected.
    :members: iter_chunks
    :show-inheritance:
 
+.. autofunction:: pg_gpu.zarr_io.parse_region
+
 .. autofunction:: pg_gpu.zarr_io.allel_zarr_to_vcz
 
 Warnings

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -80,7 +80,10 @@ Read this section if you are comparing against older pg_gpu results.
   ``materialize(region=(left, right))`` tuple and windowed analysis
   are unchanged: those intervals stay half-open, and
   ``pg_gpu.zarr_io.parse_region`` turns a region string into that
-  half-open form.
+  half-open form. Every loader also takes the other samtools forms now:
+  ``'X'`` selects a whole chromosome from a multi-contig store,
+  ``'X:1000'`` runs from a position to the chromosome end, and
+  thousands separators (``'X:1,000-2,000'``) are allowed.
 * Row lists are validated at assignment and at resolution: assigning
   ``sample_sets`` and passing a row list as a population argument both
   raise ``ValueError`` for out-of-range or duplicated rows instead of

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -71,6 +71,16 @@ Read this section if you are comparing against older pg_gpu results.
   ``sample_sets`` built by ``load_pop_file`` now lists ``2i`` and
   ``2i + 1`` for each member, and hand-written index lists that assumed
   the previous order need updating.
+* Region strings now include their end position, matching samtools,
+  tabix, and bcftools: ``region='X:1-1000000'`` keeps a variant at
+  1,000,000, and ``'X:500-500'`` names one position. The zarr loaders,
+  ``ZarrGenotypeSource``, and ``allel_zarr_to_vcz`` used to stop one
+  base short, so a variant on the window edge went missing;
+  ``from_vcf`` reads through tabix and was already inclusive. The
+  ``materialize(region=(left, right))`` tuple and windowed analysis
+  are unchanged: those intervals stay half-open, and
+  ``pg_gpu.zarr_io.parse_region`` turns a region string into that
+  half-open form.
 * Row lists are validated at assignment and at resolution: assigning
   ``sample_sets`` and passing a row list as a population argument both
   raise ``ValueError`` for out-of-range or duplicated rows instead of

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -23,7 +23,8 @@ use ``GenotypeMatrix`` (see "Phased to Unphased" below).
    # are loaded as 2*n_samples haplotypes -- treated as phased.
    h = HaplotypeMatrix.from_vcf("data.vcf.gz")
 
-   # Load a specific genomic region (requires tabix index)
+   # Load a region; both ends are inclusive, as in samtools
+   # (requires tabix index)
    h = HaplotypeMatrix.from_vcf("data.vcf.gz", region="chr1:1000000-2000000")
 
    # Load a subset of samples

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -83,6 +83,7 @@ as well as legacy scikit-allel zarr stores. The format is auto-detected on read.
 
    # Chromosome-grouped stores (e.g., Ag1000G) require a region
    h = HaplotypeMatrix.from_zarr("ag1000g.zarr", region="3L:1-10000000")
+   h = HaplotypeMatrix.from_zarr("ag1000g.zarr", region="3L")  # whole chromosome
 
 **Quick save/reload** (for intermediate results):
 

--- a/docs/source/workflows.rst
+++ b/docs/source/workflows.rst
@@ -64,7 +64,8 @@ The ``--pop-file`` argument expects a tab-delimited file with columns
 Arguments:
 
 * ``input`` -- VCF (``.vcf``, ``.vcf.gz``, ``.bcf``) or zarr store.
-* ``--region`` -- chromosome or ``chrom:start-end``.
+* ``--region`` -- chromosome or ``chrom:start-end``, both ends inclusive
+  as in samtools.
 * ``--pop-file`` -- tab-delimited (sample, pop). Optional.
 * ``--accessible-bed`` -- BED file of accessible regions. Optional.
 * ``--window-size`` -- bp window size (default: 100,000).

--- a/examples/biobank_streaming_scan.py
+++ b/examples/biobank_streaming_scan.py
@@ -51,6 +51,7 @@ import numpy as np
 import pandas as pd
 
 from pg_gpu import HaplotypeMatrix, sfs, windowed_analysis
+from pg_gpu.zarr_io import parse_region
 
 # Per-window diversity / divergence scales: every bp here must divide
 # the streaming chunk_bp, otherwise the per-chunk windowed_analysis
@@ -78,7 +79,7 @@ def parse_args():
                         "of every window size (default 1 Mb, which "
                         "covers the 10 kb / 100 kb / 1 Mb scales).")
     p.add_argument("--heatmap-region", default=None,
-                   help="region 'start-end' bp to materialize for the "
+                   help="region 'start-end' bp (inclusive ends) to materialize for the "
                         "pairwise-r^2 heatmap (default: 1 Mb at chrom "
                         "midpoint)")
     p.add_argument("--heatmap-subsample", type=int, default=5_000,
@@ -210,7 +211,7 @@ def main():
     # simultaneously, so we materialize it eagerly with a haplotype
     # subsample from one pop.
     if args.heatmap_region:
-        lo, hi = (int(x) for x in args.heatmap_region.split("-"))
+        _, lo, hi = parse_region(args.heatmap_region)
     else:
         mid = stream.chrom_start + chrom_len // 2
         lo, hi = mid - 500_000, mid + 500_000

--- a/examples/biobank_streaming_scan.py
+++ b/examples/biobank_streaming_scan.py
@@ -212,6 +212,9 @@ def main():
     # subsample from one pop.
     if args.heatmap_region:
         _, lo, hi = parse_region(args.heatmap_region)
+        if lo is None or hi is None:
+            raise SystemExit("--heatmap-region needs both bounds, e.g. "
+                             "'1000000-2000000'")
     else:
         mid = stream.chrom_start + chrom_len // 2
         lo, hi = mid - 500_000, mid + 500_000

--- a/pg_gpu/_warnings.py
+++ b/pg_gpu/_warnings.py
@@ -301,12 +301,12 @@ def _region_span_bp(region):
     that VCF loading is the right tool even on a large file."""
     if region is None:
         return 0
-    from .zarr_io import _parse_region
+    from .zarr_io import parse_region
     try:
-        _, start, end = _parse_region(region)
+        _, start, stop = parse_region(region)
     except (ValueError, AttributeError, TypeError):
         return 0
-    return max(0, end - start)
+    return max(0, stop - start)
 
 
 def _format_warning_text(path, size_bytes, n_samples):

--- a/pg_gpu/_warnings.py
+++ b/pg_gpu/_warnings.py
@@ -296,9 +296,11 @@ def _vcf_header_sample_count(path):
 
 
 def _region_span_bp(region):
-    """Width of a ``'chrom:start-end'`` string in bp, or 0 on a parse
-    failure. Used to decide whether a region argument is small enough
-    that VCF loading is the right tool even on a large file."""
+    """Width of a region string in bp: 0 when there is no region or it
+    does not parse, ``inf`` when it leaves a bound open (a whole
+    chromosome is not a small read). Used to decide whether a region
+    argument is small enough that VCF loading is the right tool even on
+    a large file."""
     if region is None:
         return 0
     from .zarr_io import parse_region
@@ -306,6 +308,8 @@ def _region_span_bp(region):
         _, start, stop = parse_region(region)
     except (ValueError, AttributeError, TypeError):
         return 0
+    if start is None or stop is None:
+        return float('inf')
     return max(0, stop - start)
 
 

--- a/pg_gpu/accessible.py
+++ b/pg_gpu/accessible.py
@@ -6,6 +6,8 @@ boolean array with offset-aware, O(1) range queries via prefix sums.
 
 import numpy as np
 
+from .zarr_io import parse_region
+
 
 class AccessibleMask:
     """Dense boolean mask over genomic coordinates with fast range queries.
@@ -265,7 +267,8 @@ def resolve_streaming_accessible_mask(accessible_bed, source, region=None):
     source : ZarrGenotypeSource
         Streaming source; supplies ``mappable_lo``/``mappable_hi``/``chrom``.
     region : str, optional
-        ``"chrom:start-end"`` region string; its contig overrides
+        ``"chrom:start-end"`` region string (both ends inclusive, as in
+        samtools); its contig overrides
         ``source.chrom`` for matching a BED file's contig name.
 
     Returns
@@ -274,6 +277,6 @@ def resolve_streaming_accessible_mask(accessible_bed, source, region=None):
     """
     if accessible_bed is None:
         return None
-    chrom = region.split(':')[0] if region else source.chrom
+    chrom = (parse_region(region)[0] if region else None) or source.chrom
     return resolve_accessible_mask(
         accessible_bed, source.mappable_lo, source.mappable_hi - 1, chrom)

--- a/pg_gpu/accessible.py
+++ b/pg_gpu/accessible.py
@@ -277,6 +277,6 @@ def resolve_streaming_accessible_mask(accessible_bed, source, region=None):
     """
     if accessible_bed is None:
         return None
-    chrom = (parse_region(region)[0] if region else None) or source.chrom
+    chrom = parse_region(region)[0] or source.chrom
     return resolve_accessible_mask(
         accessible_bed, source.mappable_lo, source.mappable_hi - 1, chrom)

--- a/pg_gpu/genotype_matrix.py
+++ b/pg_gpu/genotype_matrix.py
@@ -10,6 +10,7 @@ import cupy as cp
 from typing import Optional
 
 from .accessible import AccessibleMask, resolve_accessible_mask
+from .zarr_io import parse_region
 
 
 def _biallelic_and_alt(ac):
@@ -607,7 +608,7 @@ class GenotypeMatrix:
                                source=f"zarr store '{path}'")
 
         n_total_sites = gt.shape[0] if include_invariant else None
-        chrom = region.split(':')[0] if region else None
+        chrom = parse_region(region)[0]
 
         gm = build_genotype_matrix(
             gt, positions,

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -471,8 +471,9 @@ class HaplotypeMatrix:
         path : str
             Path to VCF/BCF file (optionally gzipped + tabix-indexed).
         region : str, optional
-            Genomic region to load, e.g. 'chr1:1000000-2000000'.
-            Requires the VCF to be bgzipped and tabix-indexed.
+            Genomic region to load, e.g. 'chr1:1000000-2000000'. Both
+            ends are inclusive, as in samtools. Requires the VCF to be
+            bgzipped and tabix-indexed.
         samples : list of str, optional
             Subset of samples to load. If None, loads all samples.
         include_invariant : bool
@@ -571,7 +572,8 @@ class HaplotypeMatrix:
         path : str
             Path to Zarr store directory.
         region : str, optional
-            Genomic region 'chrom:start-end' to load a subset.
+            Genomic region 'chrom:start-end' to load a subset. Both
+            ends are inclusive, as in samtools.
         accessible_bed : str, optional
             Path to a BED file defining accessible/callable regions.
         pop_assignment : str, numpy.ndarray, list, dict, or False, optional

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -6,6 +6,7 @@ import warnings
 from collections import Counter, OrderedDict
 
 from .accessible import AccessibleMask, bed_to_mask, resolve_accessible_mask
+from .zarr_io import parse_region
 
 
 def _classify_vcf_qc_tags(path, tags):
@@ -85,6 +86,23 @@ def _resolve_qc_fields_vcf(callset, tag_to_path, unknown):
 #: for the haplotype matrix plus the working memory each statistic kernel
 #: needs (windowed scatter buffers, pairwise outputs, etc.).
 STREAMING_AUTO_EAGER_FRACTION = 0.5
+
+
+# Largest coordinate tabix accepts; stands in for an open end.
+_TABIX_MAX_POS = 2**31 - 1
+
+
+def _tabix_region(chrom, start, stop):
+    """Render parsed bounds as the ``'chrom'`` or ``'chrom:start-end'``
+    string tabix and scikit-allel accept: no thousands separators and no
+    open bounds. ``stop`` is half-open, as ``parse_region`` returns it."""
+    if chrom is None:
+        raise ValueError(
+            "a VCF region needs a chromosome, e.g. 'chr1:1000-2000'")
+    if start is None and stop is None:
+        return chrom
+    end = _TABIX_MAX_POS if stop is None else stop - 1
+    return f"{chrom}:{1 if start is None else start}-{end}"
 
 
 def _decide_streaming_mode(zarr_path, region, streaming, pop_assignment,
@@ -471,8 +489,9 @@ class HaplotypeMatrix:
         path : str
             Path to VCF/BCF file (optionally gzipped + tabix-indexed).
         region : str, optional
-            Genomic region to load, e.g. 'chr1:1000000-2000000'. Both
-            ends are inclusive, as in samtools. Requires the VCF to be
+            Genomic region to load: 'chrom', 'chrom:start', or
+            'chrom:start-end', e.g. 'chr1:1000000-2000000'. Both ends
+            are inclusive, as in samtools. Requires the VCF to be
             bgzipped and tabix-indexed.
         samples : list of str, optional
             Subset of samples to load. If None, loads all samples.
@@ -494,6 +513,12 @@ class HaplotypeMatrix:
         """
         from ._warnings import _maybe_memory_warn
         _maybe_memory_warn(path, region=region)
+        # scikit-allel accepts 'chrom' and 'chrom:start-end' but not an
+        # open end or thousands separators, so the samtools forms are
+        # parsed once here and re-rendered.
+        chrom, start, stop = parse_region(region)
+        if region is not None:
+            region = _tabix_region(chrom, start, stop)
         if fields:
             tag_to_path, unknown_tags = _classify_vcf_qc_tags(path, fields)
             read_fields = _build_read_vcf_fields(tag_to_path.values())
@@ -528,16 +553,11 @@ class HaplotypeMatrix:
         # is BED accessible bases within [chrom_start, chrom_end].
         chrom_start = int(positions[0])
         chrom_end = int(positions[-1])
-        chrom = None
         if region is not None:
-            chrom_part, _, range_part = region.partition(':')
-            chrom = chrom_part or None
-            if range_part:
-                start_str, _, end_str = range_part.partition('-')
-                if start_str:
-                    chrom_start = int(start_str.replace(',', ''))
-                if end_str:
-                    chrom_end = int(end_str.replace(',', ''))
+            if start is not None:
+                chrom_start = start
+            if stop is not None:
+                chrom_end = stop - 1
         elif 'variants/CHROM' in vcf:
             chrom = vcf['variants/CHROM'][0]
 
@@ -572,8 +592,9 @@ class HaplotypeMatrix:
         path : str
             Path to Zarr store directory.
         region : str, optional
-            Genomic region 'chrom:start-end' to load a subset. Both
-            ends are inclusive, as in samtools.
+            Genomic region to load: 'chrom' for a whole chromosome,
+            'chrom:start' from a position to the chromosome end, or
+            'chrom:start-end'. Both ends are inclusive, as in samtools.
         accessible_bed : str, optional
             Path to a BED file defining accessible/callable regions.
         pop_assignment : str, numpy.ndarray, list, dict, or False, optional
@@ -724,7 +745,7 @@ class HaplotypeMatrix:
                 region=region,
             )
 
-        chrom = region.split(':')[0] if region else None
+        chrom = parse_region(region)[0]
         if accessible_bed is not None:
             hm.set_accessible_mask(accessible_bed, chrom=chrom)
 

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -622,9 +622,9 @@ class WindowedAnalyzer:
         chrom : str or int
             Chromosome identifier
         start : int
-            Region start position
+            Region start position (inclusive).
         end : int
-            Region end position
+            Region end position (exclusive), as in ``get_subset_from_range``.
 
         Returns
         -------

--- a/pg_gpu/zarr_io.py
+++ b/pg_gpu/zarr_io.py
@@ -36,8 +36,13 @@ def parse_region(region):
         chrom, coords = ((None, region) if _BARE_SPAN.match(region)
                          else (region, ''))
     start_s, _, end_s = coords.partition('-')
-    start = int(start_s.replace(',', '')) if start_s else None
-    end = int(end_s.replace(',', '')) if end_s else None
+    try:
+        start = int(start_s.replace(',', '')) if start_s else None
+        end = int(end_s.replace(',', '')) if end_s else None
+    except ValueError:
+        raise ValueError(
+            f"bad region string {region!r}: expected 'chrom', 'chrom:start', "
+            f"or 'chrom:start-end'") from None
     return chrom or None, start, None if end is None else end + 1
 
 

--- a/pg_gpu/zarr_io.py
+++ b/pg_gpu/zarr_io.py
@@ -2,29 +2,90 @@
 
 import os
 import shutil
+import re
 import sys
 
 import numpy as np
 
 
+# A colon-less string is a bare span ('1000-2000') only if it looks like
+# one; anything else is a chromosome name.
+_BARE_SPAN = re.compile(r'^[\d,]+-[\d,]*$')
+
+
 def parse_region(region):
     """Parse a samtools-style region string into ``(chrom, start, stop)``.
 
-    The string is ``'chrom:start-end'`` or a bare ``'start-end'``, and both
-    ends are inclusive as in samtools, tabix, and bcftools: ``'X:500-500'``
-    names one position. The returned ``stop`` is ``end + 1``, so
-    ``(start, stop)`` is the half-open interval the rest of pg_gpu works
-    in (``slice_region``, ``materialize``, windows) and ``positions < stop``
-    is the right test. ``chrom`` is ``None`` for the bare form.
+    Accepts the forms samtools, tabix, and bcftools do: ``'chrom'``,
+    ``'chrom:start'``, ``'chrom:start-'``, and ``'chrom:start-end'``, with
+    optional thousands separators (``'chr1:1,000-2,000'``). Both ends are
+    inclusive, so ``'X:500-500'`` names one position. A bare
+    ``'start-end'`` span with no chromosome is also accepted and returns
+    ``chrom=None``.
+
+    The returned ``stop`` is ``end + 1``, so ``(start, stop)`` is the
+    half-open interval the rest of pg_gpu works in (``slice_region``,
+    ``materialize``, windows) and ``positions < stop`` is the right test.
+    A bound the string leaves open is ``None``, and ``None`` itself
+    parses to ``(None, None, None)``.
     """
-    chrom, _, coords = region.rpartition(':')
-    start, end = (int(x) for x in coords.split('-'))
-    return chrom or None, start, end + 1
+    if region is None:
+        return None, None, None
+    chrom, sep, coords = region.rpartition(':')
+    if not sep:
+        chrom, coords = ((None, region) if _BARE_SPAN.match(region)
+                         else (region, ''))
+    start_s, _, end_s = coords.partition('-')
+    start = int(start_s.replace(',', '')) if start_s else None
+    end = int(end_s.replace(',', '')) if end_s else None
+    return chrom or None, start, None if end is None else end + 1
 
 
 def _region_mask(positions, start, stop):
-    """Boolean mask of ``positions`` inside the half-open ``[start, stop)``."""
+    """Boolean mask of ``positions`` inside the half-open ``[start, stop)``;
+    a ``None`` bound is open on that side."""
+    if start is None and stop is None:
+        return np.ones(len(positions), dtype=bool)
+    if start is None:
+        return positions < stop
+    if stop is None:
+        return positions >= start
     return (positions >= start) & (positions < stop)
+
+
+def _vcz_contig_index(store, contig_arr, chrom):
+    """``(index, name)`` of ``chrom`` in a VCZ store's contig table, or of
+    the only contig with variants when ``chrom`` is ``None``.
+
+    Raises ``ValueError`` for an unknown name, or for ``None`` on a store
+    whose variants span more than one contig.
+    """
+    contig_ids = list(np.array(store['contig_id']))
+    if chrom is not None:
+        if chrom not in contig_ids:
+            raise ValueError(f"Contig {chrom!r} not found. Available: {contig_ids}")
+        idx = contig_ids.index(chrom)
+    elif contig_arr.size == 0:
+        idx = 0
+    else:
+        # min and max settle the single-contig case without sorting a
+        # copy of the whole variant axis.
+        idx = int(contig_arr.min())
+        if int(contig_arr.max()) != idx:
+            names = [contig_ids[i] for i in np.unique(contig_arr)]
+            raise ValueError(
+                f"Store contains {len(names)} contigs: {names}. "
+                "Pass region='chrom' or region='chrom:start-end' to select one."
+            )
+    return idx, (contig_ids[idx] if idx < len(contig_ids) else None)
+
+
+def _allel_group(store, chrom):
+    """The chromosome group ``chrom`` of a grouped scikit-allel store."""
+    if chrom is None or chrom not in store:
+        available = [k for k in store if hasattr(store[k], 'keys')]
+        raise ValueError(f"Chromosome {chrom!r} not found. Available: {available}")
+    return store[chrom]
 
 
 def normalize_pop_input(pop_assignment, *, zarr_path, sample_names,
@@ -157,7 +218,8 @@ def read_genotypes_vcz(store, region=None):
     store : zarr.Group
         Opened VCZ zarr store.
     region : str, optional
-        Genomic region 'chrom:start-end', both ends inclusive.
+        Genomic region string; see ``parse_region`` for the accepted
+        forms.
 
     Returns
     -------
@@ -169,15 +231,12 @@ def read_genotypes_vcz(store, region=None):
         same indices to keep their slices aligned with the genotype
         matrix.
     """
+    contig_arr = np.array(store['variant_contig'])
+    chrom, start, stop = parse_region(region)
+    # On a whole-store read this call is the multi-contig guard: a store
+    # spanning several contigs needs a region to name one.
+    contig_idx, _ = _vcz_contig_index(store, contig_arr, chrom)
     if region is not None:
-        chrom, start, stop = parse_region(region)
-        contig_ids = list(np.array(store['contig_id']))
-        if chrom not in contig_ids:
-            raise ValueError(
-                f"Contig '{chrom}' not found. Available: {contig_ids}"
-            )
-        contig_idx = contig_ids.index(chrom)
-        contig_arr = np.array(store['variant_contig'])
         pos_arr = np.array(store['variant_position'])
         mask = (contig_arr == contig_idx) & _region_mask(pos_arr, start, stop)
         indices = np.where(mask)[0]
@@ -187,15 +246,6 @@ def read_genotypes_vcz(store, region=None):
         positions = pos_arr[indices]
         variant_indices = indices
     else:
-        contig_arr = np.array(store['variant_contig'])
-        unique_contigs = np.unique(contig_arr)
-        if len(unique_contigs) > 1:
-            contig_ids = list(np.array(store['contig_id']))
-            names = [contig_ids[i] for i in unique_contigs]
-            raise ValueError(
-                f"Store contains {len(unique_contigs)} contigs: {names}. "
-                "Specify region='chrom:start-end' to select one."
-            )
         gt = np.array(store['call_genotype'])
         positions = np.array(store['variant_position'])
         variant_indices = None
@@ -234,8 +284,8 @@ def read_qc_fields(zarr_path, fields, variant_indices=None, region=None):
             # have already raised; return empty rather than introducing a
             # second error message.
             return {}
-        chrom = region.split(':')[0]
-        return _read_qc_fields_allel(store[chrom], fields, variant_indices)
+        return _read_qc_fields_allel(_allel_group(store, parse_region(region)[0]),
+                                     fields, variant_indices)
     return _read_qc_fields_allel(store, fields, variant_indices)
 
 
@@ -293,7 +343,8 @@ def read_genotypes_allel(store, region=None):
     store : zarr.Group
         Opened scikit-allel zarr store.
     region : str, optional
-        Genomic region 'chrom:start-end', both ends inclusive.
+        Genomic region string; see ``parse_region`` for the accepted
+        forms.
 
     Returns
     -------
@@ -330,7 +381,8 @@ def read_genotypes_allel_grouped(store, region):
     store : zarr.Group
         Opened zarr store with chromosome-level groups.
     region : str
-        Genomic region 'chrom:start-end', both ends inclusive.
+        Genomic region string; see ``parse_region`` for the accepted
+        forms.
         Required for grouped stores.
 
     Returns
@@ -338,19 +390,14 @@ def read_genotypes_allel_grouped(store, region):
     dict
         Keys: 'gt' (n_var, n_samples, ploidy), 'positions', 'samples'.
     """
-    if region is None:
-        available = [k for k in store if hasattr(store[k], 'keys')]
-        raise ValueError(
-            f"Grouped zarr store requires region='chrom:start-end'. "
-            f"Available groups: {available}"
-        )
     chrom, start, stop = parse_region(region)
-    if chrom not in store:
+    if chrom is None:
         available = [k for k in store if hasattr(store[k], 'keys')]
         raise ValueError(
-            f"Chromosome '{chrom}' not found. Available: {available}"
+            f"Grouped zarr store requires region='chrom' or "
+            f"'chrom:start-end'. Available groups: {available}"
         )
-    grp = store[chrom]
+    grp = _allel_group(store, chrom)
     positions = np.array(grp['variants/POS'])
     gt = np.array(grp['calldata/GT'])
     samples = list(np.array(grp['samples'])) if 'samples' in grp else None
@@ -470,9 +517,9 @@ def allel_zarr_to_vcz(allel_path, vcz_path, *, contig=None, region=None,
         the source is grouped and ``region`` does not name a contig.
         For flat stores, used as the ``contig_id`` label in the output.
     region : str, optional
-        ``"chrom:start-end"`` (or ``"start-end"`` on a flat store),
-        both ends inclusive, restricting the conversion to a position
-        range.
+        Region string restricting the conversion to a position range;
+        see ``parse_region`` for the accepted forms, including a bare
+        ``"start-end"`` on a flat store.
     variant_chunk : int
         Source variants read per streaming pass. Larger amortizes zarr
         read overhead; smaller bounds host RAM at biobank sample counts.
@@ -504,8 +551,7 @@ def allel_zarr_to_vcz(allel_path, vcz_path, *, contig=None, region=None,
             f"Expected scikit-allel layout at {allel_path}, got {layout}"
         )
 
-    chrom_from_region, lo, stop = (parse_region(region) if region
-                                   else (None, None, None))
+    chrom_from_region, lo, stop = parse_region(region)
 
     # Resolve which chromosome group to read (grouped) or use the root
     # (flat); derive the contig label that goes into the output.
@@ -517,7 +563,7 @@ def allel_zarr_to_vcz(allel_path, vcz_path, *, contig=None, region=None,
                 f"Grouped allel store requires contig=... "
                 f"Available: {available}"
             )
-        src_grp = src[contig]
+        src_grp = _allel_group(src, contig)
     else:
         src_grp = src
         if contig is None:
@@ -531,8 +577,10 @@ def allel_zarr_to_vcz(allel_path, vcz_path, *, contig=None, region=None,
         # Loading positions in full is fine -- they're int32, so even a
         # human-genome-scale chromosome (~10 M sites) is ~40 MB.
         pos_host = np.asarray(pos_arr[:])
-        lo_idx = int(np.searchsorted(pos_host, lo, side='left'))
-        hi_idx = int(np.searchsorted(pos_host, stop, side='left'))
+        lo_idx = (0 if lo is None
+                  else int(np.searchsorted(pos_host, lo, side='left')))
+        hi_idx = (n_var if stop is None
+                  else int(np.searchsorted(pos_host, stop, side='left')))
         if lo_idx == hi_idx:
             raise ValueError(f"No variants in region {region}")
         pos_out = pos_host[lo_idx:hi_idx]
@@ -612,7 +660,8 @@ def read_genotypes(path, region=None):
     path : str
         Path to zarr store directory.
     region : str, optional
-        Genomic region 'chrom:start-end', both ends inclusive.
+        Genomic region string; see ``parse_region`` for the accepted
+        forms.
 
     Returns
     -------

--- a/pg_gpu/zarr_io.py
+++ b/pg_gpu/zarr_io.py
@@ -7,11 +7,24 @@ import sys
 import numpy as np
 
 
-def _parse_region(region):
-    """Parse 'chrom:start-end' into (chrom, start, end)."""
-    chrom, coords = region.split(':')
-    start, end = [int(x) for x in coords.split('-')]
-    return chrom, start, end
+def parse_region(region):
+    """Parse a samtools-style region string into ``(chrom, start, stop)``.
+
+    The string is ``'chrom:start-end'`` or a bare ``'start-end'``, and both
+    ends are inclusive as in samtools, tabix, and bcftools: ``'X:500-500'``
+    names one position. The returned ``stop`` is ``end + 1``, so
+    ``(start, stop)`` is the half-open interval the rest of pg_gpu works
+    in (``slice_region``, ``materialize``, windows) and ``positions < stop``
+    is the right test. ``chrom`` is ``None`` for the bare form.
+    """
+    chrom, _, coords = region.rpartition(':')
+    start, end = (int(x) for x in coords.split('-'))
+    return chrom or None, start, end + 1
+
+
+def _region_mask(positions, start, stop):
+    """Boolean mask of ``positions`` inside the half-open ``[start, stop)``."""
+    return (positions >= start) & (positions < stop)
 
 
 def normalize_pop_input(pop_assignment, *, zarr_path, sample_names,
@@ -144,7 +157,7 @@ def read_genotypes_vcz(store, region=None):
     store : zarr.Group
         Opened VCZ zarr store.
     region : str, optional
-        Genomic region 'chrom:start-end'.
+        Genomic region 'chrom:start-end', both ends inclusive.
 
     Returns
     -------
@@ -157,7 +170,7 @@ def read_genotypes_vcz(store, region=None):
         matrix.
     """
     if region is not None:
-        chrom, start, end = _parse_region(region)
+        chrom, start, stop = parse_region(region)
         contig_ids = list(np.array(store['contig_id']))
         if chrom not in contig_ids:
             raise ValueError(
@@ -166,7 +179,7 @@ def read_genotypes_vcz(store, region=None):
         contig_idx = contig_ids.index(chrom)
         contig_arr = np.array(store['variant_contig'])
         pos_arr = np.array(store['variant_position'])
-        mask = (contig_arr == contig_idx) & (pos_arr >= start) & (pos_arr < end)
+        mask = (contig_arr == contig_idx) & _region_mask(pos_arr, start, stop)
         indices = np.where(mask)[0]
         if len(indices) == 0:
             raise ValueError(f"No variants in region {region}")
@@ -280,7 +293,7 @@ def read_genotypes_allel(store, region=None):
     store : zarr.Group
         Opened scikit-allel zarr store.
     region : str, optional
-        Genomic region 'chrom:start-end'.
+        Genomic region 'chrom:start-end', both ends inclusive.
 
     Returns
     -------
@@ -297,8 +310,8 @@ def read_genotypes_allel(store, region=None):
     variant_indices = None
 
     if region is not None:
-        _, start, end = _parse_region(region)
-        mask = (positions >= start) & (positions < end)
+        _, start, stop = parse_region(region)
+        mask = _region_mask(positions, start, stop)
         variant_indices = np.where(mask)[0]
         positions = positions[mask]
         gt = gt[mask]
@@ -317,7 +330,8 @@ def read_genotypes_allel_grouped(store, region):
     store : zarr.Group
         Opened zarr store with chromosome-level groups.
     region : str
-        Genomic region 'chrom:start-end'. Required for grouped stores.
+        Genomic region 'chrom:start-end', both ends inclusive.
+        Required for grouped stores.
 
     Returns
     -------
@@ -330,7 +344,7 @@ def read_genotypes_allel_grouped(store, region):
             f"Grouped zarr store requires region='chrom:start-end'. "
             f"Available groups: {available}"
         )
-    chrom, start, end = _parse_region(region)
+    chrom, start, stop = parse_region(region)
     if chrom not in store:
         available = [k for k in store if hasattr(store[k], 'keys')]
         raise ValueError(
@@ -341,7 +355,7 @@ def read_genotypes_allel_grouped(store, region):
     gt = np.array(grp['calldata/GT'])
     samples = list(np.array(grp['samples'])) if 'samples' in grp else None
 
-    mask = (positions >= start) & (positions < end)
+    mask = _region_mask(positions, start, stop)
     variant_indices = np.where(mask)[0]
     positions = positions[mask]
     gt = gt[mask]
@@ -456,8 +470,9 @@ def allel_zarr_to_vcz(allel_path, vcz_path, *, contig=None, region=None,
         the source is grouped and ``region`` does not name a contig.
         For flat stores, used as the ``contig_id`` label in the output.
     region : str, optional
-        ``"chrom:start-end"`` (or ``"start-end"`` on a flat store)
-        restricting the conversion to a position range.
+        ``"chrom:start-end"`` (or ``"start-end"`` on a flat store),
+        both ends inclusive, restricting the conversion to a position
+        range.
     variant_chunk : int
         Source variants read per streaming pass. Larger amortizes zarr
         read overhead; smaller bounds host RAM at biobank sample counts.
@@ -489,11 +504,12 @@ def allel_zarr_to_vcz(allel_path, vcz_path, *, contig=None, region=None,
             f"Expected scikit-allel layout at {allel_path}, got {layout}"
         )
 
+    chrom_from_region, lo, stop = (parse_region(region) if region
+                                   else (None, None, None))
+
     # Resolve which chromosome group to read (grouped) or use the root
     # (flat); derive the contig label that goes into the output.
     if layout == 'scikit-allel-grouped':
-        chrom_from_region = (region.split(':', 1)[0]
-                              if region and ':' in region else None)
         contig = contig or chrom_from_region
         if contig is None:
             available = [k for k in src if hasattr(src[k], 'keys')]
@@ -512,13 +528,11 @@ def allel_zarr_to_vcz(allel_path, vcz_path, *, contig=None, region=None,
     n_var, n_samp, ploidy = gt_arr.shape
 
     if region:
-        span = region.split(':', 1)[-1] if ':' in region else region
-        lo, hi = (int(x) for x in span.split('-'))
         # Loading positions in full is fine -- they're int32, so even a
         # human-genome-scale chromosome (~10 M sites) is ~40 MB.
         pos_host = np.asarray(pos_arr[:])
         lo_idx = int(np.searchsorted(pos_host, lo, side='left'))
-        hi_idx = int(np.searchsorted(pos_host, hi, side='left'))
+        hi_idx = int(np.searchsorted(pos_host, stop, side='left'))
         if lo_idx == hi_idx:
             raise ValueError(f"No variants in region {region}")
         pos_out = pos_host[lo_idx:hi_idx]
@@ -598,7 +612,7 @@ def read_genotypes(path, region=None):
     path : str
         Path to zarr store directory.
     region : str, optional
-        Genomic region 'chrom:start-end'.
+        Genomic region 'chrom:start-end', both ends inclusive.
 
     Returns
     -------

--- a/pg_gpu/zarr_source.py
+++ b/pg_gpu/zarr_source.py
@@ -20,7 +20,7 @@ import cupy as cp
 import numpy as np
 import zarr
 
-from .zarr_io import _parse_region, detect_zarr_layout
+from .zarr_io import _region_mask, detect_zarr_layout, parse_region
 
 
 #: Maximum contiguous-run count before ``slice_subsample_gpu`` falls
@@ -38,8 +38,9 @@ class ZarrGenotypeSource:
     path : str
         Filesystem path to a VCZ zarr store.
     region : str, optional
-        ``'chrom:start-end'`` to restrict the source to a single
-        sub-region. The source is single-contig regardless: a
+        ``'chrom:start-end'`` (both ends inclusive, as in samtools) to
+        restrict the source to a single sub-region. The source is
+        single-contig regardless: a
         multi-contig store without ``region`` raises.
     pop_assignment : str, optional
         Tab-delimited file mapping ``sample`` -> ``pop`` (same format as
@@ -89,14 +90,14 @@ class ZarrGenotypeSource:
         all_pos = np.array(self._store["variant_position"])
 
         if region is not None:
-            chrom, start, end = _parse_region(region)
+            chrom, start, stop = parse_region(region)
             if chrom not in contig_ids:
                 raise ValueError(
                     f"Contig {chrom!r} not found in store. "
                     f"Available: {contig_ids}"
                 )
             contig_idx = contig_ids.index(chrom)
-            mask = (all_contigs == contig_idx) & (all_pos >= start) & (all_pos < end)
+            mask = (all_contigs == contig_idx) & _region_mask(all_pos, start, stop)
         else:
             unique_contigs = np.unique(all_contigs)
             if len(unique_contigs) > 1 and contig_id is None:

--- a/pg_gpu/zarr_source.py
+++ b/pg_gpu/zarr_source.py
@@ -20,7 +20,8 @@ import cupy as cp
 import numpy as np
 import zarr
 
-from .zarr_io import _region_mask, detect_zarr_layout, parse_region
+from .zarr_io import (_region_mask, _vcz_contig_index, detect_zarr_layout,
+                      parse_region)
 
 
 #: Maximum contiguous-run count before ``slice_subsample_gpu`` falls
@@ -38,10 +39,10 @@ class ZarrGenotypeSource:
     path : str
         Filesystem path to a VCZ zarr store.
     region : str, optional
-        ``'chrom:start-end'`` (both ends inclusive, as in samtools) to
-        restrict the source to a single sub-region. The source is
-        single-contig regardless: a
-        multi-contig store without ``region`` raises.
+        Genomic region string; see ``pg_gpu.zarr_io.parse_region`` for
+        the accepted forms (``'chrom'`` alone picks a contig). The
+        source is single-contig regardless: a multi-contig store
+        without ``region`` raises.
     pop_assignment : str, optional
         Tab-delimited file mapping ``sample`` -> ``pop`` (same format as
         ``HaplotypeMatrix.load_pop_file``). Default ``None`` looks for
@@ -49,8 +50,8 @@ class ZarrGenotypeSource:
         emits a one-line stderr note so the auto-load isn't invisible.
         Pass ``pop_assignment=False`` to disable the auto-load entirely.
     contig_id : str, optional
-        Pick a contig by name when ``region`` is not given and the store
-        has multiple contigs. Ignored otherwise.
+        Pick a contig by name when ``region`` does not name one; an
+        alias for ``region='chrom'``.
 
     Attributes
     ----------
@@ -85,43 +86,16 @@ class ZarrGenotypeSource:
                 f"or HaplotypeMatrix.to_zarr(format='vcz')."
             )
 
-        contig_ids = list(np.array(self._store["contig_id"]))
         all_contigs = np.array(self._store["variant_contig"])
         all_pos = np.array(self._store["variant_position"])
 
-        if region is not None:
-            chrom, start, stop = parse_region(region)
-            if chrom not in contig_ids:
-                raise ValueError(
-                    f"Contig {chrom!r} not found in store. "
-                    f"Available: {contig_ids}"
-                )
-            contig_idx = contig_ids.index(chrom)
-            mask = (all_contigs == contig_idx) & _region_mask(all_pos, start, stop)
-        else:
-            unique_contigs = np.unique(all_contigs)
-            if len(unique_contigs) > 1 and contig_id is None:
-                names = [contig_ids[i] for i in unique_contigs]
-                raise ValueError(
-                    f"Store contains {len(unique_contigs)} contigs: "
-                    f"{names}. Pass region='chrom:start-end' or "
-                    f"contig_id=... to pick one."
-                )
-            if contig_id is not None:
-                if contig_id not in contig_ids:
-                    raise ValueError(
-                        f"Contig {contig_id!r} not found in store. "
-                        f"Available: {contig_ids}"
-                    )
-                contig_idx = contig_ids.index(contig_id)
-            else:
-                contig_idx = int(unique_contigs[0])
-            chrom = contig_ids[contig_idx]
-            mask = all_contigs == contig_idx
+        chrom, start, stop = parse_region(region)
+        contig_idx, self.chrom = _vcz_contig_index(
+            self._store, all_contigs, contig_id if chrom is None else chrom)
+        mask = (all_contigs == contig_idx) & _region_mask(all_pos, start, stop)
 
         self._zarr_var_indices = np.where(mask)[0]
         self.site_pos = all_pos[mask]
-        self.chrom = chrom
 
         cg = self._store["call_genotype"]
         # The streaming gather and the (n_dip, 2) -> 2 * n_dip haplotype layout

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,6 +106,18 @@ def sample_haplotype_counts():
     }
 
 
+def bgzip_index(vcf_path):
+    """bgzip ``vcf_path`` in place and tabix-index it; returns the ``.gz``
+    path. Skips the calling test when the htslib tools are not on PATH."""
+    import shutil
+    import subprocess
+    if shutil.which("bgzip") is None or shutil.which("tabix") is None:
+        pytest.skip("bgzip/tabix not on PATH")
+    subprocess.run(["bgzip", "-f", vcf_path], check=True)
+    subprocess.run(["tabix", "-f", "-p", "vcf", vcf_path + ".gz"], check=True)
+    return vcf_path + ".gz"
+
+
 def simulate_hm(n_samples=20, seq_length=100_000, seed=42,
                 mutation_model=None):
     """Build a small msprime-derived HaplotypeMatrix for tests.

--- a/tests/test_haplotype_matrix.py
+++ b/tests/test_haplotype_matrix.py
@@ -711,3 +711,38 @@ class TestDirectListValidation:
             windowed_statistics_fused(hm, bp_bins=np.array([0.0, 700.0]),
                                       statistics=('fst_wc',),
                                       pop1=[[0, 1], [2, 3]], pop2='p2')
+
+
+@pytest.fixture
+def indexed_vcf(tmp_path):
+    """A bgzipped, tabix-indexed VCF with the loaded positions as truth."""
+    from .conftest import bgzip_index
+    ts = msprime.sim_ancestry(samples=10, sequence_length=20_000,
+                              recombination_rate=1e-4, random_seed=7, ploidy=2)
+    ts = msprime.sim_mutations(ts, rate=1e-3, random_seed=7)
+    vcf = str(tmp_path / "r.vcf")
+    with open(vcf, "w") as f:
+        ts.write_vcf(f, contig_id="1")
+    path = bgzip_index(vcf)
+    pos = cp.asnumpy(HaplotypeMatrix.from_vcf(path).positions)
+    return path, pos
+
+
+def test_from_vcf_region_forms(indexed_vcf):
+    """Region strings follow samtools on the VCF path: inclusive ends, a
+    single position, a bare chromosome, an open end, and separators."""
+    path, pos = indexed_vcf
+    first, mid, one = int(pos[0]), int(pos[len(pos) // 2]), int(pos[3])
+
+    def positions(region):
+        return cp.asnumpy(HaplotypeMatrix.from_vcf(path, region=region).positions)
+
+    hm = HaplotypeMatrix.from_vcf(path, region=f"1:{first}-{mid}")
+    got = cp.asnumpy(hm.positions)
+    assert int(got[-1]) == mid
+    assert len(got) == int(np.sum(pos <= mid))
+    assert (hm.chrom_start, hm.chrom_end) == (first, mid)
+    assert positions(f"1:{one}-{one}").tolist() == [one]
+    np.testing.assert_array_equal(positions("1"), pos)
+    np.testing.assert_array_equal(positions(f"1:{mid}"), pos[pos >= mid])
+    np.testing.assert_array_equal(positions(f"1:{first:,}-{mid:,}"), got)

--- a/tests/test_memory_warning.py
+++ b/tests/test_memory_warning.py
@@ -70,11 +70,15 @@ class TestRegionSpan:
     def test_parses_chrom_start_end(self):
         assert _region_span_bp("chr1:1000-5000") == 4001
 
+    def test_open_bound_is_unbounded(self):
+        assert _region_span_bp("chr1:1000") == float('inf')
+        assert _region_span_bp("chr1") == float('inf')
+
     def test_none_is_zero(self):
         assert _region_span_bp(None) == 0
 
     def test_malformed_returns_zero(self):
-        assert _region_span_bp("not a region") == 0
+        assert _region_span_bp("chr1:abc-def") == 0
 
 
 class TestMaybeBiobankWarn:

--- a/tests/test_memory_warning.py
+++ b/tests/test_memory_warning.py
@@ -68,7 +68,7 @@ class TestHeaderSampleCount:
 class TestRegionSpan:
 
     def test_parses_chrom_start_end(self):
-        assert _region_span_bp("chr1:1000-5000") == 4000
+        assert _region_span_bp("chr1:1000-5000") == 4001
 
     def test_none_is_zero(self):
         assert _region_span_bp(None) == 0

--- a/tests/test_qc_fields.py
+++ b/tests/test_qc_fields.py
@@ -105,7 +105,7 @@ def _write_grouped_with_qc(tmp_path, hm, name="qc_grouped.zarr"):
     gq = rng.integers(0, 99, size=(n_var, n_samples), dtype=np.int16)
     grp.create_array("variants/MQ", data=mq)
     grp.create_array("calldata/GQ", data=gq)
-    region = f"{chrom}:{int(pos[0])}-{int(pos[-1]) + 1}"
+    region = f"{chrom}:{int(pos[0])}-{int(pos[-1])}"
     return path, region, mq, gq
 
 
@@ -207,7 +207,7 @@ class TestHaplotypeMatrixFromZarrFields:
         pos = _host(hm.positions)
         lo = int(pos[len(pos) // 4])
         hi = int(pos[3 * len(pos) // 4])
-        region = f"chr1:{lo}-{hi + 1}"
+        region = f"chr1:{lo}-{hi}"
         loaded = HaplotypeMatrix.from_zarr(
             path, region=region, fields=["MQ", "GQ"], streaming="never")
         n_loaded = loaded.haplotypes.shape[1]

--- a/tests/test_zarr_io.py
+++ b/tests/test_zarr_io.py
@@ -13,6 +13,8 @@ from pg_gpu.zarr_io import (
     vcf_to_zarr, write_allel, write_vcz,
 )
 
+from .conftest import bgzip_index
+
 
 def _host(arr):
     """Bring an array back to the host for byte-equal comparison. from_zarr
@@ -66,6 +68,20 @@ def _simulate_hm(n_samples=10, seq_length=10_000, seed=42):
 @pytest.fixture
 def hm():
     return _simulate_hm()
+
+
+def _write_multi_contig_vcz(tmp_path):
+    """Two contigs of 50 all-reference sites each: chr1 at 1..50, chr2 at
+    51..100. Returns the store path."""
+    path = str(tmp_path / "multi.vcz.zarr")
+    store = zarr.open(path, mode='w')
+    n = 100
+    store.create_array('call_genotype', data=np.zeros((n, 5, 2), dtype=np.int8))
+    store.create_array('variant_position', data=np.arange(1, n + 1, dtype=np.int32))
+    store.create_array('variant_contig',
+                       data=np.array([0] * 50 + [1] * 50, dtype=np.int8))
+    store.create_array('contig_id', data=np.array(['chr1', 'chr2'], dtype='U'))
+    return path
 
 
 @pytest.fixture
@@ -253,25 +269,44 @@ class TestGenotypeMatrixRoundTrip:
 
 class TestRegionQueries:
 
-    def test_parse_region_is_inclusive_and_returns_half_open(self):
+    def test_parse_region_forms(self):
+        """Every samtools form parses; the end is inclusive and comes back
+        as a half-open stop; an open bound is None."""
         assert parse_region("chr1:10-20") == ("chr1", 10, 21)
+        assert parse_region("chr1:1,000-2,000") == ("chr1", 1000, 2001)
+        assert parse_region("chr1:10") == ("chr1", 10, None)
+        assert parse_region("chr1:10-") == ("chr1", 10, None)
+        assert parse_region("chr1") == ("chr1", None, None)
         assert parse_region("10-20") == (None, 10, 21)
+
+    @pytest.mark.parametrize("layout", ["vcz_store", "allel_store"])
+    def test_open_ended_region(self, layout, request, hm):
+        """'chrom:start' runs from start to the end of the chromosome."""
+        store = request.getfixturevalue(layout)
+        pos = _host(hm.positions)
+        start = int(pos[len(pos) // 2])
+        hm2 = HaplotypeMatrix.from_zarr(store, region=f"chr1:{start}")
+        assert int(_host(hm2.positions)[0]) == start
+        assert hm2.num_variants == int(np.sum(pos >= start))
 
     def test_vcz_multi_contig_no_region_raises(self, tmp_path):
         """Multi-contig VCZ without region should raise."""
-        path = str(tmp_path / "multi.vcz.zarr")
-        store = zarr.open(path, mode='w')
-        n = 100
-        gt = np.zeros((n, 5, 2), dtype=np.int8)
-        pos = np.arange(n, dtype=np.int32)
-        contig = np.array([0] * 50 + [1] * 50, dtype=np.int8)
-        store.create_array('call_genotype', data=gt)
-        store.create_array('variant_position', data=pos)
-        store.create_array('variant_contig', data=contig)
-        store.create_array('contig_id',
-                           data=np.array(['chr1', 'chr2'], dtype='U'))
+        path = _write_multi_contig_vcz(tmp_path)
         with pytest.raises(ValueError, match="contains 2 contigs"):
             HaplotypeMatrix.from_zarr(path)
+
+    def test_vcz_chrom_only_region_selects_contig(self, tmp_path):
+        """'chrom' alone picks that contig; 'chrom:start' runs to its end."""
+        path = _write_multi_contig_vcz(tmp_path)
+        hm = HaplotypeMatrix.from_zarr(path, region='chr2')
+        assert _host(hm.positions).tolist() == list(range(51, 101))
+        hm = HaplotypeMatrix.from_zarr(path, region='chr2:91')
+        assert _host(hm.positions).tolist() == list(range(91, 101))
+
+    def test_grouped_chrom_only_region(self, grouped_store):
+        pos = np.asarray(zarr.open(grouped_store, mode='r')['chr1/variants/POS'][:])
+        hm = HaplotypeMatrix.from_zarr(grouped_store, region='chr1')
+        np.testing.assert_array_equal(_host(hm.positions), pos)
 
     def test_vcz_bad_contig_raises(self, vcz_store):
         with pytest.raises(ValueError, match="not found"):
@@ -396,10 +431,7 @@ class TestVcfToZarr:
         with open(vcf_path, 'w') as f:
             ts.write_vcf(f)
 
-        # bgzip and index
-        import subprocess
-        subprocess.run(['bgzip', vcf_path], check=True)
-        subprocess.run(['tabix', '-p', 'vcf', vcf_path + '.gz'], check=True)
+        bgzip_index(vcf_path)
 
         zarr_path = str(tmp_path / "test.zarr")
         vcf_to_zarr(vcf_path + '.gz', zarr_path,
@@ -422,9 +454,7 @@ class TestVcfToZarr:
         with open(vcf_path, 'w') as f:
             ts.write_vcf(f)
 
-        import subprocess
-        subprocess.run(['bgzip', vcf_path], check=True)
-        subprocess.run(['tabix', '-p', 'vcf', vcf_path + '.gz'], check=True)
+        bgzip_index(vcf_path)
 
         zarr_path = str(tmp_path / "test2.zarr")
         icf_path = str(tmp_path / "custom_icf")
@@ -448,9 +478,7 @@ class TestVcfToZarr:
         with open(vcf_path, 'w') as f:
             ts.write_vcf(f)
 
-        import subprocess
-        subprocess.run(['bgzip', vcf_path], check=True)
-        subprocess.run(['tabix', '-p', 'vcf', vcf_path + '.gz'], check=True)
+        bgzip_index(vcf_path)
 
         zarr_path = str(tmp_path / "test3.zarr")
         HaplotypeMatrix.vcf_to_zarr(

--- a/tests/test_zarr_io.py
+++ b/tests/test_zarr_io.py
@@ -9,7 +9,7 @@ import cupy as cp
 
 from pg_gpu import HaplotypeMatrix, GenotypeMatrix
 from pg_gpu.zarr_io import (
-    allel_zarr_to_vcz, detect_zarr_layout, read_genotypes,
+    allel_zarr_to_vcz, detect_zarr_layout, parse_region, read_genotypes,
     vcf_to_zarr, write_allel, write_vcz,
 )
 
@@ -253,13 +253,9 @@ class TestGenotypeMatrixRoundTrip:
 
 class TestRegionQueries:
 
-    def test_vcz_region(self, vcz_store, hm):
-        pos = hm.positions
-        mid = int(pos[len(pos) // 2])
-        region = f"chr1:{int(pos[0])}-{mid}"
-        hm2 = HaplotypeMatrix.from_zarr(vcz_store, region=region)
-        assert hm2.num_variants < hm.num_variants
-        assert np.all(hm2.positions < mid)
+    def test_parse_region_is_inclusive_and_returns_half_open(self):
+        assert parse_region("chr1:10-20") == ("chr1", 10, 21)
+        assert parse_region("10-20") == (None, 10, 21)
 
     def test_vcz_multi_contig_no_region_raises(self, tmp_path):
         """Multi-contig VCZ without region should raise."""
@@ -298,12 +294,32 @@ class TestRegionQueries:
         with pytest.raises(ValueError, match="not found"):
             HaplotypeMatrix.from_zarr(grouped_store, region='chrZ:1-100')
 
-    def test_allel_region(self, allel_store, hm):
-        pos = hm.positions
-        mid = int(pos[len(pos) // 2])
-        region = f"chr1:{int(pos[0])}-{mid}"
-        hm2 = HaplotypeMatrix.from_zarr(allel_store, region=region)
+    @pytest.mark.parametrize("layout", ["vcz_store", "allel_store"])
+    def test_region_end_is_inclusive(self, layout, request, hm):
+        """A variant sitting exactly at the region end is kept, as in
+        samtools, tabix, and bcftools."""
+        store = request.getfixturevalue(layout)
+        pos = _host(hm.positions)
+        end = int(pos[len(pos) // 2])
+        hm2 = HaplotypeMatrix.from_zarr(store, region=f"chr1:{int(pos[0])}-{end}")
         assert hm2.num_variants < hm.num_variants
+        assert int(_host(hm2.positions)[-1]) == end
+        assert hm2.num_variants == int(np.sum(pos <= end))
+
+    def test_grouped_region_end_is_inclusive(self, grouped_store):
+        pos = np.asarray(zarr.open(grouped_store, mode='r')['chr1/variants/POS'][:])
+        end = int(pos[len(pos) // 2])
+        hm2 = HaplotypeMatrix.from_zarr(grouped_store,
+                                        region=f"chr1:{int(pos[0])}-{end}")
+        assert int(_host(hm2.positions)[-1]) == end
+
+    @pytest.mark.parametrize("layout", ["vcz_store", "allel_store"])
+    def test_single_position_region(self, layout, request, hm):
+        """'chrom:p-p' names one position rather than an empty interval."""
+        store = request.getfixturevalue(layout)
+        p = int(_host(hm.positions)[3])
+        hm2 = HaplotypeMatrix.from_zarr(store, region=f"chr1:{p}-{p}")
+        assert set(_host(hm2.positions).tolist()) == {p}
 
 
 # ── Missing Data ────────────────────────────────────────────────────────
@@ -539,10 +555,11 @@ class TestAllelZarrToVcz:
         # equivalent positional slice of the source.
         src = zarr.open(allel_store, mode='r')
         src_pos = np.asarray(src['variants/POS'][:])
-        # Pick the middle 50% of the position range.
-        lo = int(np.quantile(src_pos, 0.25))
-        hi = int(np.quantile(src_pos, 0.75))
-        keep = (src_pos >= lo) & (src_pos < hi)
+        # Bound the region by two real variant positions so the
+        # inclusive end is exercised.
+        lo = int(src_pos[len(src_pos) // 4])
+        hi = int(src_pos[3 * len(src_pos) // 4])
+        keep = (src_pos >= lo) & (src_pos <= hi)
 
         out = str(tmp_path / "region.vcz")
         allel_zarr_to_vcz(allel_store, out, contig='chr1',

--- a/tests/test_zarr_io.py
+++ b/tests/test_zarr_io.py
@@ -278,6 +278,9 @@ class TestRegionQueries:
         assert parse_region("chr1:10-") == ("chr1", 10, None)
         assert parse_region("chr1") == ("chr1", None, None)
         assert parse_region("10-20") == (None, 10, 21)
+        assert parse_region(None) == (None, None, None)
+        with pytest.raises(ValueError, match="bad region string"):
+            parse_region("chr1:abc-def")
 
     @pytest.mark.parametrize("layout", ["vcz_store", "allel_store"])
     def test_open_ended_region(self, layout, request, hm):

--- a/tests/test_zarr_source.py
+++ b/tests/test_zarr_source.py
@@ -100,6 +100,14 @@ class TestConstruction:
         src = ZarrGenotypeSource(path, region=f"1:{p}-{p}")
         assert set(src.site_pos.tolist()) == {p}
 
+    def test_chrom_only_region_matches_contig_id(self, multi_contig_store):
+        path, _, hm2 = multi_contig_store
+        by_region = ZarrGenotypeSource(path, region="chrB")
+        by_id = ZarrGenotypeSource(path, contig_id="chrB")
+        np.testing.assert_array_equal(by_region.site_pos, by_id.site_pos)
+        np.testing.assert_array_equal(by_region.site_pos, np.asarray(hm2.positions))
+        assert by_region.chrom == "chrB"
+
     def test_multi_contig_requires_pick(self, multi_contig_store):
         path, _, _ = multi_contig_store
         with pytest.raises(ValueError, match="contigs"):

--- a/tests/test_zarr_source.py
+++ b/tests/test_zarr_source.py
@@ -90,7 +90,15 @@ class TestConstruction:
         first_half = full.site_pos[len(full.site_pos) // 2]
         src = ZarrGenotypeSource(path, region=f"1:0-{int(first_half)}")
         assert src.num_variants < full.num_variants
-        assert int(src.site_pos[-1]) < int(first_half)
+        # The end bound is inclusive, and first_half is a real site.
+        assert int(src.site_pos[-1]) == int(first_half)
+        assert src.num_variants == int(np.sum(full.site_pos <= first_half))
+
+    def test_single_position_region(self, vcz_store):
+        path, hm = vcz_store
+        p = int(np.asarray(hm.positions)[5])
+        src = ZarrGenotypeSource(path, region=f"1:{p}-{p}")
+        assert set(src.site_pos.tolist()) == {p}
 
     def test_multi_contig_requires_pick(self, multi_contig_store):
         path, _, _ = multi_contig_store

--- a/utils/genome_scan.py
+++ b/utils/genome_scan.py
@@ -38,6 +38,7 @@ import numpy as np
 import seaborn as sns
 
 from pg_gpu import HaplotypeMatrix, diversity, divergence, sfs, windowed_analysis
+from pg_gpu.zarr_io import parse_region
 
 
 VCF_EXTS = (".vcf", ".vcf.gz", ".bcf")
@@ -81,10 +82,10 @@ def _load_ts_input(path, args):
         ts = tskit.load(path)
 
     if args.region:
-        # Accept either 'start-end' or 'chrom:start-end' -- chrom is ignored.
-        rng = args.region.split(":")[-1]
-        start, end = (int(x) for x in rng.split("-"))
-        ts = ts.keep_intervals([[start, end]], simplify=True)
+        # The chrom prefix, if any, is ignored: a tree sequence has one contig.
+        _, start, stop = parse_region(args.region)
+        stop = min(stop, int(ts.sequence_length))
+        ts = ts.keep_intervals([[start, stop]], simplify=True)
 
     hm = HaplotypeMatrix.from_ts(ts, device="GPU")
 

--- a/utils/genome_scan.py
+++ b/utils/genome_scan.py
@@ -84,7 +84,9 @@ def _load_ts_input(path, args):
     if args.region:
         # The chrom prefix, if any, is ignored: a tree sequence has one contig.
         _, start, stop = parse_region(args.region)
-        stop = min(stop, int(ts.sequence_length))
+        seq_len = int(ts.sequence_length)
+        start = 0 if start is None else start
+        stop = seq_len if stop is None else min(stop, seq_len)
         ts = ts.keep_intervals([[start, stop]], simplify=True)
 
     hm = HaplotypeMatrix.from_ts(ts, device="GPU")


### PR DESCRIPTION
Region strings like `X:1-1000000` excluded a variant sitting exactly at the end position, and `X:500-500` selected nothing. samtools, tabix, and bcftools treat `chrom:start-end` as inclusive on both ends, and `from_vcf` already did through tabix; the zarr loaders, `ZarrGenotypeSource`, `allel_zarr_to_vcz`, and the memory-warning span check stopped one base short, so users comparing region for region saw off-by-one counts at window edges.

**Convention.** `pg_gpu.zarr_io.parse_region` (public, formerly `_parse_region`) owns it. It accepts every samtools form: `chrom`, `chrom:start`, `chrom:start-`, `chrom:start-end`, thousands separators, and a bare `start-end` for flat stores and scripts. It returns `(chrom, start, stop)` with `stop = end + 1`, the half-open form the rest of the package works in, and `None` for an open bound, so every consumer keeps writing `pos < stop` and nobody re-derives the off-by-one. `region='X'` now selects a whole chromosome from a multi-contig store.

**Paths swept.** A shared `_vcz_contig_index` resolves a contig for the VCZ reader and `ZarrGenotypeSource`; `_allel_group` does the same for grouped scikit-allel stores; `_region_mask` applies the bounds. `from_vcf` parses once and re-renders the bounds in the strict spelling scikit-allel's filter accepts. `allel_zarr_to_vcz`, `read_qc_fields`, `resolve_streaming_accessible_mask`, `_region_span_bp`, `utils/genome_scan.py`, and `examples/biobank_streaming_scan.py` all go through the parser; no hand `split(':')` remains. The `materialize(region=(left, right))` tuple and windows stay half-open; the changelog says so.

**Verification.** An empirical harness drove every path (VCF via tabix, VCZ/scikit-allel/grouped eager, streaming, kvikio, `ZarrGenotypeSource`, `read_genotypes`, `allel_zarr_to_vcz`, `genome_scan`) with an inclusive end, a single position, a whole chromosome, an open end, and separators: 78/78. Tests cover the same forms on the loaders, the streaming source, the VCF path (tabix-backed, skipped when the tools are absent), and `parse_region` itself. Full non-slow suite: 1371 passed, 78 skipped, 25 xfailed on an A100. Sphinx builds clean.

Closes #224.
