### PR TITLE
Honor the estimator and missing_data that zns and omega were handed, or refuse it

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -177,6 +177,14 @@ Read this section if you are comparing against older pg_gpu results.
 Bug fixes
 ~~~~~~~~~
 
+* ``zns`` and ``omega`` accepted ``estimator='rogers_huff'`` on a
+  ``HaplotypeMatrix`` and silently computed naive ``r2`` instead. They
+  now pair adjacent haplotypes into 0/1/2 dosages and compute the
+  dosage correlation.
+* ``zns`` and ``omega`` reject an estimator their input cannot compute:
+  the estimator names raise on a pre-computed r² array
+  (``estimator='auto'`` there means ``r2``, as documented), and a
+  streaming matrix gets a clear error pointing at ``materialize``.
 * ``zns`` and ``omega`` on a ``GenotypeMatrix`` scored sites with no
   dosage variance -- monomorphic sites, and all-heterozygous sites --
   as r^2 = 0 instead of undefined, which diluted ZnS and inflated

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -185,6 +185,11 @@ Bug fixes
   the estimator names raise on a pre-computed r² array
   (``estimator='auto'`` there means ``r2``, as documented), and a
   streaming matrix gets a clear error pointing at ``materialize``.
+* ``zns`` under the default ``sigma_d2`` estimator silently ignored
+  ``missing_data='exclude'`` and returned the ``include`` result,
+  because the estimator was smuggled through the ``missing_data``
+  argument. ``exclude`` is now applied before the estimator on every
+  path, matching ``omega``.
 * ``zns`` and ``omega`` on a ``GenotypeMatrix`` scored sites with no
   dosage variance -- monomorphic sites, and all-heterozygous sites --
   as r^2 = 0 instead of undefined, which diluted ZnS and inflated

--- a/docs/source/missing_data.rst
+++ b/docs/source/missing_data.rst
@@ -110,17 +110,23 @@ LD Estimator Choice
 For LD statistics, ``zns()`` and ``omega()`` accept an ``estimator``
 parameter independent of missing data handling:
 
-* ``estimator='auto'`` (default): use the unbiased ``sigma_d2``
-  estimator when the input is a ``HaplotypeMatrix``, and fall back to
-  naive ``r2`` for pre-computed r² arrays or ``GenotypeMatrix`` inputs
-  (where ``sigma_d2`` is not available).
-* ``estimator='r2'``: always use naive r-squared. Convenient when you
-  want the "classical" estimator regardless of input type.
-* ``estimator='sigma_d2'``: always use the unbiased multinomial
-  projection estimators (Ragsdale & Gravel 2019), computing
+* ``estimator='auto'`` (default): ``sigma_d2`` for a
+  ``HaplotypeMatrix``, ``rogers_huff`` for a ``GenotypeMatrix``, and
+  ``r2`` for a pre-computed r² array.
+* ``estimator='r2'``: naive r-squared on any input.
+* ``estimator='sigma_d2'``: the unbiased multinomial projection
+  estimators (Ragsdale & Gravel 2019), computing
   :math:`\sigma_D^2 = D^2 / \pi_2` with falling-factorial corrections.
   More robust with small or variable sample sizes; requires a
   ``HaplotypeMatrix``.
+* ``estimator='rogers_huff'``: the diploid dosage-correlation r²
+  (Rogers & Huff 2008). A ``HaplotypeMatrix`` is first paired into
+  0/1/2 dosages by adjacent rows; on a ``GenotypeMatrix`` this is the
+  same computation as ``'r2'``.
+
+An estimator the input cannot compute raises: ``sigma_d2`` needs
+haplotypes, ``rogers_huff`` needs genotype data, and a pre-computed
+array accepts only ``'r2'``.
 
 .. code-block:: python
 
@@ -368,13 +374,12 @@ Best Practices
    when you want proper handling of variable sample sizes via group-by-n
    or SFS projection.
 
-4. **The default ``estimator='auto'`` for ``zns()`` and ``omega()``
-   uses the unbiased ``sigma_d2`` estimator on ``HaplotypeMatrix``
-   inputs**, which corrects the upward bias inherent in naive
-   :math:`r^2` -- particularly important with small or variable
-   sample sizes. Pass ``estimator='r2'`` explicitly if you want the
-   classical naive estimator instead (e.g. for backward comparison
-   with a previous analysis).
+4. **The default ``estimator='auto'`` picks per input**: the unbiased
+   ``sigma_d2`` estimator on a ``HaplotypeMatrix``, the dosage
+   correlation (``rogers_huff``) on a ``GenotypeMatrix``, and plain
+   ``r2`` on a pre-computed array. Pass ``estimator='r2'`` explicitly
+   if you want the classical naive estimator everywhere (e.g. for
+   backward comparison with older results).
 
 5. **Check missingness patterns** before analysis with
    ``summarize_missing_data()`` and consider filtering sites with

--- a/pg_gpu/ld_statistics.py
+++ b/pg_gpu/ld_statistics.py
@@ -539,21 +539,21 @@ def rogers_huff_r_squared(matrix, tile_size: Optional[int] = None
     return rogers_huff_r(matrix, tile_size=tile_size) ** 2
 
 
-def _zns_tiled(mat, missing_data='include', tile_size=512):
+def _zns_tiled(mat, missing_data='include', tile_size=512, use_projection=False):
     """Compute ZnS without materializing the full r² matrix.
 
     Uses tile-based accumulation: computes r² for B×B blocks and
     sums per tile, keeping memory at O(B²) instead of O(m²).
 
-    When missing_data='project' (set internally via estimator='sigma_d2'),
-    uses unbiased multinomial projection estimators (Ragsdale & Gravel
-    2019) computing σ_D² = D²/π² per pair instead of naive r².
+    ``use_projection`` selects the unbiased multinomial projection
+    estimator (Ragsdale & Gravel 2019, σ_D² = D²/π² per pair) over
+    naive r². ``missing_data`` is applied first either way, so
+    ``'exclude'`` restricts to complete sites before the estimator runs,
+    matching ``_build_sigma_d2_matrix`` (omega's projection path).
     """
     hap_clean, valid_mask, m = _prepare_segregating(mat, missing_data)
     if m < 2:
         return 0.0
-
-    use_projection = (missing_data == 'project')  # internal: mapped from estimator='sigma_d2'
 
     B = tile_size
     total = 0.0
@@ -716,9 +716,8 @@ def zns(r2_matrix_or_matrix, missing_data='include', estimator='auto'):
         memory is O(m²) -- about 55,000 variants on an 80 GB GPU.
     missing_data : str
         ``'include'`` (default) uses per-site valid data for frequency
-        computation. ``'exclude'`` filters to sites with no missing data. Under the
-        default ``sigma_d2`` estimator the projection handles missing
-        data per pair and ``'exclude'`` is not applied.
+        computation. ``'exclude'`` filters to sites with no missing data
+        before the estimator runs, under every estimator.
     estimator : str
         ``'auto'`` (default): ``sigma_d2`` for a ``HaplotypeMatrix``,
         ``rogers_huff`` for a ``GenotypeMatrix``, ``r2`` for a
@@ -782,8 +781,8 @@ def _zns_biallelic(hm, missing_data='include', estimator='auto'):
     no second restriction and no warning. ``divergence.zx`` restricts once
     and calls this for each of its three terms."""
     estimator = _resolve_ld_estimator(estimator, 'haplotype')
-    # 'project' selects the sigma_d2 estimator inside _zns_tiled.
-    return _zns_tiled(hm, 'project' if estimator == 'sigma_d2' else missing_data)
+    return _zns_tiled(hm, missing_data,
+                      use_projection=(estimator == 'sigma_d2'))
 
 
 def _build_sigma_d2_matrix(mat, missing_data='include'):

--- a/pg_gpu/ld_statistics.py
+++ b/pg_gpu/ld_statistics.py
@@ -713,7 +713,7 @@ def zns(r2_matrix_or_matrix, missing_data='include', estimator='auto'):
         With estimator 'r2' or 'sigma_d2', a HaplotypeMatrix goes
         through tiled computation that avoids materializing the full
         m×m r² matrix; 'rogers_huff' builds the full matrix, so peak
-        memory is O(m²) -- about 55,000 variants on an 80 GB GPU.
+        memory is O(m²).
     missing_data : str
         ``'include'`` (default) uses per-site valid data for frequency
         computation. ``'exclude'`` filters to sites with no missing data

--- a/pg_gpu/ld_statistics.py
+++ b/pg_gpu/ld_statistics.py
@@ -341,26 +341,52 @@ def _tile_sigma_d2(hi, vi, hj, vj):
     return sigma_d2, valid
 
 
-def _resolve_ld_estimator(estimator: str, is_hap_matrix: bool) -> str:
-    """Resolve an LD estimator string, including the ``'auto'`` policy.
+def _resolve_ld_estimator(estimator: str, kind: str) -> str:
+    """Resolve an LD estimator string against the input ``kind``.
 
-    ``'auto'`` resolves to:
-      - ``'sigma_d2'`` for a ``HaplotypeMatrix`` (unbiased Ragsdale &
-        Gravel 2019 estimator -- the recommended path on phased data).
-      - ``'rogers_huff'`` for a ``GenotypeMatrix`` (the natural
-        diploid-dosage estimator).
-      - ``'r2'`` otherwise (pre-computed r² arrays, etc.).
-
-    Explicit ``'r2'``, ``'sigma_d2'``, and ``'rogers_huff'`` pass
-    through unchanged.
+    ``kind`` is ``'haplotype'``, ``'genotype'``, or ``'array'``
+    (a pre-computed r² matrix). ``'auto'`` resolves to ``'sigma_d2'``,
+    ``'rogers_huff'``, and ``'r2'`` respectively. Explicit names pass
+    through, except that an estimator the kind cannot compute raises:
+    ``sigma_d2`` needs haplotypes, ``rogers_huff`` needs genotype data,
+    and an array is already an r² matrix.
     """
     if estimator == 'auto':
-        return 'sigma_d2' if is_hap_matrix else 'rogers_huff'
+        return {'haplotype': 'sigma_d2', 'genotype': 'rogers_huff',
+                'array': 'r2'}[kind]
     if estimator not in ('r2', 'sigma_d2', 'rogers_huff'):
         raise ValueError(
             f"Unknown estimator: {estimator!r} "
             f"(expected one of 'auto', 'r2', 'sigma_d2', 'rogers_huff')")
+    if estimator == 'sigma_d2' and kind != 'haplotype':
+        raise ValueError("estimator='sigma_d2' requires a HaplotypeMatrix, "
+                         f"not {_KIND_NOUN[kind]}")
+    if estimator == 'rogers_huff' and kind == 'array':
+        raise ValueError("estimator='rogers_huff' needs genotype data, "
+                         f"not {_KIND_NOUN[kind]}")
     return estimator
+
+
+_KIND_NOUN = {'haplotype': 'a HaplotypeMatrix', 'genotype': 'a GenotypeMatrix',
+              'array': 'a pre-computed r² array'}
+
+
+def _ld_input_kind(obj, context):
+    """Classify an LD input as ``'haplotype'``, ``'genotype'``, or
+    ``'array'``, rejecting streaming matrices up front."""
+    from .haplotype_matrix import HaplotypeMatrix
+    from .genotype_matrix import GenotypeMatrix
+    from .streaming_matrix import _StreamingMatrixBase
+    if isinstance(obj, _StreamingMatrixBase):
+        raise NotImplementedError(
+            f"{context} needs every variant pair in scope at once, which a "
+            "streaming matrix cannot hold; call .materialize(region=(lo, hi)) "
+            "to get an eager matrix over a sub-region and compute on that.")
+    if isinstance(obj, HaplotypeMatrix):
+        return 'haplotype'
+    if isinstance(obj, GenotypeMatrix):
+        return 'genotype'
+    return 'array'
 
 
 def _dosage_from_matrix(matrix) -> "cp.ndarray":
@@ -684,21 +710,31 @@ def zns(r2_matrix_or_matrix, missing_data='include', estimator='auto'):
     r2_matrix_or_matrix : ndarray, HaplotypeMatrix, or GenotypeMatrix
         Square r-squared matrix, or a matrix object (dispatches to
         haploid or diploid r-squared computation automatically).
-        When a HaplotypeMatrix is passed, uses tiled computation to
-        avoid materializing the full m×m r² matrix.
+        With estimator 'r2' or 'sigma_d2', a HaplotypeMatrix goes
+        through tiled computation that avoids materializing the full
+        m×m r² matrix; 'rogers_huff' builds the full matrix, so peak
+        memory is O(m²) -- about 55,000 variants on an 80 GB GPU.
     missing_data : str
         ``'include'`` (default) uses per-site valid data for frequency
-        computation. ``'exclude'`` filters to sites with no missing data.
+        computation. ``'exclude'`` filters to sites with no missing data. Under the
+        default ``sigma_d2`` estimator the projection handles missing
+        data per pair and ``'exclude'`` is not applied.
     estimator : str
-        ``'auto'`` (default) uses the unbiased ``sigma_d2`` estimator
-        when the input is a ``HaplotypeMatrix``, and falls back to
-        naive ``r2`` for pre-computed r² arrays or ``GenotypeMatrix``
-        inputs (where ``sigma_d2`` is not available).
-        ``'r2'`` always computes naive r-squared.
-        ``'sigma_d2'`` always uses the unbiased multinomial projection
+        ``'auto'`` (default): ``sigma_d2`` for a ``HaplotypeMatrix``,
+        ``rogers_huff`` for a ``GenotypeMatrix``, ``r2`` for a
+        pre-computed r² array.
+        ``'r2'`` computes naive r-squared.
+        ``'sigma_d2'`` uses the unbiased multinomial projection
         estimators (Ragsdale & Gravel 2019), computing mean
         :math:`\\sigma_D^2 = D^2/\\pi_2` per pair with falling-factorial
         corrections. Requires ``HaplotypeMatrix`` input.
+        ``'rogers_huff'`` computes the diploid dosage-correlation r²
+        (Rogers & Huff 2008); a ``HaplotypeMatrix`` is first paired
+        into 0/1/2 dosages by adjacent rows, as ``pairwise_r2`` does.
+        On a ``GenotypeMatrix`` this is the same computation as
+        ``'r2'``. Raises on a pre-computed array. The pairing assumes
+        rows ``2i`` and ``2i + 1`` are one individual, and unlike
+        ``pairwise_r2`` this route tolerates missing calls.
 
     Returns
     -------
@@ -714,28 +750,30 @@ def zns(r2_matrix_or_matrix, missing_data='include', estimator='auto'):
     monomorphic sites, and sites where every called individual is
     heterozygous -- because r^2 is undefined there.
     """
-    from .haplotype_matrix import HaplotypeMatrix
-
-    if isinstance(r2_matrix_or_matrix, HaplotypeMatrix):
-        # Tiled path: O(B²) memory instead of O(m²).
+    kind = _ld_input_kind(r2_matrix_or_matrix, "zns")
+    estimator = _resolve_ld_estimator(estimator, kind)
+    if kind == 'haplotype':
         biallelic = r2_matrix_or_matrix.restrict_to_biallelic(warn_context="zns")
-        return _zns_biallelic(biallelic, missing_data, estimator)
-    estimator = _resolve_ld_estimator(estimator, False)
-
-    if estimator == 'sigma_d2':
-        raise ValueError(
-            "estimator='sigma_d2' requires a HaplotypeMatrix, "
-            "not a pre-computed r² array")
+        if estimator != 'rogers_huff':
+            # Tiled path: O(B²) memory instead of O(m²).
+            return _zns_biallelic(biallelic, missing_data, estimator)
+        # Rogers-Huff r is a diploid dosage correlation, so take the genotype
+        # path. These statistics read no populations, so drop the sample sets
+        # rather than convert-and-warn about them.
+        from .genotype_matrix import GenotypeMatrix
+        biallelic._sample_sets = None
+        r2_matrix_or_matrix = GenotypeMatrix.from_haplotype_matrix(biallelic)
 
     r2_matrix = _resolve_r2_matrix(r2_matrix_or_matrix, missing_data)
-    # Sites with no defined r^2 carry NaN rows/cols; drop them so the mean
-    # is over defined pairs.
-    r2_matrix = _drop_undefined_sites(r2_matrix)
-
-    m = r2_matrix.shape[0]
+    # Undefined sites carry NaN rows; nansum skips them without the
+    # compacting copy _drop_undefined_sites would make (omega needs that
+    # copy for its prefix sums; a scalar mean does not).
+    finite = ~cp.isnan(r2_matrix)
+    cp.fill_diagonal(finite, False)
+    m = int(cp.any(finite, axis=1).sum())
     if m < 2:
         return 0.0
-    total = cp.sum(r2_matrix) - cp.trace(r2_matrix)
+    total = cp.nansum(r2_matrix) - cp.nansum(cp.diag(r2_matrix))
     return float((total / (m * (m - 1))).get())
 
 
@@ -743,7 +781,7 @@ def _zns_biallelic(hm, missing_data='include', estimator='auto'):
     """``zns`` for a HaplotypeMatrix already restricted to biallelic sites:
     no second restriction and no warning. ``divergence.zx`` restricts once
     and calls this for each of its three terms."""
-    estimator = _resolve_ld_estimator(estimator, True)
+    estimator = _resolve_ld_estimator(estimator, 'haplotype')
     # 'project' selects the sigma_d2 estimator inside _zns_tiled.
     return _zns_tiled(hm, 'project' if estimator == 'sigma_d2' else missing_data)
 
@@ -796,14 +834,20 @@ def omega(r2_matrix_or_matrix, missing_data='include', estimator='auto'):
         ``'include'`` (default) uses per-site valid data for frequency
         computation. ``'exclude'`` filters to sites with no missing data.
     estimator : str
-        ``'auto'`` (default) uses the unbiased ``sigma_d2`` estimator
-        when the input is a ``HaplotypeMatrix``, and falls back to
-        naive ``r2`` for pre-computed r² arrays or ``GenotypeMatrix``
-        inputs (where ``sigma_d2`` is not available).
-        ``'r2'`` always computes naive r-squared.
-        ``'sigma_d2'`` always uses unbiased
+        ``'auto'`` (default): ``sigma_d2`` for a ``HaplotypeMatrix``,
+        ``rogers_huff`` for a ``GenotypeMatrix``, ``r2`` for a
+        pre-computed r² array.
+        ``'r2'`` computes naive r-squared.
+        ``'sigma_d2'`` uses unbiased
         :math:`\\sigma_D^2 = D^2/\\pi_2` (Ragsdale & Gravel 2019).
         Requires ``HaplotypeMatrix`` input.
+        ``'rogers_huff'`` computes the diploid dosage-correlation r²
+        (Rogers & Huff 2008); a ``HaplotypeMatrix`` is first paired
+        into 0/1/2 dosages by adjacent rows, as ``pairwise_r2`` does.
+        On a ``GenotypeMatrix`` this is the same computation as
+        ``'r2'``. Raises on a pre-computed array. The pairing assumes
+        rows ``2i`` and ``2i + 1`` are one individual, and unlike
+        ``pairwise_r2`` this route tolerates missing calls.
 
     Returns
     -------
@@ -819,19 +863,22 @@ def omega(r2_matrix_or_matrix, missing_data='include', estimator='auto'):
     monomorphic sites, and sites where every called individual is
     heterozygous -- because r^2 is undefined there.
     """
-    from .haplotype_matrix import HaplotypeMatrix
+    kind = _ld_input_kind(r2_matrix_or_matrix, "omega")
+    estimator = _resolve_ld_estimator(estimator, kind)
 
-    is_hm = isinstance(r2_matrix_or_matrix, HaplotypeMatrix)
-    estimator = _resolve_ld_estimator(estimator, is_hm)
-
-    if is_hm:
+    if kind == 'haplotype':
         r2_matrix_or_matrix = r2_matrix_or_matrix.restrict_to_biallelic(
             warn_context="omega")
+        if estimator == 'rogers_huff':
+            # Rogers-Huff r is a diploid dosage correlation, so take the
+            # genotype path; populations are unused, so drop the sample sets
+            # rather than convert-and-warn about them.
+            from .genotype_matrix import GenotypeMatrix
+            r2_matrix_or_matrix._sample_sets = None
+            r2_matrix_or_matrix = GenotypeMatrix.from_haplotype_matrix(
+                r2_matrix_or_matrix)
 
     if estimator == 'sigma_d2':
-        if not is_hm:
-            raise ValueError(
-                "estimator='sigma_d2' requires a HaplotypeMatrix")
         r2_matrix = _build_sigma_d2_matrix(r2_matrix_or_matrix,
                                            missing_data=missing_data)
     else:

--- a/tests/test_diploshic_stats.py
+++ b/tests/test_diploshic_stats.py
@@ -230,6 +230,36 @@ class TestZnSOmega:
             assert ld_statistics.zns(hap_data,
                                      estimator='rogers_huff') == baseline
 
+    @staticmethod
+    def _with_missing(hap_data, frac=0.03, seed=0):
+        g = cp.asnumpy(hap_data.haplotypes).copy()
+        g[np.random.default_rng(seed).random(g.shape) < frac] = -1
+        pos = cp.asnumpy(hap_data.positions)
+        return HaplotypeMatrix(g, pos, hap_data.chrom_start, hap_data.chrom_end)
+
+    def test_zns_sigma_d2_honours_exclude(self, hap_data):
+        # The default estimator (sigma_d2) used to discard missing_data,
+        # returning the include result; exclude must now restrict to
+        # complete sites first.
+        hm = self._with_missing(hap_data)
+        inc = ld_statistics.zns(hm, missing_data='include')
+        exc = ld_statistics.zns(hm, missing_data='exclude')
+        assert inc != exc
+        # And on complete data exclude drops nothing, so it equals include.
+        assert (ld_statistics.zns(hap_data, missing_data='exclude')
+                == ld_statistics.zns(hap_data, missing_data='include'))
+
+    def test_zns_exclude_matches_manual_complete_site_subset(self, hap_data):
+        # exclude equals the same statistic on a matrix hand-filtered to
+        # the sites with no missing calls, under the default estimator.
+        hm = self._with_missing(hap_data)
+        g = cp.asnumpy(hm.haplotypes)
+        complete = np.where((g >= 0).all(axis=0))[0]
+        sub = hm.get_subset(complete)
+        np.testing.assert_allclose(ld_statistics.zns(hm, missing_data='exclude'),
+                                   ld_statistics.zns(sub, missing_data='include'),
+                                   rtol=1e-12)
+
 
 # ---------------------------------------------------------------------------
 # mu_ld

--- a/tests/test_diploshic_stats.py
+++ b/tests/test_diploshic_stats.py
@@ -205,6 +205,31 @@ class TestZnSOmega:
         with pytest.raises(ValueError, match="Unknown estimator"):
             ld_statistics.zns(hap_data, estimator='nonsense')
 
+    @pytest.mark.parametrize("stat", [ld_statistics.zns, ld_statistics.omega])
+    def test_rogers_huff_on_haplotypes_pairs_rows(self, hap_data, geno_data,
+                                                  stat):
+        rh = stat(hap_data, estimator='rogers_huff')
+        assert rh == stat(geno_data, estimator='rogers_huff')
+        # And it is a different estimator from naive haplotype r2.
+        assert rh != stat(hap_data, estimator='r2')
+
+    @pytest.mark.parametrize("stat", [ld_statistics.zns, ld_statistics.omega])
+    def test_rogers_huff_raises_on_precomputed_array(self, hap_data, stat):
+        with pytest.raises(ValueError, match="pre-computed"):
+            stat(hap_data.pairwise_r2(), estimator='rogers_huff')
+
+    def test_rogers_huff_reads_no_sample_sets(self, hap_data):
+        # zns takes no population argument; a gappy sample_sets must
+        # neither warn nor change the result.
+        import warnings
+        from pg_gpu import UnpairedRowsWarning
+        baseline = ld_statistics.zns(hap_data, estimator='rogers_huff')
+        hap_data.sample_sets = {'p': [0, 2]}
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UnpairedRowsWarning)
+            assert ld_statistics.zns(hap_data,
+                                     estimator='rogers_huff') == baseline
+
 
 # ---------------------------------------------------------------------------
 # mu_ld
@@ -381,3 +406,4 @@ class TestDiplotypeFreqSpec:
         freqs, n_d = diversity.diplotype_frequency_spectrum(gm)
         assert n_d == 1
         assert freqs[0] == 1.0
+

--- a/tests/test_rogers_huff.py
+++ b/tests/test_rogers_huff.py
@@ -143,23 +143,32 @@ class TestEdgeCases:
 
 
 class TestEstimatorResolver:
+    """_resolve_ld_estimator maps 'auto' per input kind and raises for
+    estimators a kind cannot compute."""
 
-    def test_auto_haplotype_resolves_to_sigma_d2(self):
-        assert _resolve_ld_estimator('auto', is_hap_matrix=True) == 'sigma_d2'
+    def test_auto_policy_per_kind(self):
+        assert _resolve_ld_estimator('auto', 'haplotype') == 'sigma_d2'
+        assert _resolve_ld_estimator('auto', 'genotype') == 'rogers_huff'
+        assert _resolve_ld_estimator('auto', 'array') == 'r2'
 
-    def test_auto_genotype_resolves_to_rogers_huff(self):
-        assert _resolve_ld_estimator(
-            'auto', is_hap_matrix=False) == 'rogers_huff'
+    def test_computable_names_pass_through(self):
+        assert _resolve_ld_estimator('rogers_huff', 'haplotype') == 'rogers_huff'
+        assert _resolve_ld_estimator('rogers_huff', 'genotype') == 'rogers_huff'
+        assert _resolve_ld_estimator('sigma_d2', 'haplotype') == 'sigma_d2'
+        for kind in ('haplotype', 'genotype', 'array'):
+            assert _resolve_ld_estimator('r2', kind) == 'r2'
 
-    def test_explicit_rogers_huff_passes_through(self):
-        assert _resolve_ld_estimator(
-            'rogers_huff', is_hap_matrix=True) == 'rogers_huff'
-        assert _resolve_ld_estimator(
-            'rogers_huff', is_hap_matrix=False) == 'rogers_huff'
+    def test_incomputable_combinations_raise(self):
+        with pytest.raises(ValueError, match="requires a HaplotypeMatrix"):
+            _resolve_ld_estimator('sigma_d2', 'genotype')
+        with pytest.raises(ValueError, match="pre-computed"):
+            _resolve_ld_estimator('sigma_d2', 'array')
+        with pytest.raises(ValueError, match="pre-computed"):
+            _resolve_ld_estimator('rogers_huff', 'array')
 
     def test_unknown_estimator_raises(self):
         with pytest.raises(ValueError, match="Unknown estimator"):
-            _resolve_ld_estimator('bogus', is_hap_matrix=True)
+            _resolve_ld_estimator('bogus', 'haplotype')
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -513,3 +513,17 @@ class TestStreamingGenotypeMatrix:
         # individual axis into row blocks. Result must match eager.
         np.testing.assert_allclose(ibs(gm_stream), ibs(gm_eager),
                                     rtol=1e-9, atol=1e-12)
+
+
+class TestPairwiseLdRejectsStreams:
+    """zns and omega need the full pair set at once."""
+
+    @pytest.mark.parametrize("cls_name", ["HaplotypeMatrix", "GenotypeMatrix"])
+    @pytest.mark.parametrize("stat_name", ["zns", "omega"])
+    def test_rejects_streams(self, vcz_store, cls_name, stat_name):
+        import pg_gpu
+        from pg_gpu import ld_statistics
+        path, _ = vcz_store
+        stream = getattr(pg_gpu, cls_name).from_zarr(path, streaming="always")
+        with pytest.raises(NotImplementedError, match="materialize"):
+            getattr(ld_statistics, stat_name)(stream)


### PR DESCRIPTION
Two coupled fixes to the estimator/missing-data contract of `zns` and `omega`, both from the release audit.

**#219 -- the estimator was ignored.** `zns` and `omega` whitelisted `estimator='rogers_huff'` but the HaplotypeMatrix branches routed on missing-data mode only, so `zns(hm, estimator='rogers_huff')` returned the naive `r2` value exactly, silently. They now pair adjacent haplotypes into 0/1/2 dosages (the `pairwise_r2` pattern) and compute the diploid dosage correlation, verified equal to the same statistic on the derived GenotypeMatrix and different from `r2`. `_resolve_ld_estimator` is now kind-aware (`'haplotype'`/`'genotype'`/`'array'`): `'auto'` resolves per kind, and an estimator a kind cannot compute raises instead of being dropped -- the names raise on a pre-computed array (`'auto'` there means `r2`). A shared `_ld_input_kind` front door classifies the input once for both functions and rejects a streaming matrix with a `materialize` pointer (`NotImplementedError`, matching the streaming classes' contract).

**#250 -- missing_data='exclude' was ignored under the default estimator.** `zns` smuggled the estimator through the `missing_data` argument as a `'project'` sentinel, so under the default `sigma_d2` estimator `missing_data='exclude'` was overwritten and the `include` result came back (verified: include and exclude identical under sigma_d2, differing under `r2`). `_zns_tiled` now takes an explicit `use_projection` flag, as its sibling `_zns_from_precomputed` already did, and the real `missing_data` reaches `_prepare_segregating`, so `exclude` restricts to complete sites before the estimator runs. `omega` already did this via `_build_sigma_d2_matrix` and is unchanged. (Filed as #250 during the review; rolled in here because it is the same silent-ignore in the same functions, one parameter over, and the sentinel lives in `_zns_biallelic`, which this PR already rewrites.)

**Both dispatch paths covered.** Eager: every (input kind, estimator) cell now computes or raises, pinned on the resolver and through the public functions; zns `exclude` now differs from `include` under the default estimator and equals the hand-filtered complete-site subset. Streaming: scalar `zns`/`omega` reject a stream of either class; windowed streaming `zns`/`omega` are unaffected (fixed-estimator, include-only per window) and were held bit-identical to eager by the equivalence tests added in #248.

**From the review pass.** `zns` reduces to a scalar over the NaN-marked matrix with `nansum`, skipping the compacting `_drop_undefined_sites` copy (~halved peak memory, ~47% less runtime at 10k sites; `omega` keeps the copy for its 2-D prefix sums). The `rogers_huff` route clears sample sets before `from_haplotype_matrix`, so a gappy `sample_sets` no longer warns about rows these population-free statistics never use. `missing_data.rst` (the "LD Estimator Choice" section and Best Practice 4) now describes the kind-based policy. A deliberate limit is documented, not engineered: on a HaplotypeMatrix the `rogers_huff` route builds the full m x m matrix (O(m²), ~55k-variant wall on an 80 GB GPU), unreachable for the window-sized inputs these statistics take.

**Left as follow-ups** (same silent-ignore shape elsewhere, out of scope): `windowed_analysis` swallows `estimator=` for fused zns/omega (noted on #200); `pairwise_r2`/`windowed_r_squared` reject the documented `'auto'` name and `mu_ld` gives a bare error on a stream (#251).

Full suite 1410 passed, slow 53 passed, ruff and Sphinx clean. `test_scikit_allel_comparison_runs_small` is a known subprocess-timeout flake under host load (#252), unrelated -- a differential benchmark shows this branch equal-or-faster than main on every touched path.

Closes #219. Closes #250.
