### PR TITLE
Drop sites with no defined r2 from genotype-path zns and omega

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -159,10 +159,12 @@ Read this section if you are comparing against older pg_gpu results.
   ``sqeuclidean``, and ``cityblock``. Other metrics now raise
   ``NotImplementedError``, and passing a ``GenotypeMatrix`` raises a
   ``TypeError``.
-* ``pairwise_r2`` returns ``NaN`` instead of ``0`` for a pair whose
-  r-squared is undefined (a site where nothing varies), with either
-  estimator. Reductions over the matrix need ``nanmean`` /
-  ``nanargmax`` now.
+* ``pairwise_r2`` and ``ld_statistics.r2_matrix_diploid`` return
+  ``NaN`` instead of ``0`` for a pair whose r-squared is undefined -- a
+  site where nothing varies; for diploid dosages that includes an
+  all-heterozygous site -- with either estimator. Reductions over a
+  stored matrix need
+  ``nanmean`` or friends now.
 * ``windowed_analysis`` with exactly two populations names the
   two-population columns the same way on every path (``fst_hudson``);
   the non-fused fallback used to suffix them
@@ -175,6 +177,11 @@ Read this section if you are comparing against older pg_gpu results.
 Bug fixes
 ~~~~~~~~~
 
+* ``zns`` and ``omega`` on a ``GenotypeMatrix`` scored sites with no
+  dosage variance -- monomorphic sites, and all-heterozygous sites --
+  as r^2 = 0 instead of undefined, which diluted ZnS and inflated
+  omega. Both statistics now drop those sites, as the haplotype path
+  already did.
 * ``patterson_d`` kept sites where one of the four populations had no
   called gametes, treating the missing population as frequency 0, which
   can flip D's sign. Such sites are now excluded from both the

--- a/pg_gpu/ld_statistics.py
+++ b/pg_gpu/ld_statistics.py
@@ -661,9 +661,10 @@ def _zns_from_precomputed(hap_clean, valid_mask, col_start, col_end,
 def _drop_undefined_sites(r2_matrix):
     """Drop sites whose r2 is undefined for every pair.
 
-    ``pairwise_r2`` marks a monomorphic or multiallelic site by NaN-ing its
-    whole row and column, so excluding undefined pairs is the same as dropping
-    those sites -- what the object-input path already does before reducing.
+    Both r^2 matrix builders NaN a site's whole row and column when its
+    r^2 is undefined: ``pairwise_r2`` for monomorphic and multiallelic
+    sites, ``_r2_matrix_diploid`` for sites with no dosage variance. So
+    excluding undefined pairs is the same as dropping those sites.
     No-op on a finite matrix. Assumes undefined entries arrive as whole
     rows/cols (all this package produces); a scattered NaN would propagate.
     """
@@ -708,7 +709,10 @@ def zns(r2_matrix_or_matrix, missing_data='include', estimator='auto'):
     -----
     A ``HaplotypeMatrix`` is first restricted to its own biallelic sites and
     a ``BiallelicOnlyWarning`` reports how many were dropped; an input that
-    is already biallelic drops nothing and stays silent.
+    is already biallelic drops nothing and stays silent. A
+    ``GenotypeMatrix`` instead drops sites with no dosage variance --
+    monomorphic sites, and sites where every called individual is
+    heterozygous -- because r^2 is undefined there.
     """
     from .haplotype_matrix import HaplotypeMatrix
 
@@ -724,8 +728,8 @@ def zns(r2_matrix_or_matrix, missing_data='include', estimator='auto'):
             "not a pre-computed r² array")
 
     r2_matrix = _resolve_r2_matrix(r2_matrix_or_matrix, missing_data)
-    # Undefined (monomorphic/multiallelic) sites carry NaN rows/cols; drop them
-    # so the mean is over defined pairs, matching the object-input path.
+    # Sites with no defined r^2 carry NaN rows/cols; drop them so the mean
+    # is over defined pairs.
     r2_matrix = _drop_undefined_sites(r2_matrix)
 
     m = r2_matrix.shape[0]
@@ -810,7 +814,10 @@ def omega(r2_matrix_or_matrix, missing_data='include', estimator='auto'):
     -----
     A ``HaplotypeMatrix`` is first restricted to its own biallelic sites and
     a ``BiallelicOnlyWarning`` reports how many were dropped; an input that
-    is already biallelic drops nothing and stays silent.
+    is already biallelic drops nothing and stays silent. A
+    ``GenotypeMatrix`` instead drops sites with no dosage variance --
+    monomorphic sites, and sites where every called individual is
+    heterozygous -- because r^2 is undefined there.
     """
     from .haplotype_matrix import HaplotypeMatrix
 
@@ -830,8 +837,8 @@ def omega(r2_matrix_or_matrix, missing_data='include', estimator='auto'):
     else:
         r2_matrix = _resolve_r2_matrix(r2_matrix_or_matrix, missing_data)
 
-    # Undefined (monomorphic/multiallelic) sites carry NaN rows/cols; drop them
-    # so the block means are over defined pairs, matching the object-input path.
+    # Sites with no defined r^2 carry NaN rows/cols; drop them so the block
+    # means are over defined pairs.
     r2_matrix = _drop_undefined_sites(r2_matrix)
 
     m = r2_matrix.shape[0]
@@ -940,8 +947,8 @@ def mu_ld(haplotype_matrix, missing_data='include'):
 def _resolve_r2_matrix(r2_matrix_or_matrix, missing_data='include'):
     """Convert a matrix object to an r2 matrix, or pass through raw arrays.
 
-    Filters to segregating sites only (excludes monomorphic variants)
-    to match diploSHIC/allel convention for ZnS/Omega.
+    Sites with no defined r^2 never reach the reducers; see the branch
+    comment below. Matches the diploSHIC/allel convention for ZnS/Omega.
     """
     from .haplotype_matrix import HaplotypeMatrix
     from .genotype_matrix import GenotypeMatrix
@@ -964,18 +971,12 @@ def _resolve_r2_matrix(r2_matrix_or_matrix, missing_data='include'):
                 from .genotype_matrix import GenotypeMatrix as GM
                 mat = GM(geno, pos)
 
-        # Haploid: filter monomorphic sites before r^2 computation.
-        # diploSHIC marks monomorphic pairs as -1 and skips them in ZnS/Omega.
-        # We match this by excluding monomorphic sites entirely.
+        # Haplotypes: drop non-segregating sites here. Diploids cannot use
+        # the same test -- an all-heterozygous site segregates but has
+        # constant dosage -- so _r2_matrix_diploid NaN-marks zero-variance
+        # rows and the reducers drop them via _drop_undefined_sites.
         if isinstance(mat, HaplotypeMatrix):
-            ind = mat._biallelic_indicator()
-            dac = cp.sum(ind == 1, axis=0)
-            n_valid = cp.sum(ind >= 0, axis=0)
-            seg = (dac > 0) & (dac < n_valid)
-            seg_idx = cp.where(seg)[0]
-            if len(seg_idx) < mat.num_variants:
-                mat = mat.get_subset(seg_idx)
-            return mat.pairwise_r2().astype(cp.float64)
+            return mat.restrict_to_segregating().pairwise_r2().astype(cp.float64)
         else:
             return _r2_matrix_diploid(mat)
     else:
@@ -998,6 +999,7 @@ def _r2_matrix_diploid(genotype_matrix):
     Returns
     -------
     r2 : cupy.ndarray, float64, shape (n_variants, n_variants)
+        NaN row and column at a site with no dosage variance; diagonal 0.
     """
     from .genotype_matrix import GenotypeMatrix
 
@@ -1024,12 +1026,14 @@ def _r2_matrix_diploid(genotype_matrix):
     # variance per variant (using valid counts)
     var = cp.sum(gn ** 2, axis=0)
 
-    # correlation via matrix multiply
-    cov = gn.T @ gn  # (n_var, n_var)
-
-    # normalize: r_ij = cov_ij / sqrt(var_i * var_j)
-    denom = cp.sqrt(cp.outer(var, var))
-    r2 = cp.where(denom > 0, (cov / denom) ** 2, 0.0)
+    # r_ij = cov_ij / sqrt(var_i * var_j), applied as a rank-1 in-place
+    # scale so peak memory stays near the one output matrix; the NaN scale
+    # at a zero-variance site spreads over its whole row and column.
+    r2 = gn.T @ gn  # (n_var, n_var)
+    inv = cp.where(var > 0, 1.0 / cp.sqrt(var), cp.nan)
+    r2 *= inv[:, None]
+    r2 *= inv[None, :]
+    r2 *= r2
     cp.fill_diagonal(r2, 0.0)
 
     return r2

--- a/tests/test_diploshic_stats.py
+++ b/tests/test_diploshic_stats.py
@@ -24,6 +24,15 @@ def geno_data(hap_data):
     return GenotypeMatrix.from_haplotype_matrix(hap_data)
 
 
+def _with_zero_variance_sites(gm):
+    """``gm`` plus sites with no dosage variance: all-reference,
+    all-alt-homozygote, and all-heterozygous."""
+    g = cp.asnumpy(gm.genotypes)
+    extra = np.tile(np.array([0, 0, 2, 2, 1, 1], np.int8), (g.shape[0], 1))
+    g2 = np.concatenate([g, extra], axis=1)
+    return GenotypeMatrix(g2, np.arange(g2.shape[1]) * 1000)
+
+
 # ---------------------------------------------------------------------------
 # GenotypeMatrix
 # ---------------------------------------------------------------------------
@@ -148,6 +157,19 @@ class TestZnSOmega:
     def test_omega_diploid(self, geno_data):
         o = ld_statistics.omega_diploid(geno_data)
         assert o >= 0
+
+    @pytest.mark.parametrize("stat", [ld_statistics.zns, ld_statistics.omega])
+    def test_diploid_ignores_zero_variance_sites(self, geno_data, stat):
+        """Sites with no defined r^2 must leave ZnS and omega unchanged."""
+        expected = stat(geno_data)
+        np.testing.assert_allclose(stat(_with_zero_variance_sites(geno_data)),
+                                   expected, rtol=1e-12)
+
+    def test_zns_diploid_all_zero_variance_is_zero(self):
+        # Every dosage 1: segregating by allele counts, no dosage variance
+        # anywhere, so everything drops and the too-few-sites value returns.
+        gm = GenotypeMatrix(np.ones((10, 6), np.int8), np.arange(6) * 1000)
+        assert ld_statistics.zns(gm) == 0.0
 
     def test_zns_default_is_sigma_d2_for_haplotype_matrix(self, hap_data):
         # Default 'auto' should resolve to sigma_d2 for HaplotypeMatrix

--- a/tests/test_streaming_kernels.py
+++ b/tests/test_streaming_kernels.py
@@ -142,6 +142,20 @@ class TestWindowedAnalysisDispatch:
                                  missing_data="include")
         _assert_frames_equivalent(df_e, df_s)
 
+    @pytest.mark.parametrize("stat", ["zns", "omega"])
+    @pytest.mark.parametrize("chunk_bp,window_size", [(25_000, 5_000),
+                                                      (50_000, 10_000)])
+    def test_windowed_ld_stat_matches_eager(self, vcz_store, stat, chunk_bp,
+                                            window_size):
+        # zns and omega run through the per-window fallback, not the fused
+        # engine, so the streaming dispatch needs its own equivalence pin.
+        eager, stream = _aligned_pair(vcz_store, chunk_bp=chunk_bp)
+        df_e = windowed_analysis(eager, window_size=window_size,
+                                 statistics=[stat])
+        df_s = windowed_analysis(stream, window_size=window_size,
+                                 statistics=[stat])
+        _assert_frames_equivalent(df_e, df_s)
+
     def test_two_pop_divergence_equivalent(self, vcz_store, tmp_path):
         # Build a two-population pop file so divergence stats have something
         # to compute. Split samples 50/50.


### PR DESCRIPTION
Found in the release audit (#218). `_r2_matrix_diploid` wrote r^2 = 0 for pairs whose r^2 is undefined, so on a `GenotypeMatrix` every site with no dosage variance stayed in the reductions: appending invariant sites diluted ZnS (0.0337 -> 0.0287 on a probe) and inflated omega far worse (1.12 -> 6.81, a fabricated partition signal), while the haplotype path was invariant.

**The predicate matters.** The obvious fix -- mirroring the haplotype branch's segregating filter -- is wrong for diploids: an all-heterozygous site segregates by allele counts yet has zero dosage variance, so `restrict_to_segregating` keeps it and it still scores 0. The definedness predicate is dosage variance, and it already lives in `_r2_matrix_diploid`'s own normalization. The matrix now NaN-marks zero-variance rows and columns (the convention `pairwise_r2` already uses, recorded in the changelog's behavior-change bullet alongside it), and the existing `_drop_undefined_sites` removes them in both `zns` and `omega`. The public alias `r2_matrix_diploid` has no callers outside the module.

**Also in the diff, from the review pass:** the normalization applies the `1/sqrt(var)` factors as a rank-1 in-place scale -- measured identical values (max diff 2.2e-16), 1.1-1.6x faster, and 4.9x lower peak memory (the old `outer`/`where` chain held five m x m temporaries; at m = 20k that is 15 GB vs 3 GB); the haplotype branch of `_resolve_r2_matrix` uses `restrict_to_segregating()` instead of a seven-line hand-rolled copy; `_drop_undefined_sites`' docstring now names both producers as the convention's single owner; and the public `zns`/`omega` Notes state the GenotypeMatrix behavior.

**Tests:** a parametrized invariance test (zns and omega unchanged by appended all-reference, all-alt, and all-heterozygous sites) and a drop-everything boundary case (all dosage-1 matrix returns the too-few-sites 0.0). Full suite 1395 passed, slow 53 passed, ruff and Sphinx clean. (`test_scikit_allel_comparison_runs_small` timed out in concurrent runs and passes alone in 47 s -- the known contention flake, tracked separately.)

Closes #218.
