### PR TITLE
Cover decomposition edge branches (dosage validation, tiny window, jackknife aggregate)

### DIFF
--- a/tests/test_local_pca.py
+++ b/tests/test_local_pca.py
@@ -629,3 +629,18 @@ class TestPcDistCornersEdges:
         # Fewer non-NaN points than corners requested cannot be placed.
         with pytest.raises(ValueError, match="at least"):
             corners(np.array([[0.0, 0.0], [1.0, 1.0]]), prop=0.5)
+
+
+class TestLocalPCAEdges:
+    """Degenerate-window and argument-validation guards on local PCA."""
+
+    def test_tiny_window_yields_nan_rows(self, small_hm):
+        # A window with fewer variants than max(k, 2) cannot form k PCs, so its
+        # eigenvalue row is NaN rather than an error.
+        res = local_pca(small_hm, window_size=1, window_type='snp', k=2)
+        assert np.isnan(np.asarray(res.eigvals)).any()
+
+    def test_jackknife_rejects_unknown_aggregate(self, small_hm):
+        with pytest.raises(ValueError, match="Unknown aggregate"):
+            local_pca_jackknife(small_hm, window_size=200, window_type='snp',
+                                k=2, n_blocks=4, aggregate='bogus')

--- a/tests/test_pca_dosage.py
+++ b/tests/test_pca_dosage.py
@@ -13,6 +13,7 @@ import allel
 
 from pg_gpu import (GenotypeMatrix, HaplotypeMatrix, pca_dosage,
                     randomized_pca_dosage)
+from pg_gpu.decomposition import _prepare_dosage
 
 
 def _polymorphic_gm(seed=0, n_ind=30, n_var=200):
@@ -95,3 +96,23 @@ class TestPCADosageTypeGuards:
         gm = GenotypeMatrix(geno, np.arange(50) * 100)
         with pytest.raises(ValueError, match="biallelic"):
             pca_dosage(gm)
+
+
+class TestPrepareDosageEdges:
+    """Guards in the dosage standardization step."""
+
+    def test_rejects_non_biallelic_dosage(self):
+        # A dosage above 2 is not biallelic-diploid, so standardization refuses
+        # it rather than producing a meaningless frequency.
+        gm = GenotypeMatrix(np.array([[3, 1], [2, 0]], dtype=np.int8),
+                            np.array([100, 200]))
+        with pytest.raises(ValueError, match="biallelic diploid dosages"):
+            _prepare_dosage(gm)
+
+    def test_empty_after_exclude_returns_no_variants(self):
+        # Every site carries a missing call, so 'exclude' drops them all and the
+        # standardized matrix has zero variants instead of dividing by zero.
+        gm = GenotypeMatrix(np.array([[-1, 0], [0, -1]], dtype=np.int8),
+                            np.array([100, 200]))
+        X = _prepare_dosage(gm, missing_data='exclude')
+        assert X.shape == (2, 0)


### PR DESCRIPTION
Next chunk of the #238 coverage campaign (after #277 and #281), finishing the self-contained `decomposition.py` edge cases. Each test drives one branch directly and was verified against the code.

- **`_prepare_dosage`** -- the non-biallelic guard (a dosage > 2 raises) and the empty-after-`exclude` path (every site missing, so the standardized matrix comes back with zero variants instead of dividing by zero).
- **`local_pca`** -- a window with fewer variants than the requested PCs (`n_variants < max(k, 2)`) returns NaN eigenvalue rows rather than erroring.
- **`local_pca_jackknife`** -- an unknown `aggregate` argument raises.

Tests only, no source changes. 45 tests pass across the two touched files on an A100.

Deferred (needs more setup, out of scope here): the empty-`WindowIterator` raise (snp/bp windows always yield at least one window on real data, so triggering zero windows needs a crafted iterator), and the streaming local-PCA path (`_local_pca_streaming`, needs a streaming-matrix fixture).

Refs #238.