### PR TITLE
Cover trivial edge branches (dist_moments, moving-window, grm, pc_dist/corners)

### DIFF
--- a/tests/test_distance_stats.py
+++ b/tests/test_distance_stats.py
@@ -1,0 +1,45 @@
+"""Small-n early returns of dist_moments.
+
+dist_moments derives variance, skewness, and kurtosis from the condensed
+vector of pairwise Hamming distances (length C(n_hap, 2)). It short-circuits
+when too few pairs exist to define a higher moment, or when the distances have
+no spread; these tests pin each of those returns.
+"""
+
+import numpy as np
+
+from pg_gpu import HaplotypeMatrix
+from pg_gpu.distance_stats import dist_moments
+
+
+def _hm(hap):
+    hap = np.asarray(hap, dtype=np.int8)
+    pos = np.arange(hap.shape[1]) * 100
+    return HaplotypeMatrix(hap, pos, 0, hap.shape[1] * 100)
+
+
+class TestDistMomentsSmallN:
+
+    def test_single_pair_returns_zeros(self):
+        # 2 haplotypes -> 1 pairwise distance -> too few to define variance.
+        assert dist_moments(_hm([[0, 1, 0], [1, 0, 1]])) == (0.0, 0.0, 0.0)
+
+    def test_zero_variance_returns_zeros(self):
+        # Identical haplotypes -> every pairwise distance 0 -> m2 == 0, so
+        # skewness and kurtosis are undefined and returned as 0.
+        assert dist_moments(_hm([[0, 1], [0, 1], [0, 1]])) == (0.0, 0.0, 0.0)
+
+    def test_three_haplotypes_skip_kurtosis(self):
+        # 3 haplotypes -> 3 distances with spread -> variance and skewness
+        # defined, but n < 4 leaves kurtosis at 0.
+        var, skew, kurt = dist_moments(
+            _hm([[0, 0, 0, 0], [1, 0, 0, 0], [1, 1, 1, 0]]))
+        assert var > 0.0
+        assert kurt == 0.0
+
+    def test_four_haplotypes_full_moments(self):
+        # >= 4 haplotypes -> 6 distances -> all three moments computed.
+        var, skew, kurt = dist_moments(
+            _hm([[0, 0, 0, 0], [1, 0, 0, 0], [1, 1, 0, 0], [1, 1, 1, 0]]))
+        assert var > 0.0
+        assert np.isfinite(skew) and np.isfinite(kurt)

--- a/tests/test_local_pca.py
+++ b/tests/test_local_pca.py
@@ -606,3 +606,26 @@ class TestFusedJackknife:
         # Jackknife should be NaN (4 < 10)
         assert result.jackknife_se is not None
         assert np.all(np.isnan(result.jackknife_se))
+
+
+class TestPcDistCornersEdges:
+    """Malformed-input guards on pc_dist and corners."""
+
+    def test_pc_dist_flat_requires_npc(self):
+        # A flat lostruct matrix carries no k, so npc must be given.
+        with pytest.raises(ValueError, match="npc must be provided"):
+            pc_dist(np.zeros((3, 10)), npc=None)
+
+    def test_pc_dist_rejects_unknown_normalize(self, small_hm):
+        res = local_pca(small_hm, window_size=200, window_type='snp', k=2)
+        with pytest.raises(ValueError, match="Unknown normalize"):
+            pc_dist(res, npc=2, normalize='bogus')
+
+    def test_corners_rejects_non_2d(self):
+        with pytest.raises(ValueError, match=r"shape \(n, 2\)"):
+            corners(np.zeros((5, 3)), prop=0.2)
+
+    def test_corners_needs_enough_points(self):
+        # Fewer non-NaN points than corners requested cannot be placed.
+        with pytest.raises(ValueError, match="at least"):
+            corners(np.array([[0.0, 0.0], [1.0, 1.0]]), prop=0.5)

--- a/tests/test_relatedness.py
+++ b/tests/test_relatedness.py
@@ -94,6 +94,14 @@ class TestGRM:
         with pytest.raises(TypeError, match="genetic_relatedness"):
             relatedness.grm(small_haplotype_matrix)
 
+    def test_all_monomorphic_returns_zeros(self):
+        # No polymorphic sites -> nothing to standardize and accumulate, so
+        # the GRM is all zeros rather than a divide-by-zero.
+        gm = GenotypeMatrix(np.zeros((3, 5), dtype=np.int8), np.arange(5) * 100)
+        grm = relatedness.grm(gm)
+        assert grm.shape == (3, 3)
+        np.testing.assert_array_equal(grm, np.zeros((3, 3)))
+
 
 class TestIBS:
     def test_shape(self, small_genotype_matrix):

--- a/tests/test_resampling.py
+++ b/tests/test_resampling.py
@@ -6,7 +6,11 @@ import numpy as np
 import pytest
 from scipy import stats
 
-from pg_gpu.resampling import block_jackknife, block_bootstrap
+import cupy as cp
+
+from pg_gpu.resampling import (
+    _moving_nanmean, _moving_nansum, block_bootstrap, block_jackknife,
+)
 
 
 # -----------------------------------------------------------------------------
@@ -167,3 +171,34 @@ class TestBlockBootstrap:
                                       n_replicates=2000, rng=0)
         # Not equal — but should agree to within a factor of ~1.5-2.
         assert 0.5 * se_jk < se_bs < 2.0 * se_jk
+
+
+class TestMovingWindowHelpers:
+    """Windowed cumsum helpers behind the moving-window statistics."""
+
+    def test_nansum_nonoverlapping(self):
+        out = _moving_nansum(cp.asarray([1., 2., 3., 4.]), size=2)
+        np.testing.assert_array_equal(cp.asnumpy(out), [3., 7.])
+
+    def test_nanmean_nonoverlapping(self):
+        out = _moving_nanmean(cp.asarray([1., 2., 3., 4.]), size=2)
+        np.testing.assert_array_equal(cp.asnumpy(out), [1.5, 3.5])
+
+    def test_nanmean_ignores_nan_in_window(self):
+        # A finite-only window averages over its non-NaN entries.
+        out = _moving_nanmean(cp.asarray([1., cp.nan, 3., 4.]), size=2)
+        np.testing.assert_array_equal(cp.asnumpy(out), [1.0, 3.5])
+
+    def test_nanmean_all_nan_window_is_nan(self):
+        # Zero finite entries -> NaN rather than a divide-by-zero.
+        out = _moving_nanmean(cp.asarray([cp.nan, cp.nan]), size=2)
+        assert bool(cp.isnan(out).all())
+
+    def test_strided_overlapping_windows(self):
+        out = _moving_nansum(cp.asarray([1., 2., 3.]), size=2, step=1)
+        np.testing.assert_array_equal(cp.asnumpy(out), [3., 5.])
+
+    def test_window_larger_than_data_is_empty(self):
+        # No window fits, so the result is empty rather than an error.
+        assert _moving_nanmean(cp.asarray([1., 2.]), size=5).shape == (0,)
+        assert _moving_nansum(cp.asarray([1., 2.]), size=5).shape == (0,)


### PR DESCRIPTION
First slice of #238, taking the pure-logic coverage gaps that need no fixtures or special environment. Each added test was confirmed to close its target branch.

- **distance_stats.dist_moments** — the `n<2`, zero-variance (`m2==0`), and `n<4` early returns (small pairwise-distance vectors).
- **resampling._moving_nansum / _moving_nanmean** — windowed cumsum over non-overlapping, strided, NaN, all-NaN, and too-large (empty-result) windows (`resampling.py` now 100%).
- **relatedness.grm** — an all-monomorphic matrix returns a zero GRM instead of dividing by zero.
- **decomposition.pc_dist / corners** — the malformed-input raises: missing `npc` on a flat matrix, unknown `normalize`, non-`(n,2)` input, and too few non-NaN points.

Tests only, no source changes. 89 passed on an A100.

Note: #238 is a multi-module coverage epic; this PR does the trivial tier. The heavier items (streaming-relatedness fixtures, non-VCZ zarr handler, `moments_ld` arg-validation + missing-data comparison, `genotype_matrix` mask/transfer lifecycle, plotting/accessible edge inputs) remain.

Refs #238.