### PR TITLE
Hash haplotypes exactly for Garud H and haplotype counts

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -387,7 +387,7 @@ Two-population (one kernel launch for all):
 
 Selection scan statistics:
 
-- ``garud_h1``, ``garud_h12``, ``garud_h123``, ``garud_h2h1`` -- Garud's H statistics per window (prefix-sum hashing + shared-memory sort)
+- ``garud_h1``, ``garud_h12``, ``garud_h123``, ``garud_h2h1`` -- Garud's H statistics per window (exact per-window haplotype hashing + GPU sort; no limit on haplotype count)
 - ``mean_nsl`` -- mean nSL per window (per-site nSL + scatter binning)
 
 Structure / dimensionality reduction:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -177,6 +177,27 @@ Read this section if you are comparing against older pg_gpu results.
 Bug fixes
 ~~~~~~~~~
 
+* Windowed Garud's H made three float64 copies of the haplotype matrix
+  (109 GB each for 2,940 haplotypes across 4.7 million sites) and, for
+  a Garud-only request, a transposed int8 copy on top. Each window is
+  now hashed straight from the int8 matrix, in batches sized to free
+  GPU memory, and Garud-only scans skip the transposed copy.
+* A window with no variants borrowed the next window's first variant
+  and reported its Garud H; a grid whose windows all lay past the last
+  variant raised ``IndexError``. Such a window now reports one
+  haplotype (``garud_h1``, ``garud_h12`` and ``garud_h123`` of 1,
+  ``garud_h2h1`` of 0, ``haplotype_count`` of 1) on tile and sliding
+  grids alike.
+* Windowed Garud's H sorted each window's haplotypes in shared memory
+  and left every haplotype past the 2,048th unsorted, so haplotype
+  counts and H statistics were wrong for larger cohorts, and the kernel
+  failed outright past 3,072 haplotypes. The sort now runs in global
+  memory with no limit on the haplotype count.
+* ``haplotype_diversity``, ``haplotype_count``, ``garud_h`` and
+  ``moving_garud_h`` no longer make a float copy of the matrix; they
+  share the exact haplotype hash of the windowed scan.
+  ``moving_garud_h`` rejects windows outside the matrix instead of
+  reading past it.
 * ``HaplotypeMatrix.pairwise_r2`` and ``windowed_r_squared`` rejected
   ``estimator='auto'`` -- the default name for the LD estimator
   everywhere else -- with an "unknown estimator" error. They accept it

--- a/examples/biobank_streaming_scan.py
+++ b/examples/biobank_streaming_scan.py
@@ -9,8 +9,8 @@ and accumulates, in a single pass over ``stream.iter_gpu_chunks()``:
 * Joint SFS projected from the full panel to a small display grid
   via per-variant hypergeometric sampling -- every variant from
   every haplotype contributes, no subsampling.
-* Garud's H per population (uses a 1,000-haplotype subsample because
-  the fused Garud kernel caps near 1024 haplotypes).
+* Garud's H per population (uses a 1,000-haplotype subsample to keep
+  the scan quick; any haplotype count works).
 
 Then -- after the streaming walk -- materializes a 1 Mb sub-region
 with a 5,000-haplotype subsample so the pairwise-r^2 heatmap can
@@ -90,7 +90,7 @@ def parse_args():
                         "SFS, in haplotypes per population")
     p.add_argument("--garud-subsample", type=int, default=1_000,
                    help="haplotypes drawn per population for Garud's H "
-                        "(kernel caps near 1024)")
+                        "(a speed knob; any count works)")
     return p.parse_args()
 
 

--- a/pg_gpu/_haplotype_hash.py
+++ b/pg_gpu/_haplotype_hash.py
@@ -1,0 +1,283 @@
+"""Exact haplotype-identity hashing shared by Garud's H and haplotype counting.
+
+Each haplotype in a window is reduced to two float64 hashes: the in-order sum
+of a per-variant weight over the alleles it carries. One thread computes one
+haplotype's sum in variant-index order, so two identical haplotypes give
+bit-identical hashes, and a window with no variants hashes to zero. Distinct
+haplotypes differ by a random combination of weights that is never within
+rounding distance of zero, so grouping by exact hash equality counts distinct
+haplotypes exactly. The kernels read the int8 matrix directly; nothing here
+materializes a float copy of the haplotype matrix, and the per-window sort runs
+in global memory, so the haplotype count is unbounded.
+"""
+
+import cupy as cp
+import numpy as np
+
+from . import _memutil
+
+_GARUD_SALT1 = 0x9E3779B97F4A7C15   # golden-ratio constant
+_GARUD_SALT2 = 0xC6BC279692B5C323   # phi^-2-based companion
+
+_THREADS = _memutil._THREADS_PER_BLOCK
+
+# Variants per segment when hashing whole rows. Splitting a long row into
+# segments gives the GPU many threads per haplotype instead of one.
+_ROW_SEGMENT = 4096
+
+
+def _index_weights(n_var, salt):
+    """Float64 weights in ``[-1, 1)`` for variant indices ``0 .. n_var - 1``.
+
+    Splitmix64-scrambles each index with the salt. Two salts give two
+    independent weight columns; together they make a collision between
+    distinct haplotype patterns vanishingly rare. The distribution is
+    uniform rather than normal because the weights only tell patterns
+    apart.
+    """
+    s = cp.uint64(salt & 0xFFFFFFFFFFFFFFFF)
+    x = cp.arange(n_var, dtype=cp.uint64) + s
+    x = (x ^ (x >> cp.uint64(30))) * cp.uint64(0xBF58476D1CE4E5B9)
+    x = (x ^ (x >> cp.uint64(27))) * cp.uint64(0x94D049BB133111EB)
+    x = x ^ (x >> cp.uint64(31))
+    # Mantissa-pack the low 52 bits as a float64 in [1, 2); subtract 1 to
+    # get [0, 1); rescale to [-1, 1).
+    mant = (x & cp.uint64(0x000FFFFFFFFFFFFF)) | cp.uint64(0x3FF0000000000000)
+    u = mant.view(cp.float64) - 1.0
+    return 2.0 * u - 1.0
+
+
+def hash_weights(n_var):
+    """The two weight vectors ``(w1, w2)`` for a matrix with ``n_var`` variants."""
+    return _index_weights(n_var, _GARUD_SALT1), _index_weights(n_var, _GARUD_SALT2)
+
+
+# One thread per (window, haplotype). The matrix is addressed with byte
+# strides through a signed char pointer, so int8 and wider signed integer
+# matrices in C or F order are read in place: a wider element is read through
+# its low byte, which holds the allele index for the small values a haplotype
+# matrix carries (-1 for missing, 0.. for alleles). All offsets are 64-bit.
+_window_hash_kernel = cp.RawKernel(r'''
+extern "C" __global__
+void garud_window_hash(const signed char* hap, long long stride0, long long stride1,
+                       const double* w1, const double* w2,
+                       const long long* win_start, const long long* win_stop,
+                       int n_hap, int n_windows, int blocks_per_window,
+                       double* out1, double* out2) {
+    long long b = blockIdx.x;
+    int w = (int)(b / blocks_per_window);
+    int h = (int)(b % blocks_per_window) * blockDim.x + threadIdx.x;
+    if (w >= n_windows || h >= n_hap) return;
+    const signed char* row = hap + (long long)h * stride0;
+    long long lo = win_start[w];
+    long long hi = win_stop[w];
+    double a1 = 0.0;
+    double a2 = 0.0;
+    // Sequential in-order accumulation with explicit fma: identical
+    // haplotypes give bit-identical sums, and an empty window sums to zero.
+    for (long long v = lo; v < hi; v++) {
+        double x = (double)row[v * stride1];
+        a1 = fma(x, w1[v], a1);
+        a2 = fma(x, w2[v], a2);
+    }
+    long long o = (long long)w * n_hap + h;
+    out1[o] = a1;
+    out2[o] = a2;
+}
+''', 'garud_window_hash')
+
+
+# One thread per window walks that window's hashes, sorted by (h1, h2), and
+# counts runs of equal pairs: each run is one distinct haplotype. It emits the
+# sum of squared frequencies and the three largest frequencies; the H
+# statistics are derived from those in garud_from_moments. Run lengths are
+# tallied as exact integers and divided once, so the output depends only on
+# the multiset of run lengths, not on the order the sort put them in.
+_garud_walk_kernel = cp.RawKernel(r'''
+extern "C" __global__
+void garud_walk(const double* s1, const double* s2, int n_hap, int n_windows,
+                double* out_sum_f2, double* out_top0, double* out_top1,
+                double* out_top2, double* out_n_distinct) {
+    int w = blockIdx.x * blockDim.x + threadIdx.x;
+    if (w >= n_windows) return;
+    const double* a = s1 + (long long)w * n_hap;
+    const double* b = s2 + (long long)w * n_hap;
+    long long sum_r2 = 0;
+    int top0 = 0, top1 = 0, top2 = 0;
+    int run = 1;
+    int n_distinct = 0;
+    for (int i = 1; i <= n_hap; i++) {
+        bool boundary = (i == n_hap) || (a[i] != a[i - 1]) || (b[i] != b[i - 1]);
+        if (!boundary) {
+            run++;
+            continue;
+        }
+        n_distinct++;
+        sum_r2 += (long long)run * run;
+        if (run > top0) {
+            top2 = top1; top1 = top0; top0 = run;
+        } else if (run > top1) {
+            top2 = top1; top1 = run;
+        } else if (run > top2) {
+            top2 = run;
+        }
+        run = 1;
+    }
+    double n = (double)n_hap;
+    out_sum_f2[w] = (double)sum_r2 / (n * n);
+    out_top0[w] = (double)top0 / n;
+    out_top1[w] = (double)top1 / n;
+    out_top2[w] = (double)top2 / n;
+    out_n_distinct[w] = (double)n_distinct;
+}
+''', 'garud_walk')
+
+
+def garud_from_moments(sum_f2, top0, top1, top2):
+    """H1, H12, H123 and H2/H1 from haplotype-frequency moments.
+
+    ``sum_f2`` is the sum of squared haplotype frequencies (H1) and
+    ``top0 >= top1 >= top2`` the three largest frequencies, zero when fewer
+    haplotypes exist. Works on scalars and on arrays of any array module.
+    """
+    t12 = top0 + top1
+    t123 = t12 + top2
+    h12 = t12 * t12 + (sum_f2 - top0 * top0 - top1 * top1)
+    h123 = t123 * t123 + (sum_f2 - top0 * top0 - top1 * top1 - top2 * top2)
+    h2h1 = (sum_f2 - top0 * top0) / sum_f2
+    return sum_f2, h12, h123, h2h1
+
+
+def _as_kernel_input(hap):
+    """A view the hash kernel can read in place: any signed integer dtype."""
+    if hap.dtype.kind != 'i':
+        hap = hap.astype(cp.int8)
+    return hap
+
+
+def window_hashes(hap, w1, w2, win_start, win_stop):
+    """Per-window haplotype hashes.
+
+    Parameters
+    ----------
+    hap : cupy.ndarray, shape (n_hap, n_var), signed integer
+        Allele indices, -1 for missing. Any memory order.
+    w1, w2 : cupy.ndarray, float64, shape (n_var,)
+        Weight per variant, indexed by variant index (see ``hash_weights``).
+    win_start, win_stop : array_like of int
+        Right-open variant index range of each window, within ``[0, n_var]``.
+
+    Returns
+    -------
+    h1, h2 : cupy.ndarray, float64, shape (n_windows, n_hap)
+        A window with no variants hashes to 0.
+    """
+    hap = _as_kernel_input(hap)
+    n_hap, n_var = hap.shape
+    win_start = cp.ascontiguousarray(cp.asarray(win_start, dtype=cp.int64))
+    win_stop = cp.ascontiguousarray(cp.asarray(win_stop, dtype=cp.int64))
+    n_windows = int(win_start.shape[0])
+    out1 = cp.empty((n_windows, n_hap), dtype=cp.float64)
+    out2 = cp.empty((n_windows, n_hap), dtype=cp.float64)
+    if n_windows == 0:
+        return out1, out2
+    # The kernel reads the ranges unchecked.
+    if bool((win_start < 0).any()) or bool((win_stop > n_var).any()):
+        raise ValueError(f"window ranges must lie within [0, {n_var}]")
+    blocks_per_window = max(1, (n_hap + _THREADS - 1) // _THREADS)
+    if n_windows * blocks_per_window > 2 ** 31 - 1:
+        raise ValueError("too many windows for one launch; batch them")
+    w1 = cp.ascontiguousarray(w1, dtype=cp.float64)
+    w2 = cp.ascontiguousarray(w2, dtype=cp.float64)
+    stride0, stride1 = hap.strides
+    _window_hash_kernel(
+        (n_windows * blocks_per_window,), (_THREADS,),
+        (hap, np.int64(stride0), np.int64(stride1), w1, w2, win_start, win_stop,
+         np.int32(n_hap), np.int32(n_windows), np.int32(blocks_per_window),
+         out1, out2))
+    return out1, out2
+
+
+def sort_window_hashes(h1, h2):
+    """Each window's hash pairs sorted by (h1, h2), as sorted copies.
+
+    Two stable per-row argsorts (by h2, then by h1) give the lexicographic
+    order within every window, in global memory.
+    """
+    o2 = cp.argsort(h2, axis=1)
+    o1 = cp.argsort(cp.take_along_axis(h1, o2, axis=1), axis=1)
+    order = cp.take_along_axis(o2, o1, axis=1)
+    return cp.take_along_axis(h1, order, axis=1), cp.take_along_axis(h2, order, axis=1)
+
+
+def garud_walk(s1, s2):
+    """Garud statistics from per-window sorted hashes.
+
+    Returns
+    -------
+    h1, h12, h123, h2h1, n_distinct : cupy.ndarray, float64, shape (n_windows,)
+    """
+    n_windows, n_hap = s1.shape
+    moments = tuple(cp.empty(n_windows, dtype=cp.float64) for _ in range(5))
+    grid = max(1, (n_windows + _THREADS - 1) // _THREADS)
+    _garud_walk_kernel((grid,), (_THREADS,),
+                       (s1, s2, np.int32(n_hap), np.int32(n_windows), *moments))
+    return (*garud_from_moments(*moments[:4]), moments[4])
+
+
+def garud_h_windows(hap, win_start, win_stop):
+    """Garud's H1, H12, H123, H2/H1 and distinct-haplotype count per window.
+
+    Parameters
+    ----------
+    hap : cupy.ndarray, shape (n_hap, n_var), signed integer
+    win_start, win_stop : array_like of int
+        Right-open variant index range of each window.
+
+    Returns
+    -------
+    h1, h12, h123, h2h1, n_distinct : numpy.ndarray, float64, shape (n_windows,)
+        A window with no variants has one distinct haplotype: H1 = H12 =
+        H123 = 1 and H2/H1 = 0.
+
+    Windows are processed in batches sized to free GPU memory. Each window's
+    result depends only on its own variants, so batching never changes a value.
+    """
+    hap = _as_kernel_input(hap)
+    n_hap, n_var = hap.shape
+    win_start = cp.asarray(win_start, dtype=cp.int64)
+    win_stop = cp.asarray(win_stop, dtype=cp.int64)
+    n_windows = int(win_start.shape[0])
+    out = np.empty((5, n_windows), dtype=np.float64)
+    if n_windows == 0:
+        return tuple(out)
+    w1, w2 = hash_weights(n_var)
+    batch = _memutil.estimate_garud_window_batch(n_hap)
+    for b0 in range(0, n_windows, batch):
+        b1 = min(b0 + batch, n_windows)
+        h1, h2 = window_hashes(hap, w1, w2, win_start[b0:b1], win_stop[b0:b1])
+        s1, s2 = sort_window_hashes(h1, h2)
+        del h1, h2
+        stats = garud_walk(s1, s2)
+        del s1, s2
+        out[:, b0:b1] = cp.stack(stats).get()
+    return tuple(out)
+
+
+def row_hashes(hap):
+    """Whole-row hashes for counting the distinct haplotypes of a matrix.
+
+    Rows are summed in fixed segments so the GPU has many threads per
+    haplotype; every row uses the same segments in the same order, so
+    identical rows stay bit-identical. A row shorter than one segment hashes
+    exactly like a single window over the whole row.
+
+    Returns
+    -------
+    hash1, hash2 : cupy.ndarray, float64, shape (n_hap,)
+    """
+    n_var = hap.shape[1]
+    starts = cp.arange(0, n_var, _ROW_SEGMENT, dtype=cp.int64)
+    stops = cp.minimum(starts + _ROW_SEGMENT, n_var)
+    h1, h2 = window_hashes(hap, *hash_weights(n_var), starts, stops)
+    return h1.sum(axis=0), h2.sum(axis=0)

--- a/pg_gpu/_memutil.py
+++ b/pg_gpu/_memutil.py
@@ -81,6 +81,32 @@ def estimate_fused_chunk_size(n_hap, memory_fraction=0.35):
     return chunk
 
 
+# Bytes a Garud H batch holds per (window, haplotype) pair: the two hashes
+# (16), two per-row argsort passes with their gathers (about 64 at peak),
+# and sort scratch. The measured peak is 80; 96 leaves headroom for pool
+# rounding.
+_GARUD_BYTES_PER_PAIR = 96
+
+
+def estimate_garud_window_batch(n_hap, memory_fraction=0.3):
+    """Estimate how many windows a Garud H hash-and-sort batch can hold.
+
+    Parameters
+    ----------
+    n_hap : int
+        Number of haplotypes.
+    memory_fraction : float
+        Fraction of free GPU memory to budget for the batch.
+
+    Returns
+    -------
+    int
+        Number of windows per batch, at least 1.
+    """
+    return estimate_variant_chunk_size(max(n_hap, 1), bytes_per_element=_GARUD_BYTES_PER_PAIR,
+                                       n_intermediates=1, memory_fraction=memory_fraction)
+
+
 def free_gpu_pool():
     """Release unused GPU memory back to the device."""
     cp.cuda.Stream.null.synchronize()

--- a/pg_gpu/diversity.py
+++ b/pg_gpu/diversity.py
@@ -14,6 +14,7 @@ from typing import Union, Optional, Dict, Callable
 from functools import lru_cache
 from .haplotype_matrix import HaplotypeMatrix
 from ._utils import get_population_matrix
+from ._haplotype_hash import row_hashes
 
 
 def _apply_span_normalize(value, matrix, span_normalize):
@@ -1189,12 +1190,8 @@ def haplotype_diversity(haplotype_matrix: HaplotypeMatrix,
     return float(diversity)
 
 
-_HASH_SEED = 42  # fixed so identical inputs produce identical groupings across calls
-_HASH_TOL = 1e-3  # collision-safe for float32 dot products of 0/1 vectors at our n_var
-
-
 def _count_unique_haplotypes_gpu(haplotypes):
-    """Count unique haplotypes on GPU via dot-product hashing.
+    """Count unique haplotypes on GPU via exact row hashing.
 
     Caller must guarantee the input contains no missing data (-1).
 
@@ -1203,22 +1200,19 @@ def _count_unique_haplotypes_gpu(haplotypes):
     n_unique : int
     counts : cupy.ndarray of group sizes (unsorted)
     """
-    n_haplotypes, n_var = haplotypes.shape
-    rng = cp.random.RandomState(seed=_HASH_SEED)
-    w1 = rng.standard_normal(n_var, dtype=cp.float32)
-    w2 = rng.standard_normal(n_var, dtype=cp.float32)
-    h_f32 = haplotypes.astype(cp.float32)
-    hash1 = h_f32 @ w1
-    hash2 = h_f32 @ w2
+    n_haplotypes = haplotypes.shape[0]
+    hash1, hash2 = row_hashes(haplotypes)
     order = cp.lexsort(cp.stack([hash2, hash1]))
     s1 = hash1[order]
     s2 = hash2[order]
-    diff = (cp.abs(s1[1:] - s1[:-1]) > _HASH_TOL) | (cp.abs(s2[1:] - s2[:-1]) > _HASH_TOL)
+    # Identical rows hash bit-identically, so any change in either hash
+    # starts a new group.
+    diff = (s1[1:] != s1[:-1]) | (s2[1:] != s2[:-1])
     boundaries = cp.concatenate([cp.ones(1, dtype=cp.bool_), diff])
     boundary_idx = cp.where(boundaries)[0]
     tail = cp.full(1, n_haplotypes, dtype=boundary_idx.dtype)
     counts_gpu = cp.diff(cp.concatenate([boundary_idx, tail]))
-    return boundary_idx.shape[0], counts_gpu
+    return int(boundary_idx.shape[0]), counts_gpu
 
 
 def _cluster_haplotypes_with_missing(haps):

--- a/pg_gpu/selection.py
+++ b/pg_gpu/selection.py
@@ -13,6 +13,7 @@ from typing import Union, Optional, Tuple
 from .haplotype_matrix import HaplotypeMatrix
 from ._utils import get_population_matrix as _get_population_matrix
 from ._memutil import allele_counts
+from ._haplotype_hash import garud_from_moments, garud_h_windows
 
 
 # ---------------------------------------------------------------------------
@@ -183,6 +184,12 @@ def moving_garud_h(haplotype_matrix: HaplotypeMatrix,
     h12 : ndarray, float
     h123 : ndarray, float
     h2_h1 : ndarray, float
+
+    Raises
+    ------
+    ValueError
+        If ``start`` is negative, ``stop`` exceeds the variant count, or
+        ``size`` or ``step`` is below 1.
     """
     if population is not None:
         matrix = _get_population_matrix(haplotype_matrix, population)
@@ -205,75 +212,30 @@ def moving_garud_h(haplotype_matrix: HaplotypeMatrix,
     if step is None:
         step = size
 
-    has_missing = bool(cp.any(hap < 0).get())
+    if start < 0 or stop > n_variants or size < 1 or step < 1:
+        raise ValueError(
+            f"moving_garud_h needs 0 <= start, stop <= n_variants "
+            f"({n_variants}), size >= 1 and step >= 1; got start={start}, "
+            f"stop={stop}, size={size}, step={step}")
+    starts = np.arange(start, stop - size + 1, step, dtype=np.int64)
 
-    if has_missing:
+    if bool(cp.any(hap < 0).get()):
         # Fallback: per-window wildcard matching
-        results = []
-        for w_start in range(start, stop - size + 1, step):
-            w_end = w_start + size
-            hap_window = hap[:, w_start:w_end]
-            f = _distinct_haplotype_frequencies_missing(hap_window)
-            results.append(_garud_from_freqs(f))
-        results = np.array(results, dtype='f8')
-        return results[:, 0], results[:, 1], results[:, 2], results[:, 3]
+        results = np.empty((starts.size, 4), dtype=np.float64)
+        for i, w_start in enumerate(starts):
+            f = _distinct_haplotype_frequencies_missing(hap[:, w_start:w_start + size])
+            results[i] = _garud_from_freqs(f)
+        return tuple(results.T)
 
-    # GPU fast path: precompute cumulative weighted sums on GPU,
-    # compute per-window hashes on GPU, transfer only the small hash
-    # arrays to CPU for sorting/counting.
-    # float64 for prefix-sum hashing to avoid accumulation error over long ranges
-    n_hap = hap.shape[0]
-    h_f64 = hap.astype(cp.float64)
-
-    rng = cp.random.RandomState(seed=42)
-    w1 = rng.standard_normal(n_variants, dtype=cp.float64)
-    w2 = rng.standard_normal(n_variants, dtype=cp.float64)
-
-    hw1 = h_f64 * w1[cp.newaxis, :]
-    hw2 = h_f64 * w2[cp.newaxis, :]
-
-    cs1 = cp.zeros((n_hap, n_variants + 1), dtype=cp.float64)
-    cs2 = cp.zeros((n_hap, n_variants + 1), dtype=cp.float64)
-    cp.cumsum(hw1, axis=1, out=cs1[:, 1:])
-    cp.cumsum(hw2, axis=1, out=cs2[:, 1:])
-
-    windows = list(range(start, stop - size + 1, step))
-    n_windows = len(windows)
-
-    # Compute all window hashes on GPU at once: (n_windows, n_hap)
-    w_starts = cp.array(windows, dtype=cp.int64)
-    w_ends = w_starts + size
-    # Gather prefix sums at window boundaries: (n_hap, n_windows)
-    all_hash1 = cs1[:, w_ends] - cs1[:, w_starts]  # (n_hap, n_windows)
-    all_hash2 = cs2[:, w_ends] - cs2[:, w_starts]
-
-    # Transfer to CPU: (n_hap, n_windows) * 2 * 8 bytes -- small
-    ah1 = all_hash1.get().T  # (n_windows, n_hap)
-    ah2 = all_hash2.get().T
-
-    results = np.empty((n_windows, 4), dtype='f8')
-    for wi in range(n_windows):
-        order = np.lexsort((ah2[wi], ah1[wi]))
-        s1 = ah1[wi, order]
-        s2 = ah2[wi, order]
-        diff = (np.abs(s1[1:] - s1[:-1]) > 1e-6) | (np.abs(s2[1:] - s2[:-1]) > 1e-6)
-        boundaries = np.concatenate([[True], diff])
-        boundary_idx = np.where(boundaries)[0]
-        counts = np.diff(np.concatenate([boundary_idx, [n_hap]]))
-        freqs = np.sort(counts)[::-1].astype(np.float64) / n_hap
-        results[wi] = _garud_from_freqs(freqs)
-
-    return results[:, 0], results[:, 1], results[:, 2], results[:, 3]
+    return garud_h_windows(hap, starts, starts + size)[:4]
 
 
 def _garud_from_freqs(f):
-    """Compute H1/H12/H123/H2H1 from sorted frequency array."""
-    h1 = float(np.sum(f ** 2))
-    h12 = float(np.sum(f[:2]) ** 2 + np.sum(f[2:] ** 2))
-    h123 = float(np.sum(f[:3]) ** 2 + np.sum(f[3:] ** 2))
-    h2 = h1 - float(f[0] ** 2)
-    h2_h1 = h2 / h1 if h1 > 0 else 0.0
-    return h1, h12, h123, h2_h1
+    """Compute H1/H12/H123/H2H1 from a descending-sorted frequency array."""
+    f = np.asarray(f, dtype=np.float64)
+    top = np.zeros(3)
+    top[:min(3, f.size)] = f[:3]
+    return tuple(float(x) for x in garud_from_moments(float(np.sum(f ** 2)), *top))
 
 
 def _garud_h_diploid(genotype_matrix, population=None):
@@ -747,7 +709,7 @@ def _distinct_haplotype_frequencies(hap):
 def _distinct_haplotype_frequencies_missing(hap):
     """Compute distinct haplotype frequencies treating -1 as wildcard.
 
-    Uses GPU dot-product hashing when no missing data is present,
+    Uses the exact GPU row hash when no missing data is present,
     otherwise falls back to CPU wildcard matching.
 
     Parameters

--- a/pg_gpu/windowed_analysis.py
+++ b/pg_gpu/windowed_analysis.py
@@ -17,6 +17,11 @@ from .haplotype_matrix import HaplotypeMatrix
 from . import ld_statistics
 from . import divergence
 from . import diversity
+from ._haplotype_hash import garud_h_windows
+
+# Column order of the Garud H family, as garud_h_windows returns it.
+_FUSED_GARUD_STATS = ('garud_h1', 'garud_h12', 'garud_h123', 'garud_h2h1',
+                      'haplotype_count')
 
 # Kwargs that the 'local_pca' / 'local_pca_jackknife' dispatch consumes but
 # scalar-stat paths don't accept. Filtered out before the recursive call.
@@ -1284,8 +1289,7 @@ def windowed_analysis(haplotype_matrix: HaplotypeMatrix,
     fused_single = {'pi', 'theta_w', 'tajimas_d', 'segregating_sites',
                     'singletons', 'theta_h', 'fay_wu_h', 'max_daf'}
     fused_two = {'fst', 'fst_hudson', 'fst_wc', 'dxy', 'da'}
-    fused_garud = {'garud_h1', 'garud_h12', 'garud_h123', 'garud_h2h1',
-                   'haplotype_count'}
+    fused_garud = set(_FUSED_GARUD_STATS)
     fused_selection = {'mean_nsl'}
     fused_diploshic = {'snp_dist_mean', 'snp_dist_var', 'snp_dist_min',
                        'snp_dist_max', 'mu_var', 'mu_sfs', 'mu_ld',
@@ -1328,12 +1332,15 @@ def windowed_analysis(haplotype_matrix: HaplotypeMatrix,
         pop2 = populations[1] if populations and len(populations) >= 2 else None
         population = pop1  # single-pop stats use the first population
 
-        # Choose chunked or single-shot fused based on memory
+        # Chunk the fused engine when its transposed int8 copy would not fit.
+        # A Garud-only request never builds that copy (it batches its own
+        # windows), so it runs single-shot whatever the matrix size.
         n_hap = haplotype_matrix.num_haplotypes
         n_var = haplotype_matrix.num_variants
         transpose_bytes = n_var * n_hap  # int8
         free_mem = cp.cuda.Device().mem_info[0]
-        use_chunked = transpose_bytes * 2 > free_mem * 0.7
+        use_chunked = (bool(requested - fused_garud)
+                       and transpose_bytes * 2 > free_mem * 0.7)
 
         fused_fn = (windowed_statistics_fused_chunked if use_chunked
                      else windowed_statistics_fused)
@@ -1432,14 +1439,13 @@ def _warn_fused_allele_cap(n_over):
 
 
 def _filter_fused_allele_cap_raw(hap_raw, positions, cap_source=None):
-    """Cap filter for the chunked path's un-transposed (n_hap, n_var) matrix.
+    """Cap filter for an un-transposed (n_hap, n_var) matrix.
 
     Reduces over the haplotype axis (axis 0) to get per-variant max allele
     indices without a full transpose, then slices variants (axis 1) and
     positions consistently. Drops variants whose max allele index
     >= _FUSED_MAX_ALLELES and emits a ``MultiallelicCapWarning``; missing (-1)
-    never triggers the cap. (The non-chunked single-pass path filters inline,
-    capturing the keep mask so the two-pop kernel's hap1/hap2 align.)
+    never triggers the cap.
 
     ``cap_source`` is the matrix the reduction runs over; it defaults to
     ``hap_raw`` but must be the original matrix whenever the kernels will
@@ -1800,111 +1806,6 @@ void fused_windowed_twopop(const signed char* hap1_t,
 ''', 'fused_windowed_twopop')
 
 
-# Garud's H fused kernel: one block per window, sorts haplotype hashes
-# in shared memory to count unique patterns and compute H statistics.
-_fused_garud_h_kernel = cp.RawKernel(r'''
-extern "C" __global__
-void fused_garud_h(const double* hash1,   // (n_windows, n_hap)
-                   const double* hash2,   // (n_windows, n_hap)
-                   int n_hap, int n_windows, double tol,
-                   double* out_h1, double* out_h12,
-                   double* out_h123, double* out_h2h1,
-                   double* out_n_distinct) {
-    int wid = blockIdx.x;
-    if (wid >= n_windows) return;
-    int tid = threadIdx.x;
-
-    // Load hashes into shared memory for sorting. The launcher picks
-    // blockDim.x = ceil(n_hap / 2) rounded up to a power of two so the
-    // odd-even sort has enough threads for every compare-and-swap, but
-    // that leaves blockDim.x < n_hap for many n_hap values -- a strided
-    // load is needed to cover all elements.
-    extern __shared__ double shm[];
-    double* s_h1 = shm;            // n_hap doubles
-    double* s_h2 = shm + n_hap;    // n_hap doubles
-
-    for (int i = tid; i < n_hap; i += blockDim.x) {
-        s_h1[i] = hash1[wid * n_hap + i];
-        s_h2[i] = hash2[wid * n_hap + i];
-    }
-    __syncthreads();
-
-    // Simple odd-even sort on hash1 (secondary on hash2 for ties)
-    // For n_hap <= 256 this is fast in shared memory
-    for (int phase = 0; phase < n_hap; phase++) {
-        int i = 2 * tid + (phase & 1);
-        if (i + 1 < n_hap) {
-            bool do_swap = false;
-            if (s_h1[i] > s_h1[i + 1]) {
-                do_swap = true;
-            } else if (s_h1[i] == s_h1[i + 1] && s_h2[i] > s_h2[i + 1]) {
-                do_swap = true;
-            }
-            if (do_swap) {
-                double tmp;
-                tmp = s_h1[i]; s_h1[i] = s_h1[i+1]; s_h1[i+1] = tmp;
-                tmp = s_h2[i]; s_h2[i] = s_h2[i+1]; s_h2[i+1] = tmp;
-            }
-        }
-        __syncthreads();
-    }
-
-    // Thread 0: count unique haplotypes, compute frequencies, derive H stats
-    if (tid == 0) {
-        // Count distinct haplotypes and collect top-3 frequencies
-        double inv_n = 1.0 / (double)n_hap;
-
-        // Walk sorted array, count runs
-        // We need: sum(f_i^2), and the top 3 frequencies
-        double sum_f2 = 0.0;
-        double top3[3] = {0.0, 0.0, 0.0};
-        int run_len = 1;
-        int n_distinct = 0;
-
-        for (int i = 1; i <= n_hap; i++) {
-            bool boundary = (i == n_hap);
-            if (!boundary) {
-                double d1 = s_h1[i] - s_h1[i-1];
-                double d2 = s_h2[i] - s_h2[i-1];
-                if (d1 < 0) d1 = -d1;
-                if (d2 < 0) d2 = -d2;
-                boundary = (d1 > tol) || (d2 > tol);
-            }
-            if (boundary) {
-                n_distinct++;
-                double f = (double)run_len * inv_n;
-                sum_f2 += f * f;
-                if (f > top3[0]) {
-                    top3[2] = top3[1]; top3[1] = top3[0]; top3[0] = f;
-                } else if (f > top3[1]) {
-                    top3[2] = top3[1]; top3[1] = f;
-                } else if (f > top3[2]) {
-                    top3[2] = f;
-                }
-                run_len = 1;
-            } else {
-                run_len++;
-            }
-        }
-
-        double h1_val = sum_f2;
-        double h12_val = (top3[0] + top3[1]) * (top3[0] + top3[1])
-                       + (sum_f2 - top3[0]*top3[0] - top3[1]*top3[1]);
-        double h123_val = (top3[0] + top3[1] + top3[2]) * (top3[0] + top3[1] + top3[2])
-                        + (sum_f2 - top3[0]*top3[0] - top3[1]*top3[1] - top3[2]*top3[2]);
-        double h2_val = h1_val - top3[0] * top3[0];
-        double h2h1_val = (h1_val > 0.0) ? h2_val / h1_val : 0.0;
-
-        out_h1[wid]   = h1_val;
-        out_h12[wid]  = h12_val;
-        out_h123[wid] = h123_val;
-        out_h2h1[wid] = h2h1_val;
-        out_n_distinct[wid] = (double)n_distinct;
-    }
-}
-''', 'fused_garud_h')
-
-
 def _compute_window_ranges(positions, bp_bins):
     """Map window edges to variant index ranges using searchsorted.
 
@@ -1978,8 +1879,6 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
 
     hap_raw = matrix.haplotypes
     n_hap = hap_raw.shape[0]
-    # transpose for coalesced kernel access: (n_total_var, n_hap)
-    hap = cp.ascontiguousarray(hap_raw.T.astype(cp.int8))
 
     positions = matrix.positions
     if not isinstance(positions, cp.ndarray):
@@ -1987,30 +1886,22 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
 
     # Drop sites the fused kernel's per-allele capacity can't represent (rare;
     # nucleotide data has <= 4 alleles). Must precede window indexing so the
-    # variant-index ranges are computed against the retained sites. Capture the
-    # keep mask so the two-pop path can slice hap1/hap2 to the same variants
-    # (positions/window indices are computed against the filtered set below).
-    # When two-population statistics are requested the kernel reads pop1 and
-    # pop2 rows of the original matrix, which the single-population subset
-    # need not cover, so the reduction runs over the original.
-    if any(s in ('fst', 'fst_hudson', 'fst_wc', 'dxy', 'da')
-           for s in statistics):
-        cap_src = haplotype_matrix.haplotypes
-        cap_keep = (cap_src.max(axis=0) < _FUSED_MAX_ALLELES
-                    if cap_src.shape[1] else None)
-    else:
-        cap_keep = hap.max(axis=1) < _FUSED_MAX_ALLELES if hap.shape[0] else None
-    if cap_keep is not None and not bool(cap_keep.all()):
-        _warn_fused_allele_cap(int((~cap_keep).sum()))
-        hap = hap[cap_keep]
-        positions = positions[cap_keep]
+    # variant-index ranges are computed against the retained sites. The kept
+    # indices let the two-pop path slice hap1/hap2 to the same variants. When
+    # two-population statistics are requested the kernel reads pop1 and pop2
+    # rows of the original matrix, which the single-population subset need
+    # not cover, so the reduction runs over the original.
+    two_pop_requested = any(s in ('fst', 'fst_hudson', 'fst_wc', 'dxy', 'da')
+                            for s in statistics)
+    hap_raw, positions, cap_keep = _filter_fused_allele_cap_raw(
+        hap_raw, positions,
+        cap_source=haplotype_matrix.haplotypes if two_pop_requested else None)
+    if cap_keep is not None:
         # Everything below that slices by variant-index ranges or counts
         # per site (Garud, per-window LD, the per-site scatter stats) must
         # see the same variant set the kernel arrays hold.
-        matrix = matrix.get_subset(cp.where(cap_keep)[0])
-    else:
-        cap_keep = None
-    n_total_var = hap.shape[0]
+        matrix = matrix.get_subset(cap_keep)
+    n_total_var = hap_raw.shape[1]
 
     # Support overlapping windows via explicit start/stop arrays
     if _win_starts is not None and _win_stops is not None:
@@ -2044,6 +1935,10 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
                         'singletons', 'theta_h', 'fay_wu_h', 'max_daf'}
     single_pop_requested = any(s in statistics for s in single_pop_stats)
     if single_pop_requested:
+        # Only this kernel needs the transposed (n_total_var, n_hap) int8
+        # copy for coalesced access; Garud-only and scatter-only requests
+        # skip the extra matrix-sized allocation.
+        hap = cp.ascontiguousarray(hap_raw.T, dtype=cp.int8)
         out_mpd = cp.zeros(n_windows, dtype=cp.float64)
         out_seg = cp.zeros(n_windows, dtype=cp.float64)
         out_sing = cp.zeros(n_windows, dtype=cp.float64)
@@ -2066,6 +1961,9 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
         var_count = out_count.get()
         theta_h_sum = out_theta_h.get()
         max_daf = out_max_daf.get()
+        # The later stages read the un-transposed matrix; release the copy
+        # so their batches can use the memory.
+        del hap
 
         results['n_variants'] = var_count.astype(int)
 
@@ -2214,18 +2112,9 @@ def windowed_statistics_fused(haplotype_matrix: HaplotypeMatrix,
             else:
                 results['da'] = da_sum.get()
 
-    # Garud's H via fused kernel (SNP windows using prefix-sum hashing)
-    garud_stats = {'garud_h1', 'garud_h12', 'garud_h123', 'garud_h2h1',
-                   'haplotype_count'}
-    garud_requested = any(s in statistics for s in garud_stats)
-    if garud_requested:
-        # `matrix` is already population-subsetted above (line 1722); pass
-        # population=None to avoid a double lookup that would fail because
-        # the subsetted matrix has sample_sets={'all': ...}, not the original
-        # population names.
-        _compute_fused_garud_h(matrix, None,
-                               win_start, win_stop, n_windows, statistics,
-                               results)
+    # Garud's H: exact per-window haplotype hashing, batched to GPU memory
+    if any(s in statistics for s in _FUSED_GARUD_STATS):
+        _compute_fused_garud_h(matrix, win_start, win_stop, statistics, results)
 
     # Per-site stats binned into windows via scatter_add. A variant belongs
     # to window w iff ws[w] <= pos < we[w] -- the same right-open rule
@@ -2801,8 +2690,7 @@ def windowed_statistics_fused_chunked(haplotype_matrix: HaplotypeMatrix,
     # Delegate Garud H / scatter-add stats / per-window LD to the
     # non-chunked function (they already handle large data or operate
     # per-window).
-    garud_stats = {'garud_h1', 'garud_h12', 'garud_h123', 'garud_h2h1',
-                   'haplotype_count'}
+    garud_stats = set(_FUSED_GARUD_STATS)
     scatter_stats = {*_PER_SITE_SCATTER_STATS, 'snp_dist_mean',
                      'snp_dist_var', 'snp_dist_min', 'snp_dist_max',
                      'mu_var', 'zns', 'omega', 'mu_ld', 'dist_var',
@@ -2825,41 +2713,6 @@ def windowed_statistics_fused_chunked(haplotype_matrix: HaplotypeMatrix,
     return results
 
 
-def _position_weights(positions, salt):
-    """Position-deterministic float64 weights for the Garud H hash basis.
-
-    Splitmix64-scrambles each absolute variant position to a weight in
-    ``[-1, 1)``. The weight is a pure function of the position and the
-    salt, which is what lets the Garud H kernel produce the same per-
-    window hash whether the surrounding window was computed in one
-    eager pass or split across two streaming chunks; an n_variants-
-    seeded RNG would assign a different weight to the same variant
-    every time the matrix shape changed.
-
-    Two salts produce two independent weight columns w1, w2; together
-    they make collisions between distinct haplotype patterns vanishingly
-    rare without changing the Garud H computation downstream.
-
-    The output is uniform in [-1, 1) rather than standard-normal -- the
-    kernel only uses the weights to discriminate haplotype patterns by
-    sorted hash, not to inherit any specific distribution.
-    """
-    s = cp.uint64(salt & 0xFFFFFFFFFFFFFFFF)
-    x = positions.astype(cp.uint64) + s
-    x = (x ^ (x >> cp.uint64(30))) * cp.uint64(0xBF58476D1CE4E5B9)
-    x = (x ^ (x >> cp.uint64(27))) * cp.uint64(0x94D049BB133111EB)
-    x = x ^ (x >> cp.uint64(31))
-    # Mantissa-pack the low 52 bits as a float64 in [1, 2); subtract 1 to
-    # get [0, 1); rescale to [-1, 1).
-    mant = (x & cp.uint64(0x000FFFFFFFFFFFFF)) | cp.uint64(0x3FF0000000000000)
-    u = mant.view(cp.float64) - 1.0
-    return 2.0 * u - 1.0
-
-
-_GARUD_SALT1 = 0x9E3779B97F4A7C15   # golden-ratio constant
-_GARUD_SALT2 = 0xC6BC279692B5C323   # phi^-2-based companion
-
-
 def _windowed_mean(values, bin_idx, valid_mask, n_bins):
     """Compute mean of values per window bin, returning NaN for empty bins."""
     val_sum = _scatter_sum(values[valid_mask], bin_idx[valid_mask], n_bins)
@@ -2869,266 +2722,15 @@ def _windowed_mean(values, bin_idx, valid_mask, n_bins):
     return np.where(count_cpu > 0, sum_cpu / count_cpu, np.nan)
 
 
-def _compute_fused_garud_h(haplotype_matrix, population,
-                            win_start, win_stop, n_windows, statistics,
-                            results):
-    """Compute windowed Garud's H + fused GPU kernel.
+def _compute_fused_garud_h(matrix, win_start, win_stop, statistics, results):
+    """Windowed Garud's H and distinct-haplotype count into ``results``.
 
-    Two assembly paths build the per-window haplotype hashes:
-
-    * Tile windows (``win_stop[k] == win_start[k+1]`` for all k) use
-      a per-window scatter-reduce via ``cp.add.reduceat``. Each
-      window's hash is summed from its own variants in index order,
-      so eager and streaming produce bit-identical results and the
-      kernel can use an exact-equality tolerance to bucket haplotypes.
-    * Sliding windows (overlap > 0) still use the prefix-sum trick,
-      which carries the well-known ULP-scale drift the kernel's
-      legacy ``tol=1e-3`` absorbs.
+    A window with no variants reports one haplotype.
     """
-    from ._utils import get_population_matrix
-
-    if population is not None:
-        matrix = get_population_matrix(haplotype_matrix, population)
-    else:
-        matrix = haplotype_matrix
-    if matrix.device == 'CPU':
-        matrix.transfer_to_gpu()
-
-    hap = matrix.haplotypes  # (n_hap, n_var)
-    n_hap, n_var = hap.shape
-    pos = matrix.positions
-    if not isinstance(pos, cp.ndarray):
-        pos = cp.asarray(pos)
-
-    # Tile detection. Both win_start and win_stop arrive as either
-    # numpy or cupy arrays; check on the host so the comparison is
-    # cheap and synchronous.
-    ws = win_start.get() if isinstance(win_start, cp.ndarray) else np.asarray(win_start)
-    we = win_stop.get() if isinstance(win_stop, cp.ndarray) else np.asarray(win_stop)
-    is_tile = (n_windows == 0) or bool(np.all(we[:-1] == ws[1:]))
-
-    if is_tile:
-        _garud_h_per_window_reduceat(hap, pos, win_start, win_stop,
-                                      n_hap, n_windows, statistics,
-                                      results)
-        return
-
-    # Sliding path: keep the existing prefix-sum implementation. Memory
-    # check sized for 4 (n_hap, span+1) float64 arrays (hw1, hw2,
-    # cs1, cs2); fall back to per-group chunking if a full single-pass
-    # buffer would not fit.
-    free_mem = cp.cuda.Device().mem_info[0]
-    prefix_budget = int(free_mem * 0.3)
-    cost_per_var = n_hap * 8 * 4
-    max_span = max(1, prefix_budget // cost_per_var)
-
-    if n_var <= max_span:
-        _garud_h_single_pass(hap, pos, n_hap, n_var, win_start, win_stop,
-                             n_windows, statistics, results)
-    else:
-        _garud_h_chunked(hap, pos, n_hap, n_var, win_start, win_stop,
-                         n_windows, max_span, statistics, results)
-
-
-def _garud_h_per_window_reduceat(hap, pos, win_start, win_stop, n_hap,
-                                   n_windows, statistics, results):
-    """Garud H assembling each window's hash by per-window scatter-reduce.
-
-    Cost is O(n_hap * n_var) -- the same as the prefix-sum approach --
-    but each window's hash is summed from its own variants in index
-    order, so two chunkings covering the same window produce
-    bit-identical results. With deterministic hashes the kernel can
-    bucket haplotypes by a much tighter tolerance (1e-12) than the
-    prefix-sum path's 1e-3, which means the count of distinct
-    haplotypes matches the hand-rolled reference exactly.
-
-    Requires non-overlapping tile windows so each variant is in at
-    most one window; the caller dispatches sliding windows to the
-    prefix-sum path.
-    """
-    if n_windows == 0:
-        return
-    w1 = _position_weights(pos, _GARUD_SALT1)
-    w2 = _position_weights(pos, _GARUD_SALT2)
-
-    # Slice to the variant range covered by any window. Anything left
-    # of win_start[0] and right of win_stop[-1] is not in any window
-    # and should not contribute.
-    if isinstance(win_start, cp.ndarray):
-        ws = win_start.get()
-        we = win_stop.get()
-    else:
-        ws = np.asarray(win_start)
-        we = np.asarray(win_stop)
-    v_lo = int(ws[0])
-    v_hi = int(we[-1])
-
-    hap_slice = hap[:, v_lo:v_hi].astype(cp.float64)
-    hw1 = hap_slice * w1[v_lo:v_hi][cp.newaxis, :]
-    hw2 = hap_slice * w2[v_lo:v_hi][cp.newaxis, :]
-
-    # cp.add.reduceat: bin k sums positions ws[k]-v_lo .. ws[k+1]-v_lo
-    # (exclusive), and the final bin runs to the end of the sliced
-    # array, which equals we[-1]-v_lo for tile windows.
-    rel = (ws - v_lo).astype(np.int64)
-    h1 = cp.add.reduceat(hw1, rel, axis=1)   # (n_hap, n_windows)
-    h2 = cp.add.reduceat(hw2, rel, axis=1)
-
-    all_h1 = cp.ascontiguousarray(h1.T)      # kernel wants (n_windows, n_hap)
-    all_h2 = cp.ascontiguousarray(h2.T)
-
-    _launch_garud_kernel(all_h1, all_h2, n_hap, n_windows, statistics,
-                          results, tol=1e-12)
-
-
-def _garud_h_single_pass(hap, pos, n_hap, n_var, win_start, win_stop,
-                          n_windows, statistics, results):
-    """Garud H via full prefix-sum hashing (fits in memory)."""
-    h_f64 = hap.astype(cp.float64)
-    w1 = _position_weights(pos, _GARUD_SALT1)
-    w2 = _position_weights(pos, _GARUD_SALT2)
-
-    hw1 = h_f64 * w1[cp.newaxis, :]
-    hw2 = h_f64 * w2[cp.newaxis, :]
-    cs1 = cp.zeros((n_hap, n_var + 1), dtype=cp.float64)
-    cs2 = cp.zeros((n_hap, n_var + 1), dtype=cp.float64)
-    cp.cumsum(hw1, axis=1, out=cs1[:, 1:])
-    cp.cumsum(hw2, axis=1, out=cs2[:, 1:])
-
-    all_h1 = (cs1[:, win_stop] - cs1[:, win_start]).T
-    all_h2 = (cs2[:, win_stop] - cs2[:, win_start]).T
-    all_h1 = cp.ascontiguousarray(all_h1)
-    all_h2 = cp.ascontiguousarray(all_h2)
-
-    _launch_garud_kernel(all_h1, all_h2, n_hap, n_windows, statistics,
-                          results, tol=1e-3)
-
-
-def _garud_h_chunked(hap, pos, n_hap, n_var, win_start, win_stop,
-                      n_windows, max_span, statistics, results):
-    """Garud H processing windows in groups to limit memory."""
-    from ._memutil import free_gpu_pool
-
-    out_h1 = np.empty(n_windows, dtype=np.float64)
-    out_h12 = np.empty(n_windows, dtype=np.float64)
-    out_h123 = np.empty(n_windows, dtype=np.float64)
-    out_h2h1 = np.empty(n_windows, dtype=np.float64)
-    out_n_distinct = np.empty(n_windows, dtype=np.float64)
-
-    ws_cpu = win_start.get()
-    we_cpu = win_stop.get()
-
-    # Group windows by overlapping variant spans
-    processed = np.zeros(n_windows, dtype=bool)
-    wi = 0
-    while wi < n_windows:
-        # Find a group of consecutive windows that fit in max_span
-        group_var_start = int(ws_cpu[wi])
-        group_var_end = int(we_cpu[wi])
-        group_end = wi + 1
-        while group_end < n_windows:
-            candidate_end = int(we_cpu[group_end])
-            if candidate_end - group_var_start > max_span:
-                break
-            group_var_end = candidate_end
-            group_end += 1
-
-        span = group_var_end - group_var_start
-        n_group = group_end - wi
-
-        # Compute prefix sums over just this variant span. Weights are
-        # derived from absolute variant positions so the per-span basis
-        # matches the equivalent full-matrix span -- different chunkings
-        # produce identical Garud H values on the same window.
-        hap_span = hap[:, group_var_start:group_var_end].astype(cp.float64)
-        pos_span = pos[group_var_start:group_var_end]
-        w1 = _position_weights(pos_span, _GARUD_SALT1)
-        w2 = _position_weights(pos_span, _GARUD_SALT2)
-
-        hw1 = hap_span * w1[cp.newaxis, :]
-        hw2 = hap_span * w2[cp.newaxis, :]
-        cs1 = cp.zeros((n_hap, span + 1), dtype=cp.float64)
-        cs2 = cp.zeros((n_hap, span + 1), dtype=cp.float64)
-        cp.cumsum(hw1, axis=1, out=cs1[:, 1:])
-        cp.cumsum(hw2, axis=1, out=cs2[:, 1:])
-
-        # Local window indices relative to span start
-        local_ws = cp.asarray(ws_cpu[wi:group_end] - group_var_start)
-        local_we = cp.asarray(we_cpu[wi:group_end] - group_var_start)
-
-        all_h1 = (cs1[:, local_we] - cs1[:, local_ws]).T
-        all_h2 = (cs2[:, local_we] - cs2[:, local_ws]).T
-        all_h1 = cp.ascontiguousarray(all_h1)
-        all_h2 = cp.ascontiguousarray(all_h2)
-
-        # Launch kernel for this group
-        grp_results = {}
-        _launch_garud_kernel(all_h1, all_h2, n_hap, n_group,
-                             statistics, grp_results, tol=1e-3)
-
-        # Store group results
-        for stat_name, out_arr in [('garud_h1', out_h1), ('garud_h12', out_h12),
-                                    ('garud_h123', out_h123), ('garud_h2h1', out_h2h1),
-                                    ('haplotype_count', out_n_distinct)]:
-            if stat_name in grp_results:
-                out_arr[wi:group_end] = grp_results[stat_name]
-
-        del hap_span, hw1, hw2, cs1, cs2, all_h1, all_h2
-        free_gpu_pool()
-        wi = group_end
-
-    if 'garud_h1' in statistics:
-        results['garud_h1'] = out_h1
-    if 'garud_h12' in statistics:
-        results['garud_h12'] = out_h12
-    if 'garud_h123' in statistics:
-        results['garud_h123'] = out_h123
-    if 'garud_h2h1' in statistics:
-        results['garud_h2h1'] = out_h2h1
-    if 'haplotype_count' in statistics:
-        results['haplotype_count'] = out_n_distinct.astype(int)
-
-
-def _launch_garud_kernel(all_h1, all_h2, n_hap, n_windows, statistics,
-                          results, *, tol):
-    """Launch the Garud H GPU kernel and store results.
-
-    ``tol`` is the float64 distance below which two sorted hashes are
-    treated as the same haplotype. The per-window scatter-reduce
-    hashing path passes a much tighter tolerance (1e-12) than the
-    prefix-sum path (1e-3) because its hashes are bit-identical for
-    equal haplotypes and far apart for distinct ones; the looser
-    legacy value still absorbs the ULP-scale drift the cumsum-then-
-    subtract trick introduces.
-    """
-    out_h1 = cp.empty(n_windows, dtype=cp.float64)
-    out_h12 = cp.empty(n_windows, dtype=cp.float64)
-    out_h123 = cp.empty(n_windows, dtype=cp.float64)
-    out_h2h1 = cp.empty(n_windows, dtype=cp.float64)
-    out_n_distinct = cp.empty(n_windows, dtype=cp.float64)
-
-    block = max(1, (n_hap + 1) // 2)
-    block = 1 << (block - 1).bit_length()
-    block = min(block, 1024)
-    shm_size = 2 * n_hap * 8
-
-    _fused_garud_h_kernel(
-        (n_windows,), (block,),
-        (all_h1, all_h2, np.int32(n_hap), np.int32(n_windows),
-         np.float64(tol),
-         out_h1, out_h12, out_h123, out_h2h1, out_n_distinct),
-        shared_mem=shm_size)
-
-    if 'garud_h1' in statistics:
-        results['garud_h1'] = out_h1.get()
-    if 'garud_h12' in statistics:
-        results['garud_h12'] = out_h12.get()
-    if 'garud_h123' in statistics:
-        results['garud_h123'] = out_h123.get()
-    if 'garud_h2h1' in statistics:
-        results['garud_h2h1'] = out_h2h1.get()
-    if 'haplotype_count' in statistics:
-        results['haplotype_count'] = out_n_distinct.get().astype(int)
+    values = garud_h_windows(matrix.haplotypes, win_start, win_stop)
+    for name, column in zip(_FUSED_GARUD_STATS, values):
+        if name in statistics:
+            results[name] = column.astype(int) if name == 'haplotype_count' else column
 
 
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,3 +206,24 @@ def canonical_hap_rows(call_genotype):
     haps[:, 0::2] = call_genotype[:, :, 0]
     haps[:, 1::2] = call_genotype[:, :, 1]
     return haps.T
+
+
+def founder_haplotypes(rng, n_hap, n_var, n_founders):
+    """``(n_hap, n_var)`` int8 rows drawn with replacement from random founders.
+
+    Founder alleles come from raw random bytes: ``Generator.integers`` slows
+    to microseconds per value on arrays this large.
+    """
+    raw = np.frombuffer(rng.bytes(n_founders * n_var), dtype=np.uint8)
+    founders = (raw & 1).astype(np.int8).reshape(n_founders, n_var)
+    return founders[rng.integers(0, n_founders, size=n_hap)]
+
+
+def garud_reference(hap):
+    """Garud H1, H12, H123, H2/H1 and the distinct count from exact unique rows."""
+    _, counts = np.unique(hap, axis=0, return_counts=True)
+    f = np.sort(counts)[::-1] / hap.shape[0]
+    h1 = np.sum(f ** 2)
+    return (h1, np.sum(f[:2]) ** 2 + np.sum(f[2:] ** 2),
+            np.sum(f[:3]) ** 2 + np.sum(f[3:] ** 2), (h1 - f[0] ** 2) / h1,
+            len(counts))

--- a/tests/test_diploshic_stats.py
+++ b/tests/test_diploshic_stats.py
@@ -9,6 +9,8 @@ import cupy as cp
 from pg_gpu import HaplotypeMatrix, GenotypeMatrix
 from pg_gpu import ld_statistics, diversity, selection, distance_stats
 
+from .conftest import founder_haplotypes
+
 
 @pytest.fixture
 def hap_data():
@@ -311,7 +313,7 @@ class TestDiversityNewStats:
         assert diversity.haplotype_count(matrix) == 1
 
     def test_haplotype_count_gpu_matches_naive(self):
-        """GPU dot-product hashing must match exact unique-row count on clean data."""
+        """GPU row hashing must match the exact unique-row count on clean data."""
         rng = np.random.default_rng(0)
         n_hap, n_var = 60, 2000
         # 8 distinct founders, replicated with low mutation -> many ties
@@ -323,6 +325,16 @@ class TestDiversityNewStats:
         gpu_count = diversity.haplotype_count(matrix)
         naive = len({h.tobytes() for h in hap})
         assert gpu_count == naive
+
+    def test_haplotype_count_gpu_matches_naive_many_haplotypes(self):
+        """Exact counts with thousands of haplotypes and rows hashed in segments."""
+        rng = np.random.default_rng(1)
+        n_hap, n_var = 3000, 70_000
+        hap = founder_haplotypes(rng, n_hap, n_var, 40)
+        # a few thousand scattered private mutations
+        hap.flat[rng.integers(0, hap.size, size=2000)] ^= 1
+        matrix = HaplotypeMatrix(hap, np.arange(n_var) * 100, 0, n_var * 100)
+        assert diversity.haplotype_count(matrix) == len({h.tobytes() for h in hap})
 
     def test_haplotype_count_with_missing_data(self):
         n_var = 50

--- a/tests/test_haplotype_hash.py
+++ b/tests/test_haplotype_hash.py
@@ -1,0 +1,124 @@
+"""Unit tests for the haplotype hashing kernels behind Garud's H and haplotype counts."""
+import cupy as cp
+import numpy as np
+import pytest
+
+from pg_gpu._haplotype_hash import (
+    garud_h_windows, garud_walk, hash_weights, row_hashes, sort_window_hashes,
+    window_hashes,
+)
+
+from .conftest import founder_haplotypes, garud_reference
+
+
+def _walk(hap_cpu):
+    n_var = hap_cpu.shape[1]
+    h1, h2 = window_hashes(cp.asarray(hap_cpu), *hash_weights(n_var), [0], [n_var])
+    return [float(s[0]) for s in garud_walk(*sort_window_hashes(h1, h2))]
+
+
+def test_empty_window_hashes_to_zero():
+    rng = np.random.default_rng(0)
+    hap = cp.asarray(rng.integers(0, 2, size=(6, 20), dtype=np.int8))
+    h1, h2 = window_hashes(hap, *hash_weights(20), [0, 5, 20, 3, 4], [0, 5, 20, 3, 12])
+    assert h1.shape == (5, 6)
+    np.testing.assert_array_equal(h1[:4].get(), 0.0)
+    np.testing.assert_array_equal(h2[:4].get(), 0.0)
+    assert np.all(h1[4].get() != 0.0)
+
+
+def test_hashes_match_numpy_sum():
+    rng = np.random.default_rng(1)
+    hap_cpu = rng.integers(-1, 3, size=(7, 300), dtype=np.int8)
+    w1, w2 = hash_weights(300)
+    h1, h2 = window_hashes(cp.asarray(hap_cpu), w1, w2, [0, 100], [100, 300])
+    for k, (lo, hi) in enumerate([(0, 100), (100, 300)]):
+        ref1 = hap_cpu[:, lo:hi].astype(np.float64) @ w1.get()[lo:hi]
+        ref2 = hap_cpu[:, lo:hi].astype(np.float64) @ w2.get()[lo:hi]
+        np.testing.assert_allclose(h1[k].get(), ref1, rtol=1e-12, atol=1e-12)
+        np.testing.assert_allclose(h2[k].get(), ref2, rtol=1e-12, atol=1e-12)
+
+
+def test_layouts_and_dtypes_bit_identical():
+    rng = np.random.default_rng(2)
+    base = cp.asarray(rng.integers(0, 2, size=(9, 500), dtype=np.int8))
+    w1, w2 = hash_weights(500)
+    ws, we = [0, 250, 100], [250, 500, 400]
+    ref1, ref2 = window_hashes(base, w1, w2, ws, we)
+    variants = [
+        cp.asfortranarray(base.astype(cp.int32)),           # from_ts layout
+        cp.asfortranarray(base),                            # from_vcf layout
+        base.astype(cp.int64),
+        cp.ascontiguousarray(base.T).T,                     # transposed-copy view
+    ]
+    for v in variants:
+        h1, h2 = window_hashes(v, w1, w2, ws, we)
+        np.testing.assert_array_equal(h1.get(), ref1.get())
+        np.testing.assert_array_equal(h2.get(), ref2.get())
+    # A column-strided view hashes like its contiguous copy.
+    strided = base[:, ::2]
+    n = strided.shape[1]
+    a1, a2 = window_hashes(strided, *hash_weights(n), [0], [n])
+    b1, b2 = window_hashes(cp.ascontiguousarray(strided), *hash_weights(n), [0], [n])
+    np.testing.assert_array_equal(a1.get(), b1.get())
+    np.testing.assert_array_equal(a2.get(), b2.get())
+
+
+def test_window_ranges_outside_matrix_raise():
+    hap = cp.zeros((3, 10), dtype=cp.int8)
+    w1, w2 = hash_weights(10)
+    with pytest.raises(ValueError):
+        window_hashes(hap, w1, w2, [-1], [5])
+    with pytest.raises(ValueError):
+        window_hashes(hap, w1, w2, [0], [11])
+
+
+def test_short_rows_hash_like_a_single_window():
+    rng = np.random.default_rng(3)
+    hap = cp.asarray(rng.integers(0, 2, size=(8, 1000), dtype=np.int8))
+    h1, h2 = window_hashes(hap, *hash_weights(1000), [0], [1000])
+    r1, r2 = row_hashes(hap)
+    np.testing.assert_array_equal(h1[0].get(), r1.get())
+    np.testing.assert_array_equal(h2[0].get(), r2.get())
+
+
+def test_row_hashes_segments_keep_identical_rows_identical():
+    rng = np.random.default_rng(4)
+    n_var = 150_000                     # spans three row segments
+    hap_cpu = founder_haplotypes(rng, 12, n_var, 3)
+    r1, r2 = row_hashes(cp.asarray(hap_cpu))
+    _, key_labels = np.unique(np.stack([r1.get(), r2.get()], axis=1), axis=0,
+                              return_inverse=True)
+    _, row_labels = np.unique(hap_cpu, axis=0, return_inverse=True)
+    np.testing.assert_array_equal(key_labels[:, None] == key_labels[None, :],
+                                  row_labels[:, None] == row_labels[None, :])
+
+
+@pytest.mark.parametrize("hap_cpu,expected", [
+    (np.zeros((10, 5), dtype=np.int8), (1.0, 1.0, 1.0, 0.0, 1)),
+    (np.eye(4, dtype=np.int8), (0.25, 6 / 16, 10 / 16, 0.75, 4)),
+    (np.array([[0, 0, 0], [0, 0, 0], [1, 1, 1], [1, 1, 1]], dtype=np.int8),
+     (0.5, 1.0, 1.0, 0.5, 2)),
+])
+def test_walk_closed_forms(hap_cpu, expected):
+    np.testing.assert_allclose(_walk(hap_cpu), expected, rtol=1e-12)
+
+
+def test_walk_matches_reference_past_shared_memory_limits():
+    rng = np.random.default_rng(5)
+    hap_cpu = founder_haplotypes(rng, 5000, 64, 50)
+    np.testing.assert_allclose(_walk(hap_cpu), garud_reference(hap_cpu), rtol=1e-12)
+
+
+def test_garud_h_windows_no_windows():
+    hap = cp.zeros((4, 10), dtype=cp.int8)
+    out = garud_h_windows(hap, [], [])
+    assert len(out) == 5
+    assert all(o.shape == (0,) for o in out)
+
+
+def test_garud_h_windows_no_variants():
+    hap = cp.zeros((5, 0), dtype=cp.int8)
+    out = garud_h_windows(hap, [0, 0], [0, 0])
+    for o, expected in zip(out, (1.0, 1.0, 1.0, 0.0, 1.0)):
+        np.testing.assert_array_equal(o, expected)

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -88,6 +88,20 @@ class TestMovingGarudH:
         assert np.all(h1 >= 0) and np.all(h1 <= 1)
         assert np.all(h12 >= h1)
 
+    def test_moving_garud_h_no_windows(self):
+        hap = np.random.default_rng(0).integers(0, 2, (10, 30), dtype=np.int8)
+        matrix = HaplotypeMatrix(hap, np.arange(30) * 100, 0, 3000)
+        out = selection.moving_garud_h(matrix, size=50)
+        assert len(out) == 4
+        assert all(o.shape == (0,) for o in out)
+
+    @pytest.mark.parametrize("kwargs", [dict(stop=40), dict(start=-1), dict(step=0)])
+    def test_moving_garud_h_rejects_bad_windows(self, kwargs):
+        hap = np.random.default_rng(0).integers(0, 2, (10, 30), dtype=np.int8)
+        matrix = HaplotypeMatrix(hap, np.arange(30) * 100, 0, 3000)
+        with pytest.raises(ValueError):
+            selection.moving_garud_h(matrix, size=10, **kwargs)
+
 
 class TestEHHDecay:
     """Test EHH decay computation."""

--- a/tests/test_selection_allel_comparison.py
+++ b/tests/test_selection_allel_comparison.py
@@ -10,6 +10,8 @@ import numpy as np
 import allel
 from pg_gpu import HaplotypeMatrix, selection
 
+from .conftest import founder_haplotypes
+
 
 @pytest.fixture
 def simulated_data():
@@ -244,6 +246,17 @@ class TestGarudHComparison:
                 f"H123: pg={h123_p}, allel={h123_a}"
             assert np.isclose(h2h1_p, h2h1_a, rtol=1e-10), \
                 f"H2/H1: pg={h2h1_p}, allel={h2h1_a}"
+
+    @pytest.mark.parametrize("n_hap,step", [(40, None), (40, 7), (2200, 7)])
+    def test_moving_garud_h_correspondence(self, n_hap, step):
+        n_var = 200
+        hap = founder_haplotypes(np.random.default_rng(5), n_hap, n_var, 25)
+        expected = allel.moving_garud_h(hap.T, 20, step=step)
+
+        matrix = HaplotypeMatrix(hap, np.arange(n_var) * 1000, 0, n_var * 1000)
+        got = selection.moving_garud_h(matrix, size=20, step=step)
+        for name, e, g in zip(("H1", "H12", "H123", "H2/H1"), expected, got):
+            np.testing.assert_allclose(g, e, rtol=1e-10, err_msg=name)
 
 
 class TestStandardizeComparison:

--- a/tests/test_windowed_ld_garud_coverage.py
+++ b/tests/test_windowed_ld_garud_coverage.py
@@ -8,15 +8,16 @@ Two oracle strategies, both non-tautological:
   `selection.garud_h`, `divergence.fst_hudson/dxy`, `_compute_mean_r2`). This
   pins the fused windowed engine against the independently-tested scalar path.
 
-* Multiple windows for Garud H. Non-overlapping windows drive the tile /
-  reduceat assembly; overlapping windows drive the sliding prefix-sum path.
-  Each window's H is compared to `selection.garud_h` on the bp-sliced
-  submatrix, exercising both per-window assembly routes.
+* Multiple windows for Garud H. Non-overlapping and overlapping grids both
+  hash each window from its own variants. Each window's H is compared to
+  `selection.garud_h` on the bp-sliced submatrix, and a window with no
+  variants must report a single haplotype.
 """
 import cupy as cp
 import numpy as np
 import pytest
 
+import pg_gpu._memutil as _memutil
 from pg_gpu import (
     HaplotypeMatrix, distance_stats, divergence, ld_statistics, selection,
 )
@@ -24,7 +25,7 @@ from pg_gpu.windowed_analysis import (
     WindowedAnalyzer, _compute_mean_r2, windowed_analysis,
 )
 
-from .conftest import simulate_hm
+from .conftest import founder_haplotypes, garud_reference, simulate_hm
 
 # The fused windowed engine drops multiallelic sites (as does every scalar
 # estimator here), so the oracle equalities hold; silence the notice.
@@ -51,11 +52,6 @@ def hm_twopop():
     return m
 
 
-def _positions(m):
-    pos = m.positions
-    return pos.get() if hasattr(pos, "get") else np.asarray(pos)
-
-
 def _single(m, statistics, **kwargs):
     """The one row of a single whole-matrix window."""
     df = windowed_analysis(m, window_size=_WHOLE, step_size=_WHOLE,
@@ -65,11 +61,8 @@ def _single(m, statistics, **kwargs):
 
 
 def _garud_ref(m, start, end):
-    """`selection.garud_h` on the variants a bp window covers."""
-    pos = _positions(m)
-    mask = (pos >= start) & (pos < end)
-    sub = HaplotypeMatrix(m.haplotypes[:, cp.asarray(mask)], pos[mask])
-    return selection.garud_h(sub)
+    """`selection.garud_h` on the variants a right-open bp window covers."""
+    return selection.garud_h(m.get_subset_from_range(int(start), int(end)))
 
 
 # ── whole-matrix window == scalar LD estimators ────────────────────────
@@ -135,10 +128,10 @@ def test_windowed_two_pop_fst_dxy_match_scalar(hm_twopop):
         rtol=1e-9, atol=1e-12)
 
 
-# ── multi-window Garud H: tile (reduceat) and sliding (prefix-sum) ──────
+# ── multi-window Garud H: tile and sliding grids ────────────────────────
 @pytest.mark.parametrize("window,step", [
-    (10_000, 10_000),   # non-overlapping -> tile / reduceat assembly
-    (10_000, 5_000),    # overlapping     -> sliding prefix-sum assembly
+    (10_000, 10_000),   # non-overlapping
+    (10_000, 5_000),    # overlapping
 ], ids=["tile", "sliding"])
 def test_garud_multiwindow_matches_per_window_scalar(hm, window, step):
     df = windowed_analysis(hm, window_size=window, step_size=step,
@@ -146,8 +139,6 @@ def test_garud_multiwindow_matches_per_window_scalar(hm, window, step):
     assert len(df) > 1
     compared = 0
     for _, row in df.iterrows():
-        if row["n_variants"] == 0:
-            continue
         ref = _garud_ref(hm, row["start"], row["end"])
         np.testing.assert_allclose([row[s] for s in _GARUD],
                                    [float(x) for x in ref],
@@ -156,15 +147,97 @@ def test_garud_multiwindow_matches_per_window_scalar(hm, window, step):
     assert compared > 1
 
 
-@pytest.mark.xfail(strict=True, reason="a variant-free tile (non-overlapping) "
-                   "window borrows the next window's first-variant hash via "
-                   "cp.add.reduceat instead of yielding the no-variant value")
-def test_garud_tile_empty_window_value():
-    # A non-overlapping grid with a variant-free middle window. An empty window
-    # has no differentiating sites -> one distinct haplotype -> H1/H12/H123 = 1,
-    # H2/H1 = 0 (the value the overlapping/prefix-sum path already produces).
+_GARUD_COUNT = _GARUD + ["haplotype_count"]
+
+
+def _assert_rows_match_reference(df, hap, pos):
+    """Every window's statistics equal the exact unique-row reference.
+
+    ``hap`` may live on either device; only the window's columns move to
+    the host.
+    """
+    for _, row in df.iterrows():
+        lo, hi = np.searchsorted(pos, [row["start"], row["end"]])
+        rows = hap[:, lo:hi]
+        ref = garud_reference(rows.get() if hasattr(rows, "get") else rows)
+        np.testing.assert_allclose([row[s] for s in _GARUD], ref[:4],
+                                   rtol=1e-12)
+        assert row["haplotype_count"] == ref[4]
+
+
+@pytest.mark.parametrize("pos,bounds,window,step,n_empty", [
+    ([10, 210], (0, 300), 100, 100, 1),    # variant-free middle tile
+    ([10, 20], (0, 400), 100, 100, 3),     # grid runs on past the variants
+    ([10, 20], (0, 400), 100, 50, 7),      # sliding grid, variant-free overlaps
+    ([10, 20], (200, 400), 100, 100, 2),   # every window empty
+])
+def test_garud_windows_without_variants(pos, bounds, window, step, n_empty):
+    # A window with no variants has no differentiating sites: one distinct
+    # haplotype, H1 = H12 = H123 = 1, H2/H1 = 0.
     hap = np.array([[0, 1], [1, 0], [1, 1], [0, 0]], dtype=np.int8)
-    m = HaplotypeMatrix(hap, np.array([10, 210], dtype=np.int64), 0, 300)
-    df = windowed_analysis(m, window_size=100, step_size=100, statistics=_GARUD)
-    empty = df[df["n_variants"] == 0].iloc[0]
-    np.testing.assert_allclose([empty[s] for s in _GARUD], [1.0, 1.0, 1.0, 0.0])
+    pos = np.array(pos, dtype=np.int64)
+    m = HaplotypeMatrix(hap, pos, *bounds)
+    df = windowed_analysis(m, window_size=window, step_size=step,
+                           statistics=_GARUD_COUNT)
+    assert (df["n_variants"] == 0).sum() == n_empty
+    _assert_rows_match_reference(df, hap, pos)
+
+
+@pytest.mark.parametrize("window,step", [(10_000, 10_000), (10_000, 5_000)],
+                         ids=["tile", "sliding"])
+def test_garud_window_batches_are_independent(hm, window, step, monkeypatch):
+    single = windowed_analysis(hm, window_size=window, step_size=step,
+                               statistics=_GARUD_COUNT)
+    monkeypatch.setattr(_memutil, "estimate_garud_window_batch",
+                        lambda n_hap, memory_fraction=0.3: 3)
+    batched = windowed_analysis(hm, window_size=window, step_size=step,
+                                statistics=_GARUD_COUNT)
+    assert len(single) > 3
+    for s in _GARUD_COUNT:
+        np.testing.assert_array_equal(single[s].to_numpy(),
+                                      batched[s].to_numpy())
+
+
+def test_garud_many_haplotypes_exact():
+    # 2,500 haplotypes drawn from 50 patterns: more haplotypes than a thread
+    # block could sort in shared memory, so this pins the global sort.
+    n_hap, n_var = 2500, 3000
+    hap = founder_haplotypes(np.random.default_rng(11), n_hap, n_var, 50)
+    pos = np.arange(1, n_var + 1, dtype=np.int64) * 10
+    m = HaplotypeMatrix(hap, pos, 0, n_var * 10 + 10)
+    df = windowed_analysis(m, window_size=5_000, step_size=5_000,
+                           statistics=_GARUD_COUNT)
+    assert len(df) >= 6
+    _assert_rows_match_reference(df, hap, pos)
+
+
+def test_garud_only_request_matches_combined_request(hm):
+    # A Garud-only request skips the fused engine's transposed copy of the
+    # matrix; the Garud columns must not depend on the other statistics
+    # requested alongside them.
+    alone = windowed_analysis(hm, window_size=10_000, step_size=10_000,
+                              statistics=_GARUD_COUNT)
+    combined = windowed_analysis(hm, window_size=10_000, step_size=10_000,
+                                 statistics=_GARUD_COUNT + ["pi"])
+    for s in _GARUD_COUNT:
+        np.testing.assert_array_equal(alone[s].to_numpy(),
+                                      combined[s].to_numpy())
+
+
+@pytest.mark.slow
+def test_garud_cohort_scale_stress():
+    # 3,000 haplotypes x 2,000,000 variants (6 GB of int8, built on the GPU)
+    # on a 20 kb tile grid and a 100 kb / 10 kb sliding grid; spot-check
+    # windows against exact unique rows.
+    n_hap, n_var = 3000, 2_000_000
+    rng = cp.random.default_rng(3)
+    founders = (rng.random((200, n_var), dtype=cp.float32) < 0.5).astype(cp.int8)
+    hap = founders[rng.integers(0, 200, size=n_hap)]
+    del founders
+    pos = np.arange(1, n_var + 1, dtype=np.int64) * 10
+    m = HaplotypeMatrix(hap, pos, 0, 20_000_000)
+    for window, step in [(20_000, 20_000), (100_000, 10_000)]:
+        df = windowed_analysis(m, window_size=window, step_size=step,
+                               statistics=_GARUD_COUNT)
+        _assert_rows_match_reference(df.iloc[[0, len(df) // 2, len(df) - 1]],
+                                     hap, pos)


### PR DESCRIPTION
Closes #207. Closes #294.

## Problem

- Windowed Garud H on a non-overlapping grid upcast the whole haplotype matrix to float64 three times over (109 GB each for 2,940 haplotypes across 4.7 M sites) with no memory check, and the fused engine held a transposed int8 copy on top.
- `cp.add.reduceat` gave a window with no variants the next window's first-variant hash; a grid lying entirely past the last variant raised `IndexError`. Sliding grids whose overlaps hold no variants took the same path.
- The fused kernel sorted each window in shared memory with a sort that never reached haplotypes past index 2048, so H statistics and `haplotype_count` were silently wrong above 2,048 haplotypes (50 patterns among 2,940 haplotypes came back as 913 distinct) and the kernel failed outright above 3,072.
- `haplotype_diversity`, `haplotype_count` and `garud_h` made a float32 copy of the matrix; `moving_garud_h` made five float64 copies.

## Fix

- New `pg_gpu/_haplotype_hash.py`. One int8-native kernel sums per-variant weights in index order for each (window, haplotype) pair straight from the matrix (any signed integer dtype, C or F order, read in place through byte strides), so identical haplotypes hash bit-identically and an empty window hashes to zero. Each window is sorted in global memory by two stable per-row argsorts, and a walk kernel tallies run lengths as exact integers so the statistics depend only on the run-length multiset. Windows are batched to free GPU memory through `_memutil.estimate_garud_window_batch`.
- `windowed_analysis.py` drops the reduceat, prefix-sum and chunked Garud paths and the old kernel (486 lines fewer). Garud-only requests skip the transposed copy and never take the chunked detour; the eager path reuses the existing allele-cap filter.
- `haplotype_diversity`, `haplotype_count`, `garud_h` and `moving_garud_h` share the same hash. `moving_garud_h` rejects windows outside the matrix. The four H formulas live in one function used by every path.
- Tests: a unit file for the kernels, empty-window coverage on tile and sliding grids, batching invariance, a 2,500-haplotype sort regression, a scikit-allel oracle for `moving_garud_h`, and a slow 6 GB stress case. The strict xfail from #295 is removed.
- Docs, changelog, and the biobank example help text updated.

## Verification

| Check | Result |
|---|---|
| Full suite | 1784 passed, 80 skipped, 25 xfailed, 1 failed (`test_scikit_allel_comparison_runs_small`, a 180 s subprocess timeout on a heavily loaded host; the script does not touch the changed code) |
| Bit-exact eager vs streaming Garud tests | pass |
| Regression diff against results saved from `main` (simulated and `ag1000g.X.2Mb.n113`, tile and sliding grids) | match within 1e-9 |
| Slow stress, 3,000 x 2,000,000 | passes in 24 s; the old path needed 144 GB |
| 2,940 x 500,000 tile scan, 300 windows | 0.15 s vs 0.67 s before, no large intermediates |
| Ag1000G X arm, 2,570 x 4.1 M, 20 kb tiles | pool memory 11 GB (the int8 matrix), 3 empty windows now report one haplotype, spot-checked windows match exact unique rows |

Sliding grids at extreme overlap (window 100 x step) are about 2.5x slower than the old prefix-sum path on the 500k-variant benchmark; at overlap 10 they are faster.

The scalar paths still materialize a matrix-sized boolean in their pre-existing missing-data check; that is #301.
