### PR TITLE
Route zarr v2 stores to the host fetcher; read the codec on the source

### DIFF
--- a/pg_gpu/__init__.py
+++ b/pg_gpu/__init__.py
@@ -68,11 +68,12 @@ from .decomposition import (
 )
 from .resampling import block_jackknife, block_bootstrap
 from ._warnings import (
-    BadlyChunkedWarning, HaploidDataWarning, MemoryLimitedWarning,
-    MultiallelicCapWarning, BiallelicOnlyWarning, UnpairedRowsWarning,
+    BadlyChunkedWarning, HaploidDataWarning, KvikioUnavailableWarning,
+    MemoryLimitedWarning, MultiallelicCapWarning, BiallelicOnlyWarning,
+    UnpairedRowsWarning,
 )
 
-__all__ = ['ld_statistics', 'diversity', 'divergence', 'windowed_analysis', 'selection', 'sfs', 'admixture', 'decomposition', 'plotting', 'distance_stats', 'resampling', 'HaplotypeMatrix', 'GenotypeMatrix', 'WindowedAnalyzer', 'windowed_analysis', 'AccessibleMask', 'bed_to_mask', 'parse_bed', 'LocalPCAResult', 'LostructResult', 'pca', 'randomized_pca', 'pca_dosage', 'randomized_pca_dosage', 'local_pca', 'local_pca_jackknife', 'lostruct', 'pc_dist', 'corners', 'block_jackknife', 'block_bootstrap', 'MemoryLimitedWarning', 'HaploidDataWarning', 'BadlyChunkedWarning', 'MultiallelicCapWarning', 'BiallelicOnlyWarning', 'UnpairedRowsWarning']
+__all__ = ['ld_statistics', 'diversity', 'divergence', 'windowed_analysis', 'selection', 'sfs', 'admixture', 'decomposition', 'plotting', 'distance_stats', 'resampling', 'HaplotypeMatrix', 'GenotypeMatrix', 'WindowedAnalyzer', 'windowed_analysis', 'AccessibleMask', 'bed_to_mask', 'parse_bed', 'LocalPCAResult', 'LostructResult', 'pca', 'randomized_pca', 'pca_dosage', 'randomized_pca_dosage', 'local_pca', 'local_pca_jackknife', 'lostruct', 'pc_dist', 'corners', 'block_jackknife', 'block_bootstrap', 'MemoryLimitedWarning', 'HaploidDataWarning', 'BadlyChunkedWarning', 'KvikioUnavailableWarning', 'MultiallelicCapWarning', 'BiallelicOnlyWarning', 'UnpairedRowsWarning']
 
 # Version is derived from the git tag at build time (hatch-vcs) and read here
 # from the installed package metadata, so there is no hardcoded string to keep

--- a/pg_gpu/_warnings.py
+++ b/pg_gpu/_warnings.py
@@ -63,8 +63,10 @@ class HaploidDataWarning(UserWarning):
 class BadlyChunkedWarning(UserWarning):
     """Emitted when ``backend='auto'`` picks ``host`` on a store whose
     call_genotype chunking would have defeated the kvikio fetcher's
-    win. The store is functional but a bio2zarr-style re-encode would
-    unlock the GPU-decode fast path."""
+    win. The store is functional but re-encoding as zarr v3 with
+    bio2zarr-style sample chunking
+    (``HaplotypeMatrix.vcf_to_zarr(..., zarr_format=3)``) would unlock
+    the GPU-decode fast path."""
 
 
 class KvikioUnavailableWarning(UserWarning):

--- a/pg_gpu/_warnings.py
+++ b/pg_gpu/_warnings.py
@@ -67,6 +67,18 @@ class BadlyChunkedWarning(UserWarning):
     unlock the GPU-decode fast path."""
 
 
+class KvikioUnavailableWarning(UserWarning):
+    """Emitted when ``backend='auto'`` picks ``host`` because the store
+    cannot be GPU-decoded -- most often a zarr v2 store, whose numcodecs
+    compressor decodes on the CPU. The store is functional; re-encoding
+    it as zarr v3 unlocks the kvikio GPU-decode fast path. Silence with::
+
+        import warnings
+        from pg_gpu import KvikioUnavailableWarning
+        warnings.filterwarnings("ignore", category=KvikioUnavailableWarning)
+    """
+
+
 class MultiallelicCapWarning(UserWarning):
     """Emitted when a fused windowed kernel drops sites with more alleles
     than the kernel's fixed per-allele capacity.

--- a/pg_gpu/haplotype_matrix.py
+++ b/pg_gpu/haplotype_matrix.py
@@ -891,7 +891,8 @@ class HaplotypeMatrix:
 
     @staticmethod
     def vcf_to_zarr(vcf_paths, zarr_path, worker_processes=None,
-                    icf_path=None, max_memory='4GB', show_progress=True):
+                    icf_path=None, max_memory='4GB', show_progress=True,
+                    zarr_format=None):
         """Convert VCF file(s) to VCZ-format Zarr store using bio2zarr.
 
         Parameters
@@ -910,12 +911,16 @@ class HaplotypeMatrix:
             Maximum memory for encoding step. Default '4GB'.
         show_progress : bool
             Show progress bars. Default True.
+        zarr_format : int, optional
+            Zarr metadata version to write (2 or 3). ``None`` (default)
+            uses bio2zarr's own default (v2). Pass ``3`` for a store the
+            kvikio GPU-decode backend can read.
         """
         from .zarr_io import vcf_to_zarr
         vcf_to_zarr(vcf_paths, zarr_path,
                      worker_processes=worker_processes,
                      icf_path=icf_path, max_memory=max_memory,
-                     show_progress=show_progress)
+                     show_progress=show_progress, zarr_format=zarr_format)
 
     @staticmethod
     def _haplotypes_to_gt(hap):

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -122,8 +122,8 @@ def _pick_chunk_fetcher(source, *, backend):
                 f"{source.path}: zarr v{source.zarr_format} store; the "
                 f"kvikio GPU decoder needs zarr v3 (a v2 compressor decodes "
                 f"on the CPU). Falling back to the host fetcher. Re-encode "
-                f"as zarr v3 via HaplotypeMatrix.vcf_to_zarr to enable "
-                f"kvikio.",
+                f"as zarr v3 with HaplotypeMatrix.vcf_to_zarr(..., "
+                f"zarr_format=3) to enable kvikio.",
                 KvikioUnavailableWarning, stacklevel=4,
             )
         return HostChunkFetcher(source)
@@ -143,8 +143,9 @@ def _pick_chunk_fetcher(source, *, backend):
                 f"full sample axis ({source.num_diploids} diploids); the "
                 f"kvikio fetcher gives no speedup at this chunking. "
                 f"Falling back to the host fetcher. Re-encode with "
-                f"bio2zarr-style chunking (sample_chunk ~= 1000) via "
-                f"HaplotypeMatrix.vcf_to_zarr to enable kvikio.",
+                f"HaplotypeMatrix.vcf_to_zarr(..., zarr_format=3), whose "
+                f"bio2zarr sample chunking splits the sample axis, to "
+                f"enable kvikio.",
                 BadlyChunkedWarning, stacklevel=4,
             )
         return HostChunkFetcher(source)
@@ -309,8 +310,8 @@ class KvikioChunkFetcher(ChunkFetcher):
                 f"kvikio GPU decode requires a zarr v3 store; "
                 f"{source.path} is zarr v{source.zarr_format}, whose "
                 f"numcodecs compressor decodes on the CPU. Re-encode as "
-                f"zarr v3 via HaplotypeMatrix.vcf_to_zarr to use the "
-                f"kvikio backend."
+                f"zarr v3 with HaplotypeMatrix.vcf_to_zarr(..., "
+                f"zarr_format=3) to use the kvikio backend."
             )
         if source.codec not in _NVCOMP_SUPPORTED_CODECS:
             raise ValueError(

--- a/pg_gpu/streaming_matrix.py
+++ b/pg_gpu/streaming_matrix.py
@@ -32,7 +32,7 @@ import zarr
 from kvikio.zarr import GDSStore
 
 from ._gpu_genotype_prep import build_genotype_matrix, build_haplotype_matrix
-from ._warnings import BadlyChunkedWarning
+from ._warnings import BadlyChunkedWarning, KvikioUnavailableWarning
 
 
 def _pad_to(arr, shape):
@@ -110,9 +110,22 @@ def _pick_chunk_fetcher(source, *, backend):
     if backend == "kvikio":
         return KvikioChunkFetcher(source)
 
-    codec = _store_call_genotype_codec(source.path)
-    if codec is None:
-        # codec unreadable or unsupported -> host
+    if not _kvikio_can_decode(source):
+        # A zarr v2 store decodes through CPU numcodecs, and an
+        # uncompressed or unsupported codec has no nvCOMP GPU decoder --
+        # either way kvikio cannot engage, so use the host fetcher. Hint
+        # on the v2 case (the common, fixable one) when the store is big
+        # enough that the GPU path would have mattered; small fixtures
+        # would just get noise.
+        if source.zarr_format != 3 and _store_large_enough_to_warn(source):
+            warnings.warn(
+                f"{source.path}: zarr v{source.zarr_format} store; the "
+                f"kvikio GPU decoder needs zarr v3 (a v2 compressor decodes "
+                f"on the CPU). Falling back to the host fetcher. Re-encode "
+                f"as zarr v3 via HaplotypeMatrix.vcf_to_zarr to enable "
+                f"kvikio.",
+                KvikioUnavailableWarning, stacklevel=4,
+            )
         return HostChunkFetcher(source)
     chunks = source.chunks  # already cached on the source from __init__
     whole_sample_axis = (chunks is not None and len(chunks) >= 2
@@ -124,9 +137,7 @@ def _pick_chunk_fetcher(source, *, backend):
         # buys nothing. Only warn when the store is large enough that
         # the user would actually see the speedup of a rechunk -- on
         # small test fixtures the warning is noise.
-        warn_threshold_bytes = 1 << 30  # 1 GiB of int8 footprint
-        eager_bytes = int(source.num_variants) * int(source.num_haplotypes)
-        if eager_bytes >= warn_threshold_bytes:
+        if _store_large_enough_to_warn(source):
             warnings.warn(
                 f"{source.path}: call_genotype.chunks={chunks} spans the "
                 f"full sample axis ({source.num_diploids} diploids); the "
@@ -140,48 +151,21 @@ def _pick_chunk_fetcher(source, *, backend):
     return KvikioChunkFetcher(source)
 
 
-def _store_call_genotype_codec(store_path):
-    """Return the name of the bytes-encoder codec on the store's
-    call_genotype array (e.g. ``'zstd'``), or None when the codec
-    spec cannot be read.
-
-    The codec name is what matters for picking a fetcher: nvCOMP has
-    GPU decoders for a fixed list, and the rest go through the host
-    path. Reading the spec is cheap (one JSON parse off the
-    ``call_genotype/zarr.json`` blob).
-    """
-    import json
-    import os
-    spec_path = os.path.join(str(store_path), "call_genotype", "zarr.json")
-    if not os.path.exists(spec_path):
-        return None
-    try:
-        with open(spec_path) as f:
-            spec = json.load(f)
-        for entry in spec.get("codecs", []):
-            name = entry.get("name") if isinstance(entry, dict) else None
-            if name in _NVCOMP_SUPPORTED_CODECS:
-                return name
-            if name == "bytes":
-                continue  # transparent reinterpretation; not a real codec
-        return None
-    except (OSError, json.JSONDecodeError, KeyError):
-        return None
+def _kvikio_can_decode(source):
+    """True when kvikio's nvCOMP GPU decoder can read this store: a zarr
+    v3 store (a v2 store decodes through CPU numcodecs) whose
+    call_genotype codec nvCOMP supports."""
+    return (source.zarr_format == 3
+            and source.codec in _NVCOMP_SUPPORTED_CODECS)
 
 
-def _store_call_genotype_chunks(store_path):
-    """Return ``call_genotype.chunks`` as a tuple, or None if unreadable.
-
-    Used to decide whether the store's sample-axis chunking is
-    bio2zarr-shaped (small enough chunks that kvikio's GPU codec
-    decode actually wins on sample-subset reads) or whole-axis
-    chunked (in which case the kvikio path gives no real speedup).
-    """
-    try:
-        store = zarr.open_group(store_path, mode="r")
-        return tuple(store["call_genotype"].chunks)
-    except (FileNotFoundError, KeyError, ValueError):
-        return None
+def _store_large_enough_to_warn(source):
+    """A kvikio fallback is only worth a warning on a store big enough
+    that the GPU decode path would have mattered; on small fixtures the
+    warning is just noise."""
+    warn_threshold_bytes = 1 << 30  # 1 GiB of int8 footprint
+    eager_bytes = int(source.num_variants) * int(source.num_haplotypes)
+    return eager_bytes >= warn_threshold_bytes
 
 
 def _iter_chunks_with_prefetch(chunks, prefetch, slice_fn, *,
@@ -320,16 +304,22 @@ class KvikioChunkFetcher(ChunkFetcher):
                 f"compat_mode must be 'ON', 'AUTO', or 'OFF'; "
                 f"got {compat_mode!r}"
             )
-        codec = _store_call_genotype_codec(source.path)
-        if codec is None:
+        if source.zarr_format != 3:
             raise ValueError(
-                f"KvikioChunkFetcher requires a call_genotype codec "
-                f"the nvCOMP GPU decoder supports "
-                f"({sorted(_NVCOMP_SUPPORTED_CODECS)}); could not "
-                f"identify one on {source.path}"
+                f"kvikio GPU decode requires a zarr v3 store; "
+                f"{source.path} is zarr v{source.zarr_format}, whose "
+                f"numcodecs compressor decodes on the CPU. Re-encode as "
+                f"zarr v3 via HaplotypeMatrix.vcf_to_zarr to use the "
+                f"kvikio backend."
+            )
+        if source.codec not in _NVCOMP_SUPPORTED_CODECS:
+            raise ValueError(
+                f"KvikioChunkFetcher requires a call_genotype codec the "
+                f"nvCOMP GPU decoder supports "
+                f"({sorted(_NVCOMP_SUPPORTED_CODECS)}); {source.path} has "
+                f"codec {source.codec!r}"
             )
         self._source = source
-        self._codec = codec
         # GDSStore is a separate handle from source._store: the codec
         # pipeline is cached on the zarr group, and we need a group
         # opened with the GPU buffer prototype active so nvCOMP runs

--- a/pg_gpu/zarr_io.py
+++ b/pg_gpu/zarr_io.py
@@ -686,7 +686,8 @@ def read_genotypes(path, region=None):
 
 
 def vcf_to_zarr(vcf_paths, zarr_path, worker_processes=None,
-                icf_path=None, max_memory='4GB', show_progress=True):
+                icf_path=None, max_memory='4GB', show_progress=True,
+                zarr_format=None):
     """Convert VCF file(s) to VCZ-format zarr store using bio2zarr.
 
     Uses the two-step explode + encode pipeline for control over
@@ -708,6 +709,11 @@ def vcf_to_zarr(vcf_paths, zarr_path, worker_processes=None,
         Maximum memory for encoding step. Default '4GB'.
     show_progress : bool
         Show progress bars. Default True.
+    zarr_format : int, optional
+        Zarr metadata version to write (2 or 3). ``None`` (default)
+        uses bio2zarr's own default (v2). Pass ``3`` to write a v3
+        store, which the kvikio GPU-decode backend can read; a v2
+        store decodes on the CPU.
     """
     from bio2zarr.vcf import explode, encode
 
@@ -726,7 +732,8 @@ def vcf_to_zarr(vcf_paths, zarr_path, worker_processes=None,
         encode(icf_path, zarr_path,
                worker_processes=worker_processes,
                max_memory=max_memory,
-               show_progress=show_progress)
+               show_progress=show_progress,
+               zarr_format=zarr_format)
     finally:
         try:
             if os.path.exists(icf_path):

--- a/pg_gpu/zarr_source.py
+++ b/pg_gpu/zarr_source.py
@@ -31,6 +31,29 @@ from .zarr_io import (_region_mask, _vcz_contig_index, detect_zarr_layout,
 _SLICE_SUBSAMPLE_GPU_MAX_RUNS = 64
 
 
+def _codec_name_from_metadata(meta):
+    """Return the compression codec name from ``call_genotype`` array
+    metadata (zarr's ``metadata.to_dict()``), or None when the array is
+    uncompressed.
+
+    Reads either the zarr v3 codec pipeline or the single zarr v2
+    compressor, so the caller never parses the on-disk metadata layout
+    itself. The v3 ``bytes`` codec is a transparent reinterpretation,
+    not a compressor, so it is skipped.
+    """
+    codecs = meta.get("codecs")
+    if codecs is not None:  # zarr v3 codec pipeline
+        for entry in codecs:
+            name = entry.get("name") if isinstance(entry, dict) else None
+            if name and name != "bytes":
+                return name
+        return None
+    compressor = meta.get("compressor")  # zarr v2 single compressor
+    if isinstance(compressor, dict):
+        return compressor.get("id")
+    return None
+
+
 class ZarrGenotypeSource:
     """Open a VCZ store and expose chunked + subset read primitives.
 
@@ -68,6 +91,13 @@ class ZarrGenotypeSource:
         Selected contig name.
     chunks : tuple
         ``call_genotype`` chunk shape.
+    zarr_format : int
+        Zarr metadata version of the store (2 or 3). kvikio's nvCOMP GPU
+        decoder needs a v3 store; a v2 store decodes through the CPU
+        numcodecs path.
+    codec : str or None
+        ``call_genotype`` compression codec name (e.g. ``'zstd'``,
+        ``'blosc'``), or None when the array is uncompressed.
     pop_cols : dict or None
         ``{pop_name: ndarray[hap_axis_indices]}`` when a pop file was
         resolved, else None.
@@ -105,6 +135,13 @@ class ZarrGenotypeSource:
         from ._warnings import _require_diploid_ploidy
         _require_diploid_ploidy(cg.shape[2], f"streaming zarr store '{self.path}'")
         self.chunks = tuple(cg.chunks)
+        # Read the codec and zarr format off the handle already in hand,
+        # so the fetcher-selection layer can tell a GPU-decodable v3
+        # store from a v2 store (which decodes on the CPU) without
+        # reopening or parsing the on-disk metadata itself.
+        meta = cg.metadata.to_dict()
+        self.zarr_format = int(meta.get("zarr_format", 3))
+        self.codec = _codec_name_from_metadata(meta)
         self.num_diploids = int(cg.shape[1])
         self.num_haplotypes = 2 * self.num_diploids
         self.num_variants = int(self.site_pos.size)

--- a/pg_gpu/zarr_source.py
+++ b/pg_gpu/zarr_source.py
@@ -38,14 +38,22 @@ def _codec_name_from_metadata(meta):
 
     Reads either the zarr v3 codec pipeline or the single zarr v2
     compressor, so the caller never parses the on-disk metadata layout
-    itself. The v3 ``bytes`` codec is a transparent reinterpretation,
-    not a compressor, so it is skipped.
+    itself. Descends into a v3 sharding codec, whose compressor sits one
+    level down in the shard's own pipeline. The v3 ``bytes`` codec is a
+    transparent reinterpretation, not a compressor, so it is skipped.
     """
     codecs = meta.get("codecs")
     if codecs is not None:  # zarr v3 codec pipeline
         for entry in codecs:
             name = entry.get("name") if isinstance(entry, dict) else None
-            if name and name != "bytes":
+            if name == "sharding_indexed":
+                # The shard frames an inner pipeline that holds the real
+                # compressor; recurse on its configuration (also a dict
+                # with a "codecs" list).
+                nested = _codec_name_from_metadata(entry.get("configuration", {}))
+                if nested is not None:
+                    return nested
+            elif name and name != "bytes":
                 return name
         return None
     compressor = meta.get("compressor")  # zarr v2 single compressor

--- a/tests/test_kvikio_backend.py
+++ b/tests/test_kvikio_backend.py
@@ -14,19 +14,20 @@ import zarr
 
 from pg_gpu import HaplotypeMatrix
 from pg_gpu.streaming_matrix import (
-    BadlyChunkedWarning, HostChunkFetcher, KvikioChunkFetcher,
-    _pick_chunk_fetcher, _store_call_genotype_chunks,
-    _store_call_genotype_codec,
+    HostChunkFetcher, KvikioChunkFetcher, _NVCOMP_SUPPORTED_CODECS,
+    _pick_chunk_fetcher,
 )
 from pg_gpu.zarr_source import ZarrGenotypeSource
 
 from .conftest import simulate_hm
 
 
-def _write_vcz_with_sample_chunk(path, hm, *, sample_chunk):
+def _write_vcz_with_sample_chunk(path, hm, *, sample_chunk, zarr_format=3):
     """Wrap ``zarr_io.write_vcz`` with explicit sample-axis chunking so
     tests can opt into bio2zarr-shaped or whole-sample-axis chunking
-    without hand-rolling a VCZ writer."""
+    without hand-rolling a VCZ writer. ``zarr_format=2`` writes v2
+    metadata (``.zarray`` with a single ``compressor``), the bio2zarr
+    default, which the kvikio GPU decoder cannot read."""
     from pg_gpu.zarr_io import write_vcz
     if os.path.exists(path):
         shutil.rmtree(path)
@@ -35,8 +36,9 @@ def _write_vcz_with_sample_chunk(path, hm, *, sample_chunk):
     gt = HaplotypeMatrix._haplotypes_to_gt(haps)
     n_var, n_dip = gt.shape[0], gt.shape[1]
     samples = [f"s{i}" for i in range(n_dip)]
-    write_vcz(path, gt, pos, samples=samples, contig_name="1",
-              chunks=(min(n_var, 10_000), sample_chunk, 2))
+    with zarr.config.set({"default_zarr_format": zarr_format}):
+        write_vcz(path, gt, pos, samples=samples, contig_name="1",
+                  chunks=(min(n_var, 10_000), sample_chunk, 2))
     return path
 
 
@@ -66,23 +68,49 @@ def whole_axis_store(tmp_path):
     )
 
 
-class TestStoreProbes:
+@pytest.fixture
+def bio2zarr_v2_store(tmp_path):
+    """A zarr v2 VCZ store (``.zarray`` metadata, the bio2zarr default)
+    with bio2zarr-style sample chunking. Its numcodecs compressor
+    decodes on the CPU, so kvikio must route it to the host fetcher
+    instead of handing a GPU buffer to numcodecs and crashing."""
+    hm = simulate_hm()
+    return _write_vcz_with_sample_chunk(
+        str(tmp_path / "bio2zarr_v2.vcz"),
+        hm,
+        sample_chunk=max(1, hm.num_haplotypes // 4),
+        zarr_format=2,
+    )
 
-    def test_codec_probe_picks_zstd(self, bio2zarr_store):
-        # zarr 3's create_array defaults to zstd for int dtypes; the
-        # probe reads call_genotype/zarr.json and returns the name.
-        assert _store_call_genotype_codec(bio2zarr_store) == "zstd"
 
-    def test_chunk_probe_returns_shape(self, bio2zarr_store):
-        chunks = _store_call_genotype_chunks(bio2zarr_store)
-        assert chunks is not None
+class TestSourceMetadata:
+    """ZarrGenotypeSource reads the codec, zarr format, and chunk shape
+    off the call_genotype handle it already opens, so the fetcher layer
+    never reopens or hand-parses the store's on-disk metadata."""
+
+    def test_v3_store_reports_zstd(self, bio2zarr_store):
+        # zarr v3's create_array defaults to zstd for int dtypes.
+        source = ZarrGenotypeSource(bio2zarr_store)
+        assert source.zarr_format == 3
+        assert source.codec == "zstd"
+
+    def test_v2_store_reports_compressor(self, bio2zarr_v2_store):
+        # bio2zarr writes zarr v2: a .zarray with a single compressor.
+        # Reading it through the zarr API is what tells the fetcher the
+        # store exists but cannot be GPU-decoded.
+        source = ZarrGenotypeSource(bio2zarr_v2_store)
+        assert source.zarr_format == 2
+        assert source.codec in _NVCOMP_SUPPORTED_CODECS
+
+    def test_chunks_shape(self, bio2zarr_store):
+        chunks = ZarrGenotypeSource(bio2zarr_store).chunks
         assert len(chunks) == 3
         assert chunks[2] == 2
 
-    def test_missing_store_probes_return_none(self, tmp_path):
+    def test_missing_store_raises(self, tmp_path):
         nowhere = str(tmp_path / "does-not-exist.vcz")
-        assert _store_call_genotype_codec(nowhere) is None
-        assert _store_call_genotype_chunks(nowhere) is None
+        with pytest.raises((FileNotFoundError, ValueError)):
+            ZarrGenotypeSource(nowhere)
 
 
 class TestPickFetcher:
@@ -105,13 +133,31 @@ class TestPickFetcher:
         fetcher = _pick_chunk_fetcher(source, backend="host")
         assert isinstance(fetcher, HostChunkFetcher)
 
+    def test_explicit_kvikio_on_v2_store_raises(self, bio2zarr_v2_store):
+        # backend='kvikio' on a v2 store must raise a clear "needs v3"
+        # error rather than route to kvikio and crash on decode.
+        source = ZarrGenotypeSource(bio2zarr_v2_store)
+        with pytest.raises(ValueError, match="zarr v3"):
+            _pick_chunk_fetcher(source, backend="kvikio")
+
+    def test_v2_store_host_iterates_without_crash(self, bio2zarr_v2_store):
+        # Regression: routing a v2 store to kvikio handed a cupy buffer
+        # to CPU numcodecs and crashed on the first chunk read. The v2
+        # store must go to the host fetcher and iterate cleanly.
+        source = ZarrGenotypeSource(bio2zarr_v2_store)
+        fetcher = _pick_chunk_fetcher(source, backend="auto")
+        assert isinstance(fetcher, HostChunkFetcher)
+        chunks = list(fetcher.iter_chunks([(0, 10_000), (10_000, 20_000)],
+                                          prefetch=0))
+        assert chunks
+        first_gt = np.asarray(chunks[0][3])
+        assert first_gt.size > 0
+
     def test_explicit_kvikio_on_unsupported_codec_raises(self, tmp_path):
-        # A store whose call_genotype is uncompressed (no codec in
-        # the nvCOMP-supported list). Force compressors=None so the
-        # spec ends up with just a bytes codec; the probe then
-        # cannot identify a GPU-decodable codec and the explicit
-        # backend='kvikio' should raise rather than silently produce
-        # wrong output.
+        # A v3 store whose call_genotype is uncompressed: compressors=
+        # None leaves only the bytes codec, so source.codec is None and
+        # explicit backend='kvikio' must raise rather than route to a
+        # decoder with nothing to decode.
         path = str(tmp_path / "uncompressed.vcz")
         if os.path.exists(path):
             shutil.rmtree(path)

--- a/tests/test_kvikio_backend.py
+++ b/tests/test_kvikio_backend.py
@@ -12,12 +12,14 @@ import numpy as np
 import pytest
 import zarr
 
-from pg_gpu import HaplotypeMatrix
+from pg_gpu import (
+    BadlyChunkedWarning, HaplotypeMatrix, KvikioUnavailableWarning,
+)
 from pg_gpu.streaming_matrix import (
     HostChunkFetcher, KvikioChunkFetcher, _NVCOMP_SUPPORTED_CODECS,
     _pick_chunk_fetcher,
 )
-from pg_gpu.zarr_source import ZarrGenotypeSource
+from pg_gpu.zarr_source import ZarrGenotypeSource, _codec_name_from_metadata
 
 from .conftest import simulate_hm
 
@@ -83,6 +85,31 @@ def bio2zarr_v2_store(tmp_path):
     )
 
 
+def _write_v3_blosc_store(path, *, n_var, n_dip, sample_chunk):
+    """A minimal v3 VCZ store whose call_genotype uses bio2zarr's genotype
+    codec (blosc/zstd + bitshuffle), so the kvikio nvCOMP path is exercised
+    on blosc, not only the write_vcz zstd default."""
+    from zarr.codecs.blosc import BloscCodec, BloscShuffle
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    rng = np.random.default_rng(0)
+    gt = rng.integers(0, 2, size=(n_var, n_dip, 2)).astype(np.int8)
+    g = zarr.create_group(store=path, overwrite=True, zarr_format=3)
+    cg = g.create_array(
+        "call_genotype", shape=(n_var, n_dip, 2),
+        chunks=(min(n_var, 10_000), sample_chunk, 2), dtype="int8",
+        compressors=[BloscCodec(cname="zstd", shuffle=BloscShuffle.bitshuffle)])
+    cg[:] = gt
+    g.create_array("variant_position", shape=(n_var,),
+                   dtype="int32")[:] = np.arange(1, n_var + 1, dtype=np.int32)
+    g.create_array("variant_contig", shape=(n_var,),
+                   dtype="int32")[:] = np.zeros(n_var, dtype=np.int32)
+    g.create_array("contig_id", shape=(1,), dtype="<U16")[:] = ["1"]
+    g.create_array("sample_id", shape=(n_dip,), dtype="<U16")[:] = [
+        f"s{i}" for i in range(n_dip)]
+    return path
+
+
 class TestSourceMetadata:
     """ZarrGenotypeSource reads the codec, zarr format, and chunk shape
     off the call_genotype handle it already opens, so the fetcher layer
@@ -106,6 +133,17 @@ class TestSourceMetadata:
         chunks = ZarrGenotypeSource(bio2zarr_store).chunks
         assert len(chunks) == 3
         assert chunks[2] == 2
+
+    def test_sharded_v3_codec_detected(self):
+        # A sharded v3 store nests the compressor inside the sharding
+        # codec's own pipeline; the probe must descend to find it, or a
+        # GPU-decodable store is misread as codec-less.
+        from zarr.codecs import ZstdCodec
+        g = zarr.create_group(store=zarr.storage.MemoryStore(), zarr_format=3)
+        a = g.create_array("call_genotype", shape=(100, 4, 2),
+                           chunks=(100, 4, 2), shards=(100, 4, 2),
+                           dtype="int8", compressors=[ZstdCodec()])
+        assert _codec_name_from_metadata(a.metadata.to_dict()) == "zstd"
 
     def test_missing_store_raises(self, tmp_path):
         nowhere = str(tmp_path / "does-not-exist.vcz")
@@ -184,6 +222,32 @@ class TestPickFetcher:
             _pick_chunk_fetcher(source, backend="kvikio")
 
 
+class TestFallbackWarnings:
+    """backend='auto' hints (once, size-gated) when it falls back to the
+    host fetcher on a fixable store. The fixtures are tiny, so force the
+    size gate to exercise the warning."""
+
+    def test_v2_store_warns_kvikio_unavailable(self, bio2zarr_v2_store,
+                                               monkeypatch):
+        import pg_gpu.streaming_matrix as sm
+        monkeypatch.setattr(sm, "_store_large_enough_to_warn",
+                            lambda source: True)
+        source = ZarrGenotypeSource(bio2zarr_v2_store)
+        with pytest.warns(KvikioUnavailableWarning, match="zarr v3"):
+            fetcher = _pick_chunk_fetcher(source, backend="auto")
+        assert isinstance(fetcher, HostChunkFetcher)
+
+    def test_whole_axis_warns_badly_chunked(self, whole_axis_store,
+                                            monkeypatch):
+        import pg_gpu.streaming_matrix as sm
+        monkeypatch.setattr(sm, "_store_large_enough_to_warn",
+                            lambda source: True)
+        source = ZarrGenotypeSource(whole_axis_store)
+        with pytest.warns(BadlyChunkedWarning, match="full sample axis"):
+            fetcher = _pick_chunk_fetcher(source, backend="auto")
+        assert isinstance(fetcher, HostChunkFetcher)
+
+
 class TestKvikioFetcherReads:
     """KvikioChunkFetcher should produce the same per-chunk genotype
     bytes the host fetcher does on the same store. Same source, same
@@ -214,6 +278,30 @@ class TestKvikioFetcherReads:
             assert (lh, rh) == (lk, rk)
             np.testing.assert_array_equal(gth, gtk)
             np.testing.assert_array_equal(ph, pk)
+
+    def test_v3_blosc_matches_host(self, tmp_path):
+        # bio2zarr writes v3 with a blosc(zstd, bitshuffle) codec, not the
+        # zstd of write_vcz; kvikio's nvCOMP path must decode blosc and
+        # match the host bytes -- the guarantee behind recommending
+        # vcf_to_zarr(zarr_format=3).
+        path = _write_v3_blosc_store(str(tmp_path / "v3blosc.vcz"),
+                                     n_var=30_000, n_dip=100, sample_chunk=25)
+        source = ZarrGenotypeSource(path)
+        assert source.codec == "blosc"
+        auto = _pick_chunk_fetcher(source, backend="auto")
+        assert isinstance(auto, KvikioChunkFetcher)
+        regions = [(0, 10_000), (10_000, 20_000)]
+        try:
+            kvi = [np.asarray(cp.asnumpy(gt) if isinstance(gt, cp.ndarray)
+                              else gt)
+                   for _, _, _, gt, _, _ in auto.iter_chunks(regions, prefetch=0)]
+        finally:
+            auto.close()
+        host = [np.asarray(gt) for _, _, _, gt, _, _
+                in HostChunkFetcher(source).iter_chunks(regions, prefetch=0)]
+        assert kvi and len(kvi) == len(host)
+        for a, b in zip(kvi, host):
+            np.testing.assert_array_equal(a, b)
 
 
 class TestSliceSubsampleGpu:

--- a/tests/test_zarr_io.py
+++ b/tests/test_zarr_io.py
@@ -492,6 +492,30 @@ class TestVcfToZarr:
         hm = HaplotypeMatrix.from_zarr(zarr_path)
         assert hm.num_variants > 0
 
+    def test_zarr_format_v3(self, tmp_path):
+        """zarr_format=3 writes a v3 store (zarr.json, not .zarray), the
+        layout the kvikio GPU-decode backend needs."""
+        import os
+        ts = msprime.sim_ancestry(
+            samples=4, sequence_length=5_000,
+            recombination_rate=1e-4, random_seed=45, ploidy=2,
+        )
+        ts = msprime.sim_mutations(ts, rate=1e-3, random_seed=45)
+        vcf_path = str(tmp_path / "v3.vcf")
+        with open(vcf_path, 'w') as f:
+            ts.write_vcf(f)
+        bgzip_index(vcf_path)
+
+        zarr_path = str(tmp_path / "v3.zarr")
+        vcf_to_zarr(vcf_path + '.gz', zarr_path,
+                    worker_processes=1, show_progress=False, zarr_format=3)
+
+        cg = os.path.join(zarr_path, "call_genotype")
+        assert os.path.exists(os.path.join(cg, "zarr.json"))
+        assert not os.path.exists(os.path.join(cg, ".zarray"))
+        hm = HaplotypeMatrix.from_zarr(zarr_path)
+        assert hm.num_variants > 0
+
 
 # ── Edge Cases ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Supersedes #262 with the correct fix for #223, and folds in the #261 refactor.

## The bug (caught by @nspope on #262)

kvikio's nvCOMP GPU decoder works only through zarr v3's codec pipeline. A zarr v2 store -- the bio2zarr default, including the ag1000g store -- decodes through CPU `numcodecs`. #262 made the codec probe *detect* the v2 blosc compressor and route the store to kvikio, which then handed a cupy chunk buffer to `numcodecs` and crashed on the first chunk read:

```
ValueError: Unable to avoid copy while creating an array as requested.
```

Detecting the v2 codec cannot help: v2 fundamentally cannot be GPU-decoded through zarr's pipeline.

## The fix

Gate kvikio on **a zarr v3 store with an nvCOMP-supported codec** -- the true precondition for GPU decode.

- `backend='auto'` on a v2 store -> host fetcher, with a size-gated `KvikioUnavailableWarning` hint (silent on small stores).
- `backend='kvikio'` on a v2 store -> clear `ValueError`: "kvikio GPU decode requires a zarr v3 store ...", instead of a misleading "could not identify a codec" or a mid-read crash.

## Folded-in refactor (#261)

Read the codec name and zarr format **once** on `ZarrGenotypeSource` (`source.codec`, `source.zarr_format`), off the `call_genotype` handle `__init__` already opens, and delete the two standalone on-disk probe functions. Reading through zarr's metadata API also removes the hand-parsing of the v2/v3 on-disk layout, so the malformed-`compressor` `AttributeError` @nspope flagged can no longer arise.

## Tests

- `test_v2_store_reports_compressor`, `test_v3_store_reports_zstd` -- source reads codec/format for both layouts.
- `test_explicit_kvikio_on_v2_store_raises` -- v2 + `backend='kvikio'` raises "needs v3".
- `test_v2_store_host_iterates_without_crash` -- the crash regression: a v2 store routes to host and iterates a chunk cleanly (@nspope's point that the old tests never iterated).
- Full streaming suite (GRM / IBS / LD / local PCA / biobank / kvikio): 207 passed on an A100.

Closes #223. Closes #261.