### PR TITLE
Cover moments_ld argument validation, rec-map parsing, and reporting

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,24 @@ def bgzip_index(vcf_path):
     return vcf_path + ".gz"
 
 
+@pytest.fixture
+def sample_vcf(tmp_path):
+    """A small simulated VCF on disk: 10 diploid samples, 1 kb, seed 42.
+
+    Plain text, so ``from_vcf`` reads it directly; run it through
+    ``bgzip_index`` for loaders that need a tabix index.
+    """
+    import msprime
+    ts = msprime.sim_ancestry(
+        samples=10, sequence_length=1000, recombination_rate=0.01,
+        random_seed=42, ploidy=2)
+    ts = msprime.sim_mutations(ts, rate=0.01, random_seed=42)
+    path = tmp_path / "sample.vcf"
+    with open(path, "w") as f:
+        ts.write_vcf(f, allow_position_zero=True)
+    return str(path)
+
+
 def simulate_hm(n_samples=20, seq_length=100_000, seed=42,
                 mutation_model=None):
     """Build a small msprime-derived HaplotypeMatrix for tests.

--- a/tests/test_haplotype_matrix.py
+++ b/tests/test_haplotype_matrix.py
@@ -4,32 +4,8 @@ import tskit
 import allel
 import cupy as cp
 import numpy as np
-import tempfile
-import os
 
 from pg_gpu.haplotype_matrix import HaplotypeMatrix
-
-@pytest.fixture
-def sample_vcf():
-    """Create a temporary VCF file with simulated data for testing."""
-    # Simulate some data
-    ts = msprime.sim_ancestry(
-        samples=10,
-        sequence_length=1000,
-        recombination_rate=0.01,
-        random_seed=42,
-        ploidy=2
-    )
-    ts = msprime.sim_mutations(ts, rate=0.01, random_seed=42)
-    # Create a temporary file
-    with tempfile.NamedTemporaryFile(suffix='.vcf', delete=False) as tmp:
-        # Write VCF to temporary file
-        with open(tmp.name, 'w') as f:
-            ts.write_vcf(f, allow_position_zero=True)
-        yield tmp.name
-
-    # Clean up the temporary file
-    os.unlink(tmp.name)
 
 @pytest.fixture
 def sample_ts():

--- a/tests/test_moments_ld_coverage.py
+++ b/tests/test_moments_ld_coverage.py
@@ -1,0 +1,142 @@
+"""Argument-validation, recombination-map, and progress-report coverage for the
+moments.LD-format LD pipeline (pg_gpu.moments_ld).
+
+compute_ld_statistics validates its argument combinations before doing any
+work, and the recombination-distance path parses a genetic map and derives a
+physical-distance cap. These drive the guard, parse, and report branches the
+parity tests skip. The module needs no moments install, so these run in the
+default environment.
+"""
+import numpy as np
+import pytest
+
+from pg_gpu import GenotypeMatrix, HaplotypeMatrix
+from pg_gpu.moments_ld import (compute_ld_statistics,
+                               _interpolate_genetic_distances,
+                               _max_bp_for_r_dist)
+
+
+def _hm(n_hap=8, n_var=40, seed=0):
+    rng = np.random.default_rng(seed)
+    hap = rng.integers(0, 2, size=(n_hap, n_var)).astype(np.int8)
+    return HaplotypeMatrix(hap, np.arange(1, n_var + 1) * 100, 0, n_var * 100)
+
+
+def _gm(n_ind=12, n_var=40, seed=0):
+    rng = np.random.default_rng(seed)
+    geno = rng.integers(0, 3, size=(n_ind, n_var)).astype(np.int8)
+    return GenotypeMatrix(geno, np.arange(1, n_var + 1) * 100)
+
+
+class TestArgValidation:
+
+    def test_pop_file_and_pop_assignment_conflict(self):
+        with pytest.raises(TypeError, match="only one of pop_file"):
+            compute_ld_statistics(pop_file="a", pop_assignment="b")
+
+    def test_too_many_populations(self):
+        with pytest.raises(ValueError, match="1-4 populations"):
+            compute_ld_statistics(pops=list("abcde"), bp_bins=[0, 1000])
+
+    def test_no_bins_provided(self):
+        # pops omitted -> the default two-population pair, then the bins guard.
+        with pytest.raises(ValueError, match="r_bins or bp_bins"):
+            compute_ld_statistics()
+
+    def test_pop_assignment_aliases_pop_file(self):
+        # pop_assignment is an alias for pop_file; passing it alone is accepted
+        # (the later bins guard is what raises here).
+        with pytest.raises(ValueError, match="r_bins or bp_bins"):
+            compute_ld_statistics(pop_assignment="x", pops=["p"])
+
+    def test_genotype_path_needs_a_source(self):
+        with pytest.raises(ValueError, match="vcf_file or genotype_matrix"):
+            compute_ld_statistics(pops=["p"], bp_bins=[0, 1000],
+                                  use_genotypes=True)
+
+    def test_genotype_vcf_needs_pop_file(self):
+        with pytest.raises(ValueError, match="pop_file is required"):
+            compute_ld_statistics(pops=["p"], bp_bins=[0, 1000],
+                                  use_genotypes=True, vcf_file="x.vcf")
+
+    def test_haplotype_path_needs_a_source(self):
+        with pytest.raises(ValueError, match="vcf_file or haplotype_matrix"):
+            compute_ld_statistics(pops=["p"], bp_bins=[0, 1000],
+                                  use_genotypes=False)
+
+    def test_haplotype_vcf_needs_pop_file(self):
+        with pytest.raises(ValueError, match="pop_file is required"):
+            compute_ld_statistics(pops=["p"], bp_bins=[0, 1000],
+                                  use_genotypes=False, vcf_file="x.vcf")
+
+    def test_r_bins_needs_rec_map(self):
+        with pytest.raises(ValueError, match="rec_map_file required"):
+            compute_ld_statistics(haplotype_matrix=_hm(), use_genotypes=False,
+                                  pops=["p"], r_bins=[0, 1e-5], report=False)
+
+
+class TestRecMapHelpers:
+
+    def test_interpolate_skips_malformed_lines(self, tmp_path):
+        rec = tmp_path / "rec.map"
+        rec.write_text("header line\n0 0.0\n1000 1.0\nbad row\n2000 2.0\n")
+        gd = _interpolate_genetic_distances(np.array([500.0, 1500.0]), str(rec))
+        # cM / 100 -> Morgans, linearly interpolated between the two valid rows.
+        np.testing.assert_allclose(gd, [0.005, 0.015])
+
+    def test_max_bp_single_position_returns_span(self):
+        # Fewer than two positions -> the chromosome span (here zero).
+        assert _max_bp_for_r_dist(np.array([100.0]), np.array([0.0]), 1e-5) == 0.0
+
+    def test_max_bp_no_positive_bp_diff_returns_span(self):
+        # Duplicate positions leave no positive physical gap.
+        out = _max_bp_for_r_dist(np.array([100.0, 100.0]),
+                                 np.array([0.0, 0.01]), 1e-5)
+        assert out == 0.0
+
+    def test_max_bp_flat_map_uses_rate_fallback(self):
+        # A flat genetic map has no positive local rate, so the cap falls back
+        # to max_r / span rather than a per-interval rate.
+        out = _max_bp_for_r_dist(np.array([0.0, 1000.0]),
+                                 np.array([0.0, 0.0]), 1e-5)
+        assert np.isfinite(out) and out > 0
+
+    def test_max_bp_normal_path(self):
+        out = _max_bp_for_r_dist(np.array([0.0, 1000.0, 2000.0]),
+                                 np.array([0.0, 0.01, 0.02]), 1e-5)
+        assert out > 0
+
+
+class TestReportRun:
+    """A full report=True run over each compute path prints progress and
+    returns the moments-format result dict."""
+
+    def test_genotype_report_run(self):
+        gm = _gm()
+        gm.sample_sets = {"pop0": list(range(12))}
+        res = compute_ld_statistics(genotype_matrix=gm, use_genotypes=True,
+                                    pops=["pop0"], bp_bins=[0, 500, 4000],
+                                    report=True)
+        assert set(res) == {"bins", "sums", "stats", "pops"}
+        assert res["pops"] == ["pop0"]
+
+    def test_recombination_binned_run(self, tmp_path):
+        # r_bins routes through the genetic-map interpolation and the physical
+        # distance cap, then bins pairs by recombination distance.
+        rec = tmp_path / "rmap.map"
+        rec.write_text("0 0.0\n5000 5.0\n")
+        hm = _hm()
+        hm.sample_sets = {"pop0": list(range(8))}
+        res = compute_ld_statistics(haplotype_matrix=hm, use_genotypes=False,
+                                    pops=["pop0"], r_bins=[0, 1e-5, 5e-5],
+                                    rec_map_file=str(rec), report=False)
+        assert set(res) == {"bins", "sums", "stats", "pops"}
+
+    def test_haplotype_report_run(self):
+        hm = _hm()
+        hm.sample_sets = {"pop0": list(range(8))}
+        res = compute_ld_statistics(haplotype_matrix=hm, use_genotypes=False,
+                                    pops=["pop0"], bp_bins=[0, 500, 4000],
+                                    report=True)
+        assert set(res) == {"bins", "sums", "stats", "pops"}
+        assert res["pops"] == ["pop0"]

--- a/tests/test_moments_ld_coverage.py
+++ b/tests/test_moments_ld_coverage.py
@@ -7,10 +7,12 @@ physical-distance cap. These drive the guard, parse, and report branches the
 parity tests skip. The module needs no moments install, so these run in the
 default environment.
 """
+from contextlib import nullcontext
+
 import numpy as np
 import pytest
 
-from pg_gpu import GenotypeMatrix, HaplotypeMatrix
+from pg_gpu import BiallelicOnlyWarning, GenotypeMatrix, HaplotypeMatrix
 from pg_gpu.moments_ld import (compute_ld_statistics,
                                _interpolate_genetic_distances,
                                _max_bp_for_r_dist)
@@ -138,5 +140,36 @@ class TestReportRun:
         res = compute_ld_statistics(haplotype_matrix=hm, use_genotypes=False,
                                     pops=["pop0"], bp_bins=[0, 500, 4000],
                                     report=True)
+        assert set(res) == {"bins", "sums", "stats", "pops"}
+        assert res["pops"] == ["pop0"]
+
+
+class TestVcfLoadingPath:
+    """The VCF-loading branches -- from_vcf, load_pop_file, and the
+    accessible_bed mask attached at load -- on both compute paths."""
+
+    @pytest.fixture
+    def pop_and_bed(self, tmp_path):
+        pop = tmp_path / "pops.tsv"
+        pop.write_text("sample\tpop\n"
+                       + "".join(f"tsk_{i}\tpop0\n" for i in range(10)))
+        bed = tmp_path / "acc.bed"
+        bed.write_text("1\t0\t1000\n")
+        return str(pop), str(bed)
+
+    @pytest.mark.parametrize("use_genotypes", [True, False],
+                             ids=["genotype", "haplotype"])
+    def test_vcf_with_accessible_bed(self, sample_vcf, pop_and_bed,
+                                     use_genotypes):
+        pop, bed = pop_and_bed
+        # The genotype loader is biallelic-only and drops the fixture's
+        # multiallelic sites with a warning; the haplotype loader keeps them.
+        expect = (pytest.warns(BiallelicOnlyWarning) if use_genotypes
+                  else nullcontext())
+        with expect:
+            res = compute_ld_statistics(vcf_file=sample_vcf, pop_file=pop,
+                                        pops=["pop0"], bp_bins=[0, 100, 1000],
+                                        use_genotypes=use_genotypes,
+                                        accessible_bed=bed, report=False)
         assert set(res) == {"bins", "sums", "stats", "pops"}
         assert res["pops"] == ["pop0"]


### PR DESCRIPTION
Next chunk of the #238 coverage campaign (after #277, #281, #282, #283), taking `pg_gpu.moments_ld`. The module needs no `moments` install, so these run in the default environment; they drive the guard, parse, report, and loading branches the parity tests skip. Each was verified against the code.

- **`compute_ld_statistics`** -- the eight argument-combination guards (conflicting `pop_file`/`pop_assignment`, out-of-range population count, missing bins, missing genotype/haplotype source, missing `pop_file`, `r_bins` without a rec map), the default-population and `pop_assignment`-alias paths, and a `report=True` run over each of the genotype, haplotype, and recombination-binned compute paths.
- **VCF-loading path** -- `from_vcf` + `load_pop_file` with an `accessible_bed` mask attached at load, on both the genotype and haplotype compute paths. The genotype loader is biallelic-only and drops the fixture's multiallelic sites with a `BiallelicOnlyWarning`, which the test expects; the haplotype loader keeps them.
- **`_interpolate_genetic_distances`** -- malformed map lines are skipped.
- **`_max_bp_for_r_dist`** -- the single-position, no-positive-gap, and flat-map fallbacks.

**Enabling refactor:** the msprime-simulated VCF fixture moves from `test_haplotype_matrix.py` into `conftest.py` as a shared `sample_vcf` (writing to `tmp_path` instead of a hand-managed tempfile), with the same simulation so existing expectations hold; `test_haplotype_matrix.py` (64 tests) passes unchanged on it.

Tests only, no source changes. 19 pass; `moments_ld` coverage rises from 74% to 95% (focused run).

Deferred (out of scope here): the `report=True` print lines on the VCF-loading path, the haplotype-matrix-in-genotype-path combination, the deep compute-device branches the issue marks low-value, and a full recombination-distance parity check against `moments.LD` (Nate's comment item), which belongs with a moments-env comparison fixture.

Refs #238.