### PR TITLE
Strengthen matrix/IO/infra coverage oracles

### DIFF
--- a/tests/test_genotype_matrix_coverage.py
+++ b/tests/test_genotype_matrix_coverage.py
@@ -104,10 +104,18 @@ class TestDeviceTransfer:
         arr[101] = False
         gm.set_accessible_mask(AccessibleMask(arr, offset=0))
         assert gm._accessible_idx is not None
+        idx0 = np.asarray(gm._accessible_idx).copy()
+        geno0 = np.asarray(gm.genotypes).copy()
+        pos0 = np.asarray(gm.positions).copy()
         gm.transfer_to_gpu()
         assert isinstance(gm._accessible_idx, cp.ndarray)
         gm.transfer_to_cpu()
         assert isinstance(gm._accessible_idx, np.ndarray)
+        # The round trip must preserve the index values, genotypes, and
+        # positions -- not merely their array namespace.
+        np.testing.assert_array_equal(np.asarray(gm._accessible_idx), idx0)
+        np.testing.assert_array_equal(np.asarray(gm.genotypes), geno0)
+        np.testing.assert_array_equal(np.asarray(gm.positions), pos0)
 
 
 class TestFilter:
@@ -188,7 +196,11 @@ class TestAccessibleMaskLifecycle:
         gm.set_accessible_mask(AccessibleMask(arr, offset=0))
         idx = gm._accessible_idx
         assert idx is not None
-        assert 1 not in (idx.get() if hasattr(idx, "get") else idx)
+        # Exactly the two unmasked variants (positions 1 and 201), in order --
+        # an off-by-one that kept the wrong variant would still satisfy a bare
+        # "1 not in idx".
+        np.testing.assert_array_equal(
+            idx.get() if hasattr(idx, "get") else idx, [0, 2])
 
 
 @pytest.fixture

--- a/tests/test_local_pca.py
+++ b/tests/test_local_pca.py
@@ -211,6 +211,20 @@ class TestBatchedVsLoop:
                     assert float(np.dot(v, prev)) > 0.0
                 prev = v
 
+    def test_streaming_dense_matches_dense_eigh(self):
+        # streaming-dense is a separate per-window code path from the batched
+        # dense-eigh engine; on the same valid workload it must reproduce the
+        # eigenvalues and the eigenvectors (the latter up to per-window sign).
+        from .conftest import simulate_hm
+        hm = simulate_hm(n_samples=15, seq_length=50_000, seed=7)
+        kw = dict(window_size=20, step_size=20, window_type='snp', k=2)
+        d = local_pca(hm, engine='dense-eigh', **kw)
+        s = local_pca(hm, engine='streaming-dense', **kw)
+        np.testing.assert_allclose(s.eigvals, d.eigvals, rtol=1e-6, atol=1e-8,
+                                   equal_nan=True)
+        np.testing.assert_allclose(np.abs(s.eigvecs), np.abs(d.eigvecs),
+                                   rtol=1e-6, atol=1e-6, equal_nan=True)
+
 
 # ---------------------------------------------------------------------------
 # NaN / sparse-window handling
@@ -417,11 +431,15 @@ class TestCorners:
         xy = rng.standard_normal((50, 2))
         xy[0] = np.nan
         xy[5] = np.nan
-        # Should not raise
         out = corners(xy, prop=0.1, k=3, random_state=0)
-        # NaN indices should not appear in output
-        assert 0 not in out
-        assert 5 not in out
+        # The returned corners must be the correct ORIGINAL-row indices: equal
+        # to corners on the NaN-free subset mapped back through the surviving
+        # row numbers. A back-mapping bug (returning compacted-array positions)
+        # would still exclude the NaN rows but point at the wrong originals.
+        valid_idx = np.where(~np.isnan(xy).any(axis=1))[0]
+        ref = np.asarray(corners(xy[valid_idx], prop=0.1, k=3, random_state=0))
+        assert sorted(np.asarray(out).ravel().tolist()) == \
+            sorted(valid_idx[ref].ravel().tolist())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_relatedness_streaming_coverage.py
+++ b/tests/test_relatedness_streaming_coverage.py
@@ -50,7 +50,12 @@ class TestStreamingGrmDegenerate:
     def test_empty_source_returns_zero_grm(self, poly_store):
         gm = GenotypeMatrix.from_zarr(poly_store, streaming="always",
                                       chunk_bp=500, region=_EMPTY_REGION)
-        assert np.all(relatedness.grm(gm) == 0.0)
+        A = relatedness.grm(gm)
+        # The all-zero return must keep the full (n_ind, n_ind) shape, so a
+        # regression in the empty-source individual count (an unhalved or
+        # zero-size fallback) is caught, not masked by np.all(x == 0).
+        assert A.shape == (4, 4)
+        assert np.all(A == 0.0)
 
 
 class TestStreamingIbsDegenerate:
@@ -71,7 +76,9 @@ class TestStreamingIbsDegenerate:
         ibs = relatedness._stream_ibs(gm, population="pop1",
                                       missing_data='include')
         assert ibs.shape == (2, 2)
+        off_diagonal = ibs[~np.eye(2, dtype=bool)]
         assert np.all(np.diag(ibs) == 1.0)
+        assert np.all(off_diagonal == 0.0)
 
 
 class TestStreamingGeneticRelatednessIndexes:
@@ -79,9 +86,14 @@ class TestStreamingGeneticRelatednessIndexes:
     def test_indexes_project_requested_pairs(self, poly_store):
         sh = HaplotypeMatrix.from_zarr(poly_store, streaming="always",
                                        chunk_bp=500)
-        sets = [[0, 1, 2, 3], [4, 5, 6, 7]]
+        # Four sample sets (a 4x4 matrix) and a mix of distinct off-diagonal
+        # and diagonal pairs, so a projection that mis-maps the requested
+        # row/column (or returns a diagonal element) gives a different value --
+        # a single symmetric pair on a 2x2 matrix could not distinguish these.
+        sets = [[0, 1], [2, 3], [4, 5], [6, 7]]
         full = np.asarray(relatedness.genetic_relatedness(sh, sample_sets=sets))
+        pairs = [(0, 1), (1, 2), (2, 3), (0, 0)]
         idxed = np.asarray(relatedness.genetic_relatedness(
-            sh, sample_sets=sets, indexes=[(0, 1)]))
-        assert idxed.shape == (1,)
-        np.testing.assert_allclose(idxed[0], full[0, 1])
+            sh, sample_sets=sets, indexes=pairs))
+        assert idxed.shape == (len(pairs),)
+        np.testing.assert_allclose(idxed, [full[i, j] for i, j in pairs])

--- a/tests/test_resampling.py
+++ b/tests/test_resampling.py
@@ -198,6 +198,14 @@ class TestMovingWindowHelpers:
         out = _moving_nansum(cp.asarray([1., 2., 3.]), size=2, step=1)
         np.testing.assert_array_equal(cp.asnumpy(out), [3., 5.])
 
+    def test_nanmean_strided_with_nan(self):
+        # Overlapping windows (step < size) combined with the non-NaN-count
+        # denominator: [1,nan]->1, [nan,3]->3, [3,4]->3.5. Pins that the mean
+        # divides by the finite count per window, not the window size, under
+        # overlap -- the one path the non-overlapping nanmean tests skip.
+        out = _moving_nanmean(cp.asarray([1., cp.nan, 3., 4.]), size=2, step=1)
+        np.testing.assert_array_equal(cp.asnumpy(out), [1.0, 3.0, 3.5])
+
     def test_window_larger_than_data_is_empty(self):
         # No window fits, so the result is empty rather than an error.
         assert _moving_nanmean(cp.asarray([1., 2.]), size=5).shape == (0,)


### PR DESCRIPTION
Turn shape/type-only assertions in the recent coverage tests into value oracles that pin the exercised behaviour:

- streaming relatedness: assert the empty-source GRM keeps the (n_ind, n_ind) shape; assert the empty-population IBS off-diagonal is 0; project indexes over a 4x4 matrix with distinct off-diagonal and diagonal pairs so a wrong row/column mapping is caught (a single symmetric 2x2 pair could not).
- resampling: pin _moving_nanmean under overlapping windows with a NaN, so the per-window finite-count denominator is checked, not the window size.
- genotype_matrix: assert the transfer round trip preserves index values, genotypes, and positions (not just the array namespace); assert the partial accessible index is exactly the surviving variants.
- local PCA: assert streaming-dense reproduces dense-eigh eigenvalues and eigenvectors on a valid workload (two separate code paths, previously never value-compared); assert corners returns the correct original-row indices.