### PR TITLE
Symmetrize ld_statistics.pi2 across every index pattern

### DIFF
--- a/pg_gpu/ld_statistics.py
+++ b/pg_gpu/ld_statistics.py
@@ -101,14 +101,14 @@ def pi2(counts: cp.ndarray,
         populations: Optional[Tuple[int, int, int, int]] = None,
         n_valid: Optional[cp.ndarray] = None) -> cp.ndarray:
     """
-    Compute π₂ statistic for any population configuration.
+    Compute pi2 statistic for any population configuration.
 
     Parameters
     ----------
     counts : cp.ndarray
         Haplotype counts array
     populations : tuple of int, optional
-        Four population indices (i, j, k, l) for π₂(i,j,k,l).
+        Four population indices (i, j, k, l) for pi2(i,j,k,l).
         None defaults to single population (0, 0, 0, 0)
     n_valid : cp.ndarray, optional
         Valid sample counts per population
@@ -116,7 +116,10 @@ def pi2(counts: cp.ndarray,
     Returns
     -------
     cp.ndarray
-        π₂ values for each locus
+        pi2 values for each locus. The statistic is symmetrized over the two
+        loci and the two populations within each locus, so equivalent index
+        patterns (e.g. ``(i, j, k, l)`` and ``(k, l, i, j)``) return the same
+        value.
     """
     if populations is None:
         # Single population case
@@ -1379,7 +1382,32 @@ def _pi2_single(counts: cp.ndarray, n_valid: Optional[cp.ndarray] = None) -> cp.
 def _pi2_multi(counts: cp.ndarray,
                populations: Tuple[int, int, int, int],
                n_valid: Optional[cp.ndarray] = None) -> cp.ndarray:
-    """Compute π₂ for multiple populations."""
+    """Compute the symmetrized pi2 for a population index pattern.
+
+    pi2 is invariant under swapping its two loci and under swapping the two
+    populations within a locus, so the named statistic is the raw
+    per-arrangement term averaged over that symmetry orbit. Averaging makes
+    ``pi2`` return the same kind of quantity for every index pattern, and
+    matches the fused pipeline, which sums the same orbit one layer up in
+    ``generate_stat_specs``. When the orbit collapses to a single
+    arrangement (e.g. one population), the average is that one term.
+    """
+    i, j, k, l = populations
+    orbit = {(i, j, k, l), (i, j, l, k), (j, i, k, l), (j, i, l, k),
+             (k, l, i, j), (l, k, i, j), (k, l, j, i), (l, k, j, i)}
+    return sum(_pi2_single_term(counts, cfg, n_valid)
+               for cfg in orbit) / len(orbit)
+
+
+def _pi2_single_term(counts: cp.ndarray,
+                     populations: Tuple[int, int, int, int],
+                     n_valid: Optional[cp.ndarray] = None) -> cp.ndarray:
+    """Raw (un-symmetrized) pi2 term for one population arrangement.
+
+    Returns the single index term for ``(i, j, k, l)`` -- locus A between
+    pops i, j and locus B between pops k, l. ``_pi2_multi`` averages this
+    over the arrangement's symmetry orbit to form the named statistic.
+    """
     i, j, k, l = populations
 
     def get_pop_data(pop_idx):
@@ -1405,18 +1433,18 @@ def _pi2_multi(counts: cp.ndarray,
         result = _pi2_iiij(counts, (single_pop, triple_pop, triple_pop, triple_pop), n_valid)
 
     elif i == j and k == l:
-        # pi2(i,i,k,k) -- two pairs
+        # pi2(i,i,k,k): the raw term, locus A drawn from pop i and locus B
+        # from pop k. _pi2_multi averages it with the locus-swapped term.
         c11, c12, c13, c14, n1 = get_pop_data(i)
         c21, c22, c23, c24, n2 = get_pop_data(k)
 
-        numer1 = (c11 + c12) * (c13 + c14) * (c21 + c23) * (c22 + c24)
-        numer2 = (c21 + c22) * (c23 + c24) * (c11 + c13) * (c12 + c14)
+        numer = (c11 + c12) * (c13 + c14) * (c21 + c23) * (c22 + c24)
 
         denom = n1 * (n1 - 1) * n2 * (n2 - 1)
 
         valid_mask = (n1 >= 2) & (n2 >= 2)
         result = cp.zeros_like(n1, dtype=cp.float64)
-        result[valid_mask] = 0.5 * (numer1[valid_mask] + numer2[valid_mask]) / denom[valid_mask]
+        result[valid_mask] = numer[valid_mask] / denom[valid_mask]
 
     elif i == j and k != l:
         # pi2(i,i,k,l) type -- handles both 2 and 3 distinct populations

--- a/tests/test_ld_statistics_multipop_counts.py
+++ b/tests/test_ld_statistics_multipop_counts.py
@@ -1,26 +1,23 @@
-"""Coverage for the counts-based multi-population LD moment API, and a guard on
-its symmetrization consistency.
+"""Coverage for the counts-based multi-population LD moment API.
 
 `ld_statistics.dz` / `ld_statistics.pi2` accept a concatenated per-population
-counts array and a population-index tuple, and dispatch through `_dz_multi` /
-`_pi2_multi` to per-index-pattern formulas -- including the three- and
-four-distinct-population branches that have no in-package caller (the pipeline
-computes multi-population moments through the fused CUDA kernels) and were
-untested, though the module is public.
+counts array and a population-index tuple, and dispatch to a per-index-pattern
+formula for each population configuration.
 
-Each pattern is cross-checked against the fused kernels (`compute_all_dz_hap` /
-`compute_all_pi2_hap`) on the same counts. Those kernels return the raw
-single-index term for every pattern and are validated against moments.LD (see
-test_moments_ld_multipop), so agreement pins the counts-API formula for that
-term.
+The two statistics follow different, self-consistent conventions:
 
-`dz` returns the raw single-index term for every pattern, so it agrees
-throughout. `pi2` does not: the `_pi2_multi` iikk branch self-symmetrizes
-(returns `0.5*(numer1+numer2)`, the two-locus average) while every other pi2
-branch returns a single term. So `ld_statistics.pi2` returns a different kind
-of quantity depending on the index pattern -- an inconsistent public contract.
-That case is marked xfail(strict) below so the mismatch is pinned and a fix
-(unifying the convention) trips the marker.
+* `dz` returns the raw single-index term for every pattern, so it is
+  cross-checked directly against the fused kernel (`compute_all_dz_hap`) on the
+  same counts.
+* `pi2` returns the *symmetrized* statistic for every pattern. pi2 is invariant
+  under swapping its two loci and under swapping the two populations within a
+  locus, so the named statistic averages the raw term over that symmetry orbit.
+  It is cross-checked against the same average of the fused kernel
+  (`compute_all_pi2_hap`) over the orbit -- the average the fused pipeline
+  applies one layer up in `generate_stat_specs`.
+
+Because the fused kernels are validated against moments.LD (see
+test_moments_ld_multipop), agreement pins each counts-API formula.
 """
 import numpy as np
 import cupy as cp
@@ -58,28 +55,37 @@ def _agree(a, b):
                                rtol=1e-9, atol=1e-12, equal_nan=True)
 
 
+def _pi2_orbit(cfg):
+    """The (i,j,k,l) arrangements pi2 is symmetric over: swap the two loci,
+    and swap the two populations within each locus."""
+    i, j, k, l = cfg
+    return {(i, j, k, l), (i, j, l, k), (j, i, k, l), (j, i, l, k),
+            (k, l, i, j), (l, k, i, j), (k, l, j, i), (l, k, j, i)}
+
+
+def _pi2_symmetrized_fused(pops, cfg):
+    """The fused pi2 kernel averaged over cfg's symmetry orbit -- the
+    symmetrized statistic ld_statistics.pi2 returns for every pattern."""
+    orbit = _pi2_orbit(cfg)
+    return sum(compute_all_pi2_hap(pops, [c])[0] for c in orbit) / len(orbit)
+
+
 # Dz(i,j,k): the i,i,j / i,j,i / i,j,j (two-pop) and all-different (three
-# distinct) branches. Dz returns a single term for every pattern -> all agree.
+# distinct) branches. Dz returns a single term for every pattern -> all agree
+# with the raw fused call.
 DZ_CONFIGS = [(0, 0, 1), (0, 1, 0), (0, 1, 1), (0, 1, 2)]
 
-# pi2 patterns across every branch. All return a single term matching the
-# fused raw call, EXCEPT iikk, whose _pi2_multi branch self-symmetrizes --
-# an inconsistent contract, pinned as an expected failure.
+# pi2 patterns across every branch: iiij (degenerate), ijij, iikk, the three-
+# and four-distinct branches, and the shared-population orderings. Each returns
+# the symmetrized statistic, cross-checked against the orbit-averaged kernel.
 PI2_CONFIGS = [
-    (0, 0, 0, 1),                                          # iiij
+    (0, 0, 0, 1),                                          # iiij (degenerate)
     (0, 1, 0, 1),                                          # ijij
+    (0, 0, 1, 1),                                          # iikk
     (0, 0, 1, 2),                                          # iikl (3 distinct)
     (0, 1, 2, 2),                                          # ijkk (3 distinct)
     (0, 1, 2, 0), (0, 1, 0, 2), (0, 1, 1, 2), (0, 1, 2, 1),  # shared, orderings
     (0, 1, 2, 3),                                          # all-different
-    pytest.param(
-        (0, 0, 1, 1),                                     # iikk -- self-symmetrizes
-        marks=pytest.mark.xfail(
-            strict=True,
-            reason="_pi2_multi iikk branch returns the two-locus average "
-                   "0.5*(numer1+numer2) while every other pi2 branch returns "
-                   "a single index term; ld_statistics.pi2 is inconsistent "
-                   "across index patterns")),
 ]
 
 
@@ -90,13 +96,21 @@ def test_dz_counts_api_matches_fused(counts_and_pops, cfg):
            compute_all_dz_hap(pops, [cfg])[0])
 
 
-@pytest.mark.parametrize("cfg", PI2_CONFIGS,
-                         ids=[str(c.values[0]) if hasattr(c, "values") else str(c)
-                              for c in PI2_CONFIGS])
-def test_pi2_counts_api_matches_fused(counts_and_pops, cfg):
+@pytest.mark.parametrize("cfg", PI2_CONFIGS, ids=[str(c) for c in PI2_CONFIGS])
+def test_pi2_counts_api_matches_symmetrized_fused(counts_and_pops, cfg):
     counts, n_valid, pops = counts_and_pops
     _agree(ld_statistics.pi2(counts, cfg, n_valid),
-           compute_all_pi2_hap(pops, [cfg])[0])
+           _pi2_symmetrized_fused(pops, cfg))
+
+
+def test_pi2_is_symmetric_across_orbit(counts_and_pops):
+    # pi2 returns one quantity for every arrangement in an index pattern's
+    # symmetry orbit, so a locus swap or a within-locus population swap leaves
+    # the result unchanged.
+    counts, n_valid, _ = counts_and_pops
+    base = ld_statistics.pi2(counts, (0, 0, 1, 2), n_valid)
+    for cfg in [(0, 0, 2, 1), (1, 2, 0, 0), (2, 1, 0, 0)]:
+        _agree(ld_statistics.pi2(counts, cfg, n_valid), base)
 
 
 def test_multi_pop_configs_are_non_degenerate(counts_and_pops):


### PR DESCRIPTION
Closes #279.

## Problem

`ld_statistics.pi2`'s iikk branch self-symmetrized (`0.5 * (numer1 + numer2)`) while every other branch returned a raw single index term. So the same public function returned a different *kind* of quantity depending on the population-index pattern -- an incoherent contract, and a maintenance landmine (`dz` symmetrizes in its callers, pi2 `iikk` symmetrized internally).

## Fix

`pi2` now returns the **symmetrized** statistic for every pattern. pi2 is invariant under swapping its two loci and under swapping the two populations within a locus, so `_pi2_multi` averages the raw per-arrangement term (`_pi2_single_term`) over that symmetry orbit; the iikk branch is de-symmetrized into the raw term. This is the identical averaging the fused pipeline applies one layer up in `generate_stat_specs`, so the counts API now agrees with the fused kernels and with `moments.LD` for every pattern.

## Validation

- **Ground truth:** the symmetric counts-API pi2 equals moments' symmetrized statistic (moments' own raw term, orbit-averaged) to 1e-9 for every pattern -- iikk and all three/four-distinct patterns included.
- **Two-population pipeline unchanged:** its patterns `(0,0,0,1)`, `(0,1,0,1)`, `(0,0,1,1)` average equal orbit terms, so their values are identical to before; the full default-env LD suite passes (50 passed, incl. `test_two_pop_stats` and the validation tests).
- **Cross-check test updated** (`test_ld_statistics_multipop_counts.py`): pi2 is now checked against the symmetrized fused-kernel oracle, the iikk `xfail` (filed as this issue) is removed, and a direct orbit-symmetry test was added. 16 pass, no xfail.

## Deferred follow-ups (out of scope here)

- The pi2 symmetry orbit is now written in `_pi2_multi` and, separately, hand-expanded as a weight table in `ld_pipeline.generate_stat_specs`. They are provably equivalent and could share one `_pi2_orbit` helper -- but that touches the moments-critical fused path, so it is left for a dedicated PR.
- After this fix `pi2` self-symmetrizes while `dz` still returns raw terms (symmetrized by its callers) -- the pi2/dz convention split #279 noted. Unifying `dz` the same way needs its own caller sweep.