### PR TITLE
Cover the remaining GenotypeMatrix and zarr_io edge branches

### DIFF
--- a/tests/test_genotype_matrix_coverage.py
+++ b/tests/test_genotype_matrix_coverage.py
@@ -8,7 +8,7 @@ import numpy as np
 import cupy as cp
 import pytest
 
-from pg_gpu import GenotypeMatrix
+from pg_gpu import BiallelicOnlyWarning, GenotypeMatrix
 from pg_gpu.accessible import AccessibleMask
 
 
@@ -29,6 +29,51 @@ class TestInitValidation:
     def test_empty_positions_raises(self):
         with pytest.raises(ValueError, match="positions cannot be empty"):
             GenotypeMatrix(np.zeros((2, 3), dtype=np.int8), np.array([]))
+
+    def test_sample_sets_must_be_a_dict(self):
+        gm = _gm([[0, 1], [2, 0]])
+        with pytest.raises(ValueError, match="must be a dictionary"):
+            gm.sample_sets = [[0, 1]]
+
+
+class TestInitNormalization:
+    """Inputs the constructor reshapes rather than rejects."""
+
+    def test_gpu_positions_follow_cpu_genotypes(self):
+        # The genotype array decides the device; positions are moved to match.
+        gm = GenotypeMatrix(np.zeros((2, 3), dtype=np.int8),
+                            cp.arange(1, 4) * 100)
+        assert isinstance(gm.positions, np.ndarray)
+
+    def test_array_mask_without_bounds_counts_the_whole_mask(self):
+        # A boolean array becomes a mask at offset 0, and with no chrom
+        # bounds every accessible base in it counts as callable.
+        arr = np.ones(300, dtype=bool)
+        arr[:50] = False
+        gm = GenotypeMatrix(np.zeros((2, 3), dtype=np.int8),
+                            np.array([101, 201, 251]), accessible_mask=arr)
+        assert isinstance(gm.accessible_mask, AccessibleMask)
+        assert gm.n_total_sites == 250
+
+
+class TestAccessors:
+    """Defaults on a bare matrix: sample sets, invariant-site info, repr."""
+
+    def test_sample_sets_default_to_every_individual(self):
+        gm = _gm([[0, 1], [2, 0], [1, 1]])
+        assert gm.sample_sets == {"all": [0, 1, 2]}
+
+    def test_invariant_info_absent_without_total_sites(self):
+        gm = _gm([[0, 1], [2, 0]])
+        assert not gm.has_invariant_info
+        assert gm.n_invariant_sites is None
+
+    def test_repr_reports_shape_and_position_range(self):
+        gm = _gm([[0, 1], [2, 0]])  # positions 1, 101
+        text = repr(gm)
+        assert "shape=(2, 2)" in text
+        assert "first_position=1" in text
+        assert "last_position=101" in text
 
 
 class TestDeviceTransfer:
@@ -77,9 +122,17 @@ class TestFilter:
         with pytest.raises(ValueError, match="genotypes mask shape mismatch"):
             gm.filter(genotypes=np.ones((2, 3), dtype=bool))
 
-    def test_filtering_all_variants_out_returns_empty(self):
+    @pytest.mark.parametrize("device", ["CPU", "GPU"])
+    def test_filtering_all_variants_out_returns_empty(self, device):
+        # The empty result is built on the same device as its source.
         gm = _gm([[0, 1, 2], [2, 1, 0]])
+        if device == "GPU":
+            gm.transfer_to_gpu()
         out = gm.filter(variants=np.zeros(3, dtype=bool))
+        assert out.device == device
+        xp = cp if device == "GPU" else np
+        assert isinstance(out.genotypes, xp.ndarray)
+        assert isinstance(out.positions, xp.ndarray)
         assert out.genotypes.shape == (2, 0)
         assert out.positions.shape == (0,)
         assert out.n_total_sites is None
@@ -153,6 +206,14 @@ def vcz_with_fields(tmp_path):
     return path
 
 
+@pytest.fixture
+def contig1_bed(tmp_path):
+    """A BED file marking bases 1-500 of contig ``1`` accessible."""
+    bed = tmp_path / "acc.bed"
+    bed.write_text("1\t0\t500\n")
+    return str(bed)
+
+
 class TestFromZarrEager:
     """The from_zarr argument guards and the eager build path: fields,
     population assignment, and the tolerated store-reopen failure."""
@@ -192,11 +253,9 @@ class TestFromZarrEager:
         assert set(gm.sample_sets) == {"A", "B"}
         assert gm.sample_sets["A"] == [0, 1]
 
-    def test_eager_attaches_accessible_bed(self, vcz_with_fields, tmp_path):
-        bed = tmp_path / "acc.bed"
-        bed.write_text("1\t0\t5000\n")
+    def test_eager_attaches_accessible_bed(self, vcz_with_fields, contig1_bed):
         gm = GenotypeMatrix.from_zarr(vcz_with_fields, streaming="never",
-                                      accessible_bed=str(bed))
+                                      accessible_bed=contig1_bed)
         assert gm.accessible_mask is not None
 
     def test_store_reopen_failure_is_tolerated(self, vcz_with_fields, monkeypatch):
@@ -216,3 +275,28 @@ class TestFromZarrEager:
         gm = GenotypeMatrix.from_zarr(vcz_with_fields, streaming="never")
         assert isinstance(gm, GenotypeMatrix)
         assert gm.num_variants == 30
+
+
+class TestFromVcf:
+
+    def test_accessible_bed_attaches_mask(self, sample_vcf, contig1_bed):
+        # The BED is resolved on the VCF's own contig name, and the callable
+        # span is the BED interval clipped to start at the first variant.
+        with pytest.warns(BiallelicOnlyWarning):
+            gm = GenotypeMatrix.from_vcf(sample_vcf, accessible_bed=contig1_bed)
+        assert gm.accessible_mask is not None
+        assert gm.n_total_sites == 500 - gm.chrom_start + 1
+
+
+class TestToZarr:
+
+    def test_allel_format_rejects_fields(self, tmp_path):
+        gm = _gm([[0, 1, 2], [2, 1, 0]])
+        gm.fields = {"GQ": np.zeros((3, 2), dtype=np.int32)}
+        with pytest.raises(NotImplementedError, match="only supported for format='vcz'"):
+            gm.to_zarr(str(tmp_path / "out.zarr"), format="scikit-allel")
+
+    def test_unknown_format_raises(self, tmp_path):
+        gm = _gm([[0, 1, 2], [2, 1, 0]])
+        with pytest.raises(ValueError, match="Unknown format"):
+            gm.to_zarr(str(tmp_path / "out.zarr"), format="bogus")

--- a/tests/test_zarr_io.py
+++ b/tests/test_zarr_io.py
@@ -16,7 +16,7 @@ from pg_gpu.zarr_io import (
 from pg_gpu.zarr_io import (_pop_array_to_map, _region_mask,
                             allel_zarr_to_vcz, normalize_pop_input,
                             read_genotypes_allel,
-                            read_genotypes_allel_grouped)
+                            read_genotypes_allel_grouped, read_qc_fields)
 from .conftest import bgzip_index
 
 
@@ -547,6 +547,18 @@ class TestEdgeCases:
         assert hm.num_variants == 5
         assert np.all(hm.haplotypes == -1)
 
+    def test_explicit_chunks_are_honored(self, tmp_path):
+        """Chunks passed to write_vcz shape the genotype arrays on disk."""
+        rng = np.random.default_rng(0)
+        gt = rng.integers(0, 2, size=(30, 4, 2)).astype(np.int8)
+        pos = np.arange(1, 31, dtype=np.int32) * 100
+        path = str(tmp_path / "chunked.zarr")
+        write_vcz(path, gt, pos, chunks=(10, 4, 2))
+        store = zarr.open(path, mode='r')
+        assert store['call_genotype'].chunks == (10, 4, 2)
+        assert store['call_genotype_mask'].chunks == (10, 4, 2)
+        np.testing.assert_array_equal(store['call_genotype'][:], gt)
+
 
 # ── scikit-allel -> vcz conversion ──────────────────────────────────────
 
@@ -786,8 +798,9 @@ class TestRegionMaskAndPopInput:
 
 
 class TestAllelReaderAndConverterEdges:
-    """Empty regions on the scikit-allel readers, and the converter's
-    contig default, empty-region guard, and progress output."""
+    """Empty regions on the scikit-allel readers, the field reader's
+    grouped-store default, and the converter's contig default,
+    empty-region guard, and progress output."""
 
     def test_flat_allel_empty_region_raises(self, allel_store):
         store = zarr.open(allel_store, mode="r")
@@ -798,6 +811,11 @@ class TestAllelReaderAndConverterEdges:
         store = zarr.open(grouped_store, mode="r")
         with pytest.raises(ValueError, match="No variants in region"):
             read_genotypes_allel_grouped(store, region="chr1:900000-1000000")
+
+    def test_grouped_fields_without_region_return_nothing(self, grouped_store):
+        # The grouped genotype reader already raises without region=, so the
+        # field reader returns empty rather than raising a second time.
+        assert read_qc_fields(grouped_store, ["GQ"], region=None) == {}
 
     def test_convert_without_contig_labels_it_unknown(self, allel_store, tmp_path):
         out = str(tmp_path / "out.vcz")


### PR DESCRIPTION
Covers the `genotype_matrix.py` and `zarr_io.py` branches still open under #238 after #281, #285, and #286 (line numbers on current main):

`genotype_matrix.py`
- `__init__` 81: cupy positions are pulled to host when the genotype array is numpy
- `__init__` 98, 106: a boolean-array mask is wrapped as an `AccessibleMask`, and without chrom bounds the callable span is the whole mask
- `sample_sets` 162, 180: default `{"all": ...}`; non-dict raise
- 237, 273, 277: `has_invariant_info`, `n_invariant_sites` is None without `n_total_sites`, `__repr__`
- `from_vcf` 505-508: `accessible_bed=` resolved on the VCF's contig; the callable span is pinned as the BED interval clipped to start at the first variant
- `filter` 745-746: empty result built on the GPU device (the CPU copy was covered; the test is now parametrized over device and checks the array types)
- `to_zarr` 812, 818: `format='scikit-allel'` with fields; unknown format

`zarr_io.py`
- `write_vcz` 466-473: explicit `chunks=` branch, checked on disk and by round-trip
- `read_qc_fields` 292: grouped store without `region=` returns `{}`

The one-line BED that two tests wrote inline is now a `contig1_bed` fixture, and the constructor tests are split into validation (raises) and normalization (reshaped inputs) classes.

Left alone: `_vcz_contig_index` 75 (only a zero-variant store reaches it, and the matrix constructor then rejects the empty result), `allel_zarr_to_vcz` 556 (unreachable: `detect_zarr_layout` only returns vcz/allel/grouped and vcz is caught two lines earlier; a candidate for the dead-code issue), and `vcf_to_zarr` 723, 741-742 (bio2zarr wrapper; its tests cannot run under the coverage tracer).

Refs #238
