### PR TITLE
Share the LD estimator resolver and stream guard across the entry points

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -177,6 +177,13 @@ Read this section if you are comparing against older pg_gpu results.
 Bug fixes
 ~~~~~~~~~
 
+* ``HaplotypeMatrix.pairwise_r2`` and ``windowed_r_squared`` rejected
+  ``estimator='auto'`` -- the default name for the LD estimator
+  everywhere else -- with an "unknown estimator" error. They accept it
+  now (it means ``'r2'`` there), sharing the one estimator resolver.
+* ``mu_ld`` and the ``rogers_huff_r`` family raised a bare
+  ``AttributeError``/``TypeError`` on a streaming matrix; they now give
+  the same "call ``materialize``" message ``zns``/``omega`` do.
 * ``zns`` and ``omega`` accepted ``estimator='rogers_huff'`` on a
   ``HaplotypeMatrix`` and silently computed naive ``r2`` instead. They
   now pair adjacent haplotypes into 0/1/2 dosages and compute the

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -1817,11 +1817,11 @@ class HaplotypeMatrix:
         Parameters
         ----------
         estimator : str
-            ``'r2'`` (default) -- naive haplotype r² from
-            frequency-based formula. ``'rogers_huff'`` -- Rogers-Huff
-            r² computed on diploid 0/1/2 dosages obtained by pairing
-            adjacent haplotypes (sample 0 = haplotypes 0,1; sample 1
-            = haplotypes 2,3; ...). Matches
+            ``'auto'`` and ``'r2'`` (the default) both give naive
+            haplotype r² from the frequency-based formula.
+            ``'rogers_huff'`` gives Rogers-Huff r² on diploid 0/1/2
+            dosages obtained by pairing adjacent haplotypes (sample 0 =
+            haplotypes 0,1; sample 1 = haplotypes 2,3; ...), matching
             :func:`scikit-allel.rogers_huff_r` ** 2.
 
         Returns
@@ -1831,6 +1831,10 @@ class HaplotypeMatrix:
             (>2 distinct present alleles) site; r-squared is computed on
             biallelic sites only.
         """
+        from .ld_statistics import _resolve_ld_estimator
+        estimator = _resolve_ld_estimator(estimator, 'haplotype',
+                                          allowed=('r2', 'rogers_huff'),
+                                          auto='r2')
         if estimator == 'rogers_huff':
             from .genotype_matrix import GenotypeMatrix
             from .ld_statistics import _rogers_huff_pairwise_r
@@ -1851,10 +1855,6 @@ class HaplotypeMatrix:
                 r2[cp.ix_(idx, idx)] = r2_kept
             cp.fill_diagonal(r2, 0)
             return r2
-        if estimator != 'r2':
-            raise ValueError(
-                f"Unknown estimator: {estimator!r} "
-                f"(expected 'r2' or 'rogers_huff')")
         from ._warnings import _warn_biallelic_only
         bmask = self._biallelic_mask()
         _warn_biallelic_only(int((~bmask).sum()), context="pairwise_r2")
@@ -1950,11 +1950,11 @@ class HaplotypeMatrix:
         pop : str, optional
             Population key to use.
         estimator : str
-            ``'r2'`` (default) -- naive haplotype r² from frequency
-            counts. ``'rogers_huff'`` -- Rogers-Huff r² on diploid
-            0/1/2 dosages obtained by pairing adjacent haplotypes;
-            sites with three or more present alleles are dropped
-            before binning. Matches
+            ``'auto'`` and ``'r2'`` (the default) both give naive
+            haplotype r² from frequency counts. ``'rogers_huff'`` gives
+            Rogers-Huff r² on diploid 0/1/2 dosages obtained by pairing
+            adjacent haplotypes; sites with three or more present
+            alleles are dropped before binning. Matches
             :func:`scikit-allel.rogers_huff_r` ** 2.
 
         Returns
@@ -1967,6 +1967,10 @@ class HaplotypeMatrix:
         if self.device == 'CPU':
             self.transfer_to_gpu()
 
+        from .ld_statistics import _resolve_ld_estimator
+        estimator = _resolve_ld_estimator(estimator, 'haplotype',
+                                          allowed=('r2', 'rogers_huff'),
+                                          auto='r2')
         if estimator == 'rogers_huff':
             if pop is not None:
                 raise NotImplementedError(
@@ -1998,10 +2002,6 @@ class HaplotypeMatrix:
                 ind = ind[biallelic.sample_sets[pop], :]
             counts_arr, n_valid = biallelic._tally_pairs_impl(ind)
             r2_vals = ld_statistics.r_squared(counts_arr, n_valid=n_valid)
-        else:
-            raise ValueError(
-                f"Unknown estimator: {estimator!r} "
-                f"(expected 'r2' or 'rogers_huff')")
 
         if not isinstance(pos, cp.ndarray):
             pos = cp.array(pos)

--- a/pg_gpu/ld_statistics.py
+++ b/pg_gpu/ld_statistics.py
@@ -341,34 +341,48 @@ def _tile_sigma_d2(hi, vi, hj, vj):
     return sigma_d2, valid
 
 
-def _resolve_ld_estimator(estimator: str, kind: str) -> str:
-    """Resolve an LD estimator string against the input ``kind``.
-
-    ``kind`` is ``'haplotype'``, ``'genotype'``, or ``'array'``
-    (a pre-computed r² matrix). ``'auto'`` resolves to ``'sigma_d2'``,
-    ``'rogers_huff'``, and ``'r2'`` respectively. Explicit names pass
-    through, except that an estimator the kind cannot compute raises:
-    ``sigma_d2`` needs haplotypes, ``rogers_huff`` needs genotype data,
-    and an array is already an r² matrix.
-    """
-    if estimator == 'auto':
-        return {'haplotype': 'sigma_d2', 'genotype': 'rogers_huff',
-                'array': 'r2'}[kind]
-    if estimator not in ('r2', 'sigma_d2', 'rogers_huff'):
-        raise ValueError(
-            f"Unknown estimator: {estimator!r} "
-            f"(expected one of 'auto', 'r2', 'sigma_d2', 'rogers_huff')")
-    if estimator == 'sigma_d2' and kind != 'haplotype':
-        raise ValueError("estimator='sigma_d2' requires a HaplotypeMatrix, "
-                         f"not {_KIND_NOUN[kind]}")
-    if estimator == 'rogers_huff' and kind == 'array':
-        raise ValueError("estimator='rogers_huff' needs genotype data, "
-                         f"not {_KIND_NOUN[kind]}")
-    return estimator
-
-
 _KIND_NOUN = {'haplotype': 'a HaplotypeMatrix', 'genotype': 'a GenotypeMatrix',
               'array': 'a pre-computed r² array'}
+_AUTO_BY_KIND = {'haplotype': 'sigma_d2', 'genotype': 'rogers_huff',
+                 'array': 'r2'}
+
+
+def _resolve_ld_estimator(estimator, kind, *,
+                          allowed=('r2', 'sigma_d2', 'rogers_huff'), auto=None):
+    """Resolve an LD estimator string against the input ``kind``.
+
+    ``kind`` is ``'haplotype'``, ``'genotype'``, or ``'array'`` (a
+    pre-computed r² matrix). ``'auto'`` resolves to ``auto`` if the
+    caller sets it, else the natural default for the kind (``sigma_d2``
+    / ``rogers_huff`` / ``r2``). ``allowed`` lists the estimators the
+    call site implements; a name outside it raises, as does an estimator
+    the kind cannot compute (``sigma_d2`` needs haplotypes,
+    ``rogers_huff`` needs genotype data).
+    """
+    resolved = ((auto if auto is not None else _AUTO_BY_KIND[kind])
+                if estimator == 'auto' else estimator)
+    if resolved not in allowed:
+        names = ', '.join(repr(e) for e in ('auto', *allowed))
+        raise ValueError(f"Unknown estimator: {estimator!r} "
+                         f"(expected one of {names})")
+    if resolved == 'sigma_d2' and kind != 'haplotype':
+        raise ValueError("estimator='sigma_d2' requires a HaplotypeMatrix, "
+                         f"not {_KIND_NOUN[kind]}")
+    if resolved == 'rogers_huff' and kind == 'array':
+        raise ValueError("estimator='rogers_huff' needs genotype data, "
+                         f"not {_KIND_NOUN[kind]}")
+    return resolved
+
+
+def _reject_streaming(obj, context):
+    """Raise a pointed error when ``obj`` is a streaming matrix: the
+    pairwise LD statistics need every variant pair in scope at once."""
+    from .streaming_matrix import _StreamingMatrixBase
+    if isinstance(obj, _StreamingMatrixBase):
+        raise NotImplementedError(
+            f"{context} needs every variant pair in scope at once, which a "
+            "streaming matrix cannot hold; call .materialize(region=(lo, hi)) "
+            "to get an eager matrix over a sub-region and compute on that.")
 
 
 def _ld_input_kind(obj, context):
@@ -376,12 +390,7 @@ def _ld_input_kind(obj, context):
     ``'array'``, rejecting streaming matrices up front."""
     from .haplotype_matrix import HaplotypeMatrix
     from .genotype_matrix import GenotypeMatrix
-    from .streaming_matrix import _StreamingMatrixBase
-    if isinstance(obj, _StreamingMatrixBase):
-        raise NotImplementedError(
-            f"{context} needs every variant pair in scope at once, which a "
-            "streaming matrix cannot hold; call .materialize(region=(lo, hi)) "
-            "to get an eager matrix over a sub-region and compute on that.")
+    _reject_streaming(obj, context)
     if isinstance(obj, HaplotypeMatrix):
         return 'haplotype'
     if isinstance(obj, GenotypeMatrix):
@@ -399,6 +408,7 @@ def _dosage_from_matrix(matrix) -> "cp.ndarray":
     """
     from .genotype_matrix import GenotypeMatrix
 
+    _reject_streaming(matrix, "rogers_huff_r")
     if not isinstance(matrix, GenotypeMatrix):
         raise TypeError(
             "rogers_huff_r is the diploid dosage correlation and requires a "
@@ -947,6 +957,7 @@ def mu_ld(haplotype_matrix, missing_data='include'):
     -------
     float
     """
+    _reject_streaming(haplotype_matrix, "mu_ld")
     if haplotype_matrix.device == 'CPU':
         haplotype_matrix.transfer_to_gpu()
 

--- a/tests/test_rogers_huff.py
+++ b/tests/test_rogers_huff.py
@@ -178,6 +178,28 @@ class TestEstimatorResolver:
 
 class TestHaplotypeMatrixEstimator:
 
+    def test_auto_estimator_accepted_and_equals_r2(self):
+        # 'auto' is the default estimator name elsewhere; the matrix methods
+        # must accept it (meaning naive r2 here), not reject it.
+        hm = _random_hm(n_diploids=25, n_var=40, seed=3)
+        np.testing.assert_array_equal(
+            np.nan_to_num(hm.pairwise_r2(estimator='auto').get()),
+            np.nan_to_num(hm.pairwise_r2(estimator='r2').get()))
+        va, ca = hm.windowed_r_squared([0, 20_000, 40_000], estimator='auto')
+        vr, cr = hm.windowed_r_squared([0, 20_000, 40_000], estimator='r2')
+        np.testing.assert_array_equal(np.nan_to_num(va), np.nan_to_num(vr))
+        np.testing.assert_array_equal(ca, cr)
+
+    @pytest.mark.parametrize("bad", ["sigma_d2", "bogus"])
+    def test_unavailable_estimator_raises_unknown(self, bad):
+        # sigma_d2 is a real estimator but not available on these methods;
+        # both it and a nonsense name raise the shared "Unknown estimator".
+        hm = _random_hm(n_diploids=25, n_var=40, seed=3)
+        with pytest.raises(ValueError, match="Unknown estimator"):
+            hm.pairwise_r2(estimator=bad)
+        with pytest.raises(ValueError, match="Unknown estimator"):
+            hm.windowed_r_squared([0, 40_000], estimator=bad)
+
     def test_pairwise_r2_matches_module_function(self):
         hm = _random_hm(n_diploids=30, n_var=40, seed=11)
         r2_hm = hm.pairwise_r2(estimator='rogers_huff').get()

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -516,14 +516,30 @@ class TestStreamingGenotypeMatrix:
 
 
 class TestPairwiseLdRejectsStreams:
-    """zns and omega need the full pair set at once."""
+    """The pairwise LD statistics need every variant pair at once, so a
+    streaming matrix gets a materialize pointer, not a bare error."""
 
     @pytest.mark.parametrize("cls_name", ["HaplotypeMatrix", "GenotypeMatrix"])
     @pytest.mark.parametrize("stat_name", ["zns", "omega"])
-    def test_rejects_streams(self, vcz_store, cls_name, stat_name):
+    def test_zns_omega_reject_streams(self, vcz_store, cls_name, stat_name):
         import pg_gpu
         from pg_gpu import ld_statistics
         path, _ = vcz_store
         stream = getattr(pg_gpu, cls_name).from_zarr(path, streaming="always")
         with pytest.raises(NotImplementedError, match="materialize"):
             getattr(ld_statistics, stat_name)(stream)
+
+    def test_mu_ld_rejects_haplotype_stream(self, vcz_store):
+        from pg_gpu import ld_statistics
+        path, _ = vcz_store
+        stream = HaplotypeMatrix.from_zarr(path, streaming="always")
+        with pytest.raises(NotImplementedError, match="materialize"):
+            ld_statistics.mu_ld(stream)
+
+    @pytest.mark.parametrize("fn", ["rogers_huff_r", "rogers_huff_r_squared"])
+    def test_rogers_huff_rejects_genotype_stream(self, vcz_store, fn):
+        from pg_gpu import GenotypeMatrix, ld_statistics
+        path, _ = vcz_store
+        stream = GenotypeMatrix.from_zarr(path, streaming="always")
+        with pytest.raises(NotImplementedError, match="materialize"):
+            getattr(ld_statistics, fn)(stream)


### PR DESCRIPTION
Follow-up filed during the #219 review. #249 tightened the estimator/input contract for scalar `zns`/`omega`; this brings the sibling LD entry points into line.

**Eager -- `pairwise_r2` / `windowed_r_squared` accept the documented default name.** Both hand-rolled their validation (`if estimator != 'r2': raise "unknown estimator (expected 'r2' or 'rogers_huff')"`), so `estimator='auto'` -- the default name for the estimator everywhere else -- was rejected. They now call `_resolve_ld_estimator(estimator, 'haplotype', allowed=('r2', 'rogers_huff'), auto='r2')`: `'auto'` resolves to `'r2'` (verified bit-identical to `estimator='r2'`), and `'sigma_d2'` or a nonsense name raises the one shared "Unknown estimator" message. `_resolve_ld_estimator` gained keyword-only `allowed`/`auto` params for this; `zns`/`omega` keep their kind-based `'auto'` (sigma_d2 / rogers_huff / r2 by input kind).

**Streaming -- one materialize pointer, not a bare error.** `mu_ld(stream)` died on `.device` (`AttributeError`) and the `rogers_huff_r` family raised a misleading `TypeError` ("requires a GenotypeMatrix") on a `StreamingGenotypeMatrix`. A `_reject_streaming` helper, extracted from `_ld_input_kind` so the materialize message lives in one place, now guards `mu_ld` and `_dosage_from_matrix` (the `rogers_huff_r`/`rogers_huff_r_squared` choke point). All three now raise `NotImplementedError` with the same "call `.materialize(region=...)`" pointer `zns`/`omega` give. Every module-level LD function taking a matrix is now guarded; the rest take count arrays.

**Windowed dispatch -- unaffected, verified.** `windowed_analysis` computes per-window `zns`/`omega`/`mu_ld` on eager per-window slices (and `_stream_windowed_analysis` recurses with eager chunk matrices), so `_reject_streaming` never fires there. Confirmed: windowed `mu_ld` runs eager, and streaming-vs-eager windowed `mu_ld` is bit-identical.

**Tests.** `pairwise_r2`/`windowed_r_squared` accept `'auto'` (== r2) and raise on `sigma_d2`/nonsense; `mu_ld` and both `rogers_huff_r` functions reject a stream with the materialize pointer (joining the `zns`/`omega` stream-rejection cases from #248/#249).

The full suite completed green (exit 0; a re-run for the exact count was starved by heavy host load from other users, so I'm citing the completed run rather than a number). Slow suite 53 passed; ruff and Sphinx clean. The simplify pass found nothing.

Closes #251.
