### PR TITLE
Cover the remaining moments_ld branches

### DIFF
--- a/tests/test_moments_ld_coverage.py
+++ b/tests/test_moments_ld_coverage.py
@@ -110,8 +110,9 @@ class TestRecMapHelpers:
 
 
 class TestReportRun:
-    """A full report=True run over each compute path prints progress and
-    returns the moments-format result dict."""
+    """Full runs over each compute path: progress reporting on and off,
+    recombination-distance binning, and the union filter across
+    populations, each returning the moments-format result dict."""
 
     def test_genotype_report_run(self):
         gm = _gm()
@@ -122,17 +123,39 @@ class TestReportRun:
         assert set(res) == {"bins", "sums", "stats", "pops"}
         assert res["pops"] == ["pop0"]
 
-    def test_recombination_binned_run(self, tmp_path):
+    def test_recombination_binned_run(self, tmp_path, capsys):
         # r_bins routes through the genetic-map interpolation and the physical
-        # distance cap, then bins pairs by recombination distance.
+        # distance cap, then bins pairs by recombination distance. The map is
+        # 1e-5 M/bp, so bins up to 1e-2 M admit pairs up to about 1 kb apart;
+        # the inner edge sits between the 100 bp multiples of the variant
+        # spacing so no pair lands on a bin boundary.
         rec = tmp_path / "rmap.map"
         rec.write_text("0 0.0\n5000 5.0\n")
         hm = _hm()
         hm.sample_sets = {"pop0": list(range(8))}
         res = compute_ld_statistics(haplotype_matrix=hm, use_genotypes=False,
-                                    pops=["pop0"], r_bins=[0, 1e-5, 5e-5],
+                                    pops=["pop0"], r_bins=[0, 1.5e-3, 1e-2],
                                     rec_map_file=str(rec), report=False)
         assert set(res) == {"bins", "sums", "stats", "pops"}
+        # Both recombination bins receive pairs; the last entry holds H.
+        assert all(np.any(np.asarray(s) != 0) for s in res["sums"][:-1])
+        # report=False keeps the run silent.
+        assert capsys.readouterr().out == ""
+
+    def test_shared_individual_counted_once_in_union_filter(self):
+        # The biallelic filter runs over the union of the populations and
+        # counts an individual listed in both once. A site whose only call is
+        # that individual's stays below the two-call minimum, so no pair forms
+        # and every LD bin stays at zero.
+        geno = np.ones((12, 2), dtype=np.int8)  # site 0: heterozygous in all
+        geno[:, 1] = -1
+        geno[4, 1] = 1                           # site 1: one call, individual 4
+        gm = GenotypeMatrix(geno, np.array([100, 200]))
+        gm.sample_sets = {"pop0": list(range(0, 8)), "pop1": list(range(4, 12))}
+        res = compute_ld_statistics(genotype_matrix=gm, use_genotypes=True,
+                                    pops=["pop0", "pop1"], bp_bins=[0, 500],
+                                    report=False)
+        assert all(np.all(np.asarray(s) == 0) for s in res["sums"][:-1])
 
     def test_haplotype_report_run(self):
         hm = _hm()
@@ -145,8 +168,9 @@ class TestReportRun:
 
 
 class TestVcfLoadingPath:
-    """The VCF-loading branches -- from_vcf, load_pop_file, and the
-    accessible_bed mask attached at load -- on both compute paths."""
+    """The VCF-loading branches -- from_vcf, load_pop_file, the
+    accessible_bed mask attached at load, and the progress line -- on both
+    compute paths."""
 
     @pytest.fixture
     def pop_and_bed(self, tmp_path):
@@ -160,7 +184,7 @@ class TestVcfLoadingPath:
     @pytest.mark.parametrize("use_genotypes", [True, False],
                              ids=["genotype", "haplotype"])
     def test_vcf_with_accessible_bed(self, sample_vcf, pop_and_bed,
-                                     use_genotypes):
+                                     use_genotypes, capsys):
         pop, bed = pop_and_bed
         # The genotype loader is biallelic-only and drops the fixture's
         # multiallelic sites with a warning; the haplotype loader keeps them.
@@ -170,6 +194,7 @@ class TestVcfLoadingPath:
             res = compute_ld_statistics(vcf_file=sample_vcf, pop_file=pop,
                                         pops=["pop0"], bp_bins=[0, 100, 1000],
                                         use_genotypes=use_genotypes,
-                                        accessible_bed=bed, report=False)
+                                        accessible_bed=bed, report=True)
         assert set(res) == {"bins", "sums", "stats", "pops"}
         assert res["pops"] == ["pop0"]
+        assert f"Loading {sample_vcf}" in capsys.readouterr().out


### PR DESCRIPTION
Covers the `moments_ld.py` branches still open under #238 after #284 (moments env; line numbers on current main):

- `_compute_ld_sums` 365: pairs binned by genetic distance. `test_recombination_binned_run` used `r_bins` up to `5e-5` on a `1e-5 M/bp` map, which caps pairs at 5 bp on a matrix with variants 100 bp apart, so no pair was ever binned and the test passed on an empty loop. The bins now reach `1e-2` (pairs up to about 1 kb), with the inner edge placed between the pair distances so no pair sits on a boundary, and every LD bin is asserted to carry signal. The same run checks that `report=False` prints nothing.
- `compute_ld_statistics` 175, 196: the `report=True` "Loading ..." lines on both VCF paths, checked through `capsys`.
- `_compute_ld_sums` 312: an individual listed in two populations is counted once in the union biallelic filter. A two-site matrix whose second site is called only in the shared individual forms no pair, so every LD bin stays at zero.

Left alone: 168 (`from_haplotype_matrix` always returns a GPU matrix, so the transfer after it cannot run; a candidate for the dead-code issue), 338 (positions are always cupy by the time `_compute_ld_sums` runs on the public path), and the pre-loaded-matrix device branches the issue already excludes.

Refs #238
