### PR TITLE
Lay out from_ts rows by individual, not by sample order

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -175,6 +175,15 @@ Read this section if you are comparing against older pg_gpu results.
 Bug fixes
 ~~~~~~~~~
 
+* ``HaplotypeMatrix.from_ts`` laid out rows in ``ts.samples()`` order and
+  assumed each individual's two nodes were adjacent there. tskit does not
+  promise that (``simplify`` renumbers samples freely), so on a reordered
+  tree sequence every statistic that rebuilds individuals from adjacent
+  rows (``fst_weir_cockerham``, ``heterozygosity_observed``,
+  ``GenotypeMatrix.from_haplotype_matrix``) was silently wrong. Rows now
+  follow the individuals, so individual ``i`` owns rows ``2i`` and
+  ``2i + 1`` whatever the sample order; ordinary msprime output is
+  unchanged.
 * ``divergence.zx`` computed each of its three ZnS values on a different
   site set, because ``zns`` drops the sites that are multiallelic within
   the matrix it is handed. The whole matrix is now restricted to

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -110,23 +110,24 @@ _TS_LAYOUT_HINT = ("Simplify to the sample nodes you want, or build the "
 
 
 def _ts_row_order(ts):
-    """Sample nodes of ``ts`` grouped by individual, or ``None`` to keep
-    ``ts.samples()`` order.
+    """``(order, paired)``: the sample-node row order ``from_ts`` uses, and
+    whether adjacent rows pair into individuals.
 
     tskit does not promise that an individual's nodes sit together in
     ``ts.samples()`` (``simplify`` renumbers freely), and the statistics
     that rebuild individuals from adjacent rows have no other way to know.
-    ``None`` means nothing in the input defines a pairing (no individuals,
-    or one sample node each), so the default decode order stands.
-    Individuals with no sample nodes own no rows; non-sample nodes inside
-    an individual are ignored.
+    ``order`` is ``None`` whenever the default decode order already serves:
+    nothing in the input defines a pairing (no individuals, or one sample
+    node each; ``paired`` is False), or the grouped order equals
+    ``ts.samples()`` anyway. Individuals with no sample nodes own no rows;
+    non-sample nodes inside an individual are ignored.
     """
     samples = ts.samples()
     owner = ts.nodes_individual[samples]
     per_individual = np.bincount(owner[owner != tskit.NULL],
                                  minlength=ts.num_individuals)
     if (per_individual <= 1).all():
-        return None
+        return None, False
     if (owner == tskit.NULL).any():
         raise ValueError(
             "from_ts cannot lay out rows by individual: sample node "
@@ -143,7 +144,10 @@ def _ts_row_order(ts):
     # Node id order within an individual is the order individual.nodes reports
     # and the order write_vcf emits alleles in, so from_ts and from_vcf of the
     # VCF written from the same tree sequence produce identical rows.
-    return samples[np.lexsort((samples, owner))]
+    order = samples[np.lexsort((samples, owner))]
+    if np.array_equal(order, samples):
+        return None, True
+    return order, True
 
 
 def _decide_streaming_mode(zarr_path, region, streaming, pop_assignment,
@@ -1025,10 +1029,13 @@ class HaplotypeMatrix:
             each pop name maps to the haplotype row indices of its
             samples. The no-demography case (``sim_ancestry(samples=N)``
             with a single unnamed population) leaves ``sample_sets``
-            unset. Users who need custom groupings can overwrite
+            unset. An individual whose two sample nodes belong to
+            different populations raises, because a population subset
+            cannot pair it; assign ``sample_sets`` by hand for such data.
+            Users who need custom groupings can overwrite
             ``hm.sample_sets`` after construction.
         """
-        row_nodes = _ts_row_order(ts)
+        row_nodes, paired = _ts_row_order(ts)
         # Passing samples= makes tskit decode node by node, 1.3-1.8x slower
         # than the default order, so only pay it when the rows really move.
         haplotypes = (ts.genotype_matrix() if row_nodes is None
@@ -1063,7 +1070,23 @@ class HaplotypeMatrix:
                 # Ascending, so each list reads as whole individuals: the
                 # pairing consumers take consecutive entries as one sample,
                 # while ts.samples(population=) returns node order.
-                sample_sets[name] = sorted(row_of[s] for s in nodes.tolist())
+                rows = sorted(row_of[s] for s in nodes.tolist())
+                if paired:
+                    # A row whose partner row (2i <-> 2i + 1) is missing means
+                    # this individual's gametes sit in different populations,
+                    # which a paired row list cannot represent.
+                    rowset = set(rows)
+                    lone = [r for r in rows if (r ^ 1) not in rowset]
+                    if lone:
+                        ind = int(ts.nodes_individual[row_nodes[lone[0]]])
+                        raise ValueError(
+                            f"population {name!r} holds one gamete of "
+                            f"individual {ind} but not the other: its sample "
+                            f"nodes belong to different populations. "
+                            f"sample_sets pair consecutive rows into "
+                            f"individuals, so this layout cannot be "
+                            f"auto-registered. Assign sample_sets by hand.")
+                sample_sets[name] = rows
         if sample_sets:
             hm.sample_sets = sample_sets
 

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -105,6 +105,47 @@ def _tabix_region(chrom, start, stop):
     return f"{chrom}:{1 if start is None else start}-{end}"
 
 
+_TS_LAYOUT_HINT = ("Simplify to the sample nodes you want, or build the "
+                   "matrix by hand.")
+
+
+def _ts_row_order(ts):
+    """Sample nodes of ``ts`` grouped by individual, or ``None`` to keep
+    ``ts.samples()`` order.
+
+    tskit does not promise that an individual's nodes sit together in
+    ``ts.samples()`` (``simplify`` renumbers freely), and the statistics
+    that rebuild individuals from adjacent rows have no other way to know.
+    ``None`` means nothing in the input defines a pairing (no individuals,
+    or one sample node each), so the default decode order stands.
+    Individuals with no sample nodes own no rows; non-sample nodes inside
+    an individual are ignored.
+    """
+    samples = ts.samples()
+    owner = ts.nodes_individual[samples]
+    per_individual = np.bincount(owner[owner != tskit.NULL],
+                                 minlength=ts.num_individuals)
+    if (per_individual <= 1).all():
+        return None
+    if (owner == tskit.NULL).any():
+        raise ValueError(
+            "from_ts cannot lay out rows by individual: sample node "
+            f"{samples[owner == tskit.NULL][0]} belongs to no individual while "
+            f"others do. {_TS_LAYOUT_HINT}")
+    bad = np.flatnonzero((per_individual > 0) & (per_individual != 2))
+    if bad.size:
+        from ._warnings import ISSUE_URL
+        raise ValueError(
+            "from_ts needs two sample nodes per individual to lay out rows 2i "
+            f"and 2i + 1; individual {bad[0]} has {per_individual[bad[0]]}. "
+            f"{_TS_LAYOUT_HINT} pg_gpu's loaders support diploid data only; "
+            f"haploid and polyploid input is not yet supported (see {ISSUE_URL}).")
+    # Node id order within an individual is the order individual.nodes reports
+    # and the order write_vcf emits alleles in, so from_ts and from_vcf of the
+    # VCF written from the same tree sequence produce identical rows.
+    return samples[np.lexsort((samples, owner))]
+
+
 def _decide_streaming_mode(zarr_path, region, streaming, pop_assignment,
                            free_gpu_bytes=None,
                            fraction=STREAMING_AUTO_EAGER_FRACTION):
@@ -179,6 +220,11 @@ class HaplotypeMatrix:
     ``diversity.inbreeding_coefficient``, genotype-mode LD, and the
     ``to_zarr`` writer -- assumes it. ``sample_sets`` therefore lists both
     gametes of each member, e.g. sample 3 contributes ``[6, 7]``.
+
+    The one exception is ``from_ts`` on a tree sequence with no individuals,
+    or with one sample node per individual: those rows keep ``ts.samples()``
+    order and do not pair, so the consumers above have no defined meaning on
+    them.
 
     Statistics that treat rows as independent gametes are unaffected by the
     order; only the ones above pair rows.
@@ -965,6 +1011,15 @@ class HaplotypeMatrix:
             HaplotypeMatrix: A new HaplotypeMatrix instance
 
         Notes:
+            Rows are grouped by individual: when every sample node belongs
+            to an individual with two sample nodes, individual ``i`` owns
+            rows ``2i`` and ``2i + 1`` regardless of the order of
+            ``ts.samples()``, which ``simplify`` is free to change. A tree
+            sequence with no individuals, or with one sample node per
+            individual (``ploidy=1``), keeps ``ts.samples()`` order; the
+            statistics that pair adjacent rows into individuals have no
+            defined meaning on such input. Any other layout raises.
+
             Populations declared in the tree sequence (with a name in
             metadata) are automatically registered in ``sample_sets``:
             each pop name maps to the haplotype row indices of its
@@ -973,8 +1028,13 @@ class HaplotypeMatrix:
             unset. Users who need custom groupings can overwrite
             ``hm.sample_sets`` after construction.
         """
-        # Convert ts to haplotype matrix
-        haplotypes = ts.genotype_matrix().T
+        row_nodes = _ts_row_order(ts)
+        # Passing samples= makes tskit decode node by node, 1.3-1.8x slower
+        # than the default order, so only pay it when the rows really move.
+        haplotypes = (ts.genotype_matrix() if row_nodes is None
+                      else ts.genotype_matrix(samples=row_nodes)).T
+        if row_nodes is None:
+            row_nodes = ts.samples()
         positions = ts.tables.sites.position
         # tskit uses 0-based exclusive ends (positions in [0, sequence_length))
         # while pg_gpu treats chrom_end as 1-based inclusive. Subtract 1 so
@@ -993,14 +1053,17 @@ class HaplotypeMatrix:
             hm.set_accessible_mask(accessible_bed, chrom=chrom)
 
         sample_sets = {}
-        sample_idx = {s: i for i, s in enumerate(ts.samples())}
+        row_of = {s: i for i, s in enumerate(row_nodes.tolist())}
         for pop in ts.populations():
             name = pop.metadata.get("name") if pop.metadata else None
             if name is None:
                 continue
             nodes = ts.samples(population=pop.id)
             if len(nodes):
-                sample_sets[name] = [sample_idx[s] for s in nodes]
+                # Ascending, so each list reads as whole individuals: the
+                # pairing consumers take consecutive entries as one sample,
+                # while ts.samples(population=) returns node order.
+                sample_sets[name] = sorted(row_of[s] for s in nodes.tolist())
         if sample_sets:
             hm.sample_sets = sample_sets
 

--- a/tests/test_haplotype_matrix.py
+++ b/tests/test_haplotype_matrix.py
@@ -797,8 +797,16 @@ class TestFromTsRowOrder:
             assert hm.sample_sets[name] == expect
 
     def test_no_individuals_keeps_sample_order(self):
-        ts = msprime.simulate(sample_size=6, length=1e3, mutation_rate=1e-3,
-                              random_seed=3)
+        # sim_ancestry always records individuals, so strip them through the
+        # tables: this is what hand-built or pre-individual tree sequences
+        # look like.
+        ts = msprime.sim_ancestry(3, sequence_length=1e3, random_seed=3, ploidy=2)
+        ts = msprime.sim_mutations(ts, rate=1e-3, random_seed=3)
+        tables = ts.dump_tables()
+        tables.individuals.clear()
+        tables.nodes.individual = np.full(tables.nodes.num_rows, tskit.NULL,
+                                          dtype=np.int32)
+        ts = tables.tree_sequence()
         assert ts.num_individuals == 0
         np.testing.assert_array_equal(HaplotypeMatrix.from_ts(ts).haplotypes,
                                       ts.genotype_matrix().T)

--- a/tests/test_haplotype_matrix.py
+++ b/tests/test_haplotype_matrix.py
@@ -835,6 +835,20 @@ class TestFromTsRowOrder:
         with pytest.raises(ValueError, match="individual 0 has 3"):
             HaplotypeMatrix.from_ts(with_individual(2, 0))
 
+    def test_split_individual_across_populations_raises(self):
+        # Legal in the tables (Nate's admixture-at-the-present example): one
+        # individual with a gamete in each population. The auto-registered
+        # sample_sets cannot pair it, so from_ts must say so instead of
+        # building lists that mis-pair downstream.
+        ts = self._ts()
+        tables = ts.dump_tables()
+        population = tables.nodes.population.copy()
+        other = int(population[ts.samples()[-1]])
+        population[int(ts.individual(0).nodes[1])] = other
+        tables.nodes.population = population
+        with pytest.raises(ValueError, match="one gamete of individual 0"):
+            HaplotypeMatrix.from_ts(tables.tree_sequence())
+
     def test_non_sample_node_in_individual_is_ignored(self):
         ts = self._ts()
         tables = ts.dump_tables()

--- a/tests/test_haplotype_matrix.py
+++ b/tests/test_haplotype_matrix.py
@@ -1,5 +1,6 @@
 import pytest
 import msprime
+import tskit
 import allel
 import cupy as cp
 import numpy as np
@@ -84,21 +85,31 @@ def test_from_ts_default_population(sample_ts):
     assert len(hm.sample_sets["pop_0"]) == hm.num_haplotypes
 
 
-def test_from_ts_populates_sample_sets_from_demography():
-    """Named populations in the tree sequence auto-register as sample_sets."""
+def _two_pop_ts(samples, seq_length, seed, mutation_rate=1e-8, model=None):
+    """Two named populations A and B that split from AB 5,000 generations ago."""
     demography = msprime.Demography()
-    demography.add_population(name="A", initial_size=10_000)
-    demography.add_population(name="B", initial_size=10_000)
-    demography.add_population(name="AB", initial_size=10_000)
+    for name in ("A", "B", "AB"):
+        demography.add_population(name=name, initial_size=10_000)
     demography.add_population_split(time=5_000, derived=["A", "B"],
                                     ancestral="AB")
-    ts = msprime.sim_ancestry(
-        samples={"A": 12, "B": 8},
-        sequence_length=100_000,
-        recombination_rate=1e-8,
-        demography=demography,
-        random_seed=42, ploidy=2)
-    ts = msprime.sim_mutations(ts, rate=1e-8, random_seed=42)
+    ts = msprime.sim_ancestry(samples=samples, sequence_length=seq_length,
+                              recombination_rate=1e-8, demography=demography,
+                              random_seed=seed, ploidy=2)
+    return msprime.sim_mutations(ts, rate=mutation_rate, random_seed=seed,
+                                 model=model)
+
+
+def _scrambled(ts):
+    """The same tree sequence with one gamete of every individual listed
+    first, then the others: a legal sample order in which no individual's
+    nodes sit together."""
+    n = ts.num_individuals
+    return ts.simplify(samples=[2 * i for i in range(n)] + [2 * i + 1 for i in range(n)])
+
+
+def test_from_ts_populates_sample_sets_from_demography():
+    """Named populations in the tree sequence auto-register as sample_sets."""
+    ts = _two_pop_ts({"A": 12, "B": 8}, seq_length=100_000, seed=42)
 
     hm = HaplotypeMatrix.from_ts(ts)
 
@@ -746,3 +757,80 @@ def test_from_vcf_region_forms(indexed_vcf):
     np.testing.assert_array_equal(positions("1"), pos)
     np.testing.assert_array_equal(positions(f"1:{mid}"), pos[pos >= mid])
     np.testing.assert_array_equal(positions(f"1:{first:,}-{mid:,}"), got)
+
+
+
+class TestFromTsRowOrder:
+    """from_ts lays out rows by individual, not by ts.samples() order."""
+
+    @staticmethod
+    def _ts():
+        return _two_pop_ts({"A": 4, "B": 4}, seq_length=5e4, seed=7,
+                           mutation_rate=1e-7, model="binary")
+
+    def test_ordinary_msprime_output_is_unchanged(self):
+        ts = self._ts()
+        np.testing.assert_array_equal(HaplotypeMatrix.from_ts(ts).haplotypes,
+                                      ts.genotype_matrix().T)
+
+    def test_rows_follow_individuals_after_simplify(self):
+        ts = self._ts()
+        ts2 = _scrambled(ts)
+        assert list(ts2.individual(0).nodes) != [0, 1]  # the order really moved
+        hm, hm2 = HaplotypeMatrix.from_ts(ts), HaplotypeMatrix.from_ts(ts2)
+        for t, m in ((ts, hm), (ts2, hm2)):
+            nodes = [n for i in range(t.num_individuals)
+                     for n in sorted(t.individual(i).nodes)]
+            np.testing.assert_array_equal(m.haplotypes, t.genotype_matrix()[:, nodes].T)
+        # Same individuals in the same rows, so every downstream statistic
+        # that pairs rows agrees between the two loads.
+        np.testing.assert_array_equal(hm.haplotypes, hm2.haplotypes)
+
+    def test_population_sets_follow_individuals(self):
+        ts2 = _scrambled(self._ts())
+        hm = HaplotypeMatrix.from_ts(ts2)
+        pop_id = {p.metadata["name"]: p.id for p in ts2.populations() if p.metadata}
+        for name in ("A", "B"):
+            expect = [r for i in range(ts2.num_individuals)
+                      if ts2.node(ts2.individual(i).nodes[0]).population == pop_id[name]
+                      for r in (2 * i, 2 * i + 1)]
+            assert hm.sample_sets[name] == expect
+
+    def test_no_individuals_keeps_sample_order(self):
+        ts = msprime.simulate(sample_size=6, length=1e3, mutation_rate=1e-3,
+                              random_seed=3)
+        assert ts.num_individuals == 0
+        np.testing.assert_array_equal(HaplotypeMatrix.from_ts(ts).haplotypes,
+                                      ts.genotype_matrix().T)
+
+    @pytest.mark.filterwarnings("error")
+    def test_haploid_keeps_sample_order_silently(self):
+        ts = msprime.sim_ancestry(5, sequence_length=1e4, random_seed=3, ploidy=1)
+        ts = msprime.sim_mutations(ts, rate=1e-3, random_seed=3)
+        np.testing.assert_array_equal(HaplotypeMatrix.from_ts(ts).haplotypes,
+                                      ts.genotype_matrix().T)
+
+    def test_mixed_layouts_raise(self):
+        ts = self._ts()
+
+        def with_individual(node, value):
+            tables = ts.dump_tables()
+            individual = tables.nodes.individual.copy()
+            individual[node] = value
+            tables.nodes.individual = individual
+            return tables.tree_sequence()
+
+        # A sample node with no individual, next to samples that have one.
+        with pytest.raises(ValueError, match="belongs to no individual"):
+            HaplotypeMatrix.from_ts(with_individual(0, tskit.NULL))
+        # An individual with three sample nodes.
+        with pytest.raises(ValueError, match="individual 0 has 3"):
+            HaplotypeMatrix.from_ts(with_individual(2, 0))
+
+    def test_non_sample_node_in_individual_is_ignored(self):
+        ts = self._ts()
+        tables = ts.dump_tables()
+        tables.nodes.add_row(flags=0, time=1.0, individual=0)  # not a sample
+        np.testing.assert_array_equal(
+            HaplotypeMatrix.from_ts(tables.tree_sequence()).haplotypes,
+            ts.genotype_matrix().T)


### PR DESCRIPTION
`HaplotypeMatrix.from_ts` built its rows from `ts.genotype_matrix()`, which follows `ts.samples()`, and assumed each individual's two nodes sat next to each other there. tskit does not promise that; `simplify` renumbers samples freely. On a reordered tree sequence every statistic that rebuilds individuals from adjacent rows was silently wrong: on the issue's example `heterozygosity_observed` moves from 0.253080 to 0.243297 and `fst_weir_cockerham` from 0.008242 to 0.000248, while `pi` is unchanged, so nothing looks broken.

**What changes.** A new `_ts_row_order` groups the sample nodes by individual (node id order within an individual, which is also the order `write_vcf` emits, so `from_ts` and `from_vcf` keep producing identical rows) and `from_ts` decodes with `ts.genotype_matrix(samples=...)` in that order. Population `sample_sets` map nodes to rows through the same order and are sorted, so each population's list reads as whole individuals for the pairing consumers. Ordinary msprime output is already grouped, and for it the default decode runs unchanged: the `samples=` path costs 1.3-1.8x and is only taken when rows actually move.

**The cases.** Every sample node in an individual with two sample nodes: rows by individual. No individuals (`msprime.simulate`, hand-built tables) or one sample node per individual (`ploidy=1`): `ts.samples()` order, silently, since nothing defines a pairing; the class docstring now names this exception to the row-order rule. Anything else (orphan samples next to individuals, three sample nodes in one individual): `ValueError`, with the diploid-only pointer the other loaders give (#121).

**Tests.** The issue's reproduction (same tree sequence as simulated and after a scrambling `simplify`; rows match each individual's nodes and the two loads are identical), population sets after reordering against an exact expected list, the no-individual and haploid cases, the two raising layouts, and a non-sample node inside an individual. The demography test now shares the two-population helper. Full suite 1380 passed, slow 53 passed, ruff and Sphinx clean; the 39 existing `from_ts` call sites are bit-identical.

Closes #192.
