### PR TITLE
Better memory management for moments.LD statistics with multiple pops

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -192,6 +192,16 @@ Bug fixes
   different matrices. They now share one definition. Sites showing only
   alleles ``0`` and ``2``, or only ``1`` and ``2``, are kept rather
   than dropped, and sites where nothing varies are kept too.
+* ``moments_ld.compute_ld_statistics`` ran out of GPU memory for three
+  and four populations: the automatic pair-chunk size assumed the work
+  per pair grew in proportion to the number of populations, but the
+  number of LD statistics grows faster (3, 15, 45, 105 for one to four
+  populations), so it chose a chunk several times too large. The
+  estimate now scales with the statistic count, and a lower bound that
+  could force a chunk larger than fits in memory was removed.
+  ``compute_ld_statistics`` also gained ``chunk_size`` and
+  ``available_memory_bytes`` arguments to override the estimate; they do
+  not change results, only memory use.
 
 New warnings
 ~~~~~~~~~~~~

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -197,8 +197,7 @@ Bug fixes
   per pair grew in proportion to the number of populations, but the
   number of LD statistics grows faster (3, 15, 45, 105 for one to four
   populations), so it chose a chunk several times too large. The
-  estimate now scales with the statistic count, and a lower bound that
-  could force a chunk larger than fits in memory was removed.
+  estimate now scales with the statistic count.
   ``compute_ld_statistics`` also gained ``chunk_size`` and
   ``available_memory_bytes`` arguments to override the estimate; they do
   not change results, only memory use.

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -2238,7 +2238,8 @@ class HaplotypeMatrix:
         n_bins = len(bp_bins_arr) - 1
         bp_bins_cp = cp.array(bp_bins_arr)
         if chunk_size == 'auto':
-            chunk_size = _estimate_ld_chunk_size(seg.num_haplotypes)
+            num_stats = 3  # single-pop DD/Dz/pi2
+            chunk_size = _estimate_ld_chunk_size(seg.num_haplotypes, num_stats)
 
         pos = seg.positions
         if not isinstance(pos, cp.ndarray):
@@ -2313,9 +2314,9 @@ class HaplotypeMatrix:
         pop1_indices = seg._sample_sets[pop1]
         pop2_indices = seg._sample_sets[pop2]
         if chunk_size == 'auto':
-            chunk_size = _estimate_ld_chunk_size(
-                max(len(pop1_indices), len(pop2_indices))
-            )
+            num_stats = 15  # two-pop DD/Dz/pi2
+            num_haplos = max(len(pop1_indices), len(pop2_indices))
+            chunk_size = _estimate_ld_chunk_size(num_haplos * 2, num_stats)
 
         pos = seg.positions
         if not isinstance(pos, cp.ndarray):
@@ -2440,7 +2441,9 @@ def _stream_ld_single_pop(streaming_hm, *, bp_bins, raw, chunk_size):
     n_bins = len(bp_bins_arr) - 1
     bp_bins_cp = cp.array(bp_bins_arr)
     if chunk_size == 'auto':
-        chunk_size_int = _estimate_ld_chunk_size(streaming_hm.num_haplotypes)
+        num_stats = 3  # single-pop DD/Dz/pi2
+        chunk_size_int = _estimate_ld_chunk_size(
+            streaming_hm.num_haplotypes, num_stats)
     else:
         chunk_size_int = int(chunk_size)
     bin_sums = cp.zeros((n_bins, 3), dtype=cp.float64)
@@ -2486,9 +2489,9 @@ def _stream_ld_two_pops(streaming_hm, *, bp_bins, pop1, pop2, raw,
     pop1_indices = streaming_hm.sample_sets[pop1]
     pop2_indices = streaming_hm.sample_sets[pop2]
     if chunk_size == 'auto':
-        chunk_size_int = _estimate_ld_chunk_size(
-            max(len(pop1_indices), len(pop2_indices))
-        )
+        num_stats = 15  # two-pop DD/Dz/pi2
+        num_haplos = max(len(pop1_indices), len(pop2_indices))
+        chunk_size_int = _estimate_ld_chunk_size(num_haplos * 2, num_stats)
     else:
         chunk_size_int = int(chunk_size)
     bin_sums = cp.zeros((n_bins, 15), dtype=cp.float64)

--- a/pg_gpu/ld_pipeline.py
+++ b/pg_gpu/ld_pipeline.py
@@ -49,7 +49,8 @@ def estimate_ld_chunk_size(n_gathered_rows, n_stats,
     if n_stats < 1:
         raise ValueError("n_stats must be positive")
     if available_memory_bytes is None:
-        available_memory_bytes = int(cp.cuda.Device().mem_info[0] * 0.5)
+        available_memory_bytes = cp.cuda.Device().mem_info[0] * 0.5
+    available_memory_bytes = int(available_memory_bytes)
 
     bytes_per_pair = (4 * n_gathered_rows + 50 * n_stats) * 3
     fit = available_memory_bytes // bytes_per_pair

--- a/pg_gpu/ld_pipeline.py
+++ b/pg_gpu/ld_pipeline.py
@@ -18,13 +18,14 @@ def estimate_ld_chunk_size(n_haplotypes_per_pop, available_memory_bytes=None,
     """
     Estimate optimal chunk size for LD computation based on GPU memory.
 
-    Memory per pair (N pairs, H haplotypes per pop, P populations):
-    - hap_i, hap_j arrays (P pops): 4 * H * P * N bytes
-    - counts arrays: 32 * P * N bytes
-    - statistics: 120 * P * N bytes
-    - Overhead (~3x): accounts for intermediates, fragmentation
-
-    Formula: bytes_per_pair = (4*H*P + 150*P) * 3
+    Per-pair memory has two parts: the gathered genotype/haplotype slabs, which
+    scale with haplotypes * populations, and the per-pair working set (counts,
+    statistics, kernel intermediates), which scales with the *number* of LD
+    statistics ``n_ld = len(ld_names(num_pops))`` -- 3 / 15 / 45 / 105 for 1-4
+    pops -- not with ``num_pops``. The ``50 * n_ld`` term is anchored so it
+    matches the historical ``150 * num_pops`` at one population (n_ld == 3) and
+    keeps scaling with the true statistic count above it. The ``* 3`` overhead
+    and the 50%-of-free budget below are the safety margin.
 
     Parameters
     ----------
@@ -43,10 +44,13 @@ def estimate_ld_chunk_size(n_haplotypes_per_pop, available_memory_bytes=None,
     if available_memory_bytes is None:
         available_memory_bytes = int(cp.cuda.Device().mem_info[0] * 0.5)
 
-    bytes_per_pair = (4 * n_haplotypes_per_pop * num_pops + 150 * num_pops) * 3
-    chunk_size = available_memory_bytes // bytes_per_pair
+    n_ld = len(ld_names(num_pops))
+    bytes_per_pair = (4 * n_haplotypes_per_pop * num_pops + 50 * n_ld) * 3
+    fit = available_memory_bytes // bytes_per_pair
 
-    return max(100_000, min(chunk_size, 10_000_000))
+    # Cap per-chunk work at the ceiling. There is no lower floor: a minimum
+    # above what fits would defeat the estimate on a tight or contended GPU.
+    return max(1, min(fit, 10_000_000))
 
 
 # ---------------------------------------------------------------------------

--- a/pg_gpu/ld_pipeline.py
+++ b/pg_gpu/ld_pipeline.py
@@ -13,44 +13,47 @@ import cupy as cp
 # ---------------------------------------------------------------------------
 
 
-def estimate_ld_chunk_size(n_haplotypes_per_pop, available_memory_bytes=None,
-                           num_pops=2):
+def estimate_ld_chunk_size(n_gathered_rows, n_stats,
+                           available_memory_bytes=None):
     """
     Estimate optimal chunk size for LD computation based on GPU memory.
 
-    Memory per pair (N pairs, H haplotypes per pop, P populations,
-    S = len(ld_names(P)) statistics: 3 / 15 / 45 / 105 for P = 1-4):
-    - gathered genotype/haplotype slabs (P pops): 4 * H * P * N bytes
-    - working set (counts, statistics, intermediates): 50 * S * N bytes
-    - Overhead (~3x): accounts for intermediates, fragmentation
+    The per-pair cost is modelled as two terms (R rows gathered per pair
+    across populations, S statistics per pair):
+    - a data term growing with R, the per-pair genotype/haplotype gather. The
+      genotype path reads the matrix in place rather than gathering per pair,
+      so this term overestimates it.
+    - a working-set term (counts, statistics, intermediates) growing with the
+      statistic count S.
 
-    Formula: bytes_per_pair = (4*H*P + 50*S) * 3
-
-    The working set scales with the number of statistics S, not with P; the
-    constant sets a one-population run (S == 3) to 150 bytes per pair. The * 3
-    overhead and the 50%-of-free budget below are the safety margin.
+    Concretely bytes_per_pair = (4*R + 50*S) * 3, evaluated against half the
+    free memory. The constant sets a run of three statistics to 150 bytes per
+    pair; the * 3 overhead and the 50%-of-free budget are the safety margin.
 
     Parameters
     ----------
-    n_haplotypes_per_pop : int
-        Number of haplotypes in the larger population
+    n_gathered_rows : int
+        Total haplotype/genotype rows gathered per pair, summed over the
+        populations (e.g. haplotypes per pop times the number of pops).
+    n_stats : int
+        Number of statistic values accumulated per pair (for the LD moments,
+        the length of the statistic basis for the requested populations).
     available_memory_bytes : int, optional
         Available GPU memory in bytes. If None, queries the GPU.
-    num_pops : int
-        Number of populations (default 2)
 
     Returns
     -------
     int
         Recommended chunk size (number of pairs per iteration)
     """
+    if n_stats < 1:
+        raise ValueError("n_stats must be positive")
     if available_memory_bytes is None:
         available_memory_bytes = int(cp.cuda.Device().mem_info[0] * 0.5)
 
-    n_ld = len(ld_names(num_pops))
-    bytes_per_pair = (4 * n_haplotypes_per_pop * num_pops + 50 * n_ld) * 3
+    bytes_per_pair = (4 * n_gathered_rows + 50 * n_stats) * 3
     fit = available_memory_bytes // bytes_per_pair
-    return max(1, min(fit, 10_000_000))
+    return max(1_000, min(fit, 10_000_000))
 
 
 # ---------------------------------------------------------------------------

--- a/pg_gpu/ld_pipeline.py
+++ b/pg_gpu/ld_pipeline.py
@@ -18,14 +18,17 @@ def estimate_ld_chunk_size(n_haplotypes_per_pop, available_memory_bytes=None,
     """
     Estimate optimal chunk size for LD computation based on GPU memory.
 
-    Per-pair memory has two parts: the gathered genotype/haplotype slabs, which
-    scale with haplotypes * populations, and the per-pair working set (counts,
-    statistics, kernel intermediates), which scales with the *number* of LD
-    statistics ``n_ld = len(ld_names(num_pops))`` -- 3 / 15 / 45 / 105 for 1-4
-    pops -- not with ``num_pops``. The ``50 * n_ld`` term is anchored so it
-    matches the historical ``150 * num_pops`` at one population (n_ld == 3) and
-    keeps scaling with the true statistic count above it. The ``* 3`` overhead
-    and the 50%-of-free budget below are the safety margin.
+    Memory per pair (N pairs, H haplotypes per pop, P populations,
+    S = len(ld_names(P)) statistics: 3 / 15 / 45 / 105 for P = 1-4):
+    - gathered genotype/haplotype slabs (P pops): 4 * H * P * N bytes
+    - working set (counts, statistics, intermediates): 50 * S * N bytes
+    - Overhead (~3x): accounts for intermediates, fragmentation
+
+    Formula: bytes_per_pair = (4*H*P + 50*S) * 3
+
+    The working set scales with the number of statistics S, not with P; the
+    constant sets a one-population run (S == 3) to 150 bytes per pair. The * 3
+    overhead and the 50%-of-free budget below are the safety margin.
 
     Parameters
     ----------
@@ -47,9 +50,6 @@ def estimate_ld_chunk_size(n_haplotypes_per_pop, available_memory_bytes=None,
     n_ld = len(ld_names(num_pops))
     bytes_per_pair = (4 * n_haplotypes_per_pop * num_pops + 50 * n_ld) * 3
     fit = available_memory_bytes // bytes_per_pair
-
-    # Cap per-chunk work at the ceiling. There is no lower floor: a minimum
-    # above what fits would defeat the estimate on a tight or contended GPU.
     return max(1, min(fit, 10_000_000))
 
 

--- a/pg_gpu/moments_ld.py
+++ b/pg_gpu/moments_ld.py
@@ -341,13 +341,14 @@ def _compute_ld_sums(mat, pops, bins, gen_dists_gpu, max_bp_dist,
     bins_gpu = cp.asarray(bins)
     pop_indices = [mat.sample_sets[p] for p in pops]
     max_samp = max(len(pi) for pi in pop_indices)
-    if chunk_size is None:
-        chunk_size = _estimate_ld_chunk_size(
-            max_samp, available_memory_bytes=available_memory_bytes,
-            num_pops=num_pops)
 
     ld_stat_names = _ld_names(num_pops)
     n_ld = len(ld_stat_names)
+
+    if chunk_size is None:
+        chunk_size = _estimate_ld_chunk_size(
+            max_samp * num_pops, n_ld,
+            available_memory_bytes=available_memory_bytes)
 
     # Genetic-distance lookup: filter once outside the loop so fancy-indexing
     # on the keep-mask doesn't repeat per chunk.

--- a/pg_gpu/moments_ld.py
+++ b/pg_gpu/moments_ld.py
@@ -44,7 +44,7 @@ def compute_ld_statistics(
     r_bins=None, bp_bins=None, use_genotypes=True,
     report=True, haplotype_matrix=None,
     genotype_matrix=None, accessible_bed=None,
-    pop_assignment=None,
+    pop_assignment=None, chunk_size=None, available_memory_bytes=None,
 ):
     """GPU LD statistics in the moments.LD.Parsing.compute_ld_statistics output format.
 
@@ -127,6 +127,14 @@ def compute_ld_statistics(
     accessible_bed : str, optional
         Path to a BED file defining accessible/callable regions. Variants
         at inaccessible positions are removed before computing statistics.
+    chunk_size : int, optional
+        Pairs processed per GPU batch. Overrides the automatic estimate; use
+        it to bound peak memory when the estimate is too large (e.g. many
+        populations on a contended GPU). Chunking only partitions an additive
+        sum, so the result is identical for any value.
+    available_memory_bytes : int, optional
+        Memory budget for the automatic chunk-size estimate, in bytes.
+        Defaults to half the free GPU memory. Ignored if ``chunk_size`` is set.
 
     Returns
     -------
@@ -218,10 +226,13 @@ def compute_ld_statistics(
 
     if use_genotypes:
         ld_sums = _compute_ld_sums(mat, pops, bins, gen_dists_gpu, max_bp_dist,
-                                    use_genotypes=True)
+                                    use_genotypes=True, chunk_size=chunk_size,
+                                    available_memory_bytes=available_memory_bytes)
         het = _compute_heterozygosity(mat, pops, use_genotypes=True)
     else:
-        ld_sums = _compute_ld_sums(mat, pops, bins, gen_dists_gpu, max_bp_dist)
+        ld_sums = _compute_ld_sums(mat, pops, bins, gen_dists_gpu, max_bp_dist,
+                                   chunk_size=chunk_size,
+                                   available_memory_bytes=available_memory_bytes)
         het = _compute_heterozygosity(mat, pops)
 
     if report:
@@ -278,7 +289,8 @@ def _max_bp_for_r_dist(positions, gen_dists, max_r):
 
 
 def _compute_ld_sums(mat, pops, bins, gen_dists_gpu, max_bp_dist,
-                     use_genotypes=False):
+                     use_genotypes=False, chunk_size=None,
+                     available_memory_bytes=None):
     """Compute LD statistic sums per bin on GPU for N populations.
 
     Handles both haplotype (4-way) and genotype (9-way) count modes.
@@ -329,7 +341,10 @@ def _compute_ld_sums(mat, pops, bins, gen_dists_gpu, max_bp_dist,
     bins_gpu = cp.asarray(bins)
     pop_indices = [mat.sample_sets[p] for p in pops]
     max_samp = max(len(pi) for pi in pop_indices)
-    chunk_size = _estimate_ld_chunk_size(max_samp, num_pops=num_pops)
+    if chunk_size is None:
+        chunk_size = _estimate_ld_chunk_size(
+            max_samp, available_memory_bytes=available_memory_bytes,
+            num_pops=num_pops)
 
     ld_stat_names = _ld_names(num_pops)
     n_ld = len(ld_stat_names)

--- a/tests/test_ld_pipeline.py
+++ b/tests/test_ld_pipeline.py
@@ -47,3 +47,7 @@ class TestEstimateLdChunkSize:
 
     def test_ceiling_caps_large_budgets(self):
         assert estimate_ld_chunk_size(50, 3, 10**12) == 10_000_000
+
+    def test_float_budget_gives_int_chunk(self):
+        # A float budget must not leak a float chunk size.
+        assert isinstance(estimate_ld_chunk_size(400, 105, 5.0e9), int)

--- a/tests/test_ld_pipeline.py
+++ b/tests/test_ld_pipeline.py
@@ -1,0 +1,45 @@
+"""Unit tests for the LD pair-pipeline helpers.
+
+The chunk-size estimator is pure arithmetic on an explicit memory budget, so
+these tests pass ``available_memory_bytes`` and never query the GPU or try to
+provoke an out-of-memory condition (which is platform-dependent).
+"""
+import pytest
+
+from pg_gpu.ld_pipeline import estimate_ld_chunk_size, ld_names
+
+
+class TestEstimateLdChunkSize:
+    def test_single_pop_matches_historical_anchor(self):
+        # The workspace term is anchored so that at one population (n_ld == 3)
+        # it equals the historical 150 * num_pops, leaving P=1 unchanged.
+        assert len(ld_names(1)) == 3
+        H, budget = 50, 1050 * 1_000_000  # bytes_per_pair = (4*50 + 150)*3 = 1050
+        assert estimate_ld_chunk_size(H, budget, num_pops=1) == 1_000_000
+
+    def test_chunk_shrinks_as_populations_grow(self):
+        # More populations -> more LD statistics (3/15/45/105) -> heavier
+        # per-pair working set -> a smaller chunk for the same budget.
+        H, budget = 100, 5_000_000_000
+        sizes = [estimate_ld_chunk_size(H, budget, num_pops=p) for p in (1, 2, 3, 4)]
+        assert sizes == sorted(sizes, reverse=True)
+        assert len(set(sizes)) == 4  # strictly decreasing, none clamped here
+
+    def test_scales_with_statistic_count(self):
+        # Lock the 50 * n_ld workspace term for four populations (n_ld == 105).
+        H, budget = 100, 5_000_000_000
+        bytes_per_pair = (4 * H * 4 + 50 * len(ld_names(4))) * 3
+        assert estimate_ld_chunk_size(H, budget, num_pops=4) == budget // bytes_per_pair
+
+    def test_estimate_never_exceeds_capacity(self):
+        # On a tight budget where fewer than 100k pairs fit, the estimate
+        # returns what fits rather than being lifted to a fixed minimum (the
+        # removed 100k floor), which would have overshot memory.
+        H, budget = 100, 1_000_000_000
+        bytes_per_pair = (4 * H * 4 + 50 * len(ld_names(4))) * 3
+        fit = budget // bytes_per_pair
+        assert fit < 100_000
+        assert estimate_ld_chunk_size(H, budget, num_pops=4) == fit
+
+    def test_ceiling_caps_large_budgets(self):
+        assert estimate_ld_chunk_size(50, 10**12, num_pops=1) == 10_000_000

--- a/tests/test_ld_pipeline.py
+++ b/tests/test_ld_pipeline.py
@@ -10,36 +10,40 @@ from pg_gpu.ld_pipeline import estimate_ld_chunk_size, ld_names
 
 
 class TestEstimateLdChunkSize:
-    def test_single_pop_matches_historical_anchor(self):
-        # The workspace term is anchored so that at one population (n_ld == 3)
-        # it equals the historical 150 * num_pops, leaving P=1 unchanged.
-        assert len(ld_names(1)) == 3
-        H, budget = 50, 1050 * 1_000_000  # bytes_per_pair = (4*50 + 150)*3 = 1050
-        assert estimate_ld_chunk_size(H, budget, num_pops=1) == 1_000_000
-
-    def test_chunk_shrinks_as_populations_grow(self):
-        # More populations -> more LD statistics (3/15/45/105) -> heavier
-        # per-pair working set -> a smaller chunk for the same budget.
+    def test_chunk_shrinks_as_statistics_grow(self):
+        # More statistics -> heavier per-pair working set -> a smaller chunk for
+        # the same budget. The LD basis grows 3/15/45/105 with the populations,
+        # and gathered rows grow with them (H per pop times pops).
         H, budget = 100, 5_000_000_000
-        sizes = [estimate_ld_chunk_size(H, budget, num_pops=p) for p in (1, 2, 3, 4)]
+        sizes = [estimate_ld_chunk_size(H * p, len(ld_names(p)), budget)
+                 for p in (1, 2, 3, 4)]
         assert sizes == sorted(sizes, reverse=True)
         assert len(set(sizes)) == 4  # strictly decreasing, none clamped here
 
     def test_scales_with_statistic_count(self):
-        # Lock the 50 * n_ld workspace term for four populations (n_ld == 105).
-        H, budget = 100, 5_000_000_000
-        bytes_per_pair = (4 * H * 4 + 50 * len(ld_names(4))) * 3
-        assert estimate_ld_chunk_size(H, budget, num_pops=4) == budget // bytes_per_pair
+        # Lock the 50 * n_stats workspace term for a 105-statistic basis.
+        rows, budget, n_stats = 400, 5_000_000_000, len(ld_names(4))
+        bytes_per_pair = (4 * rows + 50 * n_stats) * 3
+        assert (estimate_ld_chunk_size(rows, n_stats, budget)
+                == budget // bytes_per_pair)
 
-    def test_estimate_never_exceeds_capacity(self):
-        # On a tight budget where fewer than 100k pairs fit, the estimate
-        # returns what fits rather than being lifted to a fixed minimum (the
-        # removed 100k floor), which would have overshot memory.
-        H, budget = 100, 1_000_000_000
-        bytes_per_pair = (4 * H * 4 + 50 * len(ld_names(4))) * 3
+    def test_rejects_nonpositive_statistic_count(self):
+        with pytest.raises(ValueError):
+            estimate_ld_chunk_size(400, 0, 1_000_000_000)
+
+    def test_returns_what_fits_between_floor_and_ceiling(self):
+        # A budget admitting more than the floor and less than the ceiling is
+        # passed through unclamped.
+        rows, budget, n_stats = 400, 1_000_000_000, len(ld_names(4))
+        bytes_per_pair = (4 * rows + 50 * n_stats) * 3
         fit = budget // bytes_per_pair
-        assert fit < 100_000
-        assert estimate_ld_chunk_size(H, budget, num_pops=4) == fit
+        assert 1_000 < fit < 10_000_000
+        assert estimate_ld_chunk_size(rows, n_stats, budget) == fit
+
+    def test_floor_applied_on_tight_budget(self):
+        # A budget too small for the floor still returns 1k pairs rather than a
+        # handful, which would launch far too many kernels.
+        assert estimate_ld_chunk_size(400, len(ld_names(4)), 1_000_000) == 1_000
 
     def test_ceiling_caps_large_budgets(self):
-        assert estimate_ld_chunk_size(50, 10**12, num_pops=1) == 10_000_000
+        assert estimate_ld_chunk_size(50, 3, 10**12) == 10_000_000

--- a/tests/test_moments_ld.py
+++ b/tests/test_moments_ld.py
@@ -164,6 +164,20 @@ class TestLDStatistics:
         np.testing.assert_allclose(g, m, rtol=1e-6,
             err_msg="Heterozygosity sums mismatch")
 
+    def test_chunk_size_override_is_result_invariant(self, gpu_stats,
+                                                      biallelic01_vcf):
+        # A pair chunk is just a partition of an additive sum, so a small
+        # chunk_size (~7 chunks here) must give the same sums as the auto
+        # estimate, which fits this data in one chunk.
+        forced = compute_ld_statistics(
+            biallelic01_vcf, pop_file=POP_FILE, pops=POPS,
+            bp_bins=BP_BINS, use_genotypes=False, report=False,
+            chunk_size=500_000,
+        )
+        for i in range(len(gpu_stats['bins'])):
+            np.testing.assert_allclose(forced['sums'][i], gpu_stats['sums'][i],
+                rtol=1e-6, err_msg=f"chunk_size changed sums in bin {i}")
+
 
 class TestHeterozygosity:
     """Verify heterozygosity computation independently."""


### PR DESCRIPTION
Closes #245.

`moments_ld.compute_ld_statistics` ran out of GPU memory for three and four populations (#245). The pair loop is chunked to a memory budget by `estimate_ld_chunk_size`, but that estimate modelled the per-pair working set as linear in the number of populations, while the number of LD statistics computed per pair grows faster than that: 3, 15, 45, and 105 for one to four populations. For three and four populations it under-budgeted and chose a chunk several times too large.

The estimate now scales its working-set term by the statistic count rather than the population count, anchored so a one-population run is unchanged. The lower bound on the returned chunk is also removed: the value it wrapped is already how many pairs fit, so the bound could only raise the chunk above what fits and run out of memory on its own.

`compute_ld_statistics` gains `chunk_size` and `available_memory_bytes` arguments to override the estimate for cases where it still misjudges. Neither changes results, because a pair chunk only partitions an additive sum over pairs; they affect memory use only.

Tests check the estimate against an explicit memory budget, so they do not depend on device memory or try to trigger an out-of-memory condition, and confirm that an explicit `chunk_size` gives the same sums as the automatic estimate.