### PR TITLE
Exclude zero-call sites from patterson_d

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -175,6 +175,13 @@ Read this section if you are comparing against older pg_gpu results.
 Bug fixes
 ~~~~~~~~~
 
+* ``patterson_d`` kept sites where one of the four populations had no
+  called gametes, treating the missing population as frequency 0, which
+  can flip D's sign. Such sites are now excluded from both the
+  numerator and denominator (num = den = 0), matching scikit-allel,
+  which returns nan there. ``moving_patterson_d`` and
+  ``average_patterson_d`` share the fix. ``missing_data='exclude'`` was
+  already correct.
 * ``HaplotypeMatrix.from_ts`` laid out rows in ``ts.samples()`` order and
   assumed each individual's two nodes were adjacent there. tskit does not
   promise that (``simplify`` renumbers samples freely), so on a reordered

--- a/docs/source/missing_data.rst
+++ b/docs/source/missing_data.rst
@@ -56,6 +56,10 @@ Consider a site with 100 haplotypes where 10 are missing (``-1``):
 For statistics that require a single sample size (e.g., Tajima's D
 variance formula), the harmonic mean of per-site sample sizes is used.
 
+A population with no called gametes at a site has no allele frequency
+there, so ``patterson_d`` excludes such sites entirely (both terms zero)
+rather than treating the frequency as 0.
+
 Supported Statistics
 --------------------
 
@@ -81,7 +85,8 @@ Every public function accepts the ``missing_data`` parameter:
      - per-site n
      - filter sites
    * - Admixture (patterson_d, f2, f3, f4)
-     - per-site n
+     - per-site n; patterson_d also drops sites where a population has
+       zero calls
      - filter sites
    * - Selection scans (ihs, nsl, xpehh)
      - wildcard in shared-site length (SSL)

--- a/pg_gpu/admixture.py
+++ b/pg_gpu/admixture.py
@@ -241,6 +241,12 @@ def patterson_d(haplotype_matrix: HaplotypeMatrix,
     four populations are excluded (num = den = 0) and a ``BiallelicOnlyWarning``
     is emitted with the dropped-site count. A multiallelic generalization is a
     possible future extension.
+
+    Under ``missing_data='include'``, a site where any of the four
+    populations has no called gametes is also excluded (num = den = 0),
+    without a warning: a zero-call population has no allele frequency,
+    and treating it as frequency 0 can flip D's sign. scikit-allel drops
+    the same sites (its per-site values are nan there).
     """
     return tuple(v.get() for v in
                  _patterson_d_gpu(haplotype_matrix, pop_a, pop_b, pop_c, pop_d,
@@ -252,7 +258,8 @@ def _patterson_d_gpu(haplotype_matrix, pop_a, pop_b, pop_c, pop_d,
     """Like patterson_d but returns CuPy arrays (no D2H transfer).
 
     BIALLELIC-RESTRICTED: D (ABBA-BABA) is defined on biallelic SNPs; sites with
-    >2 alleles across the four pops are excluded (num=den=0). On the retained
+    >2 alleles across the four pops are excluded (num=den=0). Sites where any
+    pop has zero called gametes are also excluded (num=den=0). On the retained
     sites the allele frequency is a proper per-allele frequency (count of the
     single alt allele / n), NOT cp.sum(hap)/n -- so a biallelic {0,2}-type site
     is handled correctly, not index-inflated. The multiallelic generalization is
@@ -283,12 +290,19 @@ def _patterson_d_gpu(haplotype_matrix, pop_a, pop_b, pop_c, pop_d,
     alt = cp.where(present, cp.arange(k)[None, :], -1).argmax(axis=1)[:, None]
 
     def freq(x, n):
+        # n == 0 implies a zero alt count, so the clamp returns 0.0 there;
+        # those sites leave the result through `defined` below anyway.
         alt_count = cp.take_along_axis(x, alt, axis=1)[:, 0]
-        return cp.where(n > 0, alt_count / n, 0.0)
+        return alt_count / cp.maximum(n, 1.0)
+
+    # A population with zero called gametes has no frequency at the site; a
+    # frequency-0 stand-in would keep the site in both terms and can flip
+    # D's sign.
+    defined = biallelic & (na > 0) & (nb > 0) & (nc > 0) & (nd > 0)
 
     a, b, c, d = freq(xa, na), freq(xb, nb), freq(xc, nc), freq(xd, nd)
-    num = cp.where(biallelic, (a - b) * (c - d), 0.0)
-    den = cp.where(biallelic,
+    num = cp.where(defined, (a - b) * (c - d), 0.0)
+    den = cp.where(defined,
                    (a + b - 2 * a * b) * (c + d - 2 * c * d), 0.0)
     return num, den
 

--- a/tests/test_admixture_allel_comparison.py
+++ b/tests/test_admixture_allel_comparison.py
@@ -29,10 +29,8 @@ def _make_matrix(hap_dict, n_var=100):
 
 
 def _allele_counts(hap):
-    """Compute allele counts (n_variants, 2) from haplotype array."""
-    n = hap.shape[0]
-    dac = np.sum(hap, axis=0)
-    return np.column_stack([n - dac, dac])
+    """Allele counts (n_variants, 2); ``-1`` counts as a missing call."""
+    return np.column_stack([np.sum(hap == 0, axis=0), np.sum(hap == 1, axis=0)])
 
 
 @pytest.fixture
@@ -230,3 +228,69 @@ class TestKnownValues:
         num, den = admixture.patterson_d(matrix, 'A', 'B', 'C', 'D')
         # numerator should be exactly 0 since a == b
         np.testing.assert_array_almost_equal(num, 0.0)
+
+
+class TestPattersonDZeroCallSites:
+    """Sites where one population has no called gametes leave D entirely."""
+
+    @pytest.fixture
+    def zero_call_data(self, four_pop_data):
+        """four_pop_data with all calls missing in one pop at some sites."""
+        _, base = four_pop_data
+        pops = {name: hap.copy() for name, hap in base.items()}
+        missing = np.zeros(pops['A'].shape[1], dtype=bool)
+        pops['A'][:, 10:20] = -1
+        pops['C'][:, 50:55] = -1
+        missing[10:20] = True
+        missing[50:55] = True
+        return _make_matrix(pops), pops, missing
+
+    def test_zero_call_sites_match_allel(self, zero_call_data):
+        matrix, pops, missing = zero_call_data
+        num_pg, den_pg = admixture.patterson_d(matrix, 'A', 'B', 'C', 'D')
+        acs = [_allele_counts(pops[p]) for p in 'ABCD']
+        num_a, den_a = allel.patterson_d(*acs)
+
+        # allel's nan sites are exactly our zeroed sites.
+        undefined = np.isnan(num_a) | np.isnan(den_a)
+        np.testing.assert_array_equal(undefined, missing)
+        np.testing.assert_array_equal(num_pg[undefined], 0.0)
+        np.testing.assert_array_equal(den_pg[undefined], 0.0)
+        # The defined sites agree.
+        np.testing.assert_allclose(num_pg[~undefined], num_a[~undefined],
+                                   rtol=1e-10)
+        np.testing.assert_allclose(den_pg[~undefined], den_a[~undefined],
+                                   rtol=1e-10)
+
+    def test_zero_call_site_contributes_nothing(self):
+        """The aggregate D over [zero-call site, informative site] is the
+        informative site's own ratio; a frequency-0 stand-in would have let
+        the zero-call site move it."""
+        pops = {
+            'A': np.array([[-1, 1], [-1, 1]], dtype=np.int8),
+            'B': np.array([[1, 1], [1, 0]], dtype=np.int8),
+            'C': np.array([[1, 1], [1, 0]], dtype=np.int8),
+            'D': np.array([[0, 0], [0, 0]], dtype=np.int8),
+        }
+        num, den = admixture.patterson_d(_make_matrix(pops), 'A', 'B', 'C', 'D')
+        assert num[0] == 0.0 and den[0] == 0.0
+        np.testing.assert_allclose(np.nansum(num) / np.nansum(den),
+                                   num[1] / den[1], rtol=1e-12)
+
+    def test_average_d_matches_allel_with_zero_call_sites(self, zero_call_data):
+        matrix, pops, _ = zero_call_data
+        d_pg, se_pg, z_pg, _, _ = admixture.average_patterson_d(
+            matrix, 'A', 'B', 'C', 'D', blen=20)
+        acs = [_allele_counts(pops[p]) for p in 'ABCD']
+        d_a, se_a, z_a, _, _ = allel.average_patterson_d(*acs, blen=20)
+        np.testing.assert_allclose(d_pg, d_a, rtol=1e-10)
+        np.testing.assert_allclose(se_pg, se_a, rtol=1e-5)
+
+    def test_exclude_mode_drops_only_the_missing_sites(self, zero_call_data):
+        matrix, _, missing = zero_call_data
+        num, den = admixture.patterson_d(matrix, 'A', 'B', 'C', 'D',
+                                         missing_data='exclude')
+        # The base data has no other missing calls, so exclude keeps
+        # exactly the fully-called sites.
+        assert num.shape == den.shape == ((~missing).sum(),)
+        assert np.isfinite(np.nansum(num) / np.nansum(den))

--- a/tests/test_admixture_allel_comparison.py
+++ b/tests/test_admixture_allel_comparison.py
@@ -277,6 +277,18 @@ class TestPattersonDZeroCallSites:
         np.testing.assert_allclose(np.nansum(num) / np.nansum(den),
                                    num[1] / den[1], rtol=1e-12)
 
+    def test_moving_d_matches_allel_with_zero_call_sites(self, zero_call_data):
+        """size=5 puts three windows entirely inside the missing blocks, so
+        this also pins the all-undefined-window -> NaN convention."""
+        matrix, pops, _ = zero_call_data
+        d_pg = admixture.moving_patterson_d(matrix, 'A', 'B', 'C', 'D', size=5)
+        acs = [_allele_counts(pops[p]) for p in 'ABCD']
+        with np.errstate(invalid='ignore'):  # allel reaches NaN through 0/0
+            d_a = allel.moving_patterson_d(*acs, size=5)
+        np.testing.assert_array_equal(np.isnan(d_pg), np.isnan(d_a))
+        valid = ~np.isnan(d_a)
+        np.testing.assert_allclose(d_pg[valid], d_a[valid], rtol=1e-10)
+
     def test_average_d_matches_allel_with_zero_call_sites(self, zero_call_data):
         matrix, pops, _ = zero_call_data
         d_pg, se_pg, z_pg, _, _ = admixture.average_patterson_d(


### PR DESCRIPTION
Found in the release audit (#217). `_patterson_d_gpu`'s `freq()` returned 0.0 for a population with zero valid calls at a site, which kept the site in both the numerator and denominator; a missing population masquerading as frequency 0 can flip D's sign (the issue's two-site example: pg_gpu +0.333, scikit-allel -1.0).

**Fix.** Sites where any of the four populations has no called gametes now leave both terms (`num = den = 0`), folded into the same mask the biallelic filter uses (`defined = biallelic & called`), so the aggregate ratio matches scikit-allel's nansum over its nan sites exactly. The exclusion is silent, matching how the package treats undefined sites under `'include'` elsewhere (pi at n < 2, the between-population term at n = 0). `moving_patterson_d` and `average_patterson_d` share the fix through the one helper; there is no windowed-engine D path. f2/f3/f4 were verified safe: every population contributes a zero factor to their denominators, so a zero-call site already yields exactly 0 there. `missing_data='exclude'` was already correct.

`freq` now divides by `max(n, 1)` instead of a `cp.where` guard (identical values, since a zero-call site has a zero alt count; fewer kernels), and the undefined-site rule is stated once for users (the `patterson_d` Notes), once for maintainers (the mask comment), and in the `missing_data` reference page, whose admixture row previously said "use all sites".

**Tests** (against scikit-allel in `test_admixture_allel_comparison.py`): allel's nan set equals our zeroed set exactly on a fixture with all-missing blocks in two populations, and defined sites agree at 1e-10; a hand-built two-site case shows the zero-call site contributing nothing to the aggregate; `average_patterson_d` matches `allel.average_patterson_d` on the missing-data fixture at the file's standard tolerances; `exclude` mode keeps exactly the fully-called sites.

Full suite 1392 passed, slow 53 passed, ruff and Sphinx clean.

Closes #217.
