### PR TITLE
Wire up existing eta-family estimators to scalar statistics

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -184,6 +184,11 @@ Bug fixes
 * ``mu_ld`` and the ``rogers_huff_r`` family raised a bare
   ``AttributeError``/``TypeError`` on a streaming matrix; they now give
   the same "call ``materialize``" message ``zns``/``omega`` do.
+* ``diversity_stats`` listed the Achaz eta-family estimators (``eta1``,
+  ``eta1_star``, ``minus_eta1``, ``minus_eta1_star``) as available but
+  raised ``Unknown statistic`` when asked for them. It now computes them
+  through the per-allele scalar path, giving the same values as
+  ``FrequencySpectrum.theta`` on both biallelic and multiallelic data.
 * ``zns`` and ``omega`` accepted ``estimator='rogers_huff'`` on a
   ``HaplotypeMatrix`` and silently computed naive ``r2`` instead. They
   now pair adjacent haplotypes into 0/1/2 dosages and compute the

--- a/pg_gpu/diversity.py
+++ b/pg_gpu/diversity.py
@@ -465,9 +465,9 @@ def project_sfs(sfs, n_from, n_to):
 # FrequencySpectrum: power-user class for SFS analysis
 # ---------------------------------------------------------------------------
 
-# Weight functions for the SFS dot-product path, used by
-# FrequencySpectrum.theta for custom callables; the built-in estimator
-# names go through the per-allele _ac_contribution path.
+# Weight vectors for the SFS dot-product path, used by FrequencySpectrum.theta
+# for built-in names and custom callables alike; the scalar functions and
+# diversity_stats use the per-allele _ac_contribution path instead.
 def _weights_watterson(n):
     w = np.zeros(n + 1)
     a1 = np.sum(1.0 / np.arange(1, n))
@@ -1009,7 +1009,12 @@ def diversity_stats(haplotype_matrix: HaplotypeMatrix,
     population : str or list, optional
         Population name or list of sample indices. If None, uses all samples
     statistics : list
-        List of statistics to compute
+        List of statistics to compute. Theta estimators: ``pi``,
+        ``theta_w``, ``theta_h``, ``theta_l``, and the Achaz eta-family
+        ``eta1``, ``eta1_star``, ``minus_eta1``, ``minus_eta1_star``.
+        Neutrality tests: ``tajimas_d``, ``fay_wus_h``,
+        ``normalized_fay_wus_h``, ``zeng_e``. Also ``segregating_sites``,
+        ``singletons``, ``n_variants``, ``haplotype_diversity``.
     span_normalize : bool
         ``True`` (default): auto-detect best denominator.
         ``False``: return raw sums.
@@ -1024,7 +1029,9 @@ def diversity_stats(haplotype_matrix: HaplotypeMatrix,
     """
     # Map stat names to estimator names for batched computation
     theta_stats = {'pi': 'pi', 'theta_w': 'watterson', 'theta_h': 'theta_h',
-                   'theta_l': 'theta_l'}
+                   'theta_l': 'theta_l', 'eta1': 'eta1',
+                   'eta1_star': 'eta1_star', 'minus_eta1': 'minus_eta1',
+                   'minus_eta1_star': 'minus_eta1_star'}
     # Neutrality tests: (w1, w2) weight pairs
     test_specs = {
         'tajimas_d': ('pi', 'watterson'),

--- a/pg_gpu/diversity.py
+++ b/pg_gpu/diversity.py
@@ -1088,7 +1088,7 @@ def diversity_stats(haplotype_matrix: HaplotypeMatrix,
             results['n_variants'] = m.num_variants
         elif stat == 'haplotype_diversity':
             results['haplotype_diversity'] = haplotype_diversity(haplotype_matrix, population, missing_data)
-        elif stat not in ('pi', 'theta_w', 'theta_h', 'theta_l', 'tajimas_d'):
+        else:
             raise ValueError(f"Unknown statistic: {stat}")
 
     # Give back keys in the caller's order; the theta batch above fills

--- a/tests/test_achaz.py
+++ b/tests/test_achaz.py
@@ -424,3 +424,59 @@ class TestFrequencySpectrumEdges:
         fs = FrequencySpectrum(hm, n_total_sites=n_seg + 50)
         # The 50 monomorphic sites land in bin 0 at the top sample size.
         assert fs.sfs_by_n[fs.n_max][0] == 50
+
+
+class TestEtaScalarPath:
+    """The eta-family through diversity_stats (the per-allele scalar path):
+    absolute values from the Achaz definition and multiallelic per-allele
+    decomposition."""
+
+    ETA = ['eta1', 'eta1_star', 'minus_eta1', 'minus_eta1_star']
+
+    def test_absolute_values_match_achaz_definition(self):
+        # n=8 haplotypes; one column per known derived-allele count.
+        n = 8
+        counts = [1, 1, 1, 7, 3, 3, 2, 6]
+        hap = np.zeros((n, len(counts)), dtype=np.int8)
+        for j, c in enumerate(counts):
+            hap[:c, j] = 1
+        hm = HaplotypeMatrix(hap, np.arange(len(counts)) * 100)
+
+        a1 = np.sum(1.0 / np.arange(1, n))
+        cnt = np.array(counts)
+        expected = {
+            'eta1': np.sum(cnt == 1) / a1,
+            'eta1_star': np.sum((cnt == 1) | (cnt == n - 1)) / a1,
+            'minus_eta1': np.sum((cnt >= 2) & (cnt < n)) / (a1 - 1),
+            'minus_eta1_star': (np.sum((cnt >= 2) & (cnt <= n - 2))
+                                / (a1 - 1 - 1.0 / (n - 1))),
+        }
+        got = diversity.diversity_stats(hm, statistics=self.ETA,
+                                        span_normalize=False)
+        for name in self.ETA:
+            np.testing.assert_allclose(got[name], expected[name], rtol=1e-12,
+                                       err_msg=name)
+
+    @pytest.mark.parametrize("name", ETA)
+    def test_multiallelic_equals_per_allele_split(self, name):
+        # A multiallelic site contributes per derived allele, so eta on data
+        # with >2-allele sites equals eta on the same data split into one
+        # biallelic indicator column per derived allele.
+        rng = np.random.default_rng(3)
+        n = 12
+        hap = rng.integers(0, 3, size=(n, 40)).astype(np.int8)
+        assert any(len(np.unique(hap[:, j])) > 2 for j in range(hap.shape[1]))
+
+        split = np.stack(
+            [(hap[:, j] == a).astype(np.int8)
+             for j in range(hap.shape[1])
+             for a in np.unique(hap[:, j]) if a > 0],
+            axis=1)
+
+        hm = HaplotypeMatrix(hap, np.arange(hap.shape[1]) * 100)
+        hm_split = HaplotypeMatrix(split, np.arange(split.shape[1]) * 100)
+        multi = diversity.diversity_stats(hm, statistics=[name],
+                                          span_normalize=False)[name]
+        decomp = diversity.diversity_stats(hm_split, statistics=[name],
+                                           span_normalize=False)[name]
+        np.testing.assert_allclose(multi, decomp, rtol=1e-12)

--- a/tests/test_implementation_parity.py
+++ b/tests/test_implementation_parity.py
@@ -289,19 +289,18 @@ _STATS = {
         True, "value",
         lambda hm, md: divergence.fst_weir_cockerham(hm, POP1, POP2, missing_data=md),
         None, None, "fst_wc", "fst_wc"),
-}
-
-# The Achaz eta-family: scalar (per-allele _ac_contribution, reached through
-# diversity_stats) vs the SFS dot-product (FrequencySpectrum.theta). Both are
-# per-allele-correct, so they agree on every condition -- including multiallelic,
-# unlike pi/theta_w. Not windowed, so only the fs path is checked.
-for _eta in ("eta1", "eta1_star", "minus_eta1", "minus_eta1_star"):
-    _STATS[_eta] = _Stat(
+    # The Achaz eta-family: the per-allele scalar path (via diversity_stats) is
+    # the reference; the SFS dot-product (FrequencySpectrum.theta) is the one
+    # path checked against it. Both are per-allele-correct, so they agree on
+    # every condition (no xfail), and eta is not a windowed stat.
+    **{name: _Stat(
         False, "value",
-        lambda hm, md, name=_eta: diversity.diversity_stats(
+        lambda hm, md, name=name: diversity.diversity_stats(
             hm, statistics=[name], span_normalize=False, missing_data=md)[name],
-        lambda fs, name=_eta: fs.theta(name, span_normalize=False),
+        lambda fs, name=name: fs.theta(name, span_normalize=False),
         None, None, None)
+       for name in ("eta1", "eta1_star", "minus_eta1", "minus_eta1_star")},
+}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_implementation_parity.py
+++ b/tests/test_implementation_parity.py
@@ -291,6 +291,18 @@ _STATS = {
         None, None, "fst_wc", "fst_wc"),
 }
 
+# The Achaz eta-family: scalar (per-allele _ac_contribution, reached through
+# diversity_stats) vs the SFS dot-product (FrequencySpectrum.theta). Both are
+# per-allele-correct, so they agree on every condition -- including multiallelic,
+# unlike pi/theta_w. Not windowed, so only the fs path is checked.
+for _eta in ("eta1", "eta1_star", "minus_eta1", "minus_eta1_star"):
+    _STATS[_eta] = _Stat(
+        False, "value",
+        lambda hm, md, name=_eta: diversity.diversity_stats(
+            hm, statistics=[name], span_normalize=False, missing_data=md)[name],
+        lambda fs, name=_eta: fs.theta(name, span_normalize=False),
+        None, None, None)
+
 
 # ---------------------------------------------------------------------------
 # Per-path adapters -- each returns the canonical quantity for its stat


### PR DESCRIPTION
`quickstart` lists `eta1`, `eta1_star`, `minus_eta1`, and `minus_eta1_star` as available `diversity_stats` estimators, but the code mapped only `pi`, `theta_w`, `theta_h`, and `theta_l`, so asking for an eta name raised `ValueError: Unknown statistic`. This adds the four names to the estimator map. They route through the existing `_compute_thetas` path and return the same values as `FrequencySpectrum.theta` on both biallelic and multiallelic data, which also makes the previously-unreachable eta branches of `_ac_contribution` and their two normalizer caches live. No existing results change. This fixes a coverage gap identified in #232 

A stale comment above the SFS weight vectors is corrected: it claimed the built-in names go through `_ac_contribution`, but `FrequencySpectrum.theta` uses those weights for built-in names and custom callables alike, while the scalar functions and `diversity_stats` use `_ac_contribution`.

Tests: the four estimators join the implementation-parity harness (scalar via `diversity_stats` versus the SFS dot product), agreeing on every condition including multiallelic; plus absolute values checked against the Achaz definition by hand, and a multiallelic per-allele decomposition check.