### PR TITLE
Fail the test suite on any unexpected multiallelic drop

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -175,6 +175,11 @@ Read this section if you are comparing against older pg_gpu results.
 Bug fixes
 ~~~~~~~~~
 
+* ``divergence.zx`` computed each of its three ZnS values on a different
+  site set, because ``zns`` drops the sites that are multiallelic within
+  the matrix it is handed. The whole matrix is now restricted to
+  biallelic sites before any ZnS is computed, and one
+  ``BiallelicOnlyWarning`` reports the count.
 * Pairwise distances treated a missing genotype as if it were a
   reference homozygote, so a missing call could count as a difference.
   Missing data is now skipped on both sides of the calculation.

--- a/docs/source/multiallelic.rst
+++ b/docs/source/multiallelic.rst
@@ -191,8 +191,9 @@ Two orthogonal filters are available. ``restrict_to_biallelic()`` (on a
 ``HaplotypeMatrix``) keeps sites with at most two distinct present alleles,
 leaving the allele codes unchanged -- so ``{0,1}``, ``{0,2}`` and
 reference-absent ``{1,2}`` sites are all retained -- and drops sites with three
-or more alleles with a ``BiallelicOnlyWarning``. The LD statistics are defined on
-biallelic sites and apply this themselves, so you rarely need to call it directly:
+or more alleles without warning. The LD statistics are defined on biallelic
+sites and apply it themselves, warning when they do, so you rarely need to call
+it directly:
 
 .. code-block:: python
 

--- a/pg_gpu/_warnings.py
+++ b/pg_gpu/_warnings.py
@@ -233,6 +233,8 @@ def _warn_biallelic_only(n_dropped, *, context, stacklevel=3, action="dropped"):
     if n_dropped <= 0:
         return
     warnings.warn(
+        # "is defined on biallelic sites" is the phrase the test suite's
+        # warning filter keys on (pyproject.toml); a test pins it.
         f"{context} is defined on biallelic sites; {n_dropped} "
         f"multiallelic site(s) {action}. To silence:\n"
         "    import warnings\n"

--- a/pg_gpu/divergence.py
+++ b/pg_gpu/divergence.py
@@ -1249,6 +1249,10 @@ def zx(haplotype_matrix: HaplotypeMatrix,
     stronger LD within populations than across the combined sample,
     consistent with population structure or recent admixture.
 
+    All three ZnS values are computed on one site set: sites with more
+    than two alleles across the whole sample are dropped first, and a
+    ``BiallelicOnlyWarning`` reports how many.
+
     Parameters
     ----------
     haplotype_matrix : HaplotypeMatrix
@@ -1270,11 +1274,14 @@ def zx(haplotype_matrix: HaplotypeMatrix,
     from . import ld_statistics
     from ._utils import get_population_matrix
 
-    m1 = get_population_matrix(haplotype_matrix, pop1)
-    m2 = get_population_matrix(haplotype_matrix, pop2)
-    z1 = ld_statistics.zns(m1, missing_data=missing_data)
-    z2 = ld_statistics.zns(m2, missing_data=missing_data)
-    z_total = ld_statistics.zns(haplotype_matrix, missing_data=missing_data)
+    # zns restricts to the biallelic sites of whatever matrix it is handed;
+    # restricting once up front keeps all three terms on the same sites.
+    biallelic = haplotype_matrix.restrict_to_biallelic(warn_context="zx")
+    z1 = ld_statistics._zns_biallelic(get_population_matrix(biallelic, pop1),
+                                      missing_data)
+    z2 = ld_statistics._zns_biallelic(get_population_matrix(biallelic, pop2),
+                                      missing_data)
+    z_total = ld_statistics._zns_biallelic(biallelic, missing_data)
 
     if z_total == 0:
         return float('nan')

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -1194,12 +1194,17 @@ class HaplotypeMatrix:
             accessible_mask=self.accessible_mask,
         )
 
-    def restrict_to_biallelic(self) -> "HaplotypeMatrix":
+    def restrict_to_biallelic(self, *, warn_context=None) -> "HaplotypeMatrix":
         """Restrict to biallelic sites (drop >=3-allele), preserving allele codes.
 
         Keeps sites with at most two distinct present alleles, allele codes
         unchanged, so {0,1}, {0,2}, and reference-absent {1,2} are all retained;
         sites with three or more distinct present alleles are dropped.
+
+        ``warn_context`` names a biallelic-only operation; when given, a
+        ``BiallelicOnlyWarning`` reports how many sites that operation dropped.
+        Left as ``None`` the filter is silent, which is what a direct call and
+        the chunk loops that tally their own drops want.
         """
         if self.device == 'CPU':
             self.transfer_to_gpu()
@@ -1208,7 +1213,14 @@ class HaplotypeMatrix:
 
         ac, _ = allele_counts(self.haplotypes)
         biallelic, _ = _biallelic_and_alt(ac)
-        return self._keep_sites(cp.where(biallelic)[0])
+        out = self._keep_sites(cp.where(biallelic)[0])
+        if warn_context is not None:
+            from ._warnings import _warn_biallelic_only
+            # One frame deeper than a direct caller, so the warning points at
+            # whoever called the biallelic-only operation.
+            _warn_biallelic_only(self.num_variants - out.num_variants,
+                                 context=warn_context, stacklevel=4)
+        return out
 
     def restrict_to_segregating(self) -> "HaplotypeMatrix":
         """Drop non-segregating (monomorphic) sites.
@@ -1891,12 +1903,8 @@ class HaplotypeMatrix:
             # Biallelic-restrict (drop >=3-allele, warn once) and tally on the
             # 0/1 indicator so {0,2}/{1,2} codings are handled; per-bin output
             # makes the site drop invisible.
-            from ._warnings import _warn_biallelic_only
             from pg_gpu import ld_statistics
-            biallelic = self.restrict_to_biallelic()
-            _warn_biallelic_only(
-                self.num_variants - biallelic.num_variants,
-                context="windowed_r_squared")
+            biallelic = self.restrict_to_biallelic(warn_context="windowed_r_squared")
             m = biallelic.num_variants
             pos = biallelic.positions
             ind = biallelic._biallelic_indicator()
@@ -2221,11 +2229,8 @@ class HaplotypeMatrix:
         """
         if self.device == 'CPU':
             self.transfer_to_gpu()
-        from ._warnings import _warn_biallelic_only
-        biallelic = self.restrict_to_biallelic()
-        _warn_biallelic_only(
-            self.num_variants - biallelic.num_variants,
-            context="compute_ld_statistics_gpu_single_pop")
+        biallelic = self.restrict_to_biallelic(
+            warn_context="compute_ld_statistics_gpu_single_pop")
         seg = biallelic.restrict_to_segregating()
 
         bp_bins_arr = np.array(bp_bins)
@@ -2297,11 +2302,8 @@ class HaplotypeMatrix:
         """
         if self.device == 'CPU':
             self.transfer_to_gpu()
-        from ._warnings import _warn_biallelic_only
-        biallelic = self.restrict_to_biallelic()
-        _warn_biallelic_only(
-            self.num_variants - biallelic.num_variants,
-            context="compute_ld_statistics_gpu_two_pops")
+        biallelic = self.restrict_to_biallelic(
+            warn_context="compute_ld_statistics_gpu_two_pops")
         seg = biallelic.restrict_to_segregating()
 
         bp_bins_arr = np.array(bp_bins)

--- a/pg_gpu/ld_statistics.py
+++ b/pg_gpu/ld_statistics.py
@@ -703,23 +703,20 @@ def zns(r2_matrix_or_matrix, missing_data='include', estimator='auto'):
     -------
     float
         Mean r-squared (or mean sigma_D^2 when sigma_d2 is selected).
+
+    Notes
+    -----
+    A ``HaplotypeMatrix`` is first restricted to its own biallelic sites and
+    a ``BiallelicOnlyWarning`` reports how many were dropped; an input that
+    is already biallelic drops nothing and stays silent.
     """
     from .haplotype_matrix import HaplotypeMatrix
 
-    is_hm = isinstance(r2_matrix_or_matrix, HaplotypeMatrix)
-    estimator = _resolve_ld_estimator(estimator, is_hm)
-
-    # Map estimator to internal missing_data for backward compat with _zns_tiled
-    _md = 'project' if estimator == 'sigma_d2' else missing_data
-
-    # Streaming path for HaplotypeMatrix: O(B²) memory instead of O(m²)
-    if is_hm:
-        from ._warnings import _warn_biallelic_only
-        biallelic = r2_matrix_or_matrix.restrict_to_biallelic()
-        _warn_biallelic_only(
-            r2_matrix_or_matrix.num_variants - biallelic.num_variants,
-            context="zns")
-        return _zns_tiled(biallelic, _md)
+    if isinstance(r2_matrix_or_matrix, HaplotypeMatrix):
+        # Tiled path: O(B²) memory instead of O(m²).
+        biallelic = r2_matrix_or_matrix.restrict_to_biallelic(warn_context="zns")
+        return _zns_biallelic(biallelic, missing_data, estimator)
+    estimator = _resolve_ld_estimator(estimator, False)
 
     if estimator == 'sigma_d2':
         raise ValueError(
@@ -736,6 +733,15 @@ def zns(r2_matrix_or_matrix, missing_data='include', estimator='auto'):
         return 0.0
     total = cp.sum(r2_matrix) - cp.trace(r2_matrix)
     return float((total / (m * (m - 1))).get())
+
+
+def _zns_biallelic(hm, missing_data='include', estimator='auto'):
+    """``zns`` for a HaplotypeMatrix already restricted to biallelic sites:
+    no second restriction and no warning. ``divergence.zx`` restricts once
+    and calls this for each of its three terms."""
+    estimator = _resolve_ld_estimator(estimator, True)
+    # 'project' selects the sigma_d2 estimator inside _zns_tiled.
+    return _zns_tiled(hm, 'project' if estimator == 'sigma_d2' else missing_data)
 
 
 def _build_sigma_d2_matrix(mat, missing_data='include'):
@@ -799,6 +805,12 @@ def omega(r2_matrix_or_matrix, missing_data='include', estimator='auto'):
     -------
     float
         Maximum omega value. Returns 0 if fewer than 5 SNPs.
+
+    Notes
+    -----
+    A ``HaplotypeMatrix`` is first restricted to its own biallelic sites and
+    a ``BiallelicOnlyWarning`` reports how many were dropped; an input that
+    is already biallelic drops nothing and stays silent.
     """
     from .haplotype_matrix import HaplotypeMatrix
 
@@ -806,12 +818,8 @@ def omega(r2_matrix_or_matrix, missing_data='include', estimator='auto'):
     estimator = _resolve_ld_estimator(estimator, is_hm)
 
     if is_hm:
-        from ._warnings import _warn_biallelic_only
-        biallelic = r2_matrix_or_matrix.restrict_to_biallelic()
-        _warn_biallelic_only(
-            r2_matrix_or_matrix.num_variants - biallelic.num_variants,
-            context="omega")
-        r2_matrix_or_matrix = biallelic
+        r2_matrix_or_matrix = r2_matrix_or_matrix.restrict_to_biallelic(
+            warn_context="omega")
 
     if estimator == 'sigma_d2':
         if not is_hm:

--- a/pixi.lock
+++ b/pixi.lock
@@ -5539,8 +5539,8 @@ packages:
   timestamp: 1733302019362
 - pypi: ./
   name: pg-gpu
-  version: 0.1.1.dev201+gbea31e2a5
-  sha256: bb0943662db5a089d006743bfd00b078ea5a36a73567306d9ade9ddffb8313e6
+  version: 0.1.1.dev205+g1c9d4855e
+  sha256: c34db1eddb3c315084a6024c3e6fa26316e56a296632d27837fedd0126feebec
   requires_dist:
   - bio2zarr[vcf]>=0.1
   - cupy-cuda12x[ctk]>=13.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,11 +122,11 @@ filterwarnings = [
     "ignore::zarr.errors.UnstableSpecificationWarning",
     "ignore::zarr.errors.ZarrDeprecationWarning",
     "ignore:The `compressor` argument is deprecated:UserWarning:zarr",
-    # Runtime-visible loader diagnostic; the dedicated tests assert it via local
-    # pytest.warns / simplefilter, which override this global ignore. Matched by
-    # message, not category, so pytest's warnings plugin does not import pg_gpu
-    # before pytest-cov starts measuring (which would drop module-level coverage).
-    "ignore:.* is defined on biallelic sites:UserWarning",
+    # A multiallelic drop must be expected by the test that triggers it; any
+    # other drop fails the test. Matched by message, not category, so pytest's
+    # warnings plugin does not import pg_gpu before pytest-cov starts measuring
+    # (which would drop module-level coverage); a test pins the phrase.
+    "error:.* is defined on biallelic sites:UserWarning",
 ]
 
 [tool.coverage.run]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,7 +127,10 @@ def simulate_hm(n_samples=20, seq_length=100_000, seed=42,
     (Jukes-Cantor, which can produce triallelic sites);
     ``mutation_model='binary'`` forces biallelic, which is what the
     pg_gpu-vs-allel parity tests want because pg_gpu's pi formula has
-    a known multi-allelic gap (kr-colab/pg_gpu#100).
+    a known multi-allelic gap (kr-colab/pg_gpu#100), and what the
+    streaming-versus-eager suite uses so a biallelic-only drop (an error
+    under the test configuration) cannot fail a comparison that is not
+    about it.
     """
     import msprime
     from pg_gpu import HaplotypeMatrix

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,12 +125,12 @@ def simulate_hm(n_samples=20, seq_length=100_000, seed=42,
     Centralizes what would otherwise be repeated per-test simulation
     boilerplate. ``mutation_model=None`` lets msprime pick its default
     (Jukes-Cantor, which can produce triallelic sites);
-    ``mutation_model='binary'`` forces biallelic, which is what the
-    pg_gpu-vs-allel parity tests want because pg_gpu's pi formula has
-    a known multi-allelic gap (kr-colab/pg_gpu#100), and what the
-    streaming-versus-eager suite uses so a biallelic-only drop (an error
-    under the test configuration) cannot fail a comparison that is not
-    about it.
+    ``mutation_model='binary'`` forces biallelic sites. The scikit-allel
+    parity tests want that because allel counts a multiallelic site once
+    where pg_gpu counts each allele, so the two only agree on biallelic
+    data; the streaming-versus-eager suite wants it so a biallelic-only
+    drop (an error under the test configuration) cannot fail a comparison
+    that is not about it.
     """
     import msprime
     from pg_gpu import HaplotypeMatrix

--- a/tests/test_biallelic_only_warning.py
+++ b/tests/test_biallelic_only_warning.py
@@ -63,7 +63,9 @@ def test_is_userwarning_subclass():
 
 
 def test_helper_warns_with_count_and_context():
-    with pytest.warns(BiallelicOnlyWarning, match=r"foo\.bar .*3 multiallelic site\(s\) dropped"):
+    # The full phrase is what pyproject.toml's error filter matches on.
+    with pytest.warns(BiallelicOnlyWarning,
+                      match=r"foo\.bar is defined on biallelic sites; 3 multiallelic site\(s\) dropped"):
         _warn_biallelic_only(3, context="foo.bar")
 
 

--- a/tests/test_implementation_parity.py
+++ b/tests/test_implementation_parity.py
@@ -81,8 +81,9 @@ def _two_pop_split(hm):
 def clean_hm():
     """Clean biallelic matrix (no missing) split into two populations.
 
-    ``mutation_model='binary'`` forces biallelic sites, sidestepping the
-    multiallelic folding gap so the paths are expected to agree exactly here.
+    ``mutation_model='binary'`` forces biallelic sites, so this is the
+    baseline every path must reproduce exactly; ``multiallelic_hm`` below
+    covers the per-allele conventions.
     """
     hm = simulate_hm(n_samples=24, seq_length=200_000, seed=7,
                      mutation_model="binary")

--- a/tests/test_ld_biallelic.py
+++ b/tests/test_ld_biallelic.py
@@ -13,7 +13,7 @@ import cupy as cp
 import pytest
 import msprime
 
-from pg_gpu import HaplotypeMatrix, GenotypeMatrix, BiallelicOnlyWarning
+from pg_gpu import HaplotypeMatrix, GenotypeMatrix, BiallelicOnlyWarning, divergence
 from pg_gpu.ld_statistics import zns, omega
 
 
@@ -79,9 +79,10 @@ class TestRestrictMethods:
         # an all-multiallelic matrix has no biallelic sites: zns/omega return
         # their too-few-sites value (0.0) instead of raising "genotypes cannot
         # be empty" on the empty filter output
-        for est in ('auto', 'r2'):
-            assert zns(_hm(multi), estimator=est) == 0.0
-            assert omega(_hm(multi), estimator=est) == 0.0
+        with pytest.warns(BiallelicOnlyWarning):
+            for est in ('auto', 'r2'):
+                assert zns(_hm(multi), estimator=est) == 0.0
+                assert omega(_hm(multi), estimator=est) == 0.0
 
     def test_indicator_identity_and_recode(self):
         base = [[0, 0, 1], [1, 2, 2], [0, 0, 1], [1, 2, 2]]  # {0,1},{0,2},{1,2}
@@ -144,6 +145,7 @@ class TestGeneralCodingEquivalence:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.filterwarnings("ignore::pg_gpu._warnings.BiallelicOnlyWarning")
 class TestKeepShapeOutOfDomain:
 
     def _data(self):
@@ -182,6 +184,14 @@ class TestKeepShapeOutOfDomain:
 # ---------------------------------------------------------------------------
 
 
+def _with_two_pops(hm):
+    """Split the rows into two named populations for the composite statistics."""
+    half = hm.num_haplotypes // 2
+    hm.sample_sets = {'pop1': list(range(half)),
+                      'pop2': list(range(half, hm.num_haplotypes))}
+    return hm
+
+
 class TestWarning:
 
     def _multi(self, n_multi):
@@ -200,6 +210,7 @@ class TestWarning:
         lambda hm: zns(hm, estimator='r2'),
         lambda hm: omega(hm, estimator='r2'),
         lambda hm: hm.windowed_r_squared([0, 6000, 13000]),
+        lambda hm: divergence.zx(_with_two_pops(hm), 'pop1', 'pop2'),
     ])
     def test_warns_once(self, fn):
         with warnings.catch_warnings(record=True) as w:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -13,13 +13,10 @@ from pg_gpu.zarr_source import ZarrGenotypeSource
 from .conftest import simulate_hm
 
 
-def _simulate_hm(n_samples=20, seq_length=50_000, seed=42):
-    return simulate_hm(n_samples=n_samples, seq_length=seq_length, seed=seed)
-
-
 @pytest.fixture
 def vcz_store(tmp_path):
-    hm = _simulate_hm()
+    hm = simulate_hm(n_samples=20, seq_length=50_000, seed=42,
+                     mutation_model='binary')
     hm.samples = [f"s{i}" for i in range(hm.num_haplotypes // 2)]
     path = str(tmp_path / "stream.vcz")
     hm.to_zarr(path, format="vcz", contig_name="1")
@@ -375,11 +372,8 @@ class TestMaterialize:
     def test_pairwise_r2_via_materialize(self, vcz_store):
         # The intended user pattern: streaming hm -> .materialize(region=)
         # -> pairwise_r2(). Asserts the composition produces an (n_var x n_var)
-        # matrix with the kernel's diagonal zeroed. The msprime fixture uses the
-        # default Jukes-Cantor model, so it has multiallelic sites: pairwise_r2 is
-        # biallelic-only and returns NaN for their rows/cols, while the biallelic
-        # pairs stay finite. The composition is what this test is for; the r2
-        # numerics are validated elsewhere.
+        # matrix with the kernel's diagonal zeroed. The composition is what this
+        # test is for; the r2 numerics are validated elsewhere.
         path, _ = vcz_store
         stream = HaplotypeMatrix.from_zarr(path, streaming="always",
                                             chunk_bp=5_000)

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -16,7 +16,8 @@ from .conftest import simulate_hm
 
 
 def _simulate_hm(n_samples=20, seq_length=100_000, seed=42):
-    return simulate_hm(n_samples=n_samples, seq_length=seq_length, seed=seed)
+    return simulate_hm(n_samples=n_samples, seq_length=seq_length, seed=seed,
+                       mutation_model='binary')
 
 
 @pytest.fixture

--- a/tests/test_two_pop_stats.py
+++ b/tests/test_two_pop_stats.py
@@ -3,7 +3,7 @@
 import pytest
 import numpy as np
 import msprime
-from pg_gpu import HaplotypeMatrix, divergence
+from pg_gpu import BiallelicOnlyWarning, HaplotypeMatrix, divergence
 
 
 @pytest.fixture
@@ -168,6 +168,7 @@ class TestPrecomputedDistanceMatrices:
             divergence.snn(two_pop_hm, 'pop1', 'pop2', distance_matrices=bad_dm)
 
 
+@pytest.mark.filterwarnings("ignore::pg_gpu._warnings.BiallelicOnlyWarning")
 class TestZx:
     def test_finite(self, two_pop_hm):
         val = divergence.zx(two_pop_hm, 'pop1', 'pop2')
@@ -176,3 +177,13 @@ class TestZx:
     def test_positive(self, two_pop_hm):
         val = divergence.zx(two_pop_hm, 'pop1', 'pop2')
         assert val > 0
+
+    def test_one_site_set_for_all_three_zns(self, two_pop_hm):
+        """A site that is triallelic across the sample but biallelic inside
+        one population leaves every ZnS term, so restricting the matrix
+        yourself first must not move the value."""
+        shared = two_pop_hm.restrict_to_biallelic()
+        assert shared.num_variants < two_pop_hm.num_variants
+        with pytest.warns(BiallelicOnlyWarning):
+            val = divergence.zx(two_pop_hm, 'pop1', 'pop2')
+        assert divergence.zx(shared, 'pop1', 'pop2') == pytest.approx(val)


### PR DESCRIPTION
`pyproject.toml` ignored `BiallelicOnlyWarning` for the whole suite (by message since #225, so pytest-cov keeps measuring module-level lines), which meant a statistic that started dropping or recoding sites could not fail a test. This PR flips that filter to `error`. A drop must now be expected by the test that triggers it, with `pytest.warns` or a `filterwarnings` mark; anywhere else it fails the test.

**What the promotion caught.** `divergence.zx` computed each of its three ZnS values on a different site set: `zns` drops the sites that are multiallelic within the matrix it is handed, so a site that is triallelic across the sample but biallelic inside one population entered that population's term and not the total's. On the two-population test fixture that moves `zns(pop1)` from 0.030275 to 0.030464 and `zx` from 1.903107 to 1.903249; small there, but the wrong definition (Schrider et al. 2018 compute all three on one SNP set), and it grows with how multiallelic the data is. `zx` now restricts the whole matrix once, warns once, and computes all three terms on it. A new test checks that pre-restricting the matrix yourself does not move the value, and `zx` joins the parametrized once-per-call warning test.

**Blast radius, measured.** With the filter at `error`, 28 tests failed on `main`, the same count #222 estimated, and none of the 53 `--slow` tests. They split into: 21 streaming tests whose msprime Jukes-Cantor fixtures carried a few triallelic sites that `GenotypeMatrix.from_zarr` recodes (now simulated under `mutation_model='binary'`, as the other streaming files already did); 4 `test_ld_biallelic` tests plus one streaming test that build multiallelic input on purpose (now `pytest.warns` or a class-level `filterwarnings` mark); and the 2 `TestZx` tests above.

**Small refactors that fell out.** `HaplotypeMatrix.restrict_to_biallelic` gains `warn_context=`, replacing the restrict-then-warn pair six callers had written out by hand (`zns`, `omega`, `windowed_r_squared`, both `compute_ld_statistics_gpu_*`, and `zx`). `ld_statistics._zns_biallelic` lets a caller that has already restricted skip the second pass. `zns` and `omega` docstrings now state the restriction contract. The phrase the filter keys on is pinned by `test_biallelic_only_warning`, so a rewording of the message cannot silently switch enforcement off. One doc sentence that claimed `restrict_to_biallelic` itself warns is corrected.

Full suite 1373 passed, 78 skipped, 25 xfailed; slow 53 passed; ruff clean; Sphinx builds.

Closes #222.
