### PR TITLE
Cover the I/O and infrastructure edge branches (accessible, plotting, zarr_io)

### DIFF
--- a/tests/test_accessible_mask.py
+++ b/tests/test_accessible_mask.py
@@ -5,7 +5,11 @@ import os
 import tempfile
 import pytest
 
-from pg_gpu.accessible import AccessibleMask, parse_bed, bed_to_mask
+from types import SimpleNamespace
+
+from pg_gpu.accessible import (AccessibleMask, parse_bed, bed_to_mask,
+                               resolve_accessible_mask,
+                               resolve_streaming_accessible_mask)
 from pg_gpu.haplotype_matrix import HaplotypeMatrix
 from pg_gpu.genotype_matrix import GenotypeMatrix
 
@@ -872,3 +876,37 @@ class TestSiteCountProperties:
         assert gm.n_segregating_sites == 2
         assert gm.n_callable_sites == 10
         assert gm.n_invariant_sites == 8
+
+
+class TestBedParseAndResolveEdges:
+    """Malformed or degenerate BED input, and the streaming-mask passthrough."""
+
+    def test_parse_bed_skips_lines_with_too_few_fields(self, tmp_path):
+        bed = tmp_path / "short.bed"
+        bed.write_text("1 100\n1\t200\t300\n")  # first line has two fields
+        assert parse_bed(str(bed)) == [("1", 200, 300)]
+
+    def test_resolve_raises_when_chrom_has_no_intervals(self, tmp_path):
+        bed = tmp_path / "other.bed"
+        bed.write_text("2\t0\t100\n")
+        with pytest.raises(ValueError, match="No BED intervals found"):
+            resolve_accessible_mask(str(bed), None, None, chrom="1")
+
+    def test_resolve_raises_on_inverted_interval(self, tmp_path):
+        # An end before its start leaves no positive span to build a mask on.
+        bed = tmp_path / "inverted.bed"
+        bed.write_text("1\t500\t100\n")
+        with pytest.raises(ValueError, match="Could not determine mask range"):
+            resolve_accessible_mask(str(bed), None, None, chrom="1")
+
+    def test_streaming_mask_none_passes_through(self):
+        assert resolve_streaming_accessible_mask(None, source=None) is None
+
+    def test_streaming_mask_uses_source_chrom_and_bounds(self, tmp_path):
+        # No region given: the chromosome comes from the source and the mask
+        # spans the source's mappable range.
+        bed = tmp_path / "acc.bed"
+        bed.write_text("1\t0\t1000\n")
+        source = SimpleNamespace(mappable_lo=100, mappable_hi=1000, chrom="1")
+        assert isinstance(resolve_streaming_accessible_mask(str(bed), source),
+                          AccessibleMask)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -132,3 +132,44 @@ class TestHaplotypePlots:
         _, _, pos = sim_data
         ax = plotting.plot_variant_locator(pos)
         assert ax is not None
+
+
+class TestPlotEdgeInputs:
+    """Input shapes and ranges that select the less-common drawing branches."""
+
+    def test_sfs_without_endpoint_clipping(self):
+        s = np.arange(1, 22, dtype=float)
+        assert plotting.plot_sfs(s, clip_endpoints=False) is not None
+
+    def test_pca_without_explained_variance(self):
+        coords = np.random.RandomState(0).randn(20, 3)
+        assert plotting.plot_pca(coords) is not None
+
+    def test_pairwise_distance_square_matrix_with_labels(self):
+        a = np.random.RandomState(0).rand(6, 6)
+        dist = (a + a.T) / 2
+        np.fill_diagonal(dist, 0.0)
+        ax = plotting.plot_pairwise_distance(
+            dist, labels=[f"s{i}" for i in range(6)])
+        assert ax is not None
+
+    def test_windowed_axis_in_mb(self):
+        starts = np.arange(0, 5_000_000, 500_000)  # largest start 4.5 Mb
+        ax = plotting.plot_windowed(starts, np.random.rand(len(starts)))
+        assert ax.get_xlabel() == "Position (Mb)"
+
+    def test_windowed_axis_in_bp(self):
+        starts = np.arange(0, 1000, 100)  # largest start 900 bp
+        ax = plotting.plot_windowed(starts, np.random.rand(len(starts)))
+        assert ax.get_xlabel() == "Position (bp)"
+
+    def test_windowed_panel_single_statistic(self, sim_data):
+        matrix, _, _ = sim_data
+        bp_bins = np.arange(0, 100001, 20000)
+        result = windowed_statistics(matrix, bp_bins, statistics=('pi',))
+        _, axes = plotting.plot_windowed_panel(result)
+        assert len(axes) == 1
+
+    def test_variant_locator_with_step(self, sim_data):
+        _, _, pos = sim_data
+        assert plotting.plot_variant_locator(pos, step=2) is not None

--- a/tests/test_zarr_io.py
+++ b/tests/test_zarr_io.py
@@ -13,6 +13,10 @@ from pg_gpu.zarr_io import (
     vcf_to_zarr, write_allel, write_vcz,
 )
 
+from pg_gpu.zarr_io import (_pop_array_to_map, _region_mask,
+                            allel_zarr_to_vcz, normalize_pop_input,
+                            read_genotypes_allel,
+                            read_genotypes_allel_grouped)
 from .conftest import bgzip_index
 
 
@@ -729,3 +733,83 @@ class TestAllelZarrToVcz:
         # accept on the read side either.
         hm_ref = HaplotypeMatrix.from_zarr(ref_path, streaming="never")
         assert hm_ref.num_variants == ts.num_sites
+
+
+class TestRegionMaskAndPopInput:
+    """Region masking with an open start, and every pop_assignment input form."""
+
+    def test_region_mask_open_start(self):
+        np.testing.assert_array_equal(
+            _region_mask(np.array([10, 20, 30]), None, 25), [True, True, False])
+
+    def test_pop_input_dict_drops_empty_labels(self):
+        out = normalize_pop_input({"s0": "A", "s1": ""}, zarr_path="x",
+                                  sample_names=["s0", "s1"])
+        assert out == {"s0": "A"}
+
+    def test_pop_input_array(self):
+        out = normalize_pop_input(np.array(["A", "B"]), zarr_path="x",
+                                  sample_names=["s0", "s1"])
+        assert out == {"s0": "A", "s1": "B"}
+
+    def test_pop_input_array_must_be_1d(self):
+        with pytest.raises(ValueError, match="must be 1-D"):
+            normalize_pop_input(np.array([["A"], ["B"]]), zarr_path="x",
+                                sample_names=["s0", "s1"])
+
+    def test_pop_input_array_length_must_match_samples(self):
+        with pytest.raises(ValueError, match="does not match"):
+            normalize_pop_input(np.array(["A"]), zarr_path="x",
+                                sample_names=["s0", "s1"])
+
+    def test_pop_input_zarr_key(self):
+        store = zarr.create_group(store=zarr.storage.MemoryStore())
+        store.create_array("pops", data=np.array(["A", "B"], dtype="U"))
+        out = normalize_pop_input("pops", zarr_path="x",
+                                  sample_names=["s0", "s1"], zarr_store=store)
+        assert out == {"s0": "A", "s1": "B"}
+
+    def test_pop_input_zarr_key_length_must_match_samples(self):
+        store = zarr.create_group(store=zarr.storage.MemoryStore())
+        store.create_array("pops", data=np.array(["A"], dtype="U"))
+        with pytest.raises(ValueError, match="expected 1-D of length"):
+            normalize_pop_input("pops", zarr_path="x",
+                                sample_names=["s0", "s1"], zarr_store=store)
+
+    def test_pop_input_rejects_unknown_type(self):
+        with pytest.raises(TypeError, match="pop_assignment must be"):
+            normalize_pop_input(42, zarr_path="x", sample_names=["s0"])
+
+    def test_pop_array_to_map_skips_missing_labels(self):
+        out = _pop_array_to_map([None, "", "nan", "A"], ["s0", "s1", "s2", "s3"])
+        assert out == {"s3": "A"}
+
+
+class TestAllelReaderAndConverterEdges:
+    """Empty regions on the scikit-allel readers, and the converter's
+    contig default, empty-region guard, and progress output."""
+
+    def test_flat_allel_empty_region_raises(self, allel_store):
+        store = zarr.open(allel_store, mode="r")
+        with pytest.raises(ValueError, match="No variants in region"):
+            read_genotypes_allel(store, region="1:900000-1000000")
+
+    def test_grouped_allel_empty_region_raises(self, grouped_store):
+        store = zarr.open(grouped_store, mode="r")
+        with pytest.raises(ValueError, match="No variants in region"):
+            read_genotypes_allel_grouped(store, region="chr1:900000-1000000")
+
+    def test_convert_without_contig_labels_it_unknown(self, allel_store, tmp_path):
+        out = str(tmp_path / "out.vcz")
+        allel_zarr_to_vcz(allel_store, out)
+        assert list(zarr.open(out, mode="r")["contig_id"][:]) == ["unknown"]
+
+    def test_convert_empty_region_raises(self, allel_store, tmp_path):
+        with pytest.raises(ValueError, match="No variants in region"):
+            allel_zarr_to_vcz(allel_store, str(tmp_path / "out.vcz"),
+                              region="1:900000-1000000")
+
+    def test_convert_progress_reports_to_stderr(self, allel_store, tmp_path, capsys):
+        allel_zarr_to_vcz(allel_store, str(tmp_path / "out.vcz"),
+                          contig="1", progress=True)
+        assert "[allel_zarr_to_vcz]" in capsys.readouterr().err


### PR DESCRIPTION
Next chunk of the #238 coverage campaign (after #277, #281, #282, #283, #284), closing the residual gaps in the I/O and infrastructure modules. Each test drives one less-common branch directly and was verified against the code.

- **`accessible`** -- `parse_bed` skips lines with too few fields; `resolve_accessible_mask` raises when a chromosome has no BED intervals and when an inverted interval leaves no span; the streaming-mask helper passes `None` through and otherwise resolves from the source's chromosome and mappable bounds.
- **`plotting`** -- the SFS plot without endpoint clipping, PCA without explained variance, a square distance matrix with labels, the Mb and bp axis scalings, a single-panel windowed figure, and the variant locator with a `step`.
- **`zarr_io`** -- `_region_mask` with an open start; every `pop_assignment` input form (dict, array, zarr key, their validation raises, the unknown-type rejection, and `_pop_array_to_map`'s missing-label skips); empty regions on the flat and grouped scikit-allel readers; and the allel-to-VCZ converter's contig default, empty-region guard, and progress output.

Tests only, no source changes. 216 pass across the seven files that exercise these modules (no regression). Coverage (focused run): `accessible` 93% -> **100%**, `plotting` 92% -> **100%**, `zarr_io` 83% -> **92%**.

What is deliberately left in `zarr_io`: `_vcz_contig_index` on an empty contig array (needs a crafted store), the scikit-allel QC-fields reader (needs hand-built QC arrays), `write_vcz` with explicit chunks (already covered by the kvikio tests), `vcf_to_zarr` (bio2zarr's multiprocessing breaks under the coverage tracer; tested standalone), and the `"Expected scikit-allel layout"` guard, which sits behind `detect_zarr_layout` and cannot be reached since that already raises on any unrecognized store.

Refs #238.